### PR TITLE
fix(ci): stabilize Portal Credential Health rules token probe

### DIFF
--- a/.github/workflows/portal-credential-health.yml
+++ b/.github/workflows/portal-credential-health.yml
@@ -27,6 +27,15 @@ jobs:
         with:
           node-version: 22
 
+      - name: Mint Rules API access token
+        id: rules_token
+        if: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_MONSOONFIRE_PORTAL != '' }}
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_MONSOONFIRE_PORTAL }}
+          token_format: access_token
+          access_token_scopes: https://www.googleapis.com/auth/cloud-platform
+
       - name: Run credential health checks
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -34,7 +43,7 @@ jobs:
           PORTAL_STAFF_EMAIL: ${{ secrets.PORTAL_STAFF_EMAIL }}
           PORTAL_STAFF_PASSWORD: ${{ secrets.PORTAL_STAFF_PASSWORD }}
           PORTAL_AGENT_STAFF_CREDENTIALS_JSON: ${{ secrets.PORTAL_AGENT_STAFF_CREDENTIALS_JSON }}
-          FIREBASE_RULES_API_TOKEN: ${{ secrets.FIREBASE_RULES_API_TOKEN }}
+          FIREBASE_RULES_API_TOKEN: ${{ steps.rules_token.outputs.access_token || secrets.FIREBASE_RULES_API_TOKEN }}
           PORTAL_FIREBASE_API_KEY: ${{ secrets.PORTAL_FIREBASE_API_KEY || secrets.FIREBASE_WEB_API_KEY }}
         run: |
           node ./scripts/credentials-health-check.mjs \


### PR DESCRIPTION
## Summary
- add a short-lived Rules API token mint step via `google-github-actions/auth@v2`
- wire `FIREBASE_RULES_API_TOKEN` to prefer minted access token, with fallback to existing secret token
- keep the workflow backward-compatible when the service-account secret is absent

## Why
`Portal Credential Health` is failing because the static Rules token currently in secrets is rejected by Google APIs as invalid OAuth credentials.

## Expected Outcome
The Rules API probe uses a fresh OAuth access token each run and should stop flapping on stale static tokens.
