### PR TITLE
fix: persist selected Firebase key into hosting deploy step

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -87,6 +87,7 @@ jobs:
           fi
 
           echo "Using Firebase API key source: $SELECTED_SOURCE"
+          echo "VITE_FIREBASE_API_KEY=$SELECTED_FIREBASE_API_KEY" >> "$GITHUB_ENV"
           export VITE_FIREBASE_API_KEY="$SELECTED_FIREBASE_API_KEY"
           npm --prefix web ci
           npm --prefix web run build

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -87,6 +87,7 @@ jobs:
           fi
 
           echo "Using Firebase API key source: $SELECTED_SOURCE"
+          echo "VITE_FIREBASE_API_KEY=$SELECTED_FIREBASE_API_KEY" >> "$GITHUB_ENV"
           export VITE_FIREBASE_API_KEY="$SELECTED_FIREBASE_API_KEY"
           npm --prefix web ci
           npm --prefix web run build


### PR DESCRIPTION
## Summary
- write selected VITE_FIREBASE_API_KEY into GITHUB_ENV after validation
- ensures Firebase Hosting action predeploy build uses the same validated key

## Why
- deploy workflow currently validates and builds with a key, but action-hosting-deploy rebuilds in a later step
- without env propagation, deployed bundle can still ship an invalid key and fail promotion gate auth canary
