### PR TITLE
chore: enable dependabot update automation for npm manifests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,37 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - security
+
+  - package-ecosystem: npm
+    directory: /functions
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - security
+
+  - package-ecosystem: npm
+    directory: /web
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - security
+
+  - package-ecosystem: npm
+    directory: /studio-brain
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - security


### PR DESCRIPTION
## Summary
- add `.github/dependabot.yml` covering root, `functions`, `web`, and `studio-brain` npm manifests
- schedule daily checks and apply consistent dependency/security labels

## Context
- repository already had Dependabot alerts enabled, but automated security fixes were disabled and no Dependabot update config file existed
- automated security fixes were re-enabled via repository settings/API during cleanup