### PR TITLE
Events: add source connector import + freshness automation guardrails

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -8,6 +8,8 @@
     "type-safety:guard": "node scripts/check-type-safety-guard.mjs",
     "test": "npm run archive:guard && npm run type-safety:guard && npm run build && node --test \"lib/**/*.test.js\"",
     "seed:industry-events": "node scripts/seed-industry-events.mjs --json",
+    "industry-events:import": "node scripts/import-industry-events.mjs",
+    "industry-events:freshness:audit": "node scripts/audit-industry-events-freshness.mjs",
     "agent:commerce:smoke": "node scripts/agent_commerce_smoke.js",
     "agent:commerce:smoke:strict": "node scripts/agent_commerce_smoke.js --strict --json --fixture scripts/fixtures/agent-commerce-smoke.base.json",
     "serve": "npm run build && firebase emulators:start --only functions",

--- a/functions/scripts/audit-industry-events-freshness.mjs
+++ b/functions/scripts/audit-industry-events-freshness.mjs
@@ -1,0 +1,404 @@
+#!/usr/bin/env node
+
+/* eslint-disable no-console */
+
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { getApps, initializeApp } from "firebase-admin/app";
+import { getFirestore } from "firebase-admin/firestore";
+
+const __filename = fileURLToPath(import.meta.url);
+const scriptsDir = dirname(__filename);
+const functionsRoot = resolve(scriptsDir, "..");
+
+const DEFAULT_PROJECT_ID = process.env.FIREBASE_PROJECT_ID || "monsoonfire-portal";
+const DEFAULT_FIXTURE_PATH = resolve(scriptsDir, "fixtures", "industry-events-source-fixture.json");
+const DEFAULT_ARTIFACT_PATH = resolve(functionsRoot, "output", "industry-events", "freshness-audit.json");
+const DEFAULT_STALE_REVIEW_DAYS = 21;
+const DEFAULT_RETIRE_PAST_HOURS = 48;
+
+function parseArgs(argv) {
+  const options = {
+    projectId: DEFAULT_PROJECT_ID,
+    source: "fixture",
+    fixturePath: DEFAULT_FIXTURE_PATH,
+    artifactPath: DEFAULT_ARTIFACT_PATH,
+    staleReviewDays: DEFAULT_STALE_REVIEW_DAYS,
+    retirePastHours: DEFAULT_RETIRE_PAST_HOURS,
+    limit: 500,
+    strict: false,
+    asJson: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (!arg) continue;
+
+    if (arg === "--strict") {
+      options.strict = true;
+      continue;
+    }
+    if (arg === "--json") {
+      options.asJson = true;
+      continue;
+    }
+
+    if (arg.startsWith("--source=")) {
+      options.source = String(arg.slice("--source=".length)).trim() || options.source;
+      continue;
+    }
+    if (arg.startsWith("--fixture=")) {
+      options.fixturePath = resolve(process.cwd(), String(arg.slice("--fixture=".length)).trim());
+      continue;
+    }
+    if (arg.startsWith("--artifact=")) {
+      options.artifactPath = resolve(process.cwd(), String(arg.slice("--artifact=".length)).trim());
+      continue;
+    }
+    if (arg.startsWith("--project=")) {
+      options.projectId = String(arg.slice("--project=".length)).trim() || options.projectId;
+      continue;
+    }
+    if (arg.startsWith("--stale-review-days=")) {
+      const parsed = Number.parseInt(String(arg.slice("--stale-review-days=".length)).trim(), 10);
+      if (!Number.isFinite(parsed) || parsed <= 0) throw new Error("--stale-review-days must be a positive integer");
+      options.staleReviewDays = parsed;
+      continue;
+    }
+    if (arg.startsWith("--retire-past-hours=")) {
+      const parsed = Number.parseInt(String(arg.slice("--retire-past-hours=".length)).trim(), 10);
+      if (!Number.isFinite(parsed) || parsed <= 0) throw new Error("--retire-past-hours must be a positive integer");
+      options.retirePastHours = parsed;
+      continue;
+    }
+    if (arg.startsWith("--limit=")) {
+      const parsed = Number.parseInt(String(arg.slice("--limit=".length)).trim(), 10);
+      if (!Number.isFinite(parsed) || parsed <= 0) throw new Error("--limit must be a positive integer");
+      options.limit = parsed;
+      continue;
+    }
+
+    const next = argv[index + 1];
+    if (!next || next.startsWith("--")) {
+      throw new Error(`Missing value for ${arg}`);
+    }
+
+    if (arg === "--source") {
+      options.source = String(next).trim() || options.source;
+      index += 1;
+      continue;
+    }
+    if (arg === "--fixture") {
+      options.fixturePath = resolve(process.cwd(), String(next).trim());
+      index += 1;
+      continue;
+    }
+    if (arg === "--artifact") {
+      options.artifactPath = resolve(process.cwd(), String(next).trim());
+      index += 1;
+      continue;
+    }
+    if (arg === "--project" || arg === "-p") {
+      options.projectId = String(next).trim() || options.projectId;
+      index += 1;
+      continue;
+    }
+    if (arg === "--stale-review-days") {
+      const parsed = Number.parseInt(String(next).trim(), 10);
+      if (!Number.isFinite(parsed) || parsed <= 0) throw new Error("--stale-review-days must be a positive integer");
+      options.staleReviewDays = parsed;
+      index += 1;
+      continue;
+    }
+    if (arg === "--retire-past-hours") {
+      const parsed = Number.parseInt(String(next).trim(), 10);
+      if (!Number.isFinite(parsed) || parsed <= 0) throw new Error("--retire-past-hours must be a positive integer");
+      options.retirePastHours = parsed;
+      index += 1;
+      continue;
+    }
+    if (arg === "--limit") {
+      const parsed = Number.parseInt(String(next).trim(), 10);
+      if (!Number.isFinite(parsed) || parsed <= 0) throw new Error("--limit must be a positive integer");
+      options.limit = parsed;
+      index += 1;
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return options;
+}
+
+function normalizeText(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function normalizeOptionalText(value) {
+  const text = normalizeText(value);
+  return text || null;
+}
+
+function normalizeStatus(value) {
+  const normalized = normalizeText(value).toLowerCase();
+  if (normalized === "published" || normalized === "draft" || normalized === "cancelled") return normalized;
+  return "published";
+}
+
+function toIso(value) {
+  if (value == null) return null;
+  if (value instanceof Date && Number.isFinite(value.getTime())) return value.toISOString();
+  if (typeof value === "string" || typeof value === "number") {
+    const parsed = new Date(value);
+    if (Number.isFinite(parsed.getTime())) return parsed.toISOString();
+    return null;
+  }
+  if (typeof value === "object" && value && typeof value.toDate === "function") {
+    try {
+      const parsed = value.toDate();
+      if (parsed instanceof Date && Number.isFinite(parsed.getTime())) return parsed.toISOString();
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+function toMs(value) {
+  if (!value) return null;
+  const parsed = new Date(value).getTime();
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function asArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function asObject(value) {
+  if (!value || typeof value !== "object") return {};
+  return value;
+}
+
+function slug(value) {
+  return normalizeText(value)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function toRelativePath(pathValue) {
+  const cwdPrefix = `${process.cwd()}/`;
+  if (pathValue.startsWith(cwdPrefix)) return pathValue.slice(cwdPrefix.length);
+  return pathValue;
+}
+
+function evaluateFreshness(event, policy) {
+  if (event.status !== "published") {
+    return {
+      state: "non_published",
+      flagged: false,
+      reason: null,
+      action: null,
+    };
+  }
+
+  const eventCutoffMs = toMs(event.endAt) ?? toMs(event.startAt);
+  if (eventCutoffMs !== null && eventCutoffMs < policy.nowMs - policy.retirePastMs) {
+    return {
+      state: "retired",
+      flagged: true,
+      reason: "event ended beyond retirePastHours threshold",
+      action: "Retire/archive this row and remove from active industry listing.",
+    };
+  }
+
+  const verifiedMs = toMs(event.verifiedAt);
+  if (verifiedMs === null || verifiedMs < policy.nowMs - policy.staleReviewMs) {
+    return {
+      state: "stale_review",
+      flagged: true,
+      reason: verifiedMs === null ? "verifiedAt missing" : "verifiedAt exceeded staleReviewDays threshold",
+      action: "Re-verify source link and update verifiedAt before publish promotion.",
+    };
+  }
+
+  return {
+    state: "fresh",
+    flagged: false,
+    reason: null,
+    action: null,
+  };
+}
+
+async function loadFixtureEvents(fixturePath) {
+  const raw = await readFile(fixturePath, "utf8");
+  const parsed = JSON.parse(raw);
+  const sources = asArray(parsed.sources);
+  const events = [];
+
+  for (let sourceIndex = 0; sourceIndex < sources.length; sourceIndex += 1) {
+    const source = asObject(sources[sourceIndex]);
+    const sourceId = normalizeText(source.sourceId) || `fixture-source-${sourceIndex + 1}`;
+    const sourceName = normalizeText(source.sourceName) || sourceId;
+    const sourceUrl = normalizeOptionalText(source.sourceUrl);
+    const rows = asArray(source.events);
+    for (let rowIndex = 0; rowIndex < rows.length; rowIndex += 1) {
+      const row = asObject(rows[rowIndex]);
+      const title = normalizeText(row.title);
+      const fallbackId = `${sourceId}-${slug(title || row.externalId || `row-${rowIndex + 1}`)}`;
+      events.push({
+        id: normalizeText(row.externalId) || fallbackId,
+        title: title || "Untitled event",
+        status: normalizeStatus(row.status),
+        startAt: toIso(row.startAt),
+        endAt: toIso(row.endAt),
+        verifiedAt: toIso(row.verifiedAt),
+        sourceId,
+        sourceName,
+        sourceUrl: normalizeOptionalText(row.sourceUrl) || sourceUrl,
+        row: rowIndex + 1,
+      });
+    }
+  }
+
+  return events;
+}
+
+async function loadFirestoreEvents(projectId, limit) {
+  const app =
+    getApps().length > 0
+      ? getApps()[0]
+      : initializeApp({
+          projectId,
+        });
+  const db = getFirestore(app);
+  const snap = await db.collection("industryEvents").limit(Math.min(Math.max(limit, 1), 1000)).get();
+  return snap.docs.map((docSnap) => {
+    const raw = asObject(docSnap.data());
+    return {
+      id: docSnap.id,
+      title: normalizeText(raw.title) || "Untitled event",
+      status: normalizeStatus(raw.status),
+      startAt: toIso(raw.startAt),
+      endAt: toIso(raw.endAt),
+      verifiedAt: toIso(raw.verifiedAt ?? raw.sourceVerifiedAt),
+      sourceId: normalizeOptionalText(raw.sourceFeedId),
+      sourceName: normalizeOptionalText(raw.sourceName),
+      sourceUrl: normalizeOptionalText(raw.sourceUrl),
+      row: null,
+    };
+  });
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const staleReviewMs = options.staleReviewDays * 24 * 60 * 60 * 1000;
+  const retirePastMs = options.retirePastHours * 60 * 60 * 1000;
+  const nowMs = Date.now();
+
+  let events;
+  if (options.source === "fixture") {
+    events = await loadFixtureEvents(options.fixturePath);
+  } else if (options.source === "firestore") {
+    events = await loadFirestoreEvents(options.projectId, options.limit);
+  } else {
+    throw new Error(`Unknown --source "${options.source}". Supported: fixture, firestore`);
+  }
+
+  const summary = {
+    ok: true,
+    source: options.source,
+    projectId: options.projectId,
+    scanned: 0,
+    stateCounts: {
+      fresh: 0,
+      staleReview: 0,
+      retired: 0,
+      nonPublished: 0,
+    },
+    flagged: {
+      staleReview: 0,
+      retired: 0,
+    },
+    failures: [],
+    flaggedRows: [],
+    policy: {
+      staleReviewDays: options.staleReviewDays,
+      retirePastHours: options.retirePastHours,
+      nowIso: new Date(nowMs).toISOString(),
+    },
+    fixturePath: toRelativePath(options.fixturePath),
+    artifactPath: toRelativePath(options.artifactPath),
+  };
+
+  for (const event of events) {
+    try {
+      summary.scanned += 1;
+      const decision = evaluateFreshness(event, { nowMs, staleReviewMs, retirePastMs });
+
+      if (decision.state === "fresh") summary.stateCounts.fresh += 1;
+      else if (decision.state === "stale_review") summary.stateCounts.staleReview += 1;
+      else if (decision.state === "retired") summary.stateCounts.retired += 1;
+      else summary.stateCounts.nonPublished += 1;
+
+      if (decision.flagged) {
+        if (decision.state === "stale_review") summary.flagged.staleReview += 1;
+        if (decision.state === "retired") summary.flagged.retired += 1;
+        summary.flaggedRows.push({
+          id: event.id,
+          title: event.title,
+          sourceId: event.sourceId,
+          sourceName: event.sourceName,
+          sourceUrl: event.sourceUrl,
+          state: decision.state,
+          reason: decision.reason,
+          action: decision.action,
+          status: event.status,
+          startAt: event.startAt,
+          endAt: event.endAt,
+          verifiedAt: event.verifiedAt,
+          row: event.row,
+        });
+      }
+    } catch (error) {
+      summary.failures.push({
+        id: event.id,
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  await mkdir(dirname(options.artifactPath), { recursive: true });
+  await writeFile(options.artifactPath, `${JSON.stringify(summary, null, 2)}\n`, "utf8");
+
+  const shouldFail = options.strict && (summary.flaggedRows.length > 0 || summary.failures.length > 0);
+  if (shouldFail) summary.ok = false;
+
+  if (options.asJson) {
+    process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+  } else {
+    const lines = [
+      "Industry events freshness audit summary",
+      `- source: ${summary.source}`,
+      `- scanned: ${summary.scanned}`,
+      `- fresh: ${summary.stateCounts.fresh}`,
+      `- staleReview: ${summary.stateCounts.staleReview}`,
+      `- retired: ${summary.stateCounts.retired}`,
+      `- nonPublished: ${summary.stateCounts.nonPublished}`,
+      `- failures: ${summary.failures.length}`,
+      `- artifact: ${summary.artifactPath}`,
+    ];
+    process.stdout.write(`${lines.join("\n")}\n`);
+  }
+
+  if (shouldFail) {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error) => {
+  console.error(`audit-industry-events-freshness failed: ${error instanceof Error ? error.message : String(error)}`);
+  process.exitCode = 1;
+});

--- a/functions/scripts/fixtures/industry-events-source-fixture.json
+++ b/functions/scripts/fixtures/industry-events-source-fixture.json
@@ -1,0 +1,130 @@
+{
+  "version": 1,
+  "generatedAt": "2026-03-01T00:00:00.000Z",
+  "sources": [
+    {
+      "sourceId": "fixture-curated-main",
+      "sourceName": "Fixture Curated Industry Feed",
+      "sourceUrl": "https://fixtures.monsoonfire.com/industry/main",
+      "connector": "curated-feed",
+      "events": [
+        {
+          "externalId": "nceca-2026-primary",
+          "title": "NCECA Annual Conference 2026",
+          "summary": "Primary conference row for national ceramics planning.",
+          "description": "Fixture baseline row for ingestion and triage.",
+          "mode": "hybrid",
+          "status": "published",
+          "startAt": "2026-03-26T15:00:00.000Z",
+          "endAt": "2026-03-29T01:00:00.000Z",
+          "timezone": "America/Chicago",
+          "location": "Annual host city convention center",
+          "city": "Host city",
+          "region": "US",
+          "country": "US",
+          "remoteUrl": "https://nceca.net/live",
+          "registrationUrl": "https://nceca.net/register",
+          "sourceName": "NCECA",
+          "sourceUrl": "https://nceca.net/conference-2026",
+          "tags": [
+            "conference",
+            "national"
+          ],
+          "verifiedAt": "2026-02-28T12:00:00.000Z"
+        },
+        {
+          "externalId": "nceca-2026-duplicate-url",
+          "title": "NCECA Conference 2026 (duplicate URL row)",
+          "summary": "Duplicate source URL should suppress this row.",
+          "mode": "hybrid",
+          "status": "published",
+          "startAt": "2026-03-26T16:00:00.000Z",
+          "endAt": "2026-03-29T01:00:00.000Z",
+          "timezone": "America/Chicago",
+          "location": "Annual host city convention center",
+          "country": "US",
+          "sourceUrl": "https://nceca.net/conference-2026",
+          "verifiedAt": "2026-02-28T12:00:00.000Z"
+        },
+        {
+          "externalId": "phoenix-open-studio-a",
+          "title": "Phoenix Clay Open Studio Night",
+          "summary": "First local open studio feed row.",
+          "mode": "local",
+          "status": "published",
+          "startAt": "2026-04-12T01:00:00.000Z",
+          "endAt": "2026-04-12T04:00:00.000Z",
+          "timezone": "America/Phoenix",
+          "location": "Phoenix metro area",
+          "city": "Phoenix",
+          "region": "AZ",
+          "country": "US",
+          "registrationUrl": "https://fixtures.monsoonfire.com/open-studio",
+          "tags": [
+            "phoenix",
+            "open-studio"
+          ],
+          "verifiedAt": "2026-03-01T09:00:00.000Z"
+        },
+        {
+          "externalId": "phoenix-open-studio-b",
+          "title": "Phoenix Clay Open-Studio Night",
+          "summary": "Title/date hash duplicate should suppress this row.",
+          "mode": "local",
+          "status": "published",
+          "startAt": "2026-04-12T10:30:00.000Z",
+          "endAt": "2026-04-12T12:30:00.000Z",
+          "timezone": "America/Phoenix",
+          "location": "Phoenix metro area",
+          "city": "Phoenix",
+          "region": "AZ",
+          "country": "US",
+          "verifiedAt": "2026-03-01T09:00:00.000Z"
+        },
+        {
+          "externalId": "stale-remote-congress",
+          "title": "Ceramics Congress Replay Access Window",
+          "summary": "Stale verification row for freshness checks.",
+          "mode": "remote",
+          "status": "published",
+          "startAt": "2026-05-10T14:00:00.000Z",
+          "endAt": "2026-05-12T02:00:00.000Z",
+          "timezone": "UTC",
+          "remoteUrl": "https://ceramic.school/congress/replay",
+          "sourceUrl": "https://ceramic.school/congress/replay",
+          "country": "US",
+          "verifiedAt": "2025-11-01T00:00:00.000Z"
+        },
+        {
+          "externalId": "retired-local-archive",
+          "title": "Regional Clay Meetup 2025 Archive",
+          "summary": "Past event that should be retired by freshness policy.",
+          "mode": "local",
+          "status": "published",
+          "startAt": "2025-01-10T18:00:00.000Z",
+          "endAt": "2025-01-10T22:00:00.000Z",
+          "timezone": "America/Phoenix",
+          "location": "Mesa community studio",
+          "city": "Mesa",
+          "region": "AZ",
+          "country": "US",
+          "sourceUrl": "https://fixtures.monsoonfire.com/archive/regional-clay-meetup-2025",
+          "verifiedAt": "2026-02-20T00:00:00.000Z"
+        },
+        {
+          "externalId": "invalid-missing-title",
+          "title": "",
+          "summary": "Invalid row to ensure failure artifacts are produced.",
+          "mode": "local",
+          "status": "published",
+          "startAt": "2026-07-01T16:00:00.000Z",
+          "endAt": "2026-07-01T20:00:00.000Z",
+          "timezone": "America/Phoenix",
+          "location": "Phoenix",
+          "country": "US",
+          "sourceUrl": "https://fixtures.monsoonfire.com/invalid/missing-title"
+        }
+      ]
+    }
+  ]
+}

--- a/functions/scripts/import-industry-events.mjs
+++ b/functions/scripts/import-industry-events.mjs
@@ -1,0 +1,493 @@
+#!/usr/bin/env node
+
+/* eslint-disable no-console */
+
+import { createHash } from "node:crypto";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { getApps, initializeApp } from "firebase-admin/app";
+import { getFirestore, Timestamp } from "firebase-admin/firestore";
+
+const __filename = fileURLToPath(import.meta.url);
+const scriptsDir = dirname(__filename);
+const functionsRoot = resolve(scriptsDir, "..");
+
+const DEFAULT_PROJECT_ID = process.env.FIREBASE_PROJECT_ID || "monsoonfire-portal";
+const DEFAULT_FIXTURE_PATH = resolve(scriptsDir, "fixtures", "industry-events-source-fixture.json");
+const DEFAULT_ARTIFACT_PATH = resolve(functionsRoot, "output", "industry-events", "import-report.json");
+
+function parseArgs(argv) {
+  const options = {
+    projectId: DEFAULT_PROJECT_ID,
+    source: "fixture",
+    fixturePath: DEFAULT_FIXTURE_PATH,
+    artifactPath: DEFAULT_ARTIFACT_PATH,
+    dryRun: false,
+    overwrite: false,
+    strict: false,
+    asJson: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (!arg) continue;
+
+    if (arg === "--dry-run") {
+      options.dryRun = true;
+      continue;
+    }
+    if (arg === "--overwrite") {
+      options.overwrite = true;
+      continue;
+    }
+    if (arg === "--strict") {
+      options.strict = true;
+      continue;
+    }
+    if (arg === "--json") {
+      options.asJson = true;
+      continue;
+    }
+
+    if (arg.startsWith("--source=")) {
+      options.source = String(arg.slice("--source=".length)).trim() || options.source;
+      continue;
+    }
+    if (arg.startsWith("--fixture=")) {
+      options.fixturePath = resolve(process.cwd(), String(arg.slice("--fixture=".length)).trim());
+      continue;
+    }
+    if (arg.startsWith("--artifact=")) {
+      options.artifactPath = resolve(process.cwd(), String(arg.slice("--artifact=".length)).trim());
+      continue;
+    }
+    if (arg.startsWith("--project=")) {
+      options.projectId = String(arg.slice("--project=".length)).trim() || options.projectId;
+      continue;
+    }
+
+    const next = argv[index + 1];
+    if (!next || next.startsWith("--")) {
+      throw new Error(`Missing value for ${arg}`);
+    }
+
+    if (arg === "--source") {
+      options.source = String(next).trim() || options.source;
+      index += 1;
+      continue;
+    }
+    if (arg === "--fixture") {
+      options.fixturePath = resolve(process.cwd(), String(next).trim());
+      index += 1;
+      continue;
+    }
+    if (arg === "--artifact") {
+      options.artifactPath = resolve(process.cwd(), String(next).trim());
+      index += 1;
+      continue;
+    }
+    if (arg === "--project" || arg === "-p") {
+      options.projectId = String(next).trim() || options.projectId;
+      index += 1;
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return options;
+}
+
+function normalizeText(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function normalizeOptionalText(value) {
+  const text = normalizeText(value);
+  return text || null;
+}
+
+function normalizeOptionalUrl(value) {
+  const raw = normalizeText(value);
+  if (!raw) return null;
+  try {
+    const url = new URL(raw);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+function normalizeTags(value) {
+  if (!Array.isArray(value)) return [];
+  const out = [];
+  for (const entry of value) {
+    const normalized = normalizeText(entry).toLowerCase();
+    if (!normalized || out.includes(normalized)) continue;
+    out.push(normalized);
+    if (out.length >= 20) break;
+  }
+  return out;
+}
+
+function normalizeMode(modeValue, context = {}) {
+  const explicit = normalizeText(modeValue).toLowerCase();
+  if (explicit === "local" || explicit === "remote" || explicit === "hybrid") return explicit;
+  const hasLocation = normalizeText(context.location).length > 0;
+  const hasRemoteUrl = normalizeText(context.remoteUrl).length > 0;
+  if (hasLocation && hasRemoteUrl) return "hybrid";
+  if (hasRemoteUrl) return "remote";
+  return "local";
+}
+
+function toIso(value) {
+  if (value == null) return null;
+  if (value instanceof Date && Number.isFinite(value.getTime())) return value.toISOString();
+  if (typeof value === "string" || typeof value === "number") {
+    const parsed = new Date(value);
+    if (Number.isFinite(parsed.getTime())) return parsed.toISOString();
+    return null;
+  }
+  if (typeof value === "object" && value && typeof value.toDate === "function") {
+    try {
+      const parsed = value.toDate();
+      if (parsed instanceof Date && Number.isFinite(parsed.getTime())) return parsed.toISOString();
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+function toTimestamp(value) {
+  const iso = toIso(value);
+  if (!iso) return null;
+  return Timestamp.fromDate(new Date(iso));
+}
+
+function slug(value) {
+  return normalizeText(value)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function normalizeTitleForHash(title) {
+  return normalizeText(title).toLowerCase().replace(/[^a-z0-9]+/g, " ").trim().replace(/\s+/g, " ");
+}
+
+function isoDayKey(iso) {
+  if (!iso) return "unknown-date";
+  return String(iso).slice(0, 10);
+}
+
+function buildTitleDateHash(title, startAtIso) {
+  const digest = createHash("sha256");
+  digest.update(`${normalizeTitleForHash(title)}|${isoDayKey(startAtIso)}`);
+  return digest.digest("hex").slice(0, 20);
+}
+
+function buildSourceUrlKey(url) {
+  const normalized = normalizeOptionalUrl(url);
+  if (!normalized) return null;
+  return normalized.toLowerCase();
+}
+
+function safeDocId(value) {
+  const normalized = slug(value);
+  if (!normalized) return "";
+  return normalized.slice(0, 96);
+}
+
+function buildDocId(row, sourceId, titleDateHash) {
+  const explicit = safeDocId(row.eventId || row.externalId || row.id || "");
+  if (explicit) return `${safeDocId(sourceId) || "source"}-${explicit}`.slice(0, 120);
+  const fromTitle = safeDocId(row.title || "");
+  if (fromTitle) return `${safeDocId(sourceId) || "source"}-${fromTitle}-${titleDateHash.slice(0, 8)}`.slice(0, 120);
+  return `${safeDocId(sourceId) || "source"}-row-${titleDateHash.slice(0, 12)}`;
+}
+
+function asArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function asObject(value) {
+  if (!value || typeof value !== "object") return {};
+  return value;
+}
+
+async function loadFixtureRows(fixturePath) {
+  const raw = await readFile(fixturePath, "utf8");
+  const parsed = JSON.parse(raw);
+  const sources = asArray(parsed.sources);
+  const rows = [];
+
+  for (let sourceIndex = 0; sourceIndex < sources.length; sourceIndex += 1) {
+    const source = asObject(sources[sourceIndex]);
+    const sourceId = normalizeText(source.sourceId) || `fixture-source-${sourceIndex + 1}`;
+    const sourceName = normalizeText(source.sourceName) || sourceId;
+    const sourceUrl = normalizeOptionalUrl(source.sourceUrl);
+    const connector = normalizeText(source.connector || source.type) || "fixture";
+    const events = asArray(source.events);
+
+    for (let eventIndex = 0; eventIndex < events.length; eventIndex += 1) {
+      rows.push({
+        source: {
+          sourceId,
+          sourceName,
+          sourceUrl,
+          connector,
+        },
+        row: asObject(events[eventIndex]),
+        sourceIndex,
+        eventIndex,
+      });
+    }
+  }
+
+  return rows;
+}
+
+const CONNECTORS = {
+  fixture: async (options) => loadFixtureRows(options.fixturePath),
+};
+
+function toRelativePath(pathValue) {
+  const cwdPrefix = `${process.cwd()}/`;
+  if (pathValue.startsWith(cwdPrefix)) return pathValue.slice(cwdPrefix.length);
+  return pathValue;
+}
+
+function buildDraftPayload(meta, normalized, importBatchId) {
+  return {
+    title: normalized.title,
+    summary: normalized.summary,
+    description: normalized.description,
+    mode: normalized.mode,
+    status: "draft",
+    startAt: toTimestamp(normalized.startAt),
+    endAt: toTimestamp(normalized.endAt),
+    timezone: normalized.timezone,
+    location: normalized.location,
+    city: normalized.city,
+    region: normalized.region,
+    country: normalized.country,
+    remoteUrl: normalized.remoteUrl,
+    registrationUrl: normalized.registrationUrl,
+    sourceName: normalized.sourceName,
+    sourceUrl: normalized.sourceUrl,
+    featured: false,
+    tags: normalized.tags,
+    verifiedAt: toTimestamp(normalized.verifiedAt),
+    sourceVerifiedAt: toTimestamp(normalized.verifiedAt),
+    needsReview: true,
+    reviewByAt: Timestamp.fromMillis(Date.now() + 7 * 24 * 60 * 60 * 1000),
+    freshnessState: "non_published",
+    freshnessCheckedAt: Timestamp.now(),
+    sourceConnector: meta.source.connector,
+    sourceFeedId: meta.source.sourceId,
+    sourceRecordId: normalized.sourceRecordId,
+    sourceTitleDateHash: normalized.titleDateHash,
+    sourceImportedAt: Timestamp.now(),
+    sourceImportBatchId: importBatchId,
+  };
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const connector = CONNECTORS[options.source];
+  if (!connector) {
+    throw new Error(`Unknown --source "${options.source}". Supported: ${Object.keys(CONNECTORS).join(", ")}`);
+  }
+
+  const rows = await connector(options);
+  const importBatchId = `industry-events-import-${new Date().toISOString()}`;
+  const seenSourceUrls = new Set();
+  const seenTitleDateHashes = new Set();
+  const accepted = [];
+
+  const summary = {
+    ok: true,
+    source: options.source,
+    projectId: options.projectId,
+    dryRun: options.dryRun,
+    overwrite: options.overwrite,
+    requested: rows.length,
+    accepted: 0,
+    triageDraftCount: 0,
+    duplicatesSuppressed: 0,
+    duplicateReasons: {
+      sourceUrl: 0,
+      titleDateHash: 0,
+    },
+    skippedExisting: 0,
+    created: 0,
+    updated: 0,
+    failed: 0,
+    errors: [],
+    duplicates: [],
+    acceptedPreview: [],
+    fixturePath: toRelativePath(options.fixturePath),
+    artifactPath: toRelativePath(options.artifactPath),
+    importBatchId,
+  };
+
+  for (const meta of rows) {
+    try {
+      const raw = asObject(meta.row);
+
+      const title = normalizeText(raw.title);
+      if (!title) throw new Error("title is required");
+      const startAt = toIso(raw.startAt);
+      if (!startAt) throw new Error("startAt must be a valid date");
+
+      const sourceUrl = normalizeOptionalUrl(raw.sourceUrl) || meta.source.sourceUrl || null;
+      const sourceUrlKey = buildSourceUrlKey(sourceUrl);
+      if (sourceUrlKey && seenSourceUrls.has(sourceUrlKey)) {
+        summary.duplicatesSuppressed += 1;
+        summary.duplicateReasons.sourceUrl += 1;
+        summary.duplicates.push({
+          sourceId: meta.source.sourceId,
+          row: meta.eventIndex + 1,
+          reason: "sourceUrl",
+          sourceUrl,
+          title,
+        });
+        continue;
+      }
+
+      const titleDateHash = buildTitleDateHash(title, startAt);
+      if (seenTitleDateHashes.has(titleDateHash)) {
+        summary.duplicatesSuppressed += 1;
+        summary.duplicateReasons.titleDateHash += 1;
+        summary.duplicates.push({
+          sourceId: meta.source.sourceId,
+          row: meta.eventIndex + 1,
+          reason: "titleDateHash",
+          title,
+          startAt,
+          titleDateHash,
+        });
+        continue;
+      }
+
+      if (sourceUrlKey) seenSourceUrls.add(sourceUrlKey);
+      seenTitleDateHashes.add(titleDateHash);
+
+      const summaryText = normalizeText(raw.summary) || `Imported from ${meta.source.sourceName}.`;
+      const location = normalizeOptionalText(raw.location || raw.venue);
+      const remoteUrl = normalizeOptionalUrl(raw.remoteUrl || raw.virtualUrl);
+      const normalized = {
+        title,
+        summary: summaryText,
+        description: normalizeOptionalText(raw.description),
+        mode: normalizeMode(raw.mode, { location, remoteUrl }),
+        startAt,
+        endAt: toIso(raw.endAt),
+        timezone: normalizeOptionalText(raw.timezone),
+        location,
+        city: normalizeOptionalText(raw.city),
+        region: normalizeOptionalText(raw.region || raw.state),
+        country: normalizeOptionalText(raw.country),
+        remoteUrl,
+        registrationUrl: normalizeOptionalUrl(raw.registrationUrl || raw.registerUrl),
+        sourceName: normalizeOptionalText(raw.sourceName) || meta.source.sourceName || null,
+        sourceUrl,
+        tags: normalizeTags(raw.tags),
+        verifiedAt: toIso(raw.verifiedAt),
+        sourceRecordId: normalizeOptionalText(raw.externalId || raw.id),
+        titleDateHash,
+      };
+
+      const docId = buildDocId(raw, meta.source.sourceId, titleDateHash);
+      accepted.push({ docId, normalized, meta });
+
+      if (summary.acceptedPreview.length < 25) {
+        summary.acceptedPreview.push({
+          docId,
+          title,
+          sourceId: meta.source.sourceId,
+          sourceRecordId: normalized.sourceRecordId,
+          sourceUrl: normalized.sourceUrl,
+          dedupeKey: titleDateHash,
+          status: "draft",
+        });
+      }
+    } catch (error) {
+      summary.failed += 1;
+      summary.errors.push({
+        sourceId: meta.source?.sourceId || "unknown",
+        row: meta.eventIndex + 1,
+        message: error instanceof Error ? error.message : String(error),
+        rawExternalId: normalizeOptionalText(meta.row?.externalId || meta.row?.id),
+      });
+    }
+  }
+
+  summary.accepted = accepted.length;
+  summary.triageDraftCount = accepted.length;
+
+  if (!options.dryRun && accepted.length > 0) {
+    const app =
+      getApps().length > 0
+        ? getApps()[0]
+        : initializeApp({
+            projectId: options.projectId,
+          });
+    const db = getFirestore(app);
+
+    for (const entry of accepted) {
+      const ref = db.collection("industryEvents").doc(entry.docId);
+      const existing = await ref.get();
+      const exists = existing.exists;
+      if (exists && !options.overwrite) {
+        summary.skippedExisting += 1;
+        continue;
+      }
+
+      const payload = buildDraftPayload(entry.meta, entry.normalized, importBatchId);
+      payload.createdAt = existing.get("createdAt") ?? Timestamp.now();
+      payload.createdByUid = existing.get("createdByUid") ?? "industry-events-import-script";
+      payload.updatedAt = Timestamp.now();
+      payload.updatedByUid = "industry-events-import-script";
+
+      await ref.set(payload, { merge: true });
+      if (exists) summary.updated += 1;
+      else summary.created += 1;
+    }
+  }
+
+  await mkdir(dirname(options.artifactPath), { recursive: true });
+  await writeFile(options.artifactPath, `${JSON.stringify(summary, null, 2)}\n`, "utf8");
+
+  const shouldFail = options.strict && (summary.failed > 0 || summary.accepted === 0);
+  if (shouldFail) summary.ok = false;
+
+  if (options.asJson) {
+    process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+  } else {
+    const lines = [
+      "Industry events import summary",
+      `- source: ${summary.source}`,
+      `- requested: ${summary.requested}`,
+      `- accepted: ${summary.accepted}`,
+      `- triageDraftCount: ${summary.triageDraftCount}`,
+      `- duplicatesSuppressed: ${summary.duplicatesSuppressed} (sourceUrl=${summary.duplicateReasons.sourceUrl}, titleDateHash=${summary.duplicateReasons.titleDateHash})`,
+      `- failed: ${summary.failed}`,
+      `- dryRun: ${summary.dryRun ? "yes" : "no"}`,
+      `- artifact: ${summary.artifactPath}`,
+    ];
+    process.stdout.write(`${lines.join("\n")}\n`);
+  }
+
+  if (shouldFail) {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error) => {
+  console.error(`import-industry-events failed: ${error instanceof Error ? error.message : String(error)}`);
+  process.exitCode = 1;
+});

--- a/scripts/check-industry-events-canary.mjs
+++ b/scripts/check-industry-events-canary.mjs
@@ -1,0 +1,230 @@
+#!/usr/bin/env node
+
+/* eslint-disable no-console */
+
+import { spawnSync } from "node:child_process";
+import { access, mkdir, writeFile } from "node:fs/promises";
+import { dirname, isAbsolute, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const repoRoot = resolve(dirname(__filename), "..");
+const defaultArtifactPath = resolve(repoRoot, "output", "qa", "industry-events-canary.json");
+
+function parseArgs(argv) {
+  const options = {
+    strict: false,
+    asJson: false,
+    artifactPath: defaultArtifactPath,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (!arg) continue;
+
+    if (arg === "--strict") {
+      options.strict = true;
+      continue;
+    }
+    if (arg === "--json") {
+      options.asJson = true;
+      continue;
+    }
+
+    if (arg.startsWith("--artifact=")) {
+      options.artifactPath = resolve(repoRoot, String(arg.slice("--artifact=".length)).trim());
+      continue;
+    }
+
+    const next = argv[index + 1];
+    if (!next || next.startsWith("--")) throw new Error(`Missing value for ${arg}`);
+
+    if (arg === "--artifact") {
+      options.artifactPath = resolve(repoRoot, String(next).trim());
+      index += 1;
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return options;
+}
+
+function runCommand(command, args) {
+  const result = spawnSync(command, args, {
+    cwd: repoRoot,
+    encoding: "utf8",
+    maxBuffer: 32 * 1024 * 1024,
+  });
+  const exitCode = typeof result.status === "number" ? result.status : 1;
+  return {
+    exitCode,
+    stdout: String(result.stdout || ""),
+    stderr: String(result.stderr || ""),
+  };
+}
+
+function parseJsonSafe(text) {
+  try {
+    return JSON.parse(String(text || "").trim());
+  } catch {
+    return null;
+  }
+}
+
+function truncate(text, max = 1400) {
+  if (text.length <= max) return text;
+  return `${text.slice(0, max)}...`;
+}
+
+function checkResult(checks, id, label, pass, detail) {
+  checks.push({
+    id,
+    label,
+    status: pass ? "pass" : "fail",
+    detail: detail || null,
+  });
+}
+
+async function pathExists(pathValue) {
+  try {
+    await access(pathValue);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function resolveMaybePath(pathValue) {
+  if (!pathValue || typeof pathValue !== "string") return null;
+  if (isAbsolute(pathValue)) return pathValue;
+  return resolve(repoRoot, pathValue);
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+
+  const importRun = runCommand("node", [
+    "./functions/scripts/import-industry-events.mjs",
+    "--source",
+    "fixture",
+    "--dry-run",
+    "--json",
+  ]);
+  const auditRun = runCommand("node", [
+    "./functions/scripts/audit-industry-events-freshness.mjs",
+    "--source",
+    "fixture",
+    "--json",
+  ]);
+
+  const importReport = parseJsonSafe(importRun.stdout);
+  const auditReport = parseJsonSafe(auditRun.stdout);
+  const checks = [];
+
+  checkResult(
+    checks,
+    "import-command",
+    "Import script exits cleanly",
+    importRun.exitCode === 0,
+    importRun.exitCode === 0 ? null : truncate(importRun.stderr || importRun.stdout)
+  );
+  checkResult(
+    checks,
+    "audit-command",
+    "Freshness audit exits cleanly",
+    auditRun.exitCode === 0,
+    auditRun.exitCode === 0 ? null : truncate(auditRun.stderr || auditRun.stdout)
+  );
+
+  const accepted = Number(importReport?.accepted ?? 0);
+  const triageDraftCount = Number(importReport?.triageDraftCount ?? 0);
+  checkResult(
+    checks,
+    "triage-draft",
+    "Connector rows remain in draft/triage state",
+    accepted > 0 && accepted === triageDraftCount,
+    `accepted=${accepted}, triageDraftCount=${triageDraftCount}`
+  );
+
+  const duplicateBySourceUrl = Number(importReport?.duplicateReasons?.sourceUrl ?? 0);
+  checkResult(
+    checks,
+    "dedupe-source-url",
+    "Duplicate suppression by sourceUrl",
+    duplicateBySourceUrl > 0,
+    `sourceUrl duplicates suppressed=${duplicateBySourceUrl}`
+  );
+
+  const duplicateByTitleDateHash = Number(importReport?.duplicateReasons?.titleDateHash ?? 0);
+  checkResult(
+    checks,
+    "dedupe-title-date",
+    "Duplicate suppression by normalized title/date hash",
+    duplicateByTitleDateHash > 0,
+    `titleDateHash duplicates suppressed=${duplicateByTitleDateHash}`
+  );
+
+  const staleReviewCount = Number(auditReport?.stateCounts?.staleReview ?? 0);
+  const retiredCount = Number(auditReport?.stateCounts?.retired ?? 0);
+  checkResult(
+    checks,
+    "freshness-policy",
+    "Freshness SLA flags stale/retired events",
+    staleReviewCount + retiredCount > 0,
+    `staleReview=${staleReviewCount}, retired=${retiredCount}`
+  );
+
+  const importArtifactPath = resolveMaybePath(importReport?.artifactPath);
+  const auditArtifactPath = resolveMaybePath(auditReport?.artifactPath);
+  const importArtifactExists = importArtifactPath ? await pathExists(importArtifactPath) : false;
+  const auditArtifactExists = auditArtifactPath ? await pathExists(auditArtifactPath) : false;
+  checkResult(
+    checks,
+    "artifacts",
+    "Failure/report artifacts are emitted",
+    importArtifactExists && auditArtifactExists,
+    `importArtifact=${importArtifactPath || "n/a"} (${importArtifactExists ? "present" : "missing"}), auditArtifact=${auditArtifactPath || "n/a"} (${auditArtifactExists ? "present" : "missing"})`
+  );
+
+  const passed = checks.every((check) => check.status === "pass");
+  const report = {
+    status: passed ? "pass" : "fail",
+    generatedAt: new Date().toISOString(),
+    checks,
+    import: {
+      exitCode: importRun.exitCode,
+      report: importReport,
+      stderr: truncate(importRun.stderr),
+    },
+    audit: {
+      exitCode: auditRun.exitCode,
+      report: auditReport,
+      stderr: truncate(auditRun.stderr),
+    },
+  };
+
+  await mkdir(dirname(options.artifactPath), { recursive: true });
+  await writeFile(options.artifactPath, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+
+  if (options.asJson) {
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  } else {
+    const lines = [
+      `industry-events-canary: ${report.status}`,
+      ...checks.map((check) => `- [${check.status}] ${check.label}${check.detail ? ` (${check.detail})` : ""}`),
+      `artifact: ${options.artifactPath.startsWith(`${repoRoot}/`) ? options.artifactPath.slice(repoRoot.length + 1) : options.artifactPath}`,
+    ];
+    process.stdout.write(`${lines.join("\n")}\n`);
+  }
+
+  if (options.strict && !passed) {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error) => {
+  console.error(`check-industry-events-canary failed: ${error instanceof Error ? error.message : String(error)}`);
+  process.exitCode = 1;
+});

--- a/scripts/verify-harness-dedupe-safe.mjs
+++ b/scripts/verify-harness-dedupe-safe.mjs
@@ -272,6 +272,11 @@ async function main() {
       command: "node",
       args: ["./scripts/credentials-health-check.mjs", "--apply", "--rules-probe-optional", "--json"],
     },
+    {
+      name: "industry-events-canary",
+      command: "node",
+      args: ["./scripts/check-industry-events-canary.mjs", "--json", "--strict"],
+    },
   ];
 
   const filteredTasks = tasks.filter((task) => {


### PR DESCRIPTION
## Summary
- add `functions/scripts/import-industry-events.mjs` with a baseline fixture connector, normalization, deterministic dedupe (`sourceUrl` then title/date hash), triage-only draft ingestion, and artifact output
- add `functions/scripts/audit-industry-events-freshness.mjs` with stale/retired freshness SLA evaluation and actionable artifact output
- add `functions/scripts/fixtures/industry-events-source-fixture.json` with deterministic duplicate + stale + retired + invalid rows
- wire new function scripts in `functions/package.json`
- add root `scripts/check-industry-events-canary.mjs` to enforce the guardrail expectations
- wire the canary into `scripts/verify-harness-dedupe-safe.mjs`

## Ticket
Closes #198
