### PR TITLE
fix(ci): mint credential-health rules token via gcloud

### DIFF
--- a/.github/workflows/portal-credential-health.yml
+++ b/.github/workflows/portal-credential-health.yml
@@ -27,13 +27,19 @@ jobs:
         with:
           node-version: 22
 
-      - name: Mint Rules API access token
-        id: rules_token
+      - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_MONSOONFIRE_PORTAL }}
-          token_format: access_token
-          access_token_scopes: https://www.googleapis.com/auth/cloud-platform
+
+      - name: Setup gcloud
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          project_id: monsoonfire-portal
+
+      - name: Mint Rules API access token
+        id: rules_token
+        run: echo "access_token=$(gcloud auth print-access-token)" >> "$GITHUB_OUTPUT"
 
       - name: Run credential health checks
         env:


### PR DESCRIPTION
## Summary
- replace token minting via `auth@v2 token_format=access_token` with a safer flow:
  1. authenticate using service-account credentials
  2. install gcloud
  3. mint access token using `gcloud auth print-access-token`
- keep `FIREBASE_RULES_API_TOKEN` wired to the minted access token output

## Why
The previous approach failed with `iam.serviceAccounts.getAccessToken` permission denied. This flow avoids that permission requirement while still producing a fresh OAuth token for the Rules API probe.
