### PR TITLE
fix(codex): cut churn noise in daily improvement recommendations

### DIFF
--- a/scripts/codex/daily-improvement.mjs
+++ b/scripts/codex/daily-improvement.mjs
@@ -50,6 +50,7 @@ const metadataMatchers = [
 const automationSelfChurnMatchers = [
   /^scripts\/codex\/daily-improvement\.mjs$/,
   /^scripts\/codex\/backlog-autopilot\.mjs$/,
+  /^docs\/runbooks\/codex-improvement\/[^/]+\.md$/,
 ];
 
 const secretKeyPattern = /(token|secret|password|authorization|api[_-]?key|cookie|session|private[_-]?key)/i;

--- a/scripts/portal-automation-issue-loop.mjs
+++ b/scripts/portal-automation-issue-loop.mjs
@@ -413,6 +413,15 @@ function signaturePriorityScore(signature) {
   return score;
 }
 
+function buildRollingMarkerCandidates(config) {
+  const markerHash = stableHash(config?.signaturePayload || {});
+  const prefixes = [config?.markerPrefix, ...(Array.isArray(config?.markerAliases) ? config.markerAliases : [])]
+    .map((value) => String(value || "").trim())
+    .filter(Boolean);
+  const uniquePrefixes = Array.from(new Set(prefixes));
+  return uniquePrefixes.map((prefix) => `${prefix}:${markerHash}`);
+}
+
 function selectSignatures(rawSignatures, options) {
   const withThreshold = (Array.isArray(rawSignatures) ? rawSignatures : []).filter(
     (entry) => Number(entry?.count || 0) >= options.repeatedThreshold
@@ -677,10 +686,7 @@ async function main() {
   ];
 
   for (const config of rollingConfigs) {
-    const markerHash = stableHash(config.signaturePayload);
-    const markerCandidates = [config.markerPrefix, ...(config.markerAliases || [])].map(
-      (prefix) => `${prefix}:${markerHash}`
-    );
+    const markerCandidates = buildRollingMarkerCandidates(config);
     const marker = markerCandidates[0];
     const commentBody = config.buildComment(marker);
     const existing = findIssueByTitle(repoSlug, config.title);


### PR DESCRIPTION
## Summary
- factor rolling-marker candidate construction in portal automation issue loop to centralize marker alias behavior
- suppress churn recommendations for generated codex improvement runbook markdown paths

## Why
This addresses recurring churn recommendations that were mostly automation self-noise and repeatedly reopening low-value tickets.

## Issue Coverage
- closes #253
- closes #254