### PR TITLE
feat(codex): add consolidated automation findings digest

### DIFF
--- a/.github/workflows/codex-automation-findings-summary.yml
+++ b/.github/workflows/codex-automation-findings-summary.yml
@@ -1,0 +1,72 @@
+name: Codex Automation Findings Summary
+
+on:
+  workflow_dispatch:
+    inputs:
+      apply:
+        description: Apply mode (post digest comment to rolling issue)
+        required: false
+        default: true
+        type: boolean
+  workflow_run:
+    workflows:
+      - Codex Self Improvement
+      - Codex Interaction Interrogation
+      - Codex PR Green Daily
+    types:
+      - completed
+  schedule:
+    # 07:45 America/Phoenix (MST year-round) = 14:45 UTC
+    - cron: "45 14 * * *"
+    # 16:45 America/Phoenix (MST year-round) = 23:45 UTC
+    - cron: "45 23 * * *"
+
+permissions:
+  contents: read
+  actions: read
+  issues: write
+
+concurrency:
+  group: codex-automation-global
+  cancel-in-progress: false
+
+jobs:
+  codex-findings-summary:
+    if: ${{ github.event_name != 'workflow_run' || (github.event.workflow_run.conclusion != 'skipped' && github.event.workflow_run.head_branch == 'main') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Run automation findings summary
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          MODE="--apply"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.apply }}" != "true" ]; then
+            MODE="--dry-run"
+          fi
+
+          node ./scripts/codex/automation-findings-summary.mjs ${MODE} --json
+
+      - name: Upload automation findings summary artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: codex-automation-findings-summary-${{ github.run_id }}
+          path: |
+            output/qa/codex-automation-findings-summary.md
+            output/qa/codex-automation-findings-summary.json
+          if-no-files-found: ignore
+          retention-days: 7

--- a/package.json
+++ b/package.json
@@ -180,6 +180,8 @@
     "codex:pr-green:daily": "node ./scripts/codex/daily-pr-green.mjs --dry-run --json",
     "codex:pr-green:daily:persist": "node ./scripts/codex/daily-pr-green.mjs --dry-run --persist-dry-run --json",
     "codex:pr-green:apply": "node ./scripts/codex/daily-pr-green.mjs --apply --json",
+    "codex:findings:summary": "node ./scripts/codex/automation-findings-summary.mjs --dry-run --json",
+    "codex:findings:summary:apply": "node ./scripts/codex/automation-findings-summary.mjs --apply --json",
     "branch:divergence:guard": "node ./scripts/branch-divergence-guard.mjs --json",
     "secrets:health:check": "node ./scripts/credentials-health-check.mjs --json",
     "portal:pr:functional:gate": "node ./scripts/portal-pr-functional-gate.mjs --json",

--- a/scripts/codex/automation-findings-summary.mjs
+++ b/scripts/codex/automation-findings-summary.mjs
@@ -1,0 +1,430 @@
+#!/usr/bin/env node
+
+/* eslint-disable no-console */
+
+import { mkdir, writeFile } from "node:fs/promises";
+import { spawnSync } from "node:child_process";
+import { dirname, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const repoRoot = resolve(dirname(__filename), "..", "..");
+
+const summaryIssueTitle = "Codex Automation Findings Digest (Rolling)";
+const outputDir = resolve(repoRoot, "output", "qa");
+const markdownArtifactPath = resolve(outputDir, "codex-automation-findings-summary.md");
+const jsonArtifactPath = resolve(outputDir, "codex-automation-findings-summary.json");
+
+const sources = [
+  {
+    key: "improvement",
+    label: "Continuous Improvement",
+    issueTitle: "Codex Continuous Improvement (Rolling)",
+    workflowName: "Codex Self Improvement",
+  },
+  {
+    key: "interaction",
+    label: "Interaction Interrogation",
+    issueTitle: "Codex Interaction Interrogation (Rolling)",
+    workflowName: "Codex Interaction Interrogation",
+  },
+  {
+    key: "prGreen",
+    label: "PR Green Daily",
+    issueTitle: "Codex PR Green Daily (Rolling)",
+    workflowName: "Codex PR Green Daily",
+  },
+];
+
+function parseArgs(argv) {
+  const options = {
+    apply: false,
+    dryRun: true,
+    asJson: false,
+  };
+
+  for (const arg of argv) {
+    if (arg === "--apply") {
+      options.apply = true;
+      options.dryRun = false;
+      continue;
+    }
+    if (arg === "--dry-run") {
+      options.apply = false;
+      options.dryRun = true;
+      continue;
+    }
+    if (arg === "--json") {
+      options.asJson = true;
+      continue;
+    }
+  }
+
+  return options;
+}
+
+function runCommand(command, args, { allowFailure = false, cwd = repoRoot, env = process.env } = {}) {
+  const startedAt = Date.now();
+  const result = spawnSync(command, args, { cwd, env, encoding: "utf8" });
+  const durationMs = Date.now() - startedAt;
+  const code = typeof result.status === "number" ? result.status : 1;
+  const stdout = String(result.stdout || "");
+  const stderr = String(result.stderr || "");
+
+  if (code !== 0 && !allowFailure) {
+    throw new Error(`Command failed (${code}): ${command} ${args.join(" ")}\n${stderr || stdout}`);
+  }
+
+  return {
+    code,
+    ok: code === 0,
+    stdout,
+    stderr,
+    durationMs,
+  };
+}
+
+function runGit(args, options = {}) {
+  return runCommand("git", args, options);
+}
+
+function runGh(args, options = {}) {
+  return runCommand("gh", args, options);
+}
+
+function runGhJson(args, { allowFailure = true } = {}) {
+  const response = runGh(args, { allowFailure });
+  if (!response.ok) {
+    return {
+      ok: false,
+      data: null,
+      error: response.stderr || response.stdout || "gh command failed",
+    };
+  }
+
+  try {
+    return {
+      ok: true,
+      data: response.stdout.trim() ? JSON.parse(response.stdout) : null,
+      error: "",
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      data: null,
+      error: `Invalid JSON from gh: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+}
+
+function parseRepoSlug() {
+  const fromEnv = String(process.env.GITHUB_REPOSITORY || "").trim();
+  if (fromEnv && fromEnv.includes("/")) return fromEnv;
+
+  const remote = runGit(["remote", "get-url", "origin"], { allowFailure: true });
+  if (!remote.ok) return "";
+
+  const raw = remote.stdout.trim();
+  const match = raw.match(/github\.com[:/](.+?)(?:\.git)?$/);
+  return match ? match[1] : "";
+}
+
+function uniqueList(values) {
+  const seen = new Set();
+  const output = [];
+  for (const value of values) {
+    const normalized = String(value || "").trim();
+    if (!normalized || seen.has(normalized)) continue;
+    seen.add(normalized);
+    output.push(normalized);
+  }
+  return output;
+}
+
+function extractHighlights(markdownBody, maxItems = 5) {
+  const lines = String(markdownBody || "")
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  const bulletLines = lines
+    .filter((line) => /^[-*]\s+/.test(line))
+    .map((line) => line.replace(/^[-*]\s+/, "").trim());
+
+  const fallbackLines = lines.filter(
+    (line) => !line.startsWith("#") && !line.startsWith("<") && !line.startsWith("```")
+  );
+
+  return uniqueList(bulletLines.length > 0 ? bulletLines : fallbackLines).slice(0, maxItems);
+}
+
+function findIssueByTitle(repoSlug, title) {
+  const response = runGhJson([
+    "issue",
+    "list",
+    "--repo",
+    repoSlug,
+    "--state",
+    "open",
+    "--search",
+    `"${title}" in:title`,
+    "--limit",
+    "5",
+    "--json",
+    "number,title,url,updatedAt,body",
+  ]);
+
+  if (!response.ok || !Array.isArray(response.data)) return null;
+  return response.data.find((issue) => issue.title === title) || null;
+}
+
+function fetchLatestIssueComment(repoSlug, issueNumber) {
+  const response = runGhJson([
+    "api",
+    `repos/${repoSlug}/issues/${issueNumber}/comments?per_page=1&sort=created&direction=desc`,
+  ]);
+
+  if (!response.ok || !Array.isArray(response.data) || response.data.length === 0) return null;
+  const latest = response.data[0];
+  return {
+    url: String(latest.html_url || ""),
+    createdAt: String(latest.created_at || ""),
+    body: String(latest.body || ""),
+  };
+}
+
+function fetchLatestWorkflowRun(repoSlug, workflowName) {
+  const response = runGhJson([
+    "run",
+    "list",
+    "--repo",
+    repoSlug,
+    "--workflow",
+    workflowName,
+    "--limit",
+    "1",
+    "--json",
+    "databaseId,workflowName,displayTitle,status,conclusion,createdAt,updatedAt,url",
+  ]);
+
+  if (!response.ok || !Array.isArray(response.data) || response.data.length === 0) return null;
+  return response.data[0];
+}
+
+async function ensureGhLabel(repoSlug, name, color, description, enabled) {
+  if (!enabled) return;
+  runGh(
+    [
+      "label",
+      "create",
+      name,
+      "--repo",
+      repoSlug,
+      "--color",
+      color,
+      "--description",
+      description,
+      "--force",
+    ],
+    { allowFailure: true }
+  );
+}
+
+function createSummaryComment({ generatedAtIso, sourceSummaries, okCount, needsAttentionCount, notes }) {
+  const lines = [];
+  lines.push(`## ${generatedAtIso} (Automation Findings Digest)`);
+  lines.push("");
+  lines.push("### Overall");
+  lines.push(`- Sources monitored: ${sourceSummaries.length}`);
+  lines.push(`- Healthy workflows: ${okCount}`);
+  lines.push(`- Needs attention: ${needsAttentionCount}`);
+  lines.push("");
+
+  for (const source of sourceSummaries) {
+    lines.push(`### ${source.label}`);
+    lines.push(`- Workflow: ${source.workflowStatus}`);
+    if (source.workflowUrl) lines.push(`- Latest workflow run: ${source.workflowUrl}`);
+    lines.push(`- Rolling issue: ${source.issueUrl || "not found"}`);
+    if (source.latestFindingAt) lines.push(`- Latest finding at: ${source.latestFindingAt}`);
+    lines.push("- Highlights:");
+    if (source.highlights.length === 0) {
+      lines.push("  - No highlights captured yet.");
+    } else {
+      source.highlights.forEach((entry) => lines.push(`  - ${entry}`));
+    }
+    lines.push("");
+  }
+
+  if (notes.length > 0) {
+    lines.push("### Notes");
+    notes.forEach((note) => lines.push(`- ${note}`));
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}
+
+async function writeArtifacts(markdown, report) {
+  await mkdir(outputDir, { recursive: true });
+  await writeFile(markdownArtifactPath, `${markdown}\n`, "utf8");
+  await writeFile(jsonArtifactPath, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const generatedAtIso = new Date().toISOString();
+  const repoSlug = parseRepoSlug();
+  const notes = [];
+
+  const githubAvailable = Boolean(repoSlug) && runGh(["auth", "status"], { allowFailure: true }).ok;
+  if (!repoSlug) notes.push("Unable to resolve repository slug.");
+  if (!githubAvailable) notes.push("GitHub CLI unavailable or not authenticated; reporting is local-only.");
+
+  const sourceSummaries = [];
+  for (const source of sources) {
+    const summary = {
+      key: source.key,
+      label: source.label,
+      issueTitle: source.issueTitle,
+      workflowName: source.workflowName,
+      issueUrl: "",
+      workflowUrl: "",
+      workflowStatus: "unknown",
+      workflowConclusion: "",
+      latestFindingAt: "",
+      highlights: [],
+    };
+
+    if (githubAvailable) {
+      const issue = findIssueByTitle(repoSlug, source.issueTitle);
+      if (issue) {
+        summary.issueUrl = String(issue.url || "");
+        const latestComment = fetchLatestIssueComment(repoSlug, issue.number);
+        if (latestComment) {
+          summary.latestFindingAt = latestComment.createdAt;
+          summary.highlights = extractHighlights(latestComment.body);
+        } else {
+          summary.latestFindingAt = String(issue.updatedAt || "");
+          summary.highlights = extractHighlights(issue.body || "");
+        }
+      } else {
+        notes.push(`Rolling issue not found: ${source.issueTitle}`);
+      }
+
+      const workflowRun = fetchLatestWorkflowRun(repoSlug, source.workflowName);
+      if (workflowRun) {
+        summary.workflowUrl = String(workflowRun.url || "");
+        const status = String(workflowRun.status || "unknown");
+        const conclusion = String(workflowRun.conclusion || "");
+        summary.workflowConclusion = conclusion;
+        summary.workflowStatus = conclusion ? `${status}/${conclusion}` : status;
+      } else {
+        notes.push(`No workflow run found for: ${source.workflowName}`);
+      }
+    }
+
+    sourceSummaries.push(summary);
+  }
+
+  const okCount = sourceSummaries.filter((entry) => entry.workflowConclusion === "success").length;
+  const needsAttentionCount = sourceSummaries.length - okCount;
+  const markdown = createSummaryComment({
+    generatedAtIso,
+    sourceSummaries,
+    okCount,
+    needsAttentionCount,
+    notes,
+  });
+
+  const report = {
+    status: options.apply ? "applied" : "dry-run",
+    runAtIso: generatedAtIso,
+    repo: repoSlug || null,
+    githubAvailable,
+    summary: {
+      sourcesMonitored: sourceSummaries.length,
+      healthyWorkflows: okCount,
+      workflowsNeedingAttention: needsAttentionCount,
+    },
+    sources: sourceSummaries,
+    notes,
+    artifacts: {
+      markdown: relative(repoRoot, markdownArtifactPath),
+      json: relative(repoRoot, jsonArtifactPath),
+    },
+  };
+
+  await writeArtifacts(markdown, report);
+
+  let digestIssueUrl = "";
+  if (options.apply && githubAvailable) {
+    await ensureGhLabel(repoSlug, "automation", "1d76db", "Automation-generated work", true);
+    await ensureGhLabel(repoSlug, "epic:codex-reporting", "0e8a16", "Codex automation reporting", true);
+
+    let digestIssue = findIssueByTitle(repoSlug, summaryIssueTitle);
+    if (!digestIssue) {
+      const createIssue = runGh(
+        [
+          "issue",
+          "create",
+          "--repo",
+          repoSlug,
+          "--title",
+          summaryIssueTitle,
+          "--body",
+          "Rolling consolidated digest of Codex automation findings.",
+          "--label",
+          "automation",
+          "--label",
+          "epic:codex-reporting",
+        ],
+        { allowFailure: true }
+      );
+      if (createIssue.ok) {
+        digestIssueUrl = createIssue.stdout.trim();
+      }
+      digestIssue = findIssueByTitle(repoSlug, summaryIssueTitle);
+    }
+
+    if (digestIssue?.number) {
+      digestIssueUrl = digestIssue.url;
+      runGh(
+        [
+          "issue",
+          "comment",
+          String(digestIssue.number),
+          "--repo",
+          repoSlug,
+          "--body",
+          markdown,
+        ],
+        { allowFailure: true }
+      );
+    }
+  }
+
+  report.digestIssue = digestIssueUrl || null;
+  await writeFile(jsonArtifactPath, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+
+  if (options.asJson) {
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  } else {
+    process.stdout.write(
+      [
+        `status: ${report.status}`,
+        `sources monitored: ${report.summary.sourcesMonitored}`,
+        `healthy workflows: ${report.summary.healthyWorkflows}`,
+        `needs attention: ${report.summary.workflowsNeedingAttention}`,
+        `digest issue: ${report.digestIssue || "none"}`,
+        `artifact: ${report.artifacts.markdown}`,
+        "",
+      ].join("\n")
+    );
+  }
+}
+
+main().catch((error) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`automation-findings-summary failed: ${message}`);
+  process.exit(1);
+});


### PR DESCRIPTION
## Why
The Codex automations are running, but their findings are spread across separate rolling issues.
This adds a consolidated digest reporter so you get one summary stream.

## What changed
- Added `scripts/codex/automation-findings-summary.mjs`:
  - collects latest findings from:
    - `Codex Continuous Improvement (Rolling)`
    - `Codex Interaction Interrogation (Rolling)`
    - `Codex PR Green Daily (Rolling)`
  - checks latest workflow run status for each automation workflow
  - builds a concise digest markdown + JSON artifact in `output/qa/`
  - in apply mode, opens/updates a rolling issue:
    - `Codex Automation Findings Digest (Rolling)`
- Added workflow `.github/workflows/codex-automation-findings-summary.yml`:
  - triggers on completion of:
    - `Codex Self Improvement`
    - `Codex Interaction Interrogation`
    - `Codex PR Green Daily`
  - scheduled fallback runs at 14:45 and 23:45 UTC
  - uploads digest artifacts
- Added npm scripts:
  - `codex:findings:summary`
  - `codex:findings:summary:apply`

## Validation
- Ran: `npm run codex:findings:summary`
- Result: dry-run succeeded and produced summary artifacts.
