### PR TITLE
feat(codex): add @mention ping to digest reports

### DIFF
--- a/.github/workflows/codex-automation-findings-summary.yml
+++ b/.github/workflows/codex-automation-findings-summary.yml
@@ -50,6 +50,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CODEX_REPORT_MENTION: ${{ vars.CODEX_REPORT_MENTION }}
         run: |
           set -euo pipefail
 


### PR DESCRIPTION
Adds automatic @mention in each Codex automation digest comment.

Behavior:
- Default mention target: repository owner handle.
- Optional override via repo variable: `CODEX_REPORT_MENTION`.

Files:
- `scripts/codex/automation-findings-summary.mjs`
- `.github/workflows/codex-automation-findings-summary.yml`