### PR TITLE
Suppress no-op daily improvement PR creation

### DIFF
--- a/scripts/codex/daily-improvement.mjs
+++ b/scripts/codex/daily-improvement.mjs
@@ -1780,6 +1780,7 @@ async function main() {
   }
 
   let createdTicketUrls = [];
+  let newlyCreatedTicketUrls = [];
   let prUrl = "";
   let runBranchUsed = "";
   let rollingIssueUrl = "";
@@ -1900,7 +1901,10 @@ async function main() {
 
       if (createIssue.ok) {
         const url = createIssue.stdout.trim();
-        if (url) createdTicketUrls.push(url);
+        if (url) {
+          createdTicketUrls.push(url);
+          newlyCreatedTicketUrls.push(url);
+        }
       }
     }
 
@@ -2017,7 +2021,12 @@ async function main() {
       }
     }
 
-    const shouldCreateRunPr = (recommendations.length > 0 || scoreDroppedTwice) && !skipRunPrOnDirtyAllow;
+    const shouldCreateRunPr = !skipRunPrOnDirtyAllow && (newlyCreatedTicketUrls.length > 0 || scoreDroppedTwice);
+    if (!shouldCreateRunPr && recommendations.length > 0 && !scoreDroppedTwice) {
+      notes.push(
+        "Run PR creation suppressed: recommendations mapped to existing lanes with no net-new ticket creation."
+      );
+    }
 
     if (shouldCreateRunPr) {
       const sharedRunPr = sharedCoordination?.automationPrByRunId?.[runInfo.runId];


### PR DESCRIPTION
## Summary
- track net-new recommendation tickets separately from reused existing/closed lanes
- only create an auto-improvement run PR when there is at least one net-new ticket or forced structural score-drop condition
- add an explicit note when PR creation is intentionally suppressed

## Why
- avoids churny run PRs when recommendations already map to existing lanes and no new action is created