### PR TITLE
Add missing codex friction loop script

### DIFF
--- a/scripts/codex/friction-feedback-loop.mjs
+++ b/scripts/codex/friction-feedback-loop.mjs
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+
+/* eslint-disable no-console */
+
+import { spawnSync } from "node:child_process";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const scriptDir = dirname(__filename);
+const targetScript = resolve(scriptDir, "daily-interaction.mjs");
+
+const result = spawnSync(process.execPath, [targetScript, ...process.argv.slice(2)], {
+  stdio: "inherit",
+  env: process.env,
+});
+
+if (typeof result.status === "number") {
+  process.exit(result.status);
+}
+
+process.exit(1);


### PR DESCRIPTION
## Summary
- add the missing `scripts/codex/friction-feedback-loop.mjs` entrypoint referenced by npm scripts
- proxy friction loop execution to `daily-interaction.mjs` with passthrough args

## Why
- `npm run codex:friction:loop:apply` currently fails on main with `MODULE_NOT_FOUND` because the script file is missing