### PR TITLE
chore(codex): skip duplicate interaction rolling runs

### DIFF
--- a/scripts/codex/daily-interaction.mjs
+++ b/scripts/codex/daily-interaction.mjs
@@ -800,6 +800,22 @@ function buildInteractionLogEntry({
   return `${lines.join("\n")}\n`;
 }
 
+function fetchLatestIssueCommentBody(repoSlug, issueNumber) {
+  const response = runGhJson([
+    "issue",
+    "view",
+    String(issueNumber),
+    "--repo",
+    repoSlug,
+    "--json",
+    "comments",
+  ]);
+  if (!response.ok || !response.data || typeof response.data !== "object") return "";
+  const comments = Array.isArray(response.data.comments) ? response.data.comments : [];
+  const latest = comments.length > 0 ? comments[comments.length - 1] : null;
+  return String(latest?.body || "");
+}
+
 function buildRollingIssueComment({
   runInfo,
   summary,
@@ -807,6 +823,7 @@ function buildRollingIssueComment({
   structuralDecision,
   nextFocus,
   prUrl,
+  runMarker,
 }) {
   const lines = [];
   lines.push(`## ${runInfo.dateKey} (${runInfo.runSlot})`);
@@ -837,6 +854,8 @@ function buildRollingIssueComment({
   lines.push("");
   lines.push("### Next Observation Focus");
   nextFocus.forEach((item) => lines.push(`- ${item}`));
+  lines.push("");
+  lines.push(`<!-- ${runMarker} -->`);
   lines.push("");
   return lines.join("\n");
 }
@@ -1122,6 +1141,62 @@ async function main() {
       process.stdout.write(`skipped: ${skipped.reason}\n`);
     }
     return;
+  }
+
+  if (!options.force && options.apply && options.includeGithub) {
+    const repoSlugForDuplicateCheck = parseRepoSlug();
+    if (repoSlugForDuplicateCheck) {
+      const existingRollingResp = runGhJson([
+        "issue",
+        "list",
+        "--repo",
+        repoSlugForDuplicateCheck,
+        "--state",
+        "open",
+        "--search",
+        `"${rollingIssueTitle}" in:title`,
+        "--limit",
+        "5",
+        "--json",
+        "number,title,url",
+      ]);
+      if (existingRollingResp.ok && Array.isArray(existingRollingResp.data)) {
+        const exact = existingRollingResp.data.find((issue) => issue.title === rollingIssueTitle);
+        if (exact?.number) {
+          const runMarker = `codex-interaction-rollup-run:${runInfo.runId}`;
+          const latestRollingComment = fetchLatestIssueCommentBody(
+            repoSlugForDuplicateCheck,
+            Number(exact.number)
+          );
+          if (latestRollingComment.includes(`<!-- ${runMarker} -->`)) {
+            const skipped = {
+              status: "skipped",
+              reason: `Run ${runInfo.runId} already processed by rolling issue marker`,
+              runId: runInfo.runId,
+              timeZone: TZ,
+              rollingIssue: exact.url || null,
+            };
+            await appendToolcall({
+              actor: detectRunActor(),
+              tool: "daily-interaction",
+              action: "skip-duplicate-run-rolling",
+              ok: true,
+              durationMs: Date.now() - runStartedAt.getTime(),
+              context: {
+                runId: runInfo.runId,
+                rollingIssue: exact.url || null,
+              },
+            });
+            if (options.asJson) {
+              process.stdout.write(`${JSON.stringify(skipped, null, 2)}\n`);
+            } else {
+              process.stdout.write(`skipped: ${skipped.reason}\n`);
+            }
+            return;
+          }
+        }
+      }
+    }
   }
 
   if (options.apply && !options.allowDirty && getWorkingTreeDirty()) {
@@ -2237,26 +2312,34 @@ async function main() {
     }
 
     if (rollingIssueNumber) {
-      const comment = buildRollingIssueComment({
-        runInfo,
-        summary,
-        recommendations,
-        structuralDecision,
-        nextFocus,
-        prUrl,
-      });
-      runGh(
-        [
-          "issue",
-          "comment",
-          String(rollingIssueNumber),
-          "--repo",
-          repoSlug,
-          "--body",
-          comment,
-        ],
-        { allowFailure: true }
-      );
+      const runMarker = `codex-interaction-rollup-run:${runInfo.runId}`;
+      const latestRollingComment = fetchLatestIssueCommentBody(repoSlug, rollingIssueNumber);
+      const alreadyPosted = latestRollingComment.includes(`<!-- ${runMarker} -->`);
+      if (!alreadyPosted) {
+        const comment = buildRollingIssueComment({
+          runInfo,
+          summary,
+          recommendations,
+          structuralDecision,
+          nextFocus,
+          prUrl,
+          runMarker,
+        });
+        runGh(
+          [
+            "issue",
+            "comment",
+            String(rollingIssueNumber),
+            "--repo",
+            repoSlug,
+            "--body",
+            comment,
+          ],
+          { allowFailure: true }
+        );
+      } else {
+        notes.push("Rolling issue already has this run marker; skipped duplicate interaction rollup comment.");
+      }
     }
   } else {
     if (shouldPersist) {


### PR DESCRIPTION
## Summary
- add run-scoped rolling issue marker to interaction rollup comments
- skip duplicate runs early when rolling issue already has current run marker
- avoid duplicate rolling issue comments when rerunning the same slot

## Why
- mirrors the duplicate-run protections already in daily-improvement
- prevents interaction loop churn from reruns against the same AM/PM runId