### PR TITLE
ci: stabilize Dependabot checks and tame update volume

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,35 +3,95 @@ updates:
   - package-ecosystem: npm
     directory: /
     schedule:
-      interval: daily
-    open-pull-requests-limit: 10
+      interval: weekly
+      day: monday
+      time: "08:00"
+      timezone: America/Los_Angeles
+    open-pull-requests-limit: 3
     labels:
       - dependencies
       - security
+    groups:
+      routine-version-updates:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-major
 
   - package-ecosystem: npm
     directory: /functions
     schedule:
-      interval: daily
-    open-pull-requests-limit: 10
+      interval: weekly
+      day: monday
+      time: "08:00"
+      timezone: America/Los_Angeles
+    open-pull-requests-limit: 3
     labels:
       - dependencies
       - security
+    groups:
+      routine-version-updates:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-major
 
   - package-ecosystem: npm
     directory: /web
     schedule:
-      interval: daily
-    open-pull-requests-limit: 10
+      interval: weekly
+      day: monday
+      time: "08:00"
+      timezone: America/Los_Angeles
+    open-pull-requests-limit: 3
     labels:
       - dependencies
       - security
+    groups:
+      routine-version-updates:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-major
 
   - package-ecosystem: npm
     directory: /studio-brain
     schedule:
-      interval: daily
-    open-pull-requests-limit: 10
+      interval: weekly
+      day: monday
+      time: "08:00"
+      timezone: America/Los_Angeles
+    open-pull-requests-limit: 3
     labels:
       - dependencies
       - security
+    groups:
+      routine-version-updates:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-major

--- a/.github/workflows/ci-smoke.yml
+++ b/.github/workflows/ci-smoke.yml
@@ -25,6 +25,8 @@ jobs:
   smoke:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      IS_DEPENDABOT_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.user.login == 'dependabot[bot]' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -61,7 +63,8 @@ jobs:
       - name: Install studio-brain deps
         run: npm ci --prefix studio-brain
 
-      - name: Rules + index drift blocker
+      - name: Rules release drift check
+        if: ${{ env.IS_DEPENDABOT_PR != 'true' }}
         env:
           FIREBASE_RULES_API_TOKEN: ${{ secrets.FIREBASE_RULES_API_TOKEN }}
         run: |
@@ -70,7 +73,13 @@ jobs:
             exit 1
           fi
           npm run firestore:rules:sync:check
-          node ./scripts/firestore-index-contract-guard.mjs --strict --json --no-github --report output/qa/firestore-index-contract-guard-ci.json
+
+      - name: Skip rules release drift check for Dependabot PRs
+        if: ${{ env.IS_DEPENDABOT_PR == 'true' }}
+        run: echo "Dependabot PR detected; skipping secret-backed firestore rules sync check."
+
+      - name: Index drift blocker
+        run: node ./scripts/firestore-index-contract-guard.mjs --strict --json --no-github --report output/qa/firestore-index-contract-guard-ci.json
 
       - name: Functions lint
         run: npm --prefix functions run lint

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -11,6 +11,8 @@ jobs:
   build_and_preview:
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
+    env:
+      IS_DEPENDABOT_PR: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
     steps:
       - uses: actions/checkout@v4
       - name: Build web bundle with validated Firebase API key
@@ -18,6 +20,7 @@ jobs:
         env:
           FIREBASE_WEB_API_KEY: ${{ secrets.FIREBASE_WEB_API_KEY }}
           PORTAL_FIREBASE_API_KEY: ${{ secrets.PORTAL_FIREBASE_API_KEY }}
+          IS_DEPENDABOT_PR: ${{ env.IS_DEPENDABOT_PR }}
         run: |
           set -euo pipefail
 
@@ -82,8 +85,14 @@ jobs:
           done
 
           if [ -z "$SELECTED_FIREBASE_API_KEY" ]; then
-            echo "No valid Firebase web API key candidate resolved for web build." >&2
-            exit 1
+            if [ "$IS_DEPENDABOT_PR" = "true" ]; then
+              SELECTED_FIREBASE_API_KEY="AIzaSyDependabotCiFallback0000000000000"
+              SELECTED_SOURCE="dependabot-fallback"
+              echo "Dependabot PR detected; using compile-only Firebase API key fallback."
+            else
+              echo "No valid Firebase web API key candidate resolved for web build." >&2
+              exit 1
+            fi
           fi
 
           echo "Using Firebase API key source: $SELECTED_SOURCE"
@@ -91,8 +100,14 @@ jobs:
           export VITE_FIREBASE_API_KEY="$SELECTED_FIREBASE_API_KEY"
           npm --prefix web ci
           npm --prefix web run build
-      - uses: FirebaseExtended/action-hosting-deploy@092436dca3ec6dacb231d965ae56f7ff6c09f258
+      - name: Deploy preview channel
+        if: ${{ env.IS_DEPENDABOT_PR != 'true' }}
+        uses: FirebaseExtended/action-hosting-deploy@092436dca3ec6dacb231d965ae56f7ff6c09f258
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}
           firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_MONSOONFIRE_PORTAL }}
           projectId: monsoonfire-portal
+
+      - name: Skip preview deploy for Dependabot PRs
+        if: ${{ env.IS_DEPENDABOT_PR == 'true' }}
+        run: echo "Dependabot PR detected; skipping Firebase preview deploy step."

--- a/.github/workflows/portal-pr-functional-gate.yml
+++ b/.github/workflows/portal-pr-functional-gate.yml
@@ -15,6 +15,8 @@ jobs:
   functional-gate:
     runs-on: ubuntu-latest
     timeout-minutes: 35
+    env:
+      IS_DEPENDABOT_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.user.login == 'dependabot[bot]' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -30,6 +32,7 @@ jobs:
         run: npm ci
 
       - name: Enforce Firestore rules release drift check
+        if: ${{ env.IS_DEPENDABOT_PR != 'true' }}
         env:
           FIREBASE_RULES_API_TOKEN: ${{ secrets.FIREBASE_RULES_API_TOKEN }}
         run: |
@@ -38,6 +41,10 @@ jobs:
             exit 1
           fi
           npm run firestore:rules:sync:check
+
+      - name: Skip Firestore rules release drift check for Dependabot PRs
+        if: ${{ env.IS_DEPENDABOT_PR == 'true' }}
+        run: echo "Dependabot PR detected; skipping secret-backed firestore rules sync check."
 
       - name: Setup Java for Firestore emulator
         uses: actions/setup-java@v4

--- a/.github/workflows/rules-index-drift-blocker.yml
+++ b/.github/workflows/rules-index-drift-blocker.yml
@@ -15,6 +15,8 @@ jobs:
   drift-blocker:
     runs-on: ubuntu-latest
     timeout-minutes: 25
+    env:
+      IS_DEPENDABOT_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.user.login == 'dependabot[bot]' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -29,7 +31,8 @@ jobs:
       - name: Install root deps
         run: npm ci
 
-      - name: Run rules + index drift blocker
+      - name: Enforce Firestore rules release drift check
+        if: ${{ env.IS_DEPENDABOT_PR != 'true' }}
         env:
           FIREBASE_RULES_API_TOKEN: ${{ secrets.FIREBASE_RULES_API_TOKEN }}
         run: |
@@ -39,6 +42,13 @@ jobs:
           fi
 
           npm run firestore:rules:sync:check
+
+      - name: Skip Firestore rules release drift check for Dependabot PRs
+        if: ${{ env.IS_DEPENDABOT_PR == 'true' }}
+        run: echo "Dependabot PR detected; skipping secret-backed firestore rules sync check."
+
+      - name: Run index drift blocker
+        run: |
           node ./scripts/firestore-index-contract-guard.mjs \
             --strict \
             --json \


### PR DESCRIPTION
## Why
Dependabot PRs were failing required checks for two avoidable reasons:
- secret-backed PR jobs fail on Dependabot (secrets are unavailable),
- update volume was too high and included many semver-major jumps that are noisy and often non-mergeable.

## What changed
- Made required PR workflows Dependabot-aware by skipping only secret-backed steps on Dependabot PRs:
  - `.github/workflows/portal-pr-functional-gate.yml`
  - `.github/workflows/rules-index-drift-blocker.yml`
  - `.github/workflows/ci-smoke.yml`
  - `.github/workflows/firebase-hosting-pull-request.yml` (compile-only fallback for build env; preview deploy step skipped for Dependabot PRs)
- Tightened `.github/dependabot.yml`:
  - weekly cadence (Monday 08:00 America/Los_Angeles),
  - `open-pull-requests-limit: 3` per npm block,
  - grouped routine patch/minor version updates,
  - ignored semver-major version updates by default.

## Expected result
- Dependabot PRs stop failing for missing secrets.
- CI noise drops substantially.
- Security and routine updates remain manageable and mergeable.