### PR TITLE
Daily improvement: only retrigger metadata ticket on metadata growth

### DIFF
--- a/scripts/codex/daily-improvement.mjs
+++ b/scripts/codex/daily-improvement.mjs
@@ -1464,7 +1464,7 @@ async function main() {
   const metadataTouchDelta = metadataTouchTotal24 - Number(state?.lastMetadataTouchTotal24 || 0);
   const metadataRecommendationActionable =
     metadataUnstable &&
-    (commitsSinceLast.length > 0 || metadataTouchDelta > 0 || state?.lastRunId === "1970-01-01-AM");
+    (metadataTouchDelta > 0 || state?.lastRunId === "1970-01-01-AM");
 
   if (metadataRecommendationActionable) {
     ensureRecommendation(recommendations, {


### PR DESCRIPTION
## Summary
- adjust metadata recommendation gate in `scripts/codex/daily-improvement.mjs`
- metadata-churn ticketing now retriggers only when metadata churn itself increases (`metadataTouchDelta > 0`) or on first-run bootstrap
- removes false retriggers caused by unrelated commits since last run

## Why
Issue #208 was reopened even though metadata churn count remained unchanged and no new metadata churn was introduced.

## Result
- avoids duplicate one-off metadata tickets while preserving detection when the metadata signal actually worsens

Closes #208
