### PR TITLE
feat(pst): thread/alias quality + continuity resume regressions

### DIFF
--- a/scripts/pst-memory-analysis-gateway.mjs
+++ b/scripts/pst-memory-analysis-gateway.mjs
@@ -506,6 +506,116 @@ function normalizeSubject(value) {
   return subject;
 }
 
+function normalizeIdentity(value) {
+  return String(value || "")
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, " ");
+}
+
+function extractAddressParts(value) {
+  const raw = String(value || "");
+  const parts = raw
+    .split(/[;,]/g)
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+  const entries = [];
+
+  for (const part of parts) {
+    const bracketMatch = part.match(/^(.*?)<([^>]+)>$/);
+    if (bracketMatch) {
+      const alias = normalizeWhitespace(bracketMatch[1] || "");
+      const email = toCanonicalEmail(bracketMatch[2] || "");
+      entries.push({ alias, email });
+      continue;
+    }
+
+    const directEmail = toCanonicalEmail(part);
+    if (directEmail) {
+      entries.push({ alias: "", email: directEmail });
+      continue;
+    }
+
+    const extracted = extractEmails(part);
+    if (extracted.length > 0) {
+      const cleanedAlias = normalizeWhitespace(part.replace(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi, ""));
+      for (const email of extracted) {
+        entries.push({ alias: cleanedAlias, email });
+      }
+      continue;
+    }
+
+    const alias = normalizeWhitespace(part.replace(/[<>"']/g, ""));
+    if (alias) {
+      entries.push({ alias, email: "" });
+    }
+  }
+
+  return entries;
+}
+
+function stripQuotedSections(value) {
+  const text = String(value || "");
+  if (!text.trim()) {
+    return {
+      body: "",
+      quoteLines: 0,
+      quotedMarkerCount: 0,
+    };
+  }
+
+  const lines = text.split(/\r?\n/);
+  const bodyLines = [];
+  let quoteLines = 0;
+  let quotedMarkerCount = 0;
+  let inQuotedBlock = false;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed && !inQuotedBlock) {
+      bodyLines.push("");
+      continue;
+    }
+
+    if (/^on .+wrote:$/i.test(trimmed) || /^from:\s.+$/i.test(trimmed) || /^-----original message-----$/i.test(trimmed)) {
+      inQuotedBlock = true;
+      quotedMarkerCount += 1;
+      quoteLines += 1;
+      continue;
+    }
+    if (/^>+/.test(trimmed)) {
+      inQuotedBlock = true;
+      quoteLines += 1;
+      continue;
+    }
+    if (inQuotedBlock && (/^(sent|to|subject|cc):\s/i.test(trimmed) || trimmed === "")) {
+      quoteLines += 1;
+      continue;
+    }
+    if (inQuotedBlock && trimmed && !/^[-_=]{2,}$/.test(trimmed)) {
+      // Continue skipping known quoted payload once quote mode started.
+      quoteLines += 1;
+      continue;
+    }
+
+    bodyLines.push(line);
+  }
+
+  return {
+    body: normalizeWhitespace(bodyLines.join(" ")),
+    quoteLines,
+    quotedMarkerCount,
+  };
+}
+
+function fingerprintText(value) {
+  return String(value || "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
 function toCanonicalEmail(value) {
   const trimmed = String(value || "").trim().toLowerCase();
   if (/^[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}$/i.test(trimmed)) {
@@ -603,29 +713,88 @@ function pairKey(a, b) {
   return [a, b].sort((left, right) => left.localeCompare(right)).join("::");
 }
 
+function buildAliasLookup(messages) {
+  const map = new Map();
+  const remember = (aliasValue, emailValue) => {
+    const alias = normalizeIdentity(aliasValue);
+    const email = toCanonicalEmail(emailValue);
+    if (!alias || !email) return;
+    map.set(alias, email);
+  };
+
+  for (const message of messages) {
+    for (const entry of message.fromAddressEntries) {
+      remember(entry.alias, entry.email);
+    }
+    for (const entry of message.toAddressEntries) {
+      remember(entry.alias, entry.email);
+    }
+  }
+  return map;
+}
+
+function canonicalizeIdentity(identity, aliasLookup) {
+  const normalized = normalizeIdentity(identity);
+  if (!normalized) return "";
+  const asEmail = toCanonicalEmail(normalized);
+  if (asEmail) return asEmail;
+  return aliasLookup.get(normalized) || normalized;
+}
+
+function buildThreadKey({ metadata, threadSubject, canonicalParticipants }) {
+  const meta = metadata && typeof metadata === "object" ? metadata : {};
+  const explicitThreadHint = normalizeWhitespace(
+    meta.threadId || meta.threadKey || meta.conversationId || meta.conversationIndex || meta.inReplyTo || meta.references
+  );
+  if (explicitThreadHint) {
+    return `conversation:${explicitThreadHint.toLowerCase()}`;
+  }
+  const subject = normalizeSubject(threadSubject || "");
+  if (subject) {
+    return `subject:${subject.toLowerCase()}`;
+  }
+  const participantAnchor = canonicalParticipants
+    .slice()
+    .sort((left, right) => left.localeCompare(right))
+    .slice(0, 4)
+    .join(",");
+  return `participants:${participantAnchor || "unknown"}`;
+}
+
 function createMessageModel(rawItem, index, maxSnippetChars) {
   const metadata = rawItem?.metadata && typeof rawItem.metadata === "object" ? rawItem.metadata : {};
-  const subject = normalizeSubject(metadata.subject || "");
+  const rawSubject = normalizeWhitespace(metadata.subject || "");
+  const subject = normalizeSubject(rawSubject || "");
   const fromRaw = String(metadata.from || "").trim();
   const toRaw = String(metadata.to || "").trim();
-  const fromEmails = extractEmails(fromRaw);
-  const toEmails = extractEmails(toRaw);
-  const participants = dedupeValues([...fromEmails, ...toEmails]);
+  const fromAddressEntries = extractAddressParts(fromRaw);
+  const toAddressEntries = extractAddressParts(toRaw);
+  const fromEmails = dedupeValues(fromAddressEntries.map((entry) => entry.email).filter(Boolean));
+  const toEmails = dedupeValues(toAddressEntries.map((entry) => entry.email).filter(Boolean));
+  const fromAliases = dedupeValues(fromAddressEntries.map((entry) => entry.alias).filter(Boolean));
+  const toAliases = dedupeValues(toAddressEntries.map((entry) => entry.alias).filter(Boolean));
+  const participants = dedupeValues([...fromEmails, ...toEmails, ...fromAliases, ...toAliases]);
 
   const content = normalizeWhitespace(rawItem?.content || "");
-  const snippet = clip(content, maxSnippetChars);
+  const quoteSplit = stripQuotedSections(rawItem?.content || "");
+  const contentCore = quoteSplit.body || content;
+  const snippet = clip(contentCore || content, maxSnippetChars);
   const date = parseDate(rawItem?.occurredAt || metadata.messageDate || rawItem?.createdAt || "");
   const dateLabel = date ? isoDate(date) : "unknown-date";
 
-  const threadSubject = subject || normalizeSubject(content.slice(0, 120));
-  const threadKey = threadSubject
-    ? `subject:${threadSubject.toLowerCase()}`
-    : `fallback:${participants.join(",") || "unknown"}:${dateLabel}`;
-  const signal = detectSignals(`${subject} ${content}`);
-  const tokens = tokenize(`${subject} ${content}`);
+  const threadSubject = subject || normalizeSubject(contentCore.slice(0, 120));
+  const signal = detectSignals(`${subject} ${contentCore}`);
+  const tokens = tokenize(`${subject} ${contentCore}`);
   const stableSourceId =
     String(rawItem?.clientRequestId || "").trim() ||
-    `raw-${stableHash(`${index}|${subject}|${content}|${fromRaw}|${toRaw}`).slice(0, 24)}`;
+    `raw-${stableHash(`${index}|${subject}|${contentCore}|${fromRaw}|${toRaw}`).slice(0, 24)}`;
+  const isReply =
+    /^(re|fw|fwd)\s*:/i.test(rawSubject) ||
+    quoteSplit.quotedMarkerCount > 0 ||
+    /(^|\s)wrote:/i.test(String(rawItem?.content || ""));
+  const nearDuplicateFingerprint = stableHash(
+    `${normalizeSubject(threadSubject)}|${fingerprintText(fromRaw || fromEmails[0] || "")}|${fingerprintText(contentCore)}`
+  ).slice(0, 32);
 
   return {
     index,
@@ -634,18 +803,33 @@ function createMessageModel(rawItem, index, maxSnippetChars) {
     subject,
     fromRaw,
     toRaw,
+    fromAddressEntries,
+    toAddressEntries,
     fromEmails,
     toEmails,
+    fromAliases,
+    toAliases,
     participants,
+    canonicalParticipants: participants,
+    canonicalSender: fromEmails[0] || normalizeIdentity(fromAliases[0] || fromRaw || "unknown"),
     content,
+    contentCore,
     snippet,
     date,
     dateLabel,
     threadSubject,
-    threadKey,
+    threadKey: buildThreadKey({
+      metadata,
+      threadSubject,
+      canonicalParticipants: participants,
+    }),
     signal,
     tokens,
     stableSourceId,
+    isReply,
+    quoteLines: quoteSplit.quoteLines,
+    quotedMarkerCount: quoteSplit.quotedMarkerCount,
+    nearDuplicateFingerprint,
   };
 }
 
@@ -691,7 +875,7 @@ function buildMessageInsights(messages, options) {
     .slice(0, options.maxMessageInsights);
 
   return candidates.map((message) => {
-    const sender = message.fromEmails[0] || normalizeWhitespace(message.fromRaw) || "unknown sender";
+    const sender = message.canonicalSender || message.fromEmails[0] || normalizeWhitespace(message.fromRaw) || "unknown sender";
     const recipients = message.toEmails.length > 0 ? message.toEmails.join(", ") : normalizeWhitespace(message.toRaw) || "unknown recipients";
     const subject = message.subject || "no subject";
     const categories = message.signal.categories.length > 0 ? message.signal.categories.join(", ") : "general";
@@ -710,6 +894,9 @@ function buildMessageInsights(messages, options) {
         subject,
         sender,
         recipients,
+        canonicalParticipants: message.canonicalParticipants.slice(0, 12),
+        replyDetected: message.isReply,
+        quoteLines: message.quoteLines,
         signalCategories: message.signal.categories,
       },
     });
@@ -746,9 +933,13 @@ function buildThreadSummaries(messages, options) {
       timeline: 0,
     };
     let threadScore = 0;
+    let replyMessageCount = 0;
+    let quoteLinkedMessages = 0;
 
     for (const message of sorted) {
       threadScore += message.signal.score;
+      if (message.isReply) replyMessageCount += 1;
+      if (message.quoteLines > 0 || message.quotedMarkerCount > 0) quoteLinkedMessages += 1;
       for (const category of message.signal.categories) {
         if (Object.prototype.hasOwnProperty.call(signals, category)) {
           signals[category] += 1;
@@ -758,7 +949,7 @@ function buildThreadSummaries(messages, options) {
 
     const bestMessage = [...sorted].sort((a, b) => b.signal.score - a.signal.score)[0];
     const subject = first.threadSubject || "Untitled thread";
-    const content = `Email thread "${subject}" ran ${first.dateLabel} to ${last.dateLabel} with ${sorted.length} messages across ${allParticipants.length} participants (${formatParticipantList(allParticipants)}). Themes: ${
+    const content = `Email thread "${subject}" ran ${first.dateLabel} to ${last.dateLabel} with ${sorted.length} messages across ${allParticipants.length} participants (${formatParticipantList(allParticipants)}). Reply continuity: ${replyMessageCount} replies, ${quoteLinkedMessages} quote-linked messages. Themes: ${
       topTerms.length > 0 ? topTerms.join(", ") : "mixed discussion"
     }. Signal mix: ${signals.decision} decision, ${signals.action} action, ${signals.risk} risk cues. Key takeaway: ${bestMessage.snippet}`;
 
@@ -777,6 +968,9 @@ function buildThreadSummaries(messages, options) {
           messageCount: sorted.length,
           participantCount: allParticipants.length,
           participants: allParticipants.slice(0, 12),
+          canonicalParticipants: allParticipants.slice(0, 12),
+          replyMessageCount,
+          quoteLinkedMessages,
           signalMix: signals,
           themes: topTerms,
           sourceClientRequestIds: sorted.map((message) => message.stableSourceId).slice(0, 50),
@@ -1089,17 +1283,45 @@ function main() {
   const rawEntries = readJsonl(inputPath);
   const messagesPreDedup = rawEntries.map((entry, index) => createMessageModel(entry, index, options.maxSnippetChars));
 
+  const aliasLookup = buildAliasLookup(messagesPreDedup);
+  for (const message of messagesPreDedup) {
+    const canonicalParticipants = dedupeValues(
+      message.participants
+        .map((participant) => canonicalizeIdentity(participant, aliasLookup))
+        .filter(Boolean)
+    );
+    const canonicalSender =
+      canonicalizeIdentity(
+        message.fromEmails[0] || message.fromAliases[0] || message.fromRaw || "unknown",
+        aliasLookup
+      ) || "unknown";
+    message.canonicalParticipants = canonicalParticipants.length > 0 ? canonicalParticipants : message.participants;
+    message.canonicalSender = canonicalSender;
+    message.threadKey = buildThreadKey({
+      metadata: message.metadata,
+      threadSubject: message.threadSubject,
+      canonicalParticipants: message.canonicalParticipants,
+    });
+    message.nearDuplicateFingerprint = stableHash(
+      `${message.threadKey}|${message.canonicalSender}|${fingerprintText(message.contentCore)}`
+    ).slice(0, 32);
+  }
+
   const messageByStableId = new Map();
   for (const message of messagesPreDedup) {
     if (!message.content) continue;
-    const existing = messageByStableId.get(message.stableSourceId);
+    const dedupeKey = `${message.stableSourceId}|${message.nearDuplicateFingerprint}`;
+    const existing = messageByStableId.get(dedupeKey);
     if (!existing) {
-      messageByStableId.set(message.stableSourceId, message);
+      messageByStableId.set(dedupeKey, message);
       continue;
     }
-    const existingScore = existing.signal.score;
-    if (message.signal.score > existingScore) {
-      messageByStableId.set(message.stableSourceId, message);
+    const existingScore = Number(existing.signal?.score || 0);
+    const incomingScore = Number(message.signal?.score || 0);
+    const existingBody = Number(existing.contentCore?.length || 0);
+    const incomingBody = Number(message.contentCore?.length || 0);
+    if (incomingScore > existingScore || (incomingScore === existingScore && incomingBody > existingBody)) {
+      messageByStableId.set(dedupeKey, message);
     }
   }
   const messages = [...messageByStableId.values()];
@@ -1131,6 +1353,7 @@ function main() {
       parsedMessages: messages.length,
       highSignalMessages: highSignalMessageCount,
       uniqueThreads: uniqueThreadCount,
+      aliasLinksResolved: Array.from(aliasLookup.entries()).length,
       analyzedMemoriesWritten: finalRows.length,
       ingestionReductionRatio:
         rawEntries.length > 0 ? Number((finalRows.length / rawEntries.length).toFixed(4)) : 0,

--- a/scripts/pst-memory-analysis-gateway.test.mjs
+++ b/scripts/pst-memory-analysis-gateway.test.mjs
@@ -172,3 +172,115 @@ test("pst-memory-analysis-gateway returns non-zero when input file is missing", 
     rmSync(tempDir, { recursive: true, force: true });
   }
 });
+
+test("pst-memory-analysis-gateway stitches reply chains, collapses near-duplicates, and normalizes aliases", () => {
+  const tempDir = mkdtempSync(join(tmpdir(), "pst-analysis-gateway-alias-"));
+  try {
+    const inputPath = join(tempDir, "input.jsonl");
+    const outputPath = join(tempDir, "output.jsonl");
+    const reportPath = join(tempDir, "report.json");
+
+    writeJsonl(inputPath, [
+      {
+        content:
+          "Launch thread kickoff. Decision: ship Friday if QA passes. Action item: Sam validates checklist.",
+        source: "pst:libratom",
+        metadata: {
+          subject: "Studio Launch Decision",
+          from: "Micah <wuff@example.com>",
+          to: "Sam <sam@example.com>",
+          messageDate: "2026-02-20T10:00:00Z",
+        },
+        clientRequestId: "alias-1",
+        occurredAt: "2026-02-20T10:00:00Z",
+      },
+      {
+        content:
+          "Reconfirming Friday launch once QA clears.\n\nOn Thu, Feb 20, 2026 at 10:00 AM Micah <wuff@example.com> wrote:\n> Launch thread kickoff. Decision: ship Friday if QA passes.",
+        source: "pst:libratom",
+        metadata: {
+          subject: "Re: Studio Launch Decision",
+          from: "wuff@EXAMPLE.com",
+          to: "sam@example.com",
+          messageDate: "2026-02-21T09:00:00Z",
+        },
+        clientRequestId: "alias-2",
+        occurredAt: "2026-02-21T09:00:00Z",
+      },
+      {
+        content:
+          "Reconfirming Friday launch once QA clears. On Thu, Feb 20, 2026 Micah wrote: > Launch thread kickoff. Decision: ship Friday if QA passes.",
+        source: "pst:libratom",
+        metadata: {
+          subject: "Re: Studio Launch Decision",
+          from: "Wuff <wuff@example.com>",
+          to: "Sammy <sam@example.com>",
+          messageDate: "2026-02-21T09:01:00Z",
+        },
+        clientRequestId: "alias-3",
+        occurredAt: "2026-02-21T09:01:00Z",
+      },
+      {
+        content:
+          "Following up: QA passed and we keep Friday launch. Next step: publish checklist.",
+        source: "pst:libratom",
+        metadata: {
+          subject: "Re: Studio Launch Decision",
+          from: "sammy <sam@example.com>",
+          to: "wuff@example.com",
+          messageDate: "2026-02-22T12:00:00Z",
+        },
+        clientRequestId: "alias-4",
+        occurredAt: "2026-02-22T12:00:00Z",
+      },
+    ]);
+
+    const result = runGateway([
+      "--input",
+      inputPath,
+      "--output",
+      outputPath,
+      "--report",
+      reportPath,
+      "--min-thread-messages",
+      "2",
+      "--max-output",
+      "20",
+      "--max-message-insights",
+      "10",
+      "--max-thread-summaries",
+      "5",
+      "--max-contact-facts",
+      "5",
+      "--max-trend-summaries",
+      "3",
+      "--max-correlations",
+      "2",
+    ]);
+
+    assert.equal(result.status, 0, result.stderr || "gateway alias run should succeed");
+    const report = parseJson(result.stdout);
+    assert.equal(report.status, "ok");
+    assert.equal(report.summary.rawInputRows, 4);
+    assert.ok(report.summary.parsedMessages <= 4);
+    assert.ok(Number(report.summary.aliasLinksResolved || 0) >= 2);
+
+    const outputRows = readFileSync(outputPath, "utf8")
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line) => JSON.parse(line));
+
+    const threadSummary = outputRows.find((row) => row?.metadata?.analysisType === "thread_summary");
+    assert.ok(threadSummary, "thread summary should exist");
+    assert.ok(Number(threadSummary.metadata?.replyMessageCount || 0) >= 1);
+    assert.ok(Number(threadSummary.metadata?.quoteLinkedMessages || 0) >= 1);
+    const participants = Array.isArray(threadSummary.metadata?.canonicalParticipants)
+      ? threadSummary.metadata.canonicalParticipants
+      : [];
+    assert.ok(participants.includes("wuff@example.com"));
+    assert.ok(participants.includes("sam@example.com"));
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});

--- a/scripts/pst-memory-continuity-flow.test.mjs
+++ b/scripts/pst-memory-continuity-flow.test.mjs
@@ -43,6 +43,28 @@ test("pst continuity flow reconstructs thread context, cross-links, and handoff 
     const promotedOutputPath = join(tempDir, "promoted.jsonl");
     const promotedDeadLetterPath = join(tempDir, "promoted-dead.jsonl");
     const promotedReportPath = join(tempDir, "promoted-report.json");
+    const importCheckpointPath = join(tempDir, "import-checkpoint.json");
+    const importLedgerPath = join(tempDir, "import-ledger.jsonl");
+    const importDeadLetterPath = join(tempDir, "import-dead.jsonl");
+    const importReportPath = join(tempDir, "import-report.json");
+    const mockOpenMemoryPath = join(tempDir, "mock-open-memory.mjs");
+    const continuityArtifactPath = join(tempDir, "continuity.json");
+
+    writeFileSync(
+      mockOpenMemoryPath,
+      `#!/usr/bin/env node
+const fs = await import("node:fs");
+const args = process.argv.slice(2);
+if (args[0] !== "import") {
+  process.stderr.write("unsupported command\\n");
+  process.exit(1);
+}
+const inputIndex = args.indexOf("--input");
+const inputPath = inputIndex >= 0 ? args[inputIndex + 1] : "";
+const lines = fs.readFileSync(inputPath, "utf8").split(/\\r?\\n/).map((line) => line.trim()).filter(Boolean);
+process.stdout.write(JSON.stringify({ ok: true, result: { total: lines.length, imported: lines.length, failed: 0 } }) + "\\n");
+`
+    );
 
     writeJsonl(inputPath, [
       {
@@ -143,6 +165,31 @@ test("pst continuity flow reconstructs thread context, cross-links, and handoff 
     );
     assert.ok(hasCrossLinks, "promoted rows should include cross-reference links");
 
+    const importResult = runNode([
+      "./scripts/pst-memory-import-resumable.mjs",
+      "--json",
+      "--input",
+      promotedOutputPath,
+      "--run-id",
+      "pst-continuity-flow-test",
+      "--chunk-size",
+      "2",
+      "--checkpoint",
+      importCheckpointPath,
+      "--ledger",
+      importLedgerPath,
+      "--dead-letter",
+      importDeadLetterPath,
+      "--report",
+      importReportPath,
+      "--open-memory-script",
+      mockOpenMemoryPath,
+    ]);
+    assert.equal(importResult.status, 0, importResult.stderr || "import resumable should succeed");
+    const importPayload = JSON.parse(String(importResult.stdout || "{}"));
+    assert.equal(importPayload.progress.completed, true);
+    assert.ok(Number(importPayload.totals.imported || 0) >= 2);
+
     const continuity = buildContinuityArtifact({
       runId: "pst-continuity-flow-test",
       promotedRows,
@@ -152,6 +199,7 @@ test("pst continuity flow reconstructs thread context, cross-links, and handoff 
       handoffTargetShellId: "shell-target",
       resumeHints: ["launch-thread", "qa-blocker"],
     });
+    writeFileSync(continuityArtifactPath, `${JSON.stringify(continuity, null, 2)}\n`, "utf8");
     assert.equal(continuity.activeHandoff.handoffOwner, "agent:codex");
     assert.equal(continuity.activeHandoff.handoffSourceShellId, "shell-source");
     assert.equal(continuity.activeHandoff.handoffTargetShellId, "shell-target");
@@ -175,6 +223,20 @@ test("pst continuity flow reconstructs thread context, cross-links, and handoff 
     assert.equal(monitoring.schema, "pst-memory-relationship-monitor.v1");
     assert.ok(Array.isArray(monitoring.alerts) && monitoring.alerts.length >= 5);
     assert.ok(["ok", "warn", "critical"].includes(String(monitoring.status)));
+
+    const smokeResult = runNode([
+      "./scripts/pst-memory-continuity-smoke.mjs",
+      "--json",
+      "--strict",
+      "--max-runtime-ms",
+      "5000",
+      "--artifact",
+      continuityArtifactPath,
+    ]);
+    assert.equal(smokeResult.status, 0, smokeResult.stderr || "continuity smoke should pass");
+    const smokePayload = JSON.parse(String(smokeResult.stdout || "{}"));
+    assert.equal(smokePayload.status, "pass");
+    assert.ok(Number(smokePayload.runtimeMs || 0) <= Number(smokePayload.runtimeBudgetMs || 0));
   } finally {
     rmSync(tempDir, { recursive: true, force: true });
   }

--- a/scripts/pst-memory-continuity-smoke.mjs
+++ b/scripts/pst-memory-continuity-smoke.mjs
@@ -13,6 +13,7 @@ function parseArgs(argv) {
     artifact: resolve(REPO_ROOT, "./output/memory/continuity/latest.json"),
     strict: false,
     asJson: false,
+    maxRuntimeMs: 5000,
   };
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
@@ -34,6 +35,21 @@ function parseArgs(argv) {
       options.artifact = resolve(REPO_ROOT, arg.slice("--artifact=".length));
       continue;
     }
+    if (arg === "--max-runtime-ms" && argv[index + 1]) {
+      const parsed = Number(argv[index + 1]);
+      if (Number.isFinite(parsed) && parsed > 0) {
+        options.maxRuntimeMs = Math.trunc(parsed);
+      }
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith("--max-runtime-ms=")) {
+      const parsed = Number(arg.slice("--max-runtime-ms=".length));
+      if (Number.isFinite(parsed) && parsed > 0) {
+        options.maxRuntimeMs = Math.trunc(parsed);
+      }
+      continue;
+    }
   }
   return options;
 }
@@ -48,6 +64,7 @@ function normalize(value) {
 }
 
 function run() {
+  const startedAtMs = Date.now();
   const options = parseArgs(process.argv.slice(2));
   const artifact = parseArtifact(options.artifact);
 
@@ -86,11 +103,21 @@ function run() {
 
   const topWorkstream = normalize(workstreams[0]?.workstream) || "n/a";
   const latestIntent = normalize(recentIntentTrajectory[0]?.summary) || "n/a";
+  const runtimeMs = Date.now() - startedAtMs;
+  const runtimeCheck = {
+    id: "runtime-budget",
+    ok: runtimeMs <= options.maxRuntimeMs,
+    detail: `runtime ${runtimeMs}ms (budget ${options.maxRuntimeMs}ms)`,
+  };
+  checks.push(runtimeCheck);
+
   const summary = {
     status: checks.every((check) => check.ok) ? "pass" : "warn",
     runId: normalize(artifact?.runId) || null,
     generatedAt: normalize(artifact?.generatedAt) || null,
     artifact: options.artifact,
+    runtimeMs,
+    runtimeBudgetMs: options.maxRuntimeMs,
     checks,
     resumeInProgress: {
       owner: normalize(handoff.handoffOwner) || null,
@@ -116,6 +143,7 @@ function run() {
     process.stdout.write(`- target shell: ${summary.resumeInProgress.targetShell || "n/a"}\n`);
     process.stdout.write(`- top workstream: ${summary.resumeInProgress.topWorkstream}\n`);
     process.stdout.write(`- latest intent: ${summary.resumeInProgress.latestIntent}\n`);
+    process.stdout.write(`- runtime: ${summary.runtimeMs}ms (budget ${summary.runtimeBudgetMs}ms)\n`);
     process.stdout.write(
       `- resume hints: ${summary.resumeInProgress.resumeHints.length > 0 ? summary.resumeInProgress.resumeHints.join(", ") : "n/a"}\n`
     );

--- a/scripts/pst-memory-import-resumable.test.mjs
+++ b/scripts/pst-memory-import-resumable.test.mjs
@@ -2,12 +2,17 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
-import { join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const REPO_ROOT = resolve(__dirname, "..");
 
 function runImport(args) {
   return spawnSync("node", ["./scripts/pst-memory-import-resumable.mjs", "--json", ...args], {
-    cwd: "/home/wuff/monsoonfire-portal",
+    cwd: REPO_ROOT,
     encoding: "utf8",
   });
 }
@@ -145,7 +150,7 @@ process.stdout.write(JSON.stringify({ ok: true, result: { total: lines.length, i
         mockScriptPath,
       ],
       {
-        cwd: "/home/wuff/monsoonfire-portal",
+        cwd: REPO_ROOT,
         encoding: "utf8",
         env: {
           ...process.env,
@@ -232,6 +237,167 @@ echo "{\\"ok\\":true,\\"result\\":{\\"total\\":$count,\\"imported\\":$count,\\"f
     const payload = JSON.parse(String(result.stdout || "{}"));
     assert.equal(payload.progress.completed, true);
     assert.equal(payload.totals.imported, 3);
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("pst-memory-import-resumable resumes from checkpoint without duplicating imported rows", () => {
+  const tempDir = mkdtempSync(join(tmpdir(), "pst-import-resume-idempotent-"));
+  try {
+    const inputPath = join(tempDir, "promoted.jsonl");
+    const checkpointPath = join(tempDir, "checkpoint.json");
+    const ledgerPath = join(tempDir, "ledger.jsonl");
+    const deadLetterPath = join(tempDir, "dead.jsonl");
+    const reportPath = join(tempDir, "report.json");
+    const failScriptPath = join(tempDir, "mock-open-memory-fail-second-chunk.mjs");
+    const successScriptPath = join(tempDir, "mock-open-memory-success.mjs");
+    const importStatePath = join(tempDir, "import-state.json");
+
+    const rows = new Array(5).fill(0).map((_, idx) => ({
+      content: `Resume Row ${idx + 1}`,
+      source: "pst:promoted-memory",
+      tags: ["test"],
+      metadata: { idx },
+      clientRequestId: `resume-${idx + 1}`,
+    }));
+    writeFileSync(inputPath, `${rows.map((row) => JSON.stringify(row)).join("\n")}\n`, "utf8");
+    writeFileSync(importStatePath, JSON.stringify({ imported: {} }), "utf8");
+
+    writeFileSync(
+      failScriptPath,
+      `#!/usr/bin/env node
+const fs = await import("node:fs");
+const args = process.argv.slice(2);
+if (args[0] !== "import") process.exit(1);
+const inputIndex = args.indexOf("--input");
+const inputPath = inputIndex >= 0 ? args[inputIndex + 1] : "";
+const rawLines = fs.readFileSync(inputPath, "utf8").split(/\\r?\\n/).map((line) => line.trim()).filter(Boolean);
+const rows = rawLines.map((line) => JSON.parse(line));
+if (rows.some((row) => String(row.clientRequestId || "") === "resume-3")) {
+  process.stderr.write("forced chunk failure for resume validation\\n");
+  process.exit(1);
+}
+const statePath = process.env.MOCK_IMPORT_STATE_PATH;
+const state = JSON.parse(fs.readFileSync(statePath, "utf8"));
+for (const row of rows) {
+  const key = String(row.clientRequestId || "");
+  state.imported[key] = Number(state.imported[key] || 0) + 1;
+}
+fs.writeFileSync(statePath, JSON.stringify(state), "utf8");
+process.stdout.write(JSON.stringify({ ok: true, result: { total: rows.length, imported: rows.length, failed: 0 } }) + "\\n");
+`
+    );
+
+    writeFileSync(
+      successScriptPath,
+      `#!/usr/bin/env node
+const fs = await import("node:fs");
+const args = process.argv.slice(2);
+if (args[0] !== "import") process.exit(1);
+const inputIndex = args.indexOf("--input");
+const inputPath = inputIndex >= 0 ? args[inputIndex + 1] : "";
+const rawLines = fs.readFileSync(inputPath, "utf8").split(/\\r?\\n/).map((line) => line.trim()).filter(Boolean);
+const rows = rawLines.map((line) => JSON.parse(line));
+const statePath = process.env.MOCK_IMPORT_STATE_PATH;
+const state = JSON.parse(fs.readFileSync(statePath, "utf8"));
+for (const row of rows) {
+  const key = String(row.clientRequestId || "");
+  state.imported[key] = Number(state.imported[key] || 0) + 1;
+}
+fs.writeFileSync(statePath, JSON.stringify(state), "utf8");
+process.stdout.write(JSON.stringify({ ok: true, result: { total: rows.length, imported: rows.length, failed: 0 } }) + "\\n");
+`
+    );
+
+    const firstRun = spawnSync(
+      "node",
+      [
+        "./scripts/pst-memory-import-resumable.mjs",
+        "--json",
+        "--input",
+        inputPath,
+        "--run-id",
+        "test-run-resume-idempotent",
+        "--chunk-size",
+        "2",
+        "--max-retries",
+        "0",
+        "--continue-on-error",
+        "false",
+        "--checkpoint",
+        checkpointPath,
+        "--ledger",
+        ledgerPath,
+        "--dead-letter",
+        deadLetterPath,
+        "--report",
+        reportPath,
+        "--open-memory-script",
+        failScriptPath,
+      ],
+      {
+        cwd: REPO_ROOT,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          MOCK_IMPORT_STATE_PATH: importStatePath,
+        },
+      }
+    );
+
+    assert.equal(firstRun.status, 1, "first run should stop on forced chunk failure");
+    const checkpointAfterFirstRun = JSON.parse(readFileSync(checkpointPath, "utf8"));
+    assert.equal(checkpointAfterFirstRun.nextIndex, 2, "checkpoint should persist completed first chunk");
+
+    const secondRun = spawnSync(
+      "node",
+      [
+        "./scripts/pst-memory-import-resumable.mjs",
+        "--json",
+        "--input",
+        inputPath,
+        "--run-id",
+        "test-run-resume-idempotent",
+        "--chunk-size",
+        "2",
+        "--max-retries",
+        "0",
+        "--continue-on-error",
+        "false",
+        "--checkpoint",
+        checkpointPath,
+        "--ledger",
+        ledgerPath,
+        "--dead-letter",
+        deadLetterPath,
+        "--report",
+        reportPath,
+        "--open-memory-script",
+        successScriptPath,
+      ],
+      {
+        cwd: REPO_ROOT,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          MOCK_IMPORT_STATE_PATH: importStatePath,
+        },
+      }
+    );
+
+    assert.equal(secondRun.status, 0, secondRun.stderr || "second run should resume and complete");
+    const payload = JSON.parse(String(secondRun.stdout || "{}"));
+    assert.equal(payload.progress.completed, true);
+    assert.equal(payload.progress.nextIndex, 5);
+
+    const finalState = JSON.parse(readFileSync(importStatePath, "utf8"));
+    const importedCounts = finalState.imported || {};
+    assert.equal(importedCounts["resume-1"], 1);
+    assert.equal(importedCounts["resume-2"], 1);
+    assert.equal(importedCounts["resume-3"], 1);
+    assert.equal(importedCounts["resume-4"], 1);
+    assert.equal(importedCounts["resume-5"], 1);
   } finally {
     rmSync(tempDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- improve PST analysis gateway quality for thread continuity and identity normalization:
  - reply/quote-aware body extraction
  - alias-to-email identity canonicalization
  - conversation-aware thread key derivation
  - near-duplicate collapse using canonical sender + body fingerprint
  - richer thread metadata (`replyMessageCount`, `quoteLinkedMessages`, canonical participants)
- extend PST regression coverage:
  - alias/reply-chain/near-duplicate behavior assertions in analysis gateway tests
  - continuity flow now includes resumable import stage and restart smoke consumption checks
- harden continuity smoke output with runtime budget reporting (`runtimeMs`, `runtimeBudgetMs`, runtime-budget check)
- add resumable import idempotency regression proving checkpoint resume does not duplicate imported rows

## Issues
- Closes #234
- Closes #235
