### PR TITLE
fix(ci): restore portal credential health workflow parseability

### DIFF
--- a/.github/workflows/portal-credential-health.yml
+++ b/.github/workflows/portal-credential-health.yml
@@ -29,7 +29,6 @@ jobs:
 
       - name: Mint Rules API access token
         id: rules_token
-        if: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_MONSOONFIRE_PORTAL != '' }}
         uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_MONSOONFIRE_PORTAL }}


### PR DESCRIPTION
## Summary
- remove invalid `if` expression from the Rules-token mint step in `portal-credential-health.yml`
- keep the short-lived token mint path introduced in #93 intact

## Why
GitHub rejected workflow dispatch with:
`Unrecognized named-value: 'secrets'` for the step-level `if` expression.

This patch restores workflow parseability.
