### PR TITLE
fix: point automated portal canaries to Firebase web.app target

### DIFF
--- a/.github/workflows/portal-daily-authenticated-canary.yml
+++ b/.github/workflows/portal-daily-authenticated-canary.yml
@@ -6,7 +6,7 @@ on:
       base_url:
         description: "Portal base URL"
         required: false
-        default: "https://portal.monsoonfire.com"
+        default: "https://monsoonfire-portal.web.app"
   schedule:
     # Every 30 minutes for early regression detection.
     - cron: "*/30 * * * *"
@@ -47,7 +47,7 @@ jobs:
           if [ -n "${{ github.event.inputs.base_url }}" ]; then
             echo "value=${{ github.event.inputs.base_url }}" >> "$GITHUB_OUTPUT"
           else
-            echo "value=https://portal.monsoonfire.com" >> "$GITHUB_OUTPUT"
+            echo "value=https://monsoonfire-portal.web.app" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Run authenticated canary (functional + theme)

--- a/.github/workflows/portal-post-deploy-promotion-gate.yml
+++ b/.github/workflows/portal-post-deploy-promotion-gate.yml
@@ -6,7 +6,7 @@ on:
       base_url:
         description: "Portal base URL"
         required: false
-        default: "https://portal.monsoonfire.com"
+        default: "https://monsoonfire-portal.web.app"
       skip_theme_sweep:
         description: "Skip theme sweep during promotion gate"
         required: false
@@ -54,7 +54,7 @@ jobs:
           if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ github.event.inputs.base_url }}" ]; then
             echo "value=${{ github.event.inputs.base_url }}" >> "$GITHUB_OUTPUT"
           else
-            echo "value=https://portal.monsoonfire.com" >> "$GITHUB_OUTPUT"
+            echo "value=https://monsoonfire-portal.web.app" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Run post-deploy promotion gate

--- a/.github/workflows/portal-theme-contrast-regression.yml
+++ b/.github/workflows/portal-theme-contrast-regression.yml
@@ -6,7 +6,7 @@ on:
       base_url:
         description: "Portal base URL"
         required: false
-        default: "https://portal.monsoonfire.com"
+        default: "https://monsoonfire-portal.web.app"
       min_contrast:
         description: "Minimum contrast ratio threshold"
         required: false
@@ -50,7 +50,7 @@ jobs:
           if [ -n "${{ github.event.inputs.base_url }}" ]; then
             echo "value=${{ github.event.inputs.base_url }}" >> "$GITHUB_OUTPUT"
           else
-            echo "value=https://portal.monsoonfire.com" >> "$GITHUB_OUTPUT"
+            echo "value=https://monsoonfire-portal.web.app" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Resolve min contrast

--- a/scripts/portal-authenticated-canary.mjs
+++ b/scripts/portal-authenticated-canary.mjs
@@ -10,7 +10,7 @@ import { chromium } from "playwright";
 const __filename = fileURLToPath(import.meta.url);
 const repoRoot = resolve(dirname(__filename), "..");
 
-const DEFAULT_BASE_URL = "https://portal.monsoonfire.com";
+const DEFAULT_BASE_URL = "https://monsoonfire-portal.web.app";
 const DEFAULT_OUTPUT_DIR = resolve(repoRoot, "output", "qa", "portal-authenticated-canary");
 const DEFAULT_REPORT_PATH = resolve(repoRoot, "output", "qa", "portal-authenticated-canary.json");
 

--- a/scripts/post-deploy-promotion-gate.mjs
+++ b/scripts/post-deploy-promotion-gate.mjs
@@ -10,7 +10,7 @@ import { spawnSync } from "node:child_process";
 const __filename = fileURLToPath(import.meta.url);
 const repoRoot = resolve(dirname(__filename), "..");
 
-const DEFAULT_BASE_URL = "https://portal.monsoonfire.com";
+const DEFAULT_BASE_URL = "https://monsoonfire-portal.web.app";
 const DEFAULT_REPORT_PATH = resolve(repoRoot, "output", "qa", "post-deploy-promotion-gate.json");
 
 function parseArgs(argv) {


### PR DESCRIPTION
## Summary
- switch automated post-deploy promotion gate base URL default to https://monsoonfire-portal.web.app
- switch daily authenticated canary default to https://monsoonfire-portal.web.app
- switch theme contrast regression default to https://monsoonfire-portal.web.app
- align canary and promotion-gate script defaults to the same web.app target

## Why
- merge deploy workflow publishes to Firebase Hosting site (https://monsoonfire-portal.web.app)
- portal.monsoonfire.com is currently serving a stale bundle with invalid auth key and is not updating with these deploys
- automated CI should validate the artifact that was actually deployed in the workflow