### PR TITLE
Codex Continuous Improvement 2026-03-04-AM (clean replay)

### DIFF
--- a/docs/runbooks/codex-improvement/2026-03-04-AM.md
+++ b/docs/runbooks/codex-improvement/2026-03-04-AM.md
@@ -3,12 +3,12 @@
 ## Evidence Summary
 - Window (primary): last 12h
 - Window (rollup): last 24h
-- Commits (24h): 28
-- CI failures (24h): 0
+- Commits (24h): 4
+- CI failures (24h): 7
 - Tool failure rate (24h): 0.0%
 
 ## What Changed
-- Address skill density spikes with structural guardrails
+- Stabilize repeated CI failure signature
 
 ## Why
 - Reduce recurring failures and noisy churn with small, targeted interventions.
@@ -27,14 +27,13 @@
 5. Verify branch name format and labels in created/updated PR.
 
 ## Tickets Created
-- https://github.com/monsoonfirepottery-byte/monsoonfire-portal/issues/125
+- https://github.com/monsoonfirepottery-byte/monsoonfire-portal/issues/240
 
 ## Next 12h Focus
 - Triage new failure clusters and convert top items into scoped tickets.
 - Land low-risk guardrails (lint/test/check scripts) for highest-frequency failures.
 - Verify metadata/config churn has explicit owner and rollback notes.
-- Address top recommendation first: Address skill density spikes with structural guardrails.
-- Apply structural guardrail tightening in this run and validate over next 2-3 runs.
+- Address top recommendation first: Stabilize repeated CI failure signature.
 
 ## PR Link
 - pending


### PR DESCRIPTION
Clean replay of the surviving improvement delta from #241 on top of latest `main`.

Notes:
- `document portal secret rotation policy` commit from #241 was already present on `main`.
- This PR carries the remaining `2026-03-04-AM` codex-improvement markdown update.

Supersedes #241.
