### PR TITLE
Tickets: mark events sourcing/freshness lane closed

### DIFF
--- a/tickets/P2-events-sourcing-connectors-and-freshness-automation.md
+++ b/tickets/P2-events-sourcing-connectors-and-freshness-automation.md
@@ -1,6 +1,6 @@
 # P2 — Events: Sourcing Connectors and Freshness Automation
 
-Status: Active
+Status: Closed
 Date: 2026-03-01
 Priority: P2
 Owner: Platform + Automation


### PR DESCRIPTION
## Summary
- update `tickets/P2-events-sourcing-connectors-and-freshness-automation.md` status from `Active` to `Closed`
- prevents backlog autopilot from re-queueing an already implemented lane

## Context
- implementation for this lane already shipped in PR #199
- issue #202 was a duplicate queue artifact and has been closed

Refs #202
