### PR TITLE
Fix unread counts and support message recipient handling

### DIFF
--- a/web/src/views/MessagesView.tsx
+++ b/web/src/views/MessagesView.tsx
@@ -309,10 +309,15 @@ export default function MessagesView({
       const messageId = createMessageId();
       const threadRef = doc(db, "directMessages", selectedThreadId);
       const toUids = selectedThread?.participantUids?.filter((uid) => uid !== user.uid) ?? [];
-      const toEmails = liveUsers
+      let toEmails = liveUsers
         .filter((liveUser) => toUids.includes(liveUser.id))
         .map((liveUser) => liveUser.email)
         .filter(Boolean) as string[];
+      const isSupportThread =
+        selectedThreadId.startsWith(SUPPORT_THREAD_PREFIX) || selectedThread?.kind === "support";
+      if (isSupportThread && toEmails.length === 0) {
+        toEmails = [supportEmail];
+      }
       const fromEmail = user.email || null;
       const previousMessageId = selectedThread?.lastMessageId || null;
       const references = selectedThread?.references || [];

--- a/website/assets/js/main.js
+++ b/website/assets/js/main.js
@@ -62,9 +62,9 @@
     });
 
     nav.addEventListener('click', (event) => {
-      if (event.target && event.target.matches('a')) {
-        setMenuState(false);
-      }
+      const target = event.target;
+      if (!(target instanceof Element)) return;
+      if (target.closest('a')) setMenuState(false);
     });
 
     document.addEventListener('click', (event) => {


### PR DESCRIPTION
## Summary
- fix direct-message unread badge counting to use thread last-message vs last-read timestamps
- fix announcement unread badge counting to use readBy membership
- ensure support-thread replies always include support recipient email fallback
- harden website nav close click handling for nested link targets

## Validation
- npm --prefix web run lint
- npm --prefix web run test:run
- node --check website/assets/js/main.js
- npm run test:e2e
