### PR TITLE
fix: prefer portal Firebase key in hosting builds

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -18,7 +18,6 @@ jobs:
         env:
           FIREBASE_WEB_API_KEY: ${{ secrets.FIREBASE_WEB_API_KEY }}
           PORTAL_FIREBASE_API_KEY: ${{ secrets.PORTAL_FIREBASE_API_KEY }}
-          FALLBACK_FIREBASE_API_KEY: "AIzaSyC7ynej0nGJas9me9M5oW6jHfLsWe5gHbU"
         run: |
           set -euo pipefail
 
@@ -51,7 +50,7 @@ jobs:
           }
 
           SELECTED_FIREBASE_API_KEY=""
-          for candidate in "$FIREBASE_WEB_API_KEY" "$PORTAL_FIREBASE_API_KEY" "$FALLBACK_FIREBASE_API_KEY"; do
+          for candidate in "$PORTAL_FIREBASE_API_KEY" "$FIREBASE_WEB_API_KEY"; do
             if validate_api_key "$candidate"; then
               SELECTED_FIREBASE_API_KEY="$candidate"
               break

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -18,7 +18,6 @@ jobs:
         env:
           FIREBASE_WEB_API_KEY: ${{ secrets.FIREBASE_WEB_API_KEY }}
           PORTAL_FIREBASE_API_KEY: ${{ secrets.PORTAL_FIREBASE_API_KEY }}
-          FALLBACK_FIREBASE_API_KEY: "AIzaSyC7ynej0nGJas9me9M5oW6jHfLsWe5gHbU"
         run: |
           set -euo pipefail
 
@@ -51,7 +50,7 @@ jobs:
           }
 
           SELECTED_FIREBASE_API_KEY=""
-          for candidate in "$FIREBASE_WEB_API_KEY" "$PORTAL_FIREBASE_API_KEY" "$FALLBACK_FIREBASE_API_KEY"; do
+          for candidate in "$PORTAL_FIREBASE_API_KEY" "$FIREBASE_WEB_API_KEY"; do
             if validate_api_key "$candidate"; then
               SELECTED_FIREBASE_API_KEY="$candidate"
               break


### PR DESCRIPTION
## Summary
- remove hardcoded fallback API key from Hosting build workflows
- prioritize PORTAL_FIREBASE_API_KEY ahead of FIREBASE_WEB_API_KEY when selecting build key

## Why
- Smoke and backend probes on main are passing with the portal key source
- promotion gate still fails due invalid client key in deployed bundle
- this change makes deploy use the proven-good key source first and avoids stale fallback deployment
