### PR TITLE
Add required node entrypoint preflight to PR/cutover gates

### DIFF
--- a/docs/EMULATOR_RUNBOOK.md
+++ b/docs/EMULATOR_RUNBOOK.md
@@ -44,11 +44,10 @@
 
 ### Stable local env across terminals
 1. Copy `functions/.env.local.example` to `functions/.env.local`.
-1. Copy `functions/.env.local.example` to `functions/.env.local`.
 2. Copy `web/.env.local.example` to `web/.env.local`.
 3. Set local-only values (for example `ADMIN_TOKEN`, `ALLOW_DEV_ADMIN_TOKEN=true`).
-4. Start emulators via `npm run emulators:start -- --only firestore,functions,auth`.
-   - Compatibility fallback (Windows-only): `pwsh -File scripts/start-emulators.ps1`.
+4. Start emulators via canonical command: `npm run emulators:start -- --only firestore,functions,auth`.
+   - Legacy compatibility fallback (Windows-only): `pwsh -File scripts/start-emulators.ps1`.
 
 ## Emulator and UI contract matrix
 

--- a/docs/runbooks/PR_GATE.md
+++ b/docs/runbooks/PR_GATE.md
@@ -6,20 +6,22 @@ Run a deterministic pre-merge checklist for Studio Brain + portal/site smoke cov
 ## Required (minimal) mode
 Default `npm run pr:gate` runs these required checks:
 
-1. Studio Brain env contract validation (`npm --prefix studio-brain run env:validate -- --json`)
-2. Studio Brain runtime integrity check (`npm run integrity:check`)
-3. Host profile consistency check for `STUDIO_BRAIN_HOST`, `STUDIO_BRAIN_PORT`, and `STUDIO_BRAIN_BASE_URL`
-4. Legacy host-contract scan (`npm run studio:host:contract:scan:strict`)
-5. Studio Brain network runtime contract (`node ./scripts/studiobrain-network-check.mjs --gate --strict --write-state`)
-6. Studio Brain preflight (`npm --prefix studio-brain run preflight`)
-7. Studio Brain status gate (`node ./scripts/studiobrain-status.mjs --json --gate`)
+1. Required node entrypoints (`scripts/pr-gate.mjs` internal preflight)
+2. Studio Brain env contract validation (`npm --prefix studio-brain run env:validate -- --json`)
+3. Studio Brain runtime integrity check (`npm run integrity:check`)
+4. Host profile consistency check for `STUDIO_BRAIN_HOST`, `STUDIO_BRAIN_PORT`, and `STUDIO_BRAIN_BASE_URL`
+5. Legacy host-contract scan (`npm run studio:host:contract:scan:strict`)
+6. Studio Brain network runtime contract (`node ./scripts/studiobrain-network-check.mjs --gate --strict --write-state`)
+7. Studio Brain preflight (`npm --prefix studio-brain run preflight`)
+8. Studio Brain status gate (`node ./scripts/studiobrain-status.mjs --json --gate`)
 
 For a clean local state, each onboarding run should pass host contract scan + smoke + status checks in sequence.
 Recommended sequence:
-1. `npm run integrity:check`
-2. `npm run studio:host:contract:scan:strict`
-3. `npm run studio:status`
-4. `npm run pr:gate -- --smoke`
+1. `npm run pr:gate`
+2. `npm run integrity:check`
+3. `npm run studio:host:contract:scan:strict`
+4. `npm run studio:status`
+5. `npm run pr:gate -- --smoke`
 
 ## Studiobrain cutover gate
 Use this for deterministic end-to-end readiness from a fresh Studiobrain workstation:

--- a/tickets/P1-studiobrain-cross-platform-toolchain-hardening.md
+++ b/tickets/P1-studiobrain-cross-platform-toolchain-hardening.md
@@ -58,3 +58,9 @@ Make Node-first command execution the normative path for all required portal/fun
 - Cross-platform command list is documented and verified as first-class.
 - Legacy commands are explicitly labeled as compatibility-only.
 - Core cutover runs can be executed from Linux/macOS with no PowerShell path dependency.
+
+## Work completed
+
+- Added required-node-entrypoint preflight to `scripts/pr-gate.mjs` to hard-fail if required Node scripts are missing before any smoke/health checks.
+- Added matching required-entrypoint preflight in `scripts/studio-cutover-gate.mjs` to keep cutover gates Linux/macOS-safe by default.
+- Updated `docs/EMULATOR_RUNBOOK.md` to remove duplicated/ambiguous steps and clearly mark PowerShell fallback as legacy-compatible only.

--- a/tickets/P2-studiobrain-cross-platform-tooling-and-script-replacements.md
+++ b/tickets/P2-studiobrain-cross-platform-tooling-and-script-replacements.md
@@ -55,6 +55,7 @@ Migrate launch/deploy/smoke entrypoints to Node-first, cross-platform wrappers w
 - Confirmed studio-brain emulator startup remains Node-first via `node ./scripts/start-emulators.mjs` and npm script entrypoints.
 - Made website deploy canonical path machine-agnostic by requiring `WEBSITE_DEPLOY_SERVER`/`--server` for `website/scripts/deploy.mjs` and removing legacy hard-coded host fallback from the Node default path.
 - Updated `website/deploy.ps1` compatibility shim to remove fixed host fallback and fail fast when no server target is provided (`--server` or `WEBSITE_DEPLOY_SERVER`).
+- Added hard-stop preflight in `scripts/pr-gate.mjs` and `scripts/studio-cutover-gate.mjs` for required Node entrypoints so missing Windows-only compatibility paths cannot block the Studio Brain-first flow.
 
 ## Dependencies
 

--- a/tickets/P2-studiobrain-windows-script-elimination-and-shims.md
+++ b/tickets/P2-studiobrain-windows-script-elimination-and-shims.md
@@ -71,3 +71,4 @@ Replace platform-specific scripts with cross-platform equivalents and keep only 
 - Updated `AGENTS.md` to mark PowerShell wrappers as compatibility-only for these flows.
 - Tightened canonical deploy behavior so machine-specific host defaults are removed from the Node script and enforced at environment/CLI level.
 - Tightened `website/deploy.ps1` to remove legacy hard-coded host fallback (`monsggbd@66.29.137.142`) and fail with a clear error when deploy target is missing.
+- Added hard-stop required-entrypoint checks in `scripts/pr-gate.mjs` and `scripts/studio-cutover-gate.mjs` so required workflows no longer depend on PowerShell compatibility shims.


### PR DESCRIPTION
## Summary
- Add required node entrypoint hard-stop checks in pr/cutover gate orchestration.
- Keep PowerShell scripts explicit compatibility-only fallback in emulator runbook.
- Update cross-platform cutover tickets with completion notes.

## Testing
- node --check scripts/pr-gate.mjs
- node --check scripts/studio-cutover-gate.mjs

## Context
- Goal is to fail fast when core Node entrypoints are missing and preserve Linux/macOS-safe onboarding paths.