### PR TITLE
Backlog autopilot: sync standalone ticket status from local files

### DIFF
--- a/scripts/codex/backlog-autopilot.mjs
+++ b/scripts/codex/backlog-autopilot.mjs
@@ -717,9 +717,34 @@ async function main() {
   }
   for (const task of fallbackTasks) {
     if (!task?.ticketRef) continue;
-    if (!mergedByRef.has(task.ticketRef)) {
+    const existing = mergedByRef.get(task.ticketRef);
+    if (!existing) {
       mergedByRef.set(task.ticketRef, task);
+      continue;
     }
+
+    // Local ticket files are the source-of-truth for current status and acceptance details.
+    // Refresh status metadata from fallback parsing so stale epic-hub payloads cannot reopen
+    // tickets that are already marked Closed/Done in tickets/*.md.
+    mergedByRef.set(task.ticketRef, {
+      ...existing,
+      ticketStatus: task.ticketStatus || existing.ticketStatus,
+      ticketStatusNormalized: task.ticketStatusNormalized || existing.ticketStatusNormalized,
+      ticketPriority: task.ticketPriority || existing.ticketPriority,
+      owner: task.owner || existing.owner,
+      acceptanceCriteria:
+        Array.isArray(task.acceptanceCriteria) && task.acceptanceCriteria.length > 0
+          ? task.acceptanceCriteria
+          : existing.acceptanceCriteria,
+      definitionOfDone:
+        Array.isArray(task.definitionOfDone) && task.definitionOfDone.length > 0
+          ? task.definitionOfDone
+          : existing.definitionOfDone,
+      taskOutline:
+        Array.isArray(task.taskOutline) && task.taskOutline.length > 0
+          ? task.taskOutline
+          : existing.taskOutline,
+    });
   }
   const discoveredTasks = Array.from(mergedByRef.values()).sort((left, right) => {
     const epicPriority = parsePriorityValue(left.epicPriority) - parsePriorityValue(right.epicPriority);


### PR DESCRIPTION
## Summary
- refresh standalone ticket metadata from local `tickets/*.md` even when epic-hub already returned the same `ticketRef`
- make local ticket status (`Closed`/`Done`) authoritative so stale epic-hub payloads cannot re-queue completed lanes
- preserve existing epic-hub metadata while overriding status/owner/acceptance details from ticket files

## Why
- issue #200 was auto-created even though `tickets/P1-ci-smoke-failure-firebase-emulator-host-flag-compat.md` is already `Status: Closed`
- this change prevents repeat queue noise and keeps backlog dispatch aligned with source-of-truth tickets

## Verification
- ran `node ./scripts/codex/backlog-autopilot.mjs --dry-run --json --limit 200 --max-issues 0`
- closed ticket lane no longer appears as a top candidate

Refs #200
