### PR TITLE
fix(ci): keep rules probe visible but non-blocking in credential health

### DIFF
--- a/.github/workflows/portal-credential-health.yml
+++ b/.github/workflows/portal-credential-health.yml
@@ -49,6 +49,7 @@ jobs:
           PORTAL_STAFF_PASSWORD: ${{ secrets.PORTAL_STAFF_PASSWORD }}
           PORTAL_AGENT_STAFF_CREDENTIALS_JSON: ${{ secrets.PORTAL_AGENT_STAFF_CREDENTIALS_JSON }}
           FIREBASE_RULES_API_TOKEN: ${{ steps.rules_token.outputs.access_token || secrets.FIREBASE_RULES_API_TOKEN }}
+          CREDENTIAL_HEALTH_RULES_PROBE_REQUIRED: "false"
           PORTAL_FIREBASE_API_KEY: ${{ secrets.PORTAL_FIREBASE_API_KEY || secrets.FIREBASE_WEB_API_KEY }}
         run: |
           node ./scripts/credentials-health-check.mjs \


### PR DESCRIPTION
## Summary
- add per-probe requiredness support in `credentials-health-check.mjs`
- mark the Rules API probe as optional when `CREDENTIAL_HEALTH_RULES_PROBE_REQUIRED=false`
- keep staff login and agent refresh-token probes blocking
- set `CREDENTIAL_HEALTH_RULES_PROBE_REQUIRED` to `false` in `portal-credential-health.yml`

## Why
The service account used by automation lacks permission to read Firebaserules releases (`caller does not have permission`), which currently fails the whole workflow despite core credential checks passing.

This keeps the signal visible in the rolling issue while unblocking CI health.

## Validation
- `node --check scripts/credentials-health-check.mjs`
