### PR TITLE
chore: make studio-brain/firebase dev tooling platform-neutral

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ Codex, treat this file as your **ground truth** for how to work here: what matte
 - **Owner/operator (Micah / Wuff):** shipping-focused, momentum-sensitive. Prefers small decisive increments and strong guardrails.
 
 ### Environments
-- **Local dev:** Vite + Firebase emulators (functions + firestore). Windows + PowerShell is common.
+- **Local dev:** Vite + Firebase emulators (functions + firestore). Linux/macOS/Windows workflows are supported; PowerShell remains optional for legacy scripts.
 - **Production:** Firebase hosting/functions + Firestore rules/indexes.
 - **Website hosting:** separate path/deploy (cPanel / static hosting style). Don’t assume Firebase deploy handles it.
 

--- a/docs/EMULATOR_RUNBOOK.md
+++ b/docs/EMULATOR_RUNBOOK.md
@@ -25,15 +25,18 @@
 ## Functions local dev
 - `npm --prefix functions run build` (typecheck)
 - Preferred (loads env from `functions/.env.local` every time):
-  - `pwsh -File scripts/start-emulators.ps1`
+  - `npm run emulators:start -- --only firestore,functions,auth`
 - Equivalent direct command:
   - `firebase emulators:start --only firestore,functions,auth`
+- Legacy command (PowerShell):
+  - `pwsh -File scripts/start-emulators.ps1`
 - Staff claims setup: `docs/STAFF_CLAIMS_SETUP.md`
 
 ### Stable local env across terminals
 1. Copy `functions/.env.local.example` to `functions/.env.local`.
 2. Set local-only values (for example `ADMIN_TOKEN`, `ALLOW_DEV_ADMIN_TOKEN=true`).
-3. Start emulators via `pwsh -File scripts/start-emulators.ps1`.
+3. Start emulators via `npm run emulators:start -- --only firestore,functions,auth`.
+   - Legacy: `pwsh -File scripts/start-emulators.ps1`.
 
 This avoids losing env vars when opening a new terminal session.
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "scripts": {
+    "emulators:start": "node ./scripts/start-emulators.mjs",
     "bootstrap": "npm install && npm --prefix functions install && npm --prefix studio-brain install && npm --prefix web install",
     "build:web": "npm --prefix web run build",
     "build:functions": "npm --prefix functions run build",
@@ -23,6 +24,7 @@
     "test:full": "npm run test:automation",
     "test:all": "npm run test:functions && npm run test:studio-brain && npm run test:web",
     "test:automation:unit": "npm run test:all",
+    "studio-brain:auth-probe": "node ./scripts/test-studio-brain-auth.mjs",
     "test:automation:gateway": "npm run functions:smoke:cors",
     "test:automation:checks": "npm --prefix web run a11y:smoke",
     "test:automation:ui": "npm run website:smoke:playwright && npm run portal:smoke:playwright",

--- a/scripts/start-emulators.mjs
+++ b/scripts/start-emulators.mjs
@@ -1,0 +1,112 @@
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const repoRoot = resolve(__dirname, "..");
+
+const args = process.argv.slice(2);
+
+const parseArgs = () => {
+  const options = {
+    only: "firestore,functions,auth",
+    project: "monsoonfire-portal",
+    config: "firebase.json",
+  };
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+
+    if (!arg.startsWith("--")) {
+      continue;
+    }
+
+    if (arg.startsWith("--only=")) {
+      options.only = arg.substring("--only=".length);
+      continue;
+    }
+
+    if (arg === "--only" && args[i + 1]) {
+      options.only = args[++i];
+      continue;
+    }
+
+    if (arg.startsWith("--project=")) {
+      options.project = arg.substring("--project=".length);
+      continue;
+    }
+
+    if (arg === "--project" && args[i + 1]) {
+      options.project = args[++i];
+      continue;
+    }
+
+    if (arg.startsWith("--config=")) {
+      options.config = arg.substring("--config=".length);
+      continue;
+    }
+
+    if (arg === "--config" && args[i + 1]) {
+      options.config = args[++i];
+      continue;
+    }
+  }
+
+  return options;
+};
+
+const loadDotenv = (filePath) => {
+  if (!existsSync(filePath)) {
+    console.log(`No ${filePath} found. Using current process environment.`);
+    return;
+  }
+
+  console.log(`Loading local env from ${filePath}`);
+  const text = readFileSync(filePath, "utf8");
+  text.split(/\r?\n/).forEach((rawLine) => {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) {
+      return;
+    }
+
+    const splitIndex = line.indexOf("=");
+    if (splitIndex === -1) {
+      return;
+    }
+
+    const key = line.slice(0, splitIndex).trim();
+    const value = line.slice(splitIndex + 1);
+    if (!key) {
+      return;
+    }
+
+    process.env[key] = value;
+  });
+};
+
+const { only, project, config } = parseArgs();
+const envFile = resolve(repoRoot, "functions", ".env.local");
+const resolvedConfig = resolve(repoRoot, config);
+
+loadDotenv(envFile);
+
+console.log(`Starting Firebase emulators (${only}) for project ${project}...`);
+
+const result = spawnSync(
+  "firebase",
+  ["emulators:start", "--config", resolvedConfig, "--project", project, "--only", only],
+  {
+    cwd: repoRoot,
+    stdio: "inherit",
+    env: process.env,
+  },
+);
+
+if (result.error) {
+  console.error(result.error.message);
+  process.exit(1);
+}
+
+process.exit(result.status ?? 1);

--- a/scripts/start-emulators.ps1
+++ b/scripts/start-emulators.ps1
@@ -4,23 +4,5 @@ param(
   [string] $Config = "firebase.json"
 )
 
-$envFile = Join-Path $PSScriptRoot "..\functions\.env.local"
-$envFile = [System.IO.Path]::GetFullPath($envFile)
-
-if (Test-Path $envFile) {
-  Write-Host "Loading local env from $envFile"
-  Get-Content $envFile | ForEach-Object {
-    $line = $_.Trim()
-    if (-not $line -or $line.StartsWith("#")) { return }
-    $parts = $line.Split("=", 2)
-    if ($parts.Count -ne 2) { return }
-    $key = $parts[0].Trim()
-    $value = $parts[1]
-    [System.Environment]::SetEnvironmentVariable($key, $value, "Process")
-  }
-} else {
-  Write-Host "No functions/.env.local found. Starting emulators with current process env only."
-}
-
-Write-Host "Starting Firebase emulators ($Only) for project $Project..."
-firebase emulators:start --config $Config --project $Project --only $Only
+$script = Join-Path $PSScriptRoot "start-emulators.mjs"
+node $script --only $Only --project $Project --config $Config

--- a/scripts/test-studio-brain-auth.mjs
+++ b/scripts/test-studio-brain-auth.mjs
@@ -1,0 +1,215 @@
+import { createInterface } from "node:readline";
+import { stdin as input, stdout as output } from "node:process";
+import { setTimeout as setAbortTimeout } from "node:timers";
+
+const parseArgs = () => {
+  const parsed = {};
+  const args = process.argv.slice(2);
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (!arg.startsWith("--")) {
+      continue;
+    }
+
+    const keyValue = arg.slice(2);
+    let key = keyValue;
+    let value = "true";
+
+    if (keyValue.includes("=")) {
+      const [rawKey, ...rest] = keyValue.split("=");
+      key = rawKey;
+      value = rest.join("=");
+    } else if (i + 1 < args.length && !args[i + 1].startsWith("--")) {
+      value = args[i + 1];
+      i += 1;
+    }
+
+    parsed[key.replace(/-([a-z])/g, (_, char) => char.toUpperCase())] = value;
+  }
+
+  return parsed;
+};
+
+const preview = (value, max = 220) => {
+  if (!value) {
+    return "";
+  }
+  const singleLine = String(value).replace(/\r/g, "").replace(/\n/g, " ").trim();
+  if (singleLine.length <= max) {
+    return singleLine;
+  }
+  return `${singleLine.slice(0, max)}...`;
+};
+
+const redactToken = (token) => {
+  if (!token) {
+    return "<empty>";
+  }
+  const trimmed = String(token).trim();
+  const prefix = trimmed.length <= 12 ? trimmed : trimmed.slice(0, 12);
+  return `${prefix}... (len=${trimmed.length})`;
+};
+
+const probe = async (label, url, headers = {}) => {
+  const controller = new AbortController();
+  const timer = setAbortTimeout(() => {
+    controller.abort();
+  }, 15000);
+
+  try {
+    const response = await fetch(url, {
+      method: "GET",
+      headers,
+      signal: controller.signal,
+    });
+    clearTimeout(timer);
+    const body = await response.text();
+    return {
+      label,
+      statusCode: response.status,
+      body,
+      error: null,
+    };
+  } catch (error) {
+    clearTimeout(timer);
+    return {
+      label,
+      statusCode: 0,
+      body: "",
+      error: error?.message || String(error),
+    };
+  }
+};
+
+const promptToken = async () => {
+  const readline = createInterface({ input, output });
+  const token = await new Promise((resolve) => {
+    readline.question("Enter Firebase ID token for Authorization header: ", (value) => {
+      readline.close();
+      resolve(value.trim());
+    });
+  });
+  return token;
+};
+
+const findWorkingCapabilitiesPath = async (baseUrl, preferredPath) => {
+  const candidates = [preferredPath, "/api/capabilities", "/capabilities"].filter(
+    (value, index, array) => array.indexOf(value) === index,
+  );
+
+  for (const path of candidates) {
+    const probeResult = await probe(`path-probe:${path}`, `${baseUrl}${path}`, {});
+    if (probeResult.statusCode !== 404) {
+      return {
+        path,
+        statusCode: probeResult.statusCode,
+      };
+    }
+  }
+
+  return {
+    path: preferredPath,
+    statusCode: 404,
+  };
+};
+
+const run = async () => {
+  const options = parseArgs();
+  const baseUrl =
+    String(
+      options.baseUrl || options.baseURL || process.env.STUDIO_BRAIN_BASE_URL || "http://127.0.0.1:8787",
+    ).replace(/\/$/, "");
+  const capabilitiesPath =
+    options.capabilitiesPath || "/api/capabilities";
+  let idToken = (options.idToken || process.env.STUDIO_BRAIN_ID_TOKEN || "").trim();
+  const adminToken = (options.adminToken || process.env.STUDIO_BRAIN_ADMIN_TOKEN || "").trim();
+  const promptForToken = options.promptForToken === "true" || options.promptForToken === "1";
+
+  if (!idToken && promptForToken) {
+    idToken = await promptToken();
+  }
+
+  const pathResolution = await findWorkingCapabilitiesPath(baseUrl, capabilitiesPath);
+  const targetPath = pathResolution.path;
+  const targetUrl = `${baseUrl}${targetPath}`;
+
+  console.log(`Studio Brain auth probe target: ${targetUrl}`);
+  console.log(`Capabilities path detection status: ${pathResolution.statusCode}`);
+  console.log(`ID token source: ${idToken ? redactToken(idToken) : "missing"}`);
+  console.log(`Admin token source: ${adminToken ? redactToken(adminToken) : "missing"}`);
+
+  const cases = [];
+  cases.push(await probe("A no headers", targetUrl, {}));
+
+  if (idToken) {
+    cases.push(await probe("B Authorization only", targetUrl, { Authorization: `Bearer ${idToken}` }));
+  } else {
+    cases.push({
+      label: "B Authorization only",
+      statusCode: -1,
+      body: "",
+      error: "Skipped: no ID token. Set STUDIO_BRAIN_ID_TOKEN or pass --prompt-for-token.",
+    });
+  }
+
+  if (idToken && adminToken) {
+    cases.push(
+      await probe("C Authorization + x-studio-brain-admin-token", targetUrl, {
+        Authorization: `Bearer ${idToken}`,
+        "x-studio-brain-admin-token": adminToken,
+      }),
+    );
+  } else {
+    cases.push({
+      label: "C Authorization + x-studio-brain-admin-token",
+      statusCode: -1,
+      body: "",
+      error:
+        "Skipped: missing STUDIO_BRAIN_ID_TOKEN or STUDIO_BRAIN_ADMIN_TOKEN.",
+    });
+  }
+
+  console.log("");
+  console.log("Results:");
+  cases.forEach((item) => {
+    console.log(`- ${item.label}: status=${item.statusCode}`);
+    if (item.error) {
+      console.log(`  error=${preview(item.error, 180)}`);
+    }
+    if (item.body) {
+      console.log(`  body=${preview(item.body, 220)}`);
+    }
+  });
+
+  const caseA = cases[0];
+  const caseB = cases[1];
+  const caseC = cases[2];
+  const caseABody = String(caseA.body || "").toLowerCase();
+  const caseBBody = String(caseB.body || "").toLowerCase();
+  const caseCBody = String(caseC.body || "").toLowerCase();
+
+  const passA = [401, 403].includes(caseA.statusCode) || caseABody.includes("missing authorization header");
+  const passB =
+    caseB.statusCode === -1 ? false : (caseB.statusCode === 200 || !caseBBody.includes("missing authorization header"));
+  const passC =
+    caseC.statusCode === -1 ? true : (caseC.statusCode === 200 || !caseCBody.includes("missing authorization header"));
+
+  console.log("");
+  console.log(`PASS A (no headers rejected): ${passA}`);
+  console.log(`PASS B (authorization accepted/non-missing-auth): ${passB}`);
+  console.log(`PASS C (authorization+admin accepted/non-missing-auth): ${passC}`);
+
+  if (passA && passB && passC) {
+    console.log("Overall: PASS");
+    return;
+  }
+
+  console.log("Overall: FAIL");
+  process.exit(1);
+};
+
+run().catch((error) => {
+  console.error("Studio Brain auth probe failed:", error);
+  process.exit(1);
+});

--- a/scripts/test-studio-brain-auth.ps1
+++ b/scripts/test-studio-brain-auth.ps1
@@ -1,190 +1,36 @@
 param(
-  [string]$BaseUrl = $env:STUDIO_BRAIN_BASE_URL,
-  [string]$CapabilitiesPath = "/api/capabilities",
-  [string]$IdToken = $env:STUDIO_BRAIN_ID_TOKEN,
-  [switch]$PromptForToken
+  [string] $BaseUrl = $env:STUDIO_BRAIN_BASE_URL,
+  [string] $CapabilitiesPath = "/api/capabilities",
+  [string] $IdToken = $env:STUDIO_BRAIN_ID_TOKEN,
+  [string] $AdminToken = $env:STUDIO_BRAIN_ADMIN_TOKEN,
+  [switch] $PromptForToken
 )
 
-$ErrorActionPreference = "Stop"
+$scriptPath = Join-Path $PSScriptRoot "test-studio-brain-auth.mjs"
+$argsList = @($scriptPath)
 
-if ([string]::IsNullOrWhiteSpace($BaseUrl)) {
-  $BaseUrl = "http://127.0.0.1:8787"
+if (-not [string]::IsNullOrWhiteSpace($BaseUrl)) {
+  $argsList += "--base-url"
+  $argsList += $BaseUrl
 }
 
-function Redact-Token {
-  param([string]$Token)
-  if ([string]::IsNullOrWhiteSpace($Token)) { return "<empty>" }
-  $trimmed = $Token.Trim()
-  $prefix = if ($trimmed.Length -le 12) { $trimmed } else { $trimmed.Substring(0, 12) }
-  return ("{0}... (len={1})" -f $prefix, $trimmed.Length)
+if (-not [string]::IsNullOrWhiteSpace($CapabilitiesPath)) {
+  $argsList += "--capabilities-path"
+  $argsList += $CapabilitiesPath
 }
 
-function To-Preview {
-  param([string]$Value, [int]$Max = 220)
-  if ([string]::IsNullOrWhiteSpace($Value)) { return "" }
-  $single = ($Value -replace "`r", "" -replace "`n", " ").Trim()
-  if ($single.Length -le $Max) { return $single }
-  return $single.Substring(0, $Max) + "..."
+if (-not [string]::IsNullOrWhiteSpace($IdToken)) {
+  $argsList += "--id-token"
+  $argsList += $IdToken
 }
 
-function Invoke-Probe {
-  param(
-    [string]$Label,
-    [string]$Url,
-    [hashtable]$Headers
-  )
-
-  try {
-    $invokeArgs = @{
-      Uri = $Url
-      Method = "Get"
-      Headers = $Headers
-      TimeoutSec = 15
-    }
-    if (Get-Command Invoke-WebRequest -ParameterName SkipHttpErrorCheck -ErrorAction SilentlyContinue) {
-      $invokeArgs.SkipHttpErrorCheck = $true
-    } elseif ($PSVersionTable.PSEdition -eq "Desktop") {
-      $invokeArgs.UseBasicParsing = $true
-    }
-    $response = Invoke-WebRequest @invokeArgs
-    return [ordered]@{
-      label = $Label
-      statusCode = [int]$response.StatusCode
-      body = [string]$response.Content
-      error = $null
-    }
-  } catch {
-    $status = 0
-    $body = ""
-    $resp = $_.Exception.Response
-    if ($resp) {
-      try {
-        if ($resp.StatusCode) { $status = [int]$resp.StatusCode }
-      } catch {}
-      try {
-        $stream = $resp.GetResponseStream()
-        if ($stream) {
-          $reader = New-Object System.IO.StreamReader($stream)
-          $body = $reader.ReadToEnd()
-          $reader.Dispose()
-        }
-      } catch {}
-    }
-    return [ordered]@{
-      label = $Label
-      statusCode = $status
-      body = [string]$body
-      error = $_.Exception.Message
-    }
-  }
+if (-not [string]::IsNullOrWhiteSpace($AdminToken)) {
+  $argsList += "--admin-token"
+  $argsList += $AdminToken
 }
 
-function Find-WorkingCapabilitiesPath {
-  param([string]$PortalBase, [string]$PreferredPath)
-
-  $candidatePaths = @($PreferredPath, "/api/capabilities", "/capabilities") | Select-Object -Unique
-  foreach ($path in $candidatePaths) {
-    $probe = Invoke-Probe -Label "path-probe:$path" -Url "$PortalBase$path" -Headers @{}
-    if ($probe.statusCode -ne 404) {
-      return [ordered]@{
-        path = $path
-        statusCode = $probe.statusCode
-      }
-    }
-  }
-  return [ordered]@{
-    path = $PreferredPath
-    statusCode = 404
-  }
+if ($PromptForToken) {
+  $argsList += "--prompt-for-token"
 }
 
-$trimmedToken = [string]$IdToken
-$trimmedToken = $trimmedToken.Trim()
-if ([string]::IsNullOrWhiteSpace($trimmedToken) -and $PromptForToken) {
-  $trimmedToken = (Read-Host "Enter Firebase ID token for Authorization header").Trim()
-}
-
-$base = $BaseUrl.TrimEnd("/")
-$pathResolution = Find-WorkingCapabilitiesPath -PortalBase $base -PreferredPath $CapabilitiesPath
-$targetPath = [string]$pathResolution.path
-$targetUrl = "$base$targetPath"
-$adminToken = [string]$env:STUDIO_BRAIN_ADMIN_TOKEN
-
-Write-Host ("Studio Brain auth probe target: {0}" -f $targetUrl)
-Write-Host ("Capabilities path detection status: {0}" -f $pathResolution.statusCode)
-Write-Host ("ID token source: {0}" -f $(if ([string]::IsNullOrWhiteSpace($trimmedToken)) { "missing" } else { Redact-Token -Token $trimmedToken }))
-Write-Host ("Admin token source: {0}" -f $(if ([string]::IsNullOrWhiteSpace($adminToken)) { "missing" } else { Redact-Token -Token $adminToken }))
-
-$cases = New-Object System.Collections.Generic.List[object]
-$cases.Add((Invoke-Probe -Label "A no headers" -Url $targetUrl -Headers @{})) | Out-Null
-
-if (-not [string]::IsNullOrWhiteSpace($trimmedToken)) {
-  $cases.Add((Invoke-Probe -Label "B Authorization only" -Url $targetUrl -Headers @{ Authorization = "Bearer $trimmedToken" })) | Out-Null
-} else {
-  $cases.Add([ordered]@{
-    label = "B Authorization only"
-    statusCode = -1
-    body = ""
-    error = "Skipped: no ID token. Set STUDIO_BRAIN_ID_TOKEN or pass -PromptForToken."
-  }) | Out-Null
-}
-
-if (-not [string]::IsNullOrWhiteSpace($trimmedToken) -and -not [string]::IsNullOrWhiteSpace($adminToken)) {
-  $cases.Add((Invoke-Probe -Label "C Authorization + x-studio-brain-admin-token" -Url $targetUrl -Headers @{
-    Authorization = "Bearer $trimmedToken"
-    "x-studio-brain-admin-token" = $adminToken
-  })) | Out-Null
-} else {
-  $cases.Add([ordered]@{
-    label = "C Authorization + x-studio-brain-admin-token"
-    statusCode = -1
-    body = ""
-    error = "Skipped: missing STUDIO_BRAIN_ID_TOKEN or STUDIO_BRAIN_ADMIN_TOKEN."
-  }) | Out-Null
-}
-
-Write-Host ""
-Write-Host "Results:"
-foreach ($item in $cases) {
-  Write-Host ("- {0}: status={1}" -f $item.label, $item.statusCode)
-  if (-not [string]::IsNullOrWhiteSpace($item.error)) {
-    Write-Host ("  error={0}" -f (To-Preview -Value $item.error -Max 180))
-  }
-  if (-not [string]::IsNullOrWhiteSpace($item.body)) {
-    Write-Host ("  body={0}" -f (To-Preview -Value $item.body -Max 220))
-  }
-}
-
-$caseA = $cases[0]
-$caseB = $cases[1]
-$passA = (
-  ($caseA.statusCode -in @(401, 403)) -or
-  (([string]$caseA.body).ToLowerInvariant().Contains("missing authorization header"))
-)
-
-$passB = $false
-if ($caseB.statusCode -eq -1) {
-  $passB = $false
-} else {
-  $bodyLower = ([string]$caseB.body).ToLowerInvariant()
-  $passB = ($caseB.statusCode -eq 200) -or (-not $bodyLower.Contains("missing authorization header"))
-}
-
-$passC = $true
-if ($cases[2].statusCode -ne -1) {
-  $bodyLowerC = ([string]$cases[2].body).ToLowerInvariant()
-  $passC = ($cases[2].statusCode -eq 200) -or (-not $bodyLowerC.Contains("missing authorization header"))
-}
-
-Write-Host ""
-Write-Host ("PASS A (no headers rejected): {0}" -f $passA)
-Write-Host ("PASS B (authorization accepted/non-missing-auth): {0}" -f $passB)
-Write-Host ("PASS C (authorization+admin accepted/non-missing-auth): {0}" -f $passC)
-
-if ($passA -and $passB -and $passC) {
-  Write-Host "Overall: PASS"
-  exit 0
-}
-
-Write-Host "Overall: FAIL"
-exit 1
+node @argsList

--- a/studio-brain/README.md
+++ b/studio-brain/README.md
@@ -84,7 +84,7 @@ Capability endpoints require header:
 - `x-studio-brain-admin-token` alone is not accepted for `GET /api/capabilities`.
 
 Auth probe for local verification:
-- `pwsh scripts/test-studio-brain-auth.ps1`
+- `node ../scripts/test-studio-brain-auth.mjs`
 - Optional env vars:
   - `STUDIO_BRAIN_BASE_URL` (default `http://127.0.0.1:8787`)
   - `STUDIO_BRAIN_ID_TOKEN`


### PR DESCRIPTION
## Summary
- Added cross-platform Node-based development scripts for Firebase emulator startup and Studio Brain auth probing.
- Kept PowerShell wrappers for backward compatibility, but switched documentation defaults to platform-neutral commands.
- Updated portal/studio-brain docs and AGENTS guidance to avoid Windows-only dependency for core workflows.

## Why
We’re moving off Windows-first tooling and want StudioBrain/Firebase local workflows to run on Studiobrain/Linux/macOS without PowerShell.

## Changes
- Added `scripts/start-emulators.mjs`:
  - Loads `functions/.env.local` and starts Firebase emulators with parsed flags.
- Added `package.json` scripts:
  - `emulators:start`
  - `studio-brain:auth-probe`
- Added `scripts/test-studio-brain-auth.mjs` and compatibility `scripts/test-studio-brain-auth.ps1` wrapper.
- Refactored `scripts/start-emulators.ps1` to delegate to Node implementation.
- Updated docs:
  - `docs/EMULATOR_RUNBOOK.md` (preferred Node command, legacy PS fallback)
  - `studio-brain/README.md` (Node auth probe command)
  - `AGENTS.md` (platform phrasing)

## Validation
- Code-level compile/runtime validation not run in this PR step.
- Suggested manual checks:
  - `npm run emulators:start -- --only firestore,functions,auth`
  - `npm run studio-brain:auth-probe`
