### PR TITLE
fix(codex): ensure first digest run always comments

### DIFF
--- a/scripts/codex/automation-findings-summary.mjs
+++ b/scripts/codex/automation-findings-summary.mjs
@@ -211,6 +211,11 @@ function fetchLatestWorkflowRun(repoSlug, workflowName) {
   return response.data[0];
 }
 
+function parseIssueNumberFromUrl(issueUrl) {
+  const match = String(issueUrl || "").match(/\/issues\/(\d+)$/);
+  return match ? Number(match[1]) : null;
+}
+
 async function ensureGhLabel(repoSlug, name, color, description, enabled) {
   if (!enabled) return;
   runGh(
@@ -382,8 +387,17 @@ async function main() {
       );
       if (createIssue.ok) {
         digestIssueUrl = createIssue.stdout.trim();
+        const issueNumber = parseIssueNumberFromUrl(digestIssueUrl);
+        if (issueNumber) {
+          digestIssue = {
+            number: issueNumber,
+            url: digestIssueUrl,
+          };
+        }
       }
-      digestIssue = findIssueByTitle(repoSlug, summaryIssueTitle);
+      if (!digestIssue) {
+        digestIssue = findIssueByTitle(repoSlug, summaryIssueTitle);
+      }
     }
 
     if (digestIssue?.number) {


### PR DESCRIPTION
Fixes a race where the digest workflow could create the rolling issue but skip the first comment if immediate issue search did not return the newly created issue yet.\n\nChange:\n- Parse issue number directly from the create-issue URL and comment against that number immediately.\n- Keep title-based lookup fallback in place.