### PR TITLE
chore: enforce studiobrain smoke and integrity gates

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -31,7 +31,7 @@ jobs:
         run: npm --prefix web run build
 
       - name: Run Lighthouse CI
-        run: npx --yes @lhci/cli@0.14.x autorun --config=./web/lighthouserc.json
+        run: npm --prefix web run lighthouse:local
 
       - name: Run Lighthouse CI (website)
-        run: npx --yes @lhci/cli@0.14.x autorun --config=./website/lighthouserc.json
+        run: node ./web/scripts/lighthouse-local.mjs ./website/lighthouserc.json

--- a/docs/EMULATOR_RUNBOOK.md
+++ b/docs/EMULATOR_RUNBOOK.md
@@ -1,6 +1,9 @@
 # Emulator + Extensions Runbook
 
 ## Emulator startup (portal)
+- Pre-start drift checks:
+  - `npm run integrity:check`
+  - `npm run studio:host:contract:scan:strict`
 - Recommended: run Firestore + Functions emulators while using REAL Firebase Auth.
   - In `web/.env.local`:
     - `VITE_USE_AUTH_EMULATOR=false`
@@ -35,7 +38,7 @@
   - `npm run studio:network:check:write-state`
 - Equivalent direct command:
   - `node ./scripts/start-emulators.mjs --only firestore,functions,auth`
-- Legacy compatibility shim (PowerShell):
+- Recommended compatibility path (PowerShell only):
   - `pwsh -File scripts/start-emulators.ps1`
 - Staff claims setup: `docs/STAFF_CLAIMS_SETUP.md`
 
@@ -45,7 +48,7 @@
 2. Copy `web/.env.local.example` to `web/.env.local`.
 3. Set local-only values (for example `ADMIN_TOKEN`, `ALLOW_DEV_ADMIN_TOKEN=true`).
 4. Start emulators via `npm run emulators:start -- --only firestore,functions,auth`.
-   - Compatibility fallback: `pwsh -File scripts/start-emulators.ps1`.
+   - Compatibility fallback (Windows-only): `pwsh -File scripts/start-emulators.ps1`.
 
 ## Emulator and UI contract matrix
 
@@ -70,11 +73,20 @@ This avoids losing env vars when opening a new terminal session.
 
 ## Network profile health and host stability
 - Validate host identity and profile drift before smoke or deployment workflows:
+  - `npm run studio:host:contract:scan:strict`
   - `npm run studio:network:check:gate -- --strict`
 - Recommended sequence before major cutover changes:
-  - `npm run studio:network:check:gate -- --strict`
+  - `npm run studio:host:contract:scan:strict`
   - `npm run studio:check`
+  - `npm run studio:network:check:gate -- --strict`
   - `npm run pr:gate -- --smoke`
+  - `npm run integrity:check`
+  
+Recommended clean-state definition:
+- host contract scan passes (`npm run studio:host:contract:scan:strict`)
+- status gate passes (`npm run studio:check`)
+- smoke checks pass (`npm run pr:gate -- --smoke`)
+- runtime integrity check passes (`npm run integrity:check`)
 
 ## Network profile and DHCP/static-host strategy
 

--- a/docs/runbooks/PR_GATE.md
+++ b/docs/runbooks/PR_GATE.md
@@ -7,9 +7,19 @@ Run a deterministic pre-merge checklist for Studio Brain + portal/site smoke cov
 Default `npm run pr:gate` runs these required checks:
 
 1. Studio Brain env contract validation (`npm --prefix studio-brain run env:validate -- --json`)
-2. Host profile consistency check for `STUDIO_BRAIN_HOST`, `STUDIO_BRAIN_PORT`, and `STUDIO_BRAIN_BASE_URL`
-3. Studio Brain preflight (`npm --prefix studio-brain run preflight`)
-4. Studio Brain status gate (`node ./scripts/studiobrain-status.mjs --json --gate`)
+2. Studio Brain runtime integrity check (`npm run integrity:check`)
+3. Host profile consistency check for `STUDIO_BRAIN_HOST`, `STUDIO_BRAIN_PORT`, and `STUDIO_BRAIN_BASE_URL`
+4. Legacy host-contract scan (`npm run studio:host:contract:scan:strict`)
+5. Studio Brain network runtime contract (`node ./scripts/studiobrain-network-check.mjs --gate --strict --write-state`)
+6. Studio Brain preflight (`npm --prefix studio-brain run preflight`)
+7. Studio Brain status gate (`node ./scripts/studiobrain-status.mjs --json --gate`)
+
+For a clean local state, each onboarding run should pass host contract scan + smoke + status checks in sequence.
+Recommended sequence:
+1. `npm run integrity:check`
+2. `npm run studio:host:contract:scan:strict`
+3. `npm run studio:status`
+4. `npm run pr:gate -- --smoke`
 
 ## Extended smoke mode
 Run smoke mode for PR confidence:

--- a/scripts/integrity-check.mjs
+++ b/scripts/integrity-check.mjs
@@ -1,0 +1,474 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const REPO_ROOT = resolve(__dirname, "..");
+
+const DEFAULT_TARGET_FILES = [
+  "studio-brain/.env.network.profile",
+  "studio-brain/.env.contract.schema.json",
+  "studio-brain/docker-compose.yml",
+  "studio-brain/scripts/preflight.mjs",
+  "studio-brain/scripts/env-contract-validator.mjs",
+  "studio-brain/scripts/validateCompose.mjs",
+  "studio-brain/scripts/validate-env-contract.mjs",
+  "scripts/studio-network-profile.mjs",
+  "scripts/start-emulators.mjs",
+  "scripts/studiobrain-network-check.mjs",
+  "scripts/studiobrain-status.mjs",
+  "scripts/scan-studiobrain-host-contract.mjs",
+  "scripts/pr-gate.mjs",
+  "scripts/portal-playwright-smoke.mjs",
+  "scripts/website-playwright-smoke.mjs",
+  "scripts/functions-cors-smoke.mjs",
+  "website/scripts/deploy.mjs",
+  "website/scripts/serve.mjs",
+];
+
+const DEFAULT_OVERRIDE_ENV_VAR = "STUDIO_BRAIN_INTEGRITY_OVERRIDE";
+const OVERRIDE_REQUIRED_KEYS = ["owner", "reason", "expiresAt"];
+
+function parseArgs(rawArgs = []) {
+  const parsed = {
+    manifest: null,
+    json: false,
+    strict: false,
+    failOnWarnings: false,
+    update: false,
+    init: false,
+  };
+
+  for (let index = 0; index < rawArgs.length; index += 1) {
+    const arg = rawArgs[index];
+    if (arg === "--manifest" && rawArgs[index + 1]) {
+      parsed.manifest = rawArgs[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith("--manifest=")) {
+      parsed.manifest = arg.slice("--manifest=".length);
+      continue;
+    }
+    if (arg === "--json") {
+      parsed.json = true;
+      continue;
+    }
+    if (arg === "--strict") {
+      parsed.strict = true;
+      continue;
+    }
+    if (arg === "--fail-on-warnings") {
+      parsed.failOnWarnings = true;
+      continue;
+    }
+    if (arg === "--update") {
+      parsed.update = true;
+      continue;
+    }
+    if (arg === "--init") {
+      parsed.init = true;
+      continue;
+    }
+  }
+
+  return parsed;
+}
+
+function parseOverride(rawValue) {
+  if (!rawValue) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(rawValue);
+    if (typeof parsed !== "object" || parsed === null) {
+      return { error: "Integrity override payload must be JSON object." };
+    }
+
+    const missing = OVERRIDE_REQUIRED_KEYS.filter((key) => {
+      const value = parsed[key];
+      return typeof value !== "string" || value.trim().length === 0;
+    });
+    if (missing.length > 0) {
+      return {
+        error: `Integrity override missing required key(s): ${missing.join(", ")}.`,
+      };
+    }
+
+    const expiresAt = new Date(parsed.expiresAt);
+    if (Number.isNaN(expiresAt.getTime())) {
+      return {
+        error: "Integrity override `expiresAt` must be an ISO timestamp.",
+      };
+    }
+
+    return {
+      owner: parsed.owner.trim(),
+      reason: parsed.reason.trim(),
+      expiresAt,
+      allowedPaths: Array.isArray(parsed.allowedPaths)
+        ? parsed.allowedPaths.map((path) => String(path).trim()).filter(Boolean)
+        : null,
+      source: parsed.source || "environment",
+    };
+  } catch (error) {
+    return {
+      error: `Integrity override is not valid JSON: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+}
+
+function sha256File(filePath) {
+  const data = readFileSync(filePath);
+  const hash = createHash("sha256").update(data).digest("hex");
+  return hash;
+}
+
+function toRelative(filePath) {
+  return filePath.replace(`${REPO_ROOT}/`, "");
+}
+
+function hashTarget(pathOrFile) {
+  const absolute = resolve(REPO_ROOT, pathOrFile);
+  return {
+    path: toRelative(absolute),
+    sha256: sha256File(absolute),
+    size: readFileSync(absolute).length,
+  };
+}
+
+function normalizeManifest(rawManifest) {
+  return {
+    schema: rawManifest?.schema || "studiobrain-infra-integrity-v1",
+    generatedAt: rawManifest?.generatedAt || null,
+    generatedBy: rawManifest?.generatedBy || null,
+    files: Array.isArray(rawManifest?.files) ? rawManifest.files : [],
+    metadata: rawManifest?.metadata || {},
+    allowUnknown: Boolean(rawManifest?.allowUnknown),
+  };
+}
+
+function normalizeManifestPath(manifestPath) {
+  const target = manifestPath || "studio-brain/.env.integrity.json";
+  return resolve(REPO_ROOT, target);
+}
+
+function loadManifest(manifestPath) {
+  if (!existsSync(manifestPath)) {
+    return {
+      schema: "studiobrain-infra-integrity-v1",
+      generatedAt: null,
+      generatedBy: null,
+      files: DEFAULT_TARGET_FILES.map((path) => ({ path, sha256: null, size: 0 })),
+      metadata: {
+        fallback: true,
+      },
+      allowUnknown: false,
+    };
+  }
+
+  const raw = readFileSync(manifestPath, "utf8");
+  const parsed = JSON.parse(raw);
+  return normalizeManifest(parsed);
+}
+
+function writeManifest(payload, manifestPath) {
+  const directory = dirname(manifestPath);
+  mkdirSync(directory, { recursive: true });
+
+  const output = `${JSON.stringify(payload, null, 2)}\n`;
+  writeFileSync(manifestPath, output, "utf8");
+}
+
+function buildUpdatePayload(targets) {
+  const fileRecords = targets
+    .map((path) => {
+      const absolute = resolve(REPO_ROOT, path);
+      if (!existsSync(absolute)) {
+        return null;
+      }
+
+      return {
+        path,
+        sha256: sha256File(absolute),
+        size: readFileSync(absolute).length,
+      };
+    })
+    .filter(Boolean)
+    .sort((left, right) => left.path.localeCompare(right.path));
+
+  const missing = targets.filter((path) => !existsSync(resolve(REPO_ROOT, path)));
+  return {
+    schema: "studiobrain-infra-integrity-v1",
+    generatedAt: new Date().toISOString(),
+    generatedBy: "scripts/integrity-check.mjs",
+    allowUnknown: false,
+    metadata: {
+      totalFiles: fileRecords.length,
+      missingOnUpdate: missing,
+    },
+    files: fileRecords,
+  };
+}
+
+function isPathAllowed(path, allowedPaths) {
+  if (!Array.isArray(allowedPaths) || allowedPaths.length === 0) {
+    return true;
+  }
+  return allowedPaths.includes(path);
+}
+
+function compareAgainstManifest(manifest, targets, override, options) {
+  const report = {
+    ok: true,
+    status: "pass",
+    strictMode: Boolean(options?.strict || options?.failOnWarnings),
+    manifestPath: options?.manifestPath,
+    checked: 0,
+    issues: [],
+    warnings: [],
+    appliedBy: null,
+  };
+
+  const expected = manifest.files
+    .filter((entry) => typeof entry.path === "string" && entry.path.length > 0)
+    .reduce((acc, entry) => {
+      acc[entry.path] = entry;
+      return acc;
+    }, /** @type {Record<string, {path:string,sha256:string,size:number}>} */ ({}));
+
+  const targetSet = new Set(targets);
+  for (const target of targetSet) {
+    report.checked += 1;
+    const absolute = resolve(REPO_ROOT, target);
+    const existing = expected[target];
+
+    if (!existsSync(absolute)) {
+      const issue = {
+        file: target,
+        kind: "missing",
+        expected: existing?.sha256 ? existing.sha256 : "<missing from manifest>",
+        actual: "missing",
+        message: `Required file ${target} is missing from repository checkout.`,
+      };
+      if (!isBypassAllowed(override, issue)) {
+        report.issues.push(issue);
+        report.ok = false;
+      } else {
+        report.warnings.push({ ...issue, bypassed: true });
+      }
+      continue;
+    }
+
+    if (!existing) {
+      const warning = {
+        file: target,
+        kind: "untracked",
+        expected: "<untracked>",
+        actual: "present",
+        message: `${target} is not listed in integrity manifest.`,
+      };
+      if (!manifest.allowUnknown) {
+        report.issues.push({
+          ...warning,
+          message: `${warning.message} Add it to ${toRelative(options?.manifestPath || "")} or remove local overrides.`,
+        });
+        report.ok = false;
+      } else {
+        report.warnings.push(warning);
+      }
+      continue;
+    }
+
+    const actualSha = sha256File(absolute);
+    const actualSize = readFileSync(absolute).length;
+    if (actualSha !== existing.sha256 || actualSize !== existing.size) {
+      const issue = {
+        file: target,
+        kind: "changed",
+        expected: existing.sha256,
+        actual: actualSha,
+        message: `Integrity hash mismatch for ${target}.`,
+      };
+
+      if (!isBypassAllowed(override, issue)) {
+        report.issues.push(issue);
+        report.ok = false;
+      } else {
+        report.warnings.push({ ...issue, bypassed: true });
+      }
+    }
+  }
+
+  if (options?.strict || options?.failOnWarnings) {
+    report.ok = report.ok && report.warnings.length === 0;
+  }
+
+  report.status = report.ok ? "pass" : "fail";
+  report.appliedBy = override && override.active ? {
+    owner: override.owner,
+    reason: override.reason,
+    expiresAt: override.expiresAt.toISOString(),
+  } : null;
+
+  return report;
+}
+
+function isBypassAllowed(override, issue) {
+  if (!override || !override.active) {
+    return false;
+  }
+  if (override.expiresAt.getTime() <= Date.now()) {
+    return false;
+  }
+  return isPathAllowed(issue.file, override.allowedPaths);
+}
+
+function parseOverrideToken() {
+  const rawOverride = process.env[DEFAULT_OVERRIDE_ENV_VAR];
+  const parsed = parseOverride(rawOverride);
+  if (!parsed) {
+    return null;
+  }
+  if (parsed.error) {
+    return { active: false, error: parsed.error };
+  }
+
+  return {
+    active: true,
+    owner: parsed.owner,
+    reason: parsed.reason,
+    expiresAt: parsed.expiresAt,
+    allowedPaths: parsed.allowedPaths,
+    source: parsed.source,
+  };
+}
+
+function printHuman(report, override) {
+  process.stdout.write(`Integrity check (${toRelative(report.manifestPath)}): ${report.status.toUpperCase()}\n`);
+  process.stdout.write(`  checked: ${report.checked}\n`);
+
+  if (report.issues.length === 0 && report.warnings.length === 0) {
+    process.stdout.write("  no drift detected.\n");
+  }
+
+  if (override?.active) {
+    process.stdout.write(
+      `  override: active (${override.owner}) expires ${override.expiresAt.toISOString()} reason="${override.reason}"\n`,
+    );
+  }
+
+  if (report.issues.length > 0) {
+    process.stdout.write("  issues:\n");
+    for (const issue of report.issues) {
+      process.stdout.write(`    - ${issue.file}: ${issue.message}\n`);
+      if (issue.expected) {
+        process.stdout.write(`      expected: ${issue.expected}\n`);
+      }
+      if (issue.actual) {
+        process.stdout.write(`      actual: ${issue.actual}\n`);
+      }
+    }
+  }
+
+  if (report.warnings.length > 0) {
+    process.stdout.write("  bypassed issues:\n");
+    for (const issue of report.warnings) {
+      const suffix = issue.bypassed ? " [bypassed]" : "";
+      process.stdout.write(`    - ${issue.file}: ${issue.message}${suffix}\n`);
+    }
+  }
+
+  if (!report.ok) {
+    process.stdout.write(`  remediation: run node ./scripts/integrity-check.mjs --update --manifest studio-brain/.env.integrity.json\n`);
+    process.stdout.write("  override format:\n");
+    process.stdout.write(
+      '    STUDIO_BRAIN_INTEGRITY_OVERRIDE=\'{"owner":"you@you","reason":"short reason","expiresAt":"2026-02-18T18:00:00Z","allowedPaths":["studio-brain/docker-compose.yml"]}\'\n',
+    );
+  }
+}
+
+function runIntegrityCheck(options = {}) {
+  const manifestPath = normalizeManifestPath(options.manifest);
+  const outputJson = Boolean(options.json);
+  const strict = Boolean(options.strict);
+  const failOnWarnings = Boolean(options.failOnWarnings);
+  const update = Boolean(options.update);
+
+  const manifest = loadManifest(manifestPath);
+  if (update) {
+    const payload = buildUpdatePayload(DEFAULT_TARGET_FILES);
+    writeManifest(payload, manifestPath);
+    const missing = payload.metadata?.missingOnUpdate ?? [];
+    if (missing.length > 0) {
+      process.stderr.write(`warning: manifest update skipped missing files: ${missing.join(", ")}\n`);
+    }
+  }
+
+  const override = parseOverrideToken();
+  if (override?.error) {
+    const issueReport = {
+      ok: false,
+      status: "fail",
+      manifestPath,
+      checked: 0,
+      issues: [
+        {
+          file: "override",
+          kind: "override",
+          message: override.error,
+        },
+      ],
+      warnings: [],
+    };
+    if (!outputJson) {
+      printHuman(issueReport, null);
+    } else {
+      process.stdout.write(`${JSON.stringify(issueReport, null, 2)}\n`);
+    }
+    return issueReport;
+  }
+
+  const resolvedManifest = loadManifest(manifestPath);
+  const report = compareAgainstManifest(resolvedManifest, DEFAULT_TARGET_FILES, override, {
+    strict,
+    failOnWarnings,
+    manifestPath,
+  });
+
+  if (options.verbose !== false) {
+    if (!outputJson) {
+      printHuman(report, override);
+    } else {
+      process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    }
+  }
+
+  if (update) {
+    report.autoUpdated = true;
+  }
+
+  return report;
+}
+
+function run(argv) {
+  const args = parseArgs(argv.slice(2));
+  const report = runIntegrityCheck({
+    manifest: args.manifest || "studio-brain/.env.integrity.json",
+    strict: args.strict,
+    failOnWarnings: args.failOnWarnings,
+    update: args.update || args.init,
+    json: args.json,
+    verbose: true,
+  });
+  process.exitCode = report.ok ? 0 : 1;
+}
+
+export { runIntegrityCheck };
+run(process.argv);

--- a/scripts/scan-studiobrain-host-contract.mjs
+++ b/scripts/scan-studiobrain-host-contract.mjs
@@ -1,0 +1,334 @@
+#!/usr/bin/env node
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { basename, dirname, extname, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const repoRoot = resolve(__dirname, "..");
+
+const SCAN_ROOTS = [
+  resolve(repoRoot, "scripts"),
+  resolve(repoRoot, "web"),
+  resolve(repoRoot, "functions"),
+  resolve(repoRoot, "studio-brain"),
+];
+
+const FILE_EXTENSIONS = new Set([
+  ".js",
+  ".mjs",
+  ".ts",
+  ".tsx",
+  ".jsx",
+  ".json",
+  ".yml",
+  ".yaml",
+  ".ps1",
+  ".sh",
+]);
+
+const SKIP_DIRS = new Set([
+  ".git",
+  ".github",
+  ".next",
+  "dist",
+  "build",
+  "coverage",
+  "node_modules",
+  "output",
+  "reports",
+]);
+
+const RULES = [
+  {
+    id: "studio-brain-base-url-fallback",
+    category: "studio-brain-base-url-fallback",
+    severity: "error",
+    description: "Loopback fallback for Studio Brain base URL must be explicit-local only.",
+    patterns: [
+      /\b(?:STUDIO_BRAIN_BASE_URL|SOAK_BASE_URL)\b[^#\r\n]*?(?:\|\||\?\?|=)\s*["'`]?https?:\/\/(?:127\.0\.0\.1|localhost):8787/i,
+    ],
+  },
+  {
+    id: "studio-brain-loopback-runtime",
+    category: "studio-brain-loopback-runtime",
+    severity: "error",
+    description: "Hardcoded localhost/loopback Studio Brain endpoint for non-local flows.",
+    patterns: [
+      /\b127\.0\.0\.1:8787\b/g,
+      /\blocalhost:8787\b/g,
+      /\[::1\]:8787/g,
+    ],
+  },
+  {
+    id: "legacy-host-assumption",
+    category: "legacy-host-assumption",
+    severity: "warning",
+    description: "Legacy host assumptions may drift when moving off wuff-laptop.",
+    patterns: [
+      /\bwuff-laptop\b/gi,
+    ],
+  },
+];
+
+const EXCEPTIONS = [
+  {
+    path: /[\\/]scripts[\\/]new-studio-os-v3-drill-log-entry\.ps1$/,
+    ruleIds: ["studio-brain-base-url-fallback", "studio-brain-loopback-runtime"],
+    owner: "platform@studio",
+    reason: "Template shim for CLI replay; non-production and intentionally local.",
+  },
+  {
+    path: /[\\/]scripts[\\/]portal-playwright-smoke\.mjs$/,
+    ruleIds: ["studio-brain-loopback-runtime"],
+    owner: "platform@qa",
+    reason: "Smoke helper records loopback request patterns for diagnosis.",
+  },
+  {
+    path: /[\\/]scripts[\\/]check-studio-brain-bundle\.mjs$/,
+    ruleIds: ["studio-brain-loopback-runtime"],
+    owner: "platform@automation",
+    reason: "Bundle guard script intentionally asserts no forbidden loopback artifacts in build output.",
+  },
+  {
+    path: /[\\/]web[\\/]src[\\/].+\.test\.[cm]?[jt]sx?$/,
+    ruleIds: ["studio-brain-loopback-runtime", "studio-brain-base-url-fallback"],
+    owner: "platform@web",
+    reason: "Unit tests are exercising local-to-local behavior and must retain fixtures.",
+  },
+  {
+    path: /[\\/]web[\\/]src[\\/]utils[\\/]studioBrain\.ts$/,
+    ruleIds: ["studio-brain-loopback-runtime"],
+    owner: "platform@web",
+    reason: "Client runtime intentionally supports local host contract and localhost guardrails.",
+  },
+  {
+    path: /[\\/]scripts[\\/]scan-studiobrain-host-contract\.mjs$/,
+    ruleIds: ["legacy-host-assumption"],
+    owner: "platform@automation",
+    reason: "Script documentation intentionally references migration terminology.",
+  },
+  {
+    path: /[\\/]web[\\/]\.env(\..+)?$/,
+    ruleIds: ["studio-brain-loopback-runtime"],
+    owner: "platform@web",
+    reason: "Portal local env files intentionally keep localhost/studio-brain local defaults.",
+    tokenPattern: /(?:127\.0\.0\.1|localhost):8787/,
+  },
+];
+
+const options = parseArgs(process.argv.slice(2));
+const startAt = new Date().toISOString();
+const report = {
+  timestamp: startAt,
+  strict: options.strict,
+  scannedRoots: SCAN_ROOTS.map((entry) => relative(repoRoot, entry).replace(/\\/g, "/")),
+  violations: [],
+  allowedMatches: [],
+  skippedFiles: 0,
+  scannedFiles: 0,
+};
+
+for (const root of SCAN_ROOTS) {
+  walk(root);
+}
+
+const errors = report.violations.filter((entry) => entry.severity === "error");
+const warnings = report.violations.filter((entry) => entry.severity === "warning");
+const hasFailure = errors.length > 0 || (options.strict && warnings.length > 0);
+report.summary = {
+  status: hasFailure ? "fail" : "pass",
+  errors: errors.length,
+  warnings: warnings.length,
+};
+
+if (options.json) {
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  process.exit(hasFailure ? 1 : 0);
+}
+
+if (hasFailure) {
+  process.stderr.write(`FAIL: host-contract scan found ${errors.length} error(s), ${warnings.length} warning(s).\n`);
+} else if (warnings.length > 0) {
+  process.stdout.write(`PASS (with warnings): host-contract scan found ${warnings.length} warning(s).\n`);
+} else {
+  process.stdout.write(`PASS: studio-brain host-contract scan clean. Checked ${report.scannedFiles} file(s).\n`);
+}
+
+for (const violation of report.violations) {
+  const severityLabel = violation.severity.toUpperCase();
+  const stream = violation.severity === "error" ? process.stderr : process.stdout;
+  const range = violation.rangeEnd
+    ? `range:${violation.column}-${violation.rangeEnd}`
+    : `column:${violation.column}`;
+  stream.write(`[${severityLabel}] ${violation.file}:${violation.line}:${range}\n`);
+  stream.write(`  category: ${violation.category}\n`);
+  stream.write(`  rule: ${violation.rule}\n`);
+  stream.write(`  token: ${violation.token}\n`);
+  stream.write(`  owner: ${violation.owner || "unowned"}\n`);
+  stream.write(`  reason: ${violation.reason}\n`);
+}
+
+if (report.allowedMatches.length > 0) {
+  process.stdout.write(`\nAllowed exceptions used: ${report.allowedMatches.length}\n`);
+  for (const entry of report.allowedMatches) {
+    process.stdout.write(
+      `- ${entry.file}:${entry.line}:${entry.column}-${entry.rangeEnd} ${entry.rule} (${entry.owner}) - ${entry.reason}\n`,
+    );
+  }
+}
+
+if (hasFailure) {
+  process.exit(1);
+}
+
+function walk(targetPath) {
+  const stats = statSync(targetPath);
+  if (!stats.isDirectory()) {
+    checkFile(targetPath);
+    return;
+  }
+
+  const entries = readdirSync(targetPath, { withFileTypes: true });
+  for (const entry of entries) {
+    if (entry.name.startsWith(".") && SKIP_DIRS.has(entry.name)) {
+      continue;
+    }
+    if (SKIP_DIRS.has(entry.name)) {
+      continue;
+    }
+
+    const childPath = resolve(targetPath, entry.name);
+    if (entry.isDirectory()) {
+      walk(childPath);
+      continue;
+    }
+    if (entry.isFile()) {
+      checkFile(childPath);
+    }
+  }
+}
+
+function checkFile(filePath) {
+  if (!isScannableFile(filePath)) {
+    report.skippedFiles += 1;
+    return;
+  }
+
+  let content = "";
+  try {
+    content = readFileSync(filePath, "utf8");
+  } catch {
+    report.skippedFiles += 1;
+    return;
+  }
+
+  report.scannedFiles += 1;
+  const relativePath = relative(repoRoot, filePath).replace(/\\/g, "/");
+  const lines = content.split(/\r?\n/);
+
+  for (let lineNumber = 1; lineNumber <= lines.length; lineNumber += 1) {
+    const line = lines[lineNumber - 1] ?? "";
+    RULES.forEach((rule) => {
+      rule.patterns.forEach((pattern) => {
+        const globalPattern = toGlobal(pattern);
+        let match;
+        while ((match = globalPattern.exec(line)) !== null) {
+          const token = match[0];
+          const column = match.index + 1;
+          const rangeEnd = match.index + token.length;
+          const exception = getException(relativePath, rule.id, token);
+          if (exception) {
+            report.allowedMatches.push({
+              file: relativePath,
+              line: lineNumber,
+              column,
+              rangeEnd,
+              rule: rule.id,
+              reason: exception.reason,
+              owner: exception.owner,
+              token,
+            });
+            continue;
+          }
+
+          report.violations.push({
+            file: relativePath,
+            line: lineNumber,
+            column,
+            rangeEnd,
+            token: token.trim(),
+            rule: rule.id,
+            category: rule.category,
+            severity: rule.severity,
+            owner: null,
+            reason: rule.description,
+          });
+        }
+      });
+    });
+  }
+}
+
+function isScannableFile(filePath) {
+  const fileBaseName = basename(filePath);
+  if (fileBaseName === ".env" || fileBaseName.startsWith(".env.")) {
+    return true;
+  }
+
+  if (!FILE_EXTENSIONS.has(extname(filePath).toLowerCase())) {
+    return false;
+  }
+  const baseName = relative(repoRoot, filePath);
+  const skippedPrefix = baseName.split("/")[0];
+  return !SKIP_DIRS.has(skippedPrefix);
+}
+
+function getException(relativePath, ruleId, token) {
+  const pathForMatch = relativePath.replace(/\\/g, "/");
+  const withLeadingSlash = `/${pathForMatch}`;
+
+  for (const exception of EXCEPTIONS) {
+    if (!exception.path.test(pathForMatch) && !exception.path.test(withLeadingSlash)) {
+      continue;
+    }
+    if (!exception.ruleIds.includes(ruleId)) {
+      continue;
+    }
+    if (exception.tokenPattern && !exception.tokenPattern.test(token)) {
+      continue;
+    }
+    return exception;
+  }
+
+  return null;
+}
+
+function parseArgs(args) {
+  const parsed = {
+    strict: false,
+    json: false,
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--strict") {
+      parsed.strict = true;
+      continue;
+    }
+    if (arg === "--json") {
+      parsed.json = true;
+      continue;
+    }
+  }
+
+  return parsed;
+}
+
+function toGlobal(pattern) {
+  if (pattern.flags.includes("g")) {
+    return new RegExp(pattern.source, pattern.flags);
+  }
+  return new RegExp(pattern.source, `${pattern.flags}g`);
+}

--- a/studio-brain/.env.integrity.json
+++ b/studio-brain/.env.integrity.json
@@ -1,0 +1,102 @@
+{
+  "schema": "studiobrain-infra-integrity-v1",
+  "generatedAt": "2026-02-18T21:12:46.594Z",
+  "generatedBy": "scripts/integrity-check.mjs",
+  "allowUnknown": false,
+  "metadata": {
+    "totalFiles": 18,
+    "missingOnUpdate": []
+  },
+  "files": [
+    {
+      "path": "scripts/functions-cors-smoke.mjs",
+      "sha256": "b8dce1acd9d67197642fedf8e17965ad98b0e6af1ce5881dff8beafe646691cc",
+      "size": 7999
+    },
+    {
+      "path": "scripts/portal-playwright-smoke.mjs",
+      "sha256": "31007abd509dd03f52cb0c7edace9b43cc0439670d4321c81a9e5b8b327f6a42",
+      "size": 56203
+    },
+    {
+      "path": "scripts/pr-gate.mjs",
+      "sha256": "0d748d928bcf5d3364513e269ecf4d3a81452d47570e943821dc2932ba304a15",
+      "size": 8996
+    },
+    {
+      "path": "scripts/scan-studiobrain-host-contract.mjs",
+      "sha256": "ee0c8da23f7d93e2968f60769fa0ec02f29440a5344cc3cef587ca0b43bcb500",
+      "size": 9531
+    },
+    {
+      "path": "scripts/start-emulators.mjs",
+      "sha256": "5e0a1b5faef1e6c94a571a8bc5603693436f8a71c344cc645e78e7c3c4c496a5",
+      "size": 4608
+    },
+    {
+      "path": "scripts/studio-network-profile.mjs",
+      "sha256": "d4fed9ede941ff435be9fd8e8f5e9237c9a85e4bb13210ae96501e4757096aef",
+      "size": 5658
+    },
+    {
+      "path": "scripts/studiobrain-network-check.mjs",
+      "sha256": "40b59b43a774c1872d9f274e0ff866cb01175cfe96506d4aca81052c5337bb5e",
+      "size": 7398
+    },
+    {
+      "path": "scripts/studiobrain-status.mjs",
+      "sha256": "102db87c59ddb18214e17ce7ba876fb6fa5f2e88acc07f0d569348bfb55cb0ca",
+      "size": 3890
+    },
+    {
+      "path": "scripts/website-playwright-smoke.mjs",
+      "sha256": "f586fbe4e7c07a98507827d13fc82b875b63420f5c456a421f6da81cf40878aa",
+      "size": 11461
+    },
+    {
+      "path": "studio-brain/.env.contract.schema.json",
+      "sha256": "2c00c08fa9a80e49c92ec011b7428dfb3dc927b85067bff1394fc8bfdd51477d",
+      "size": 10598
+    },
+    {
+      "path": "studio-brain/.env.network.profile",
+      "sha256": "d75431b8dd5db4af5b4efade59b81a44d77249b3872105f7c62ec0405044e024",
+      "size": 406
+    },
+    {
+      "path": "studio-brain/docker-compose.yml",
+      "sha256": "7b5ad45a6b5cbd193e80e2ab82d7dcf34774932ce84ee5bc734a2beb73361f22",
+      "size": 1671
+    },
+    {
+      "path": "studio-brain/scripts/env-contract-validator.mjs",
+      "sha256": "7251d5a7f48494459085c35e1282e50d3479ae765906ec527b816849e80de835",
+      "size": 5429
+    },
+    {
+      "path": "studio-brain/scripts/preflight.mjs",
+      "sha256": "2e8f705a6636058e5fef2e942f5eb94ca513385cbe192cc9144db529de13c83f",
+      "size": 3580
+    },
+    {
+      "path": "studio-brain/scripts/validate-env-contract.mjs",
+      "sha256": "9b11da72796a5bcd2bebb51d7c68a2193d839bd400c8c0e673b545a9ae4b2006",
+      "size": 436
+    },
+    {
+      "path": "studio-brain/scripts/validateCompose.mjs",
+      "sha256": "b7b2206c1281a7dcda763229d61612e4e02d584d1f6b4694ebf7a2baeeb4824b",
+      "size": 2300
+    },
+    {
+      "path": "website/scripts/deploy.mjs",
+      "sha256": "d2c4b3de3f8bfdf7abe4b26fbfd02fd7ca966a5b998a83e09faf36814773c8f6",
+      "size": 3300
+    },
+    {
+      "path": "website/scripts/serve.mjs",
+      "sha256": "cb3c02e279bb551835f88346b3359c51610f267130073b6f3da1f8437a5d075d",
+      "size": 4189
+    }
+  ]
+}

--- a/tickets/P2-studiobrain-script-and-infra-integrity-checks.md
+++ b/tickets/P2-studiobrain-script-and-infra-integrity-checks.md
@@ -1,6 +1,6 @@
 # P2 — Script and Infrastructure Integrity Checks for Studiobrain
 
-Status: Planned
+Status: In Progress
 Date: 2026-02-18
 Priority: P2
 Owner: Platform
@@ -56,3 +56,20 @@ Add integrity manifests and validation checks for infra-critical files and start
 ## Definition of Done
 
 - Integrity checks are documented and enforced where risk outweighs convenience.
+
+## Work completed
+
+- Added runtime integrity manifest and scanner: `scripts/integrity-check.mjs` + `studio-brain/.env.integrity.json`.
+- Integrated integrity validation into critical entrypoints:
+  - `scripts/start-emulators.mjs`
+  - `studio-brain/scripts/preflight.mjs`
+  - `scripts/pr-gate.mjs`
+  - `scripts/portal-playwright-smoke.mjs`
+  - `scripts/website-playwright-smoke.mjs`
+  - `scripts/functions-cors-smoke.mjs`
+  - `scripts/studiobrain-status.mjs`
+- Added new root commands:
+  - `npm run integrity:check`
+  - `npm run integrity:check:strict`
+  - `npm run integrity:update`
+- Documented integrity as part of PR gate and emulator onboarding (`docs/runbooks/PR_GATE.md`, `docs/EMULATOR_RUNBOOK.md`).


### PR DESCRIPTION
## Summary
- Add Studio Brain host-contract scanning and runtime integrity checks to smoke and status paths.
- Add integrity manifest generation/check scripts and integrate into PR gate/runbook documentation.
- Harden playground smoke scripts and PR gate runbook to fail fast on contract/integrity drift.

## Validation
- npm run integrity:check
- npm run studio:host:contract:scan:strict
- npm run studio:check (fails in this shell due missing required Studio Brain contract env vars).