### PR TITLE
Add open-memory automation helper stub

### DIFF
--- a/scripts/codex/open-memory-automation.mjs
+++ b/scripts/codex/open-memory-automation.mjs
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+
+/* eslint-disable no-console */
+
+function unavailableReason() {
+  if (String(process.env.OPEN_MEMORY_DISABLED || "").trim()) {
+    return "open-memory-disabled";
+  }
+  return "open-memory-not-configured";
+}
+
+export async function loadAutomationStartupMemoryContext(payload = {}) {
+  return {
+    attempted: false,
+    ok: false,
+    itemCount: 0,
+    reason: unavailableReason(),
+    error: null,
+    context: [],
+    tool: String(payload?.tool || ""),
+    runId: String(payload?.runId || ""),
+    query: String(payload?.query || ""),
+  };
+}
+
+export async function captureAutomationMemory(payload = {}) {
+  return {
+    attempted: false,
+    ok: false,
+    reason: unavailableReason(),
+    error: null,
+    status: 0,
+    tool: String(payload?.tool || ""),
+    runId: String(payload?.runId || ""),
+  };
+}


### PR DESCRIPTION
## Summary
- add `scripts/codex/open-memory-automation.mjs` used by codex automation loops
- return stable "not configured" responses for startup context and memory capture when Open Memory is unavailable

## Why
- removes repeated module-missing fallback noise across backlog/improvement loops
- keeps behavior explicit and non-fatal until Open Memory is configured