### PR TITLE
feat(ga): add roadmap live-execution unblock pack

### DIFF
--- a/docs/analytics/WEBSITE_GA_LIVE_EXECUTION_HANDOFF_TEMPLATE.md
+++ b/docs/analytics/WEBSITE_GA_LIVE_EXECUTION_HANDOFF_TEMPLATE.md
@@ -1,0 +1,54 @@
+# Website GA Live Execution Handoff Template
+
+Use this template when owner-side GA exports and live experiment outcomes are available.
+
+## Snapshot metadata
+- Retrieval date (UTC):
+- GA property:
+- Export owner:
+- Reporting window start (UTC):
+- Reporting window end (UTC):
+
+## Source artifacts (owner environment)
+- Top acquisition channels export path:
+- Landing pages export path:
+- Path-to-conversion export path:
+- Event audit export path:
+- Goal table export path:
+- Weekly dashboard export path:
+
+## Experiment execution log (minimum two)
+
+### Experiment 1
+- Hypothesis:
+- Segment:
+- Start date (UTC):
+- End date (UTC):
+- Direction result (`win`, `loss`, `inconclusive`):
+- Estimated lift or decline (%):
+- Decision:
+
+### Experiment 2
+- Hypothesis:
+- Segment:
+- Start date (UTC):
+- End date (UTC):
+- Direction result (`win`, `loss`, `inconclusive`):
+- Estimated lift or decline (%):
+- Decision:
+
+## Day-30 readout
+- Top three conversion blockers:
+- Owners assigned:
+- Wins:
+- Losses:
+- Next-quarter backlog (top five):
+
+## Command checklist
+1. `npm run website:ga:data-package:check -- --strict`
+2. `npm run website:ga:baseline:report -- --strict`
+3. `npm run website:ga:funnel:report -- --strict`
+4. `npm run website:ga:experiments:backlog -- --strict`
+5. `npm run website:ga:content:opportunities -- --strict`
+6. `npm run website:ga:dashboard:weekly -- --strict`
+7. `npm run website:ga:roadmap:readiness -- --strict`

--- a/docs/runbooks/WEBSITE_GA_30_DAY_EXECUTION_HANDOFF.md
+++ b/docs/runbooks/WEBSITE_GA_30_DAY_EXECUTION_HANDOFF.md
@@ -1,0 +1,46 @@
+# Website GA 30-Day Execution Handoff
+
+## Purpose
+Provide a deterministic handoff path so Sprint 1-4 GA automation can be executed quickly once owner-side live exports and experiment outcomes are available.
+
+## Scope
+- Ticket: `tickets/P1-website-ga-30-day-priority-roadmap.md`
+- Verification command: `npm run website:ga:roadmap:readiness -- --strict`
+- Handoff template: `docs/analytics/WEBSITE_GA_LIVE_EXECUTION_HANDOFF_TEMPLATE.md`
+
+## Pre-flight (owner environment)
+1. Confirm GA export permissions for the production property.
+2. Confirm at least two live experiment windows are complete.
+3. Prepare a dated working folder under `artifacts/ga/baseline/<YYYY-MM-DD>/`.
+4. Copy and fill `docs/analytics/WEBSITE_GA_LIVE_EXECUTION_HANDOFF_TEMPLATE.md`.
+
+## Required owner-provided inputs
+1. `top-acquisition-channels.csv`
+2. `landing-pages.csv`
+3. `path-to-conversion.csv`
+4. `event-audit.csv`
+5. `goal-table.csv`
+6. Weekly KPI source export
+7. Completed handoff template fields for two live experiments
+
+## Execution sequence
+1. `npm run website:ga:data-package:check -- --strict`
+2. `npm run website:ga:baseline:report -- --strict`
+3. `npm run website:ga:funnel:report -- --strict`
+4. `npm run website:ga:experiments:backlog -- --strict`
+5. `npm run website:ga:content:opportunities -- --strict`
+6. `npm run website:ga:dashboard:weekly -- --strict`
+7. `npm run website:ga:roadmap:readiness -- --strict`
+
+## Expected outputs
+- `artifacts/ga/reports/website-ga-data-package-check-latest.json`
+- `artifacts/ga/reports/website-ga-acquisition-quality-latest.json`
+- `artifacts/ga/reports/website-ga-funnel-friction-latest.json`
+- `artifacts/ga/reports/website-ga-experiment-backlog-latest.json`
+- `artifacts/ga/reports/website-ga-content-opportunities-latest.json`
+- `artifacts/ga/reports/website-ga-weekly-dashboard-latest.json`
+
+## Close conditions for roadmap ticket
+1. Two live experiments completed with direction decisions.
+2. Day-30 wins/losses and next-quarter backlog recorded in handoff template.
+3. Conversion blocker owners assigned.

--- a/scripts/check-website-ga-roadmap-readiness.mjs
+++ b/scripts/check-website-ga-roadmap-readiness.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+
+/* eslint-disable no-console */
+
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const repoRoot = process.cwd();
+const args = new Set(process.argv.slice(2));
+const asJson = args.has("--json");
+const strict = args.has("--strict");
+
+const checks = [];
+
+function readUtf8(path) {
+  return readFileSync(resolve(repoRoot, path), "utf8");
+}
+
+function addCheck(ok, key, message, details = null) {
+  checks.push({ ok, key, message, details });
+}
+
+function checkFile(path, patterns, key, message) {
+  if (!existsSync(resolve(repoRoot, path))) {
+    addCheck(false, key, `${message} (missing file)`, { path });
+    return;
+  }
+  const source = readUtf8(path);
+  const ok = patterns.every((pattern) => source.includes(pattern));
+  addCheck(ok, key, message, { path, requiredPatterns: patterns });
+}
+
+checkFile(
+  "package.json",
+  ['"website:ga:roadmap:readiness"', "check-website-ga-roadmap-readiness.mjs"],
+  "package-script",
+  "Package command exists for roadmap readiness validation"
+);
+
+checkFile(
+  "tickets/P1-website-ga-30-day-priority-roadmap.md",
+  [
+    "Roadmap unblock pack update (2026-03-04)",
+    "docs/runbooks/WEBSITE_GA_30_DAY_EXECUTION_HANDOFF.md",
+    "docs/analytics/WEBSITE_GA_LIVE_EXECUTION_HANDOFF_TEMPLATE.md",
+    "website:ga:roadmap:readiness",
+    "Remaining external blockers",
+  ],
+  "roadmap-ticket",
+  "Roadmap ticket captures unblock pack + explicit remaining external blockers"
+);
+
+checkFile(
+  "docs/runbooks/WEBSITE_GA_30_DAY_EXECUTION_HANDOFF.md",
+  [
+    "Purpose",
+    "Pre-flight (owner environment)",
+    "Required owner-provided inputs",
+    "Execution sequence",
+    "Close conditions for roadmap ticket",
+  ],
+  "handoff-runbook",
+  "30-day execution handoff runbook exists with operator sequence"
+);
+
+checkFile(
+  "docs/analytics/WEBSITE_GA_LIVE_EXECUTION_HANDOFF_TEMPLATE.md",
+  [
+    "Snapshot metadata",
+    "Experiment 1",
+    "Experiment 2",
+    "Day-30 readout",
+    "Command checklist",
+  ],
+  "handoff-template",
+  "Live execution handoff template captures owner-provided inputs and experiment outcomes"
+);
+
+const failed = checks.filter((check) => !check.ok);
+const result = {
+  ok: failed.length === 0,
+  strict,
+  failed: failed.length,
+  checks,
+};
+
+if (asJson) {
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+} else {
+  for (const check of checks) {
+    process.stdout.write(`${check.ok ? "PASS" : "FAIL"} ${check.key}: ${check.message}\n`);
+  }
+}
+
+if (failed.length > 0) {
+  process.exit(1);
+}

--- a/tickets/P1-website-ga-30-day-priority-roadmap.md
+++ b/tickets/P1-website-ga-30-day-priority-roadmap.md
@@ -127,3 +127,15 @@ Sprint 4 completion update (2026-02-28):
   - run monthly/weekly operating cadence against real GA exports,
   - ship and evaluate at least 2 live experiments,
   - post day-30 wins/losses and next-quarter backlog outcomes.
+
+## Roadmap unblock pack update (2026-03-04)
+- Added deterministic owner-handoff assets for live execution:
+  - `docs/runbooks/WEBSITE_GA_30_DAY_EXECUTION_HANDOFF.md`
+  - `docs/analytics/WEBSITE_GA_LIVE_EXECUTION_HANDOFF_TEMPLATE.md`
+  - `scripts/check-website-ga-roadmap-readiness.mjs`
+- Added readiness verification command:
+  - `npm run website:ga:roadmap:readiness -- --strict`
+- This does not remove the external dependency. It reduces restart friction once owner-side access/data is available.
+- Remaining external blockers:
+  - live GA property export access in owner environment
+  - live-traffic experiment windows and outcome data


### PR DESCRIPTION
## Summary
- add missing `scripts/check-website-ga-roadmap-readiness.mjs` implementation for existing package command
- add owner-ready live execution template: `docs/analytics/WEBSITE_GA_LIVE_EXECUTION_HANDOFF_TEMPLATE.md`
- add 30-day execution runbook: `docs/runbooks/WEBSITE_GA_30_DAY_EXECUTION_HANDOFF.md`
- update `tickets/P1-website-ga-30-day-priority-roadmap.md` with explicit unblock-pack update and remaining external blockers

## Why
Issue #246 is blocked by external GA export access and live-traffic data. This PR removes in-repo restart friction so owner-side data handoff can be executed immediately once access windows are available.

## Issue
- refs #246