### PR TITLE
fix(harness): suppress non-gating noise and add GA handoff runner

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "website:ga:content:opportunities": "node ./scripts/build-website-ga-content-opportunities.mjs --json",
     "website:ga:dashboard:weekly": "node ./scripts/build-website-ga-weekly-dashboard.mjs --json",
     "website:ga:roadmap:readiness": "node ./scripts/check-website-ga-roadmap-readiness.mjs --json",
+    "website:ga:roadmap:handoff": "node ./scripts/run-website-ga-roadmap-handoff.mjs --json",
     "studio:ga:monthly:report": "node ./scripts/build-studio-ga-monthly-review-report.mjs --json",
     "functions:smoke:cors": "node ./scripts/functions-cors-smoke.mjs",
     "functions:profile:coldstart": "node ./scripts/functions-coldstart-profile.mjs --artifact output/functions-coldstart-profile/latest.json",

--- a/scripts/codex/daily-improvement.mjs
+++ b/scripts/codex/daily-improvement.mjs
@@ -2107,7 +2107,26 @@ async function main() {
       }
     }
 
-    const shouldCreateRunPr = !skipRunPrOnDirtyAllow && (newlyCreatedTicketUrls.length > 0 || scoreDroppedTwice);
+    const openFocusedPr = prList.find((pr) => {
+      if (String(pr?.state || "").toLowerCase() !== "open") return false;
+      const head = String(pr?.headRefName || "").trim();
+      if (!head) return false;
+      if (head.includes(runInfo.runId)) return false;
+      if (/^codex\/(auto-improve|interaction-improve|auto-pr-green|pr-green)\//i.test(head)) return false;
+      if (hasAutomationLabel(pr)) return false;
+      return true;
+    });
+    const shouldCreateRunPr =
+      !skipRunPrOnDirtyAllow &&
+      !openFocusedPr &&
+      (newlyCreatedTicketUrls.length > 0 || scoreDroppedTwice);
+    if (openFocusedPr) {
+      notes.push(
+        `Run PR creation suppressed: focused PR already open (${String(
+          openFocusedPr.url || openFocusedPr.headRefName || "unknown"
+        )}).`
+      );
+    }
     if (!shouldCreateRunPr && recommendations.length > 0 && !scoreDroppedTwice) {
       notes.push(
         "Run PR creation suppressed: recommendations mapped to existing lanes with no net-new ticket creation."

--- a/scripts/codex/daily-interaction.mjs
+++ b/scripts/codex/daily-interaction.mjs
@@ -2014,8 +2014,24 @@ async function main() {
       }
     }
 
+    const openFocusedPr = prList.find((pr) => {
+      if (String(pr?.state || "").toLowerCase() !== "open") return false;
+      const head = String(pr?.headRefName || "").trim();
+      if (!head) return false;
+      if (head.includes(runInfo.runId)) return false;
+      if (/^codex\/(interaction-improve|auto-improve|auto-pr-green|pr-green)\//i.test(head)) return false;
+      if (hasAutomationLabel(pr)) return false;
+      return true;
+    });
+    if (openFocusedPr) {
+      notes.push(
+        `Structural PR creation suppressed: focused PR already open (${String(
+          openFocusedPr.url || openFocusedPr.headRefName || "unknown"
+        )}).`
+      );
+    }
     const shouldAttemptStructuralPr =
-      structuralDecision.mode === "Triggered" && structuralDocChangesAvailable;
+      structuralDecision.mode === "Triggered" && structuralDocChangesAvailable && !openFocusedPr;
 
     if (shouldAttemptStructuralPr) {
       const sharedEntry = sharedCoordination?.automationPrByRunId?.[runInfo.runId];

--- a/scripts/portal-automation-issue-loop.mjs
+++ b/scripts/portal-automation-issue-loop.mjs
@@ -19,6 +19,11 @@ const DEFAULT_MAX_PER_WORKFLOW = 2;
 const TUNING_ROLLING_ISSUE = "Portal Automation Threshold Tuning (Rolling)";
 const CANARY_ROLLING_ISSUE = "Portal Authenticated Canary Failures (Rolling)";
 const ROLLING_ONLY_SIGNATURE_KEYS = new Set(["promotion::promotion.risk.high"]);
+const NON_GATING_SIGNATURE_PATTERNS = [
+  /deploy to firebase hosting on pr/i,
+  /deploy preview/i,
+  /build[_-]?and[_-]?preview/i,
+];
 
 function parseArgs(argv) {
   const options = {
@@ -377,6 +382,21 @@ function isRollingOnlySignature(signature) {
   return ROLLING_ONLY_SIGNATURE_KEYS.has(signatureKey(signature));
 }
 
+function isNonGatingNoiseSignature(signature) {
+  const composite = [
+    signature?.workflowKey,
+    signature?.workflowLabel,
+    signature?.key,
+    signature?.label,
+    signature?.evidence,
+  ]
+    .map((value) => String(value || "").trim())
+    .filter(Boolean)
+    .join(" ");
+  if (!composite) return false;
+  return NON_GATING_SIGNATURE_PATTERNS.some((pattern) => pattern.test(composite));
+}
+
 function signatureGroupKey(signature) {
   const workflowKey = String(signature?.workflowKey || "workflow");
   const label = String(signature?.label || "").toLowerCase();
@@ -432,7 +452,12 @@ function selectSignatures(rawSignatures, options) {
   const rollingOnlySuppressed = Array.from(
     new Set(filtered.filter((entry) => isRollingOnlySignature(entry)).map((entry) => signatureKey(entry)))
   );
-  const issueEligible = filtered.filter((entry) => !isRollingOnlySignature(entry));
+  const nonGatingSuppressed = Array.from(
+    new Set(filtered.filter((entry) => isNonGatingNoiseSignature(entry)).map((entry) => signatureKey(entry)))
+  );
+  const issueEligible = filtered.filter(
+    (entry) => !isRollingOnlySignature(entry) && !isNonGatingNoiseSignature(entry)
+  );
   const dedupe = new Map();
   for (const signature of issueEligible) {
     const group = signatureGroupKey(signature);
@@ -471,6 +496,8 @@ function selectSignatures(rawSignatures, options) {
     dedupedCount: ranked.length,
     rollingOnlySuppressedCount: rollingOnlySuppressed.length,
     rollingOnlySuppressed,
+    nonGatingSuppressedCount: nonGatingSuppressed.length,
+    nonGatingSuppressed,
   };
 }
 
@@ -582,6 +609,7 @@ async function main() {
     dedupedCount: signatureSelection.dedupedCount,
     selectedCount: signatures.length,
     rollingOnlySuppressedCount: signatureSelection.rollingOnlySuppressedCount || 0,
+    nonGatingSuppressedCount: signatureSelection.nonGatingSuppressedCount || 0,
   };
   if (signatureSelection.eligibleCount > signatures.length) {
     report.notes.push(
@@ -591,6 +619,11 @@ async function main() {
   if ((signatureSelection.rollingOnlySuppressedCount || 0) > 0) {
     report.notes.push(
       `Suppressed rolling-only signatures: ${(signatureSelection.rollingOnlySuppressed || []).join(", ")}.`
+    );
+  }
+  if ((signatureSelection.nonGatingSuppressedCount || 0) > 0) {
+    report.notes.push(
+      `Suppressed non-gating CI signatures: ${(signatureSelection.nonGatingSuppressed || []).join(", ")}.`
     );
   }
 

--- a/scripts/run-website-ga-roadmap-handoff.mjs
+++ b/scripts/run-website-ga-roadmap-handoff.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+
+/* eslint-disable no-console */
+
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const repoRoot = process.cwd();
+const args = new Set(process.argv.slice(2));
+const asJson = args.has("--json");
+const strict = args.has("--strict");
+
+const requiredArtifacts = [
+  "artifacts/ga/reports/website-ga-data-package-check-latest.json",
+  "artifacts/ga/reports/website-ga-acquisition-quality-latest.json",
+  "artifacts/ga/reports/website-ga-funnel-friction-latest.json",
+  "artifacts/ga/reports/website-ga-experiment-backlog-latest.json",
+  "artifacts/ga/reports/website-ga-content-opportunities-latest.json",
+  "artifacts/ga/reports/website-ga-weekly-dashboard-latest.json",
+];
+
+function runNode(argsList) {
+  const result = spawnSync("node", argsList, {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+  return {
+    ok: result.status === 0,
+    code: typeof result.status === "number" ? result.status : 1,
+    stdout: String(result.stdout || ""),
+    stderr: String(result.stderr || ""),
+  };
+}
+
+function readReadinessStatus() {
+  const result = runNode(["./scripts/check-website-ga-roadmap-readiness.mjs", "--json"]);
+  if (!result.ok) {
+    return {
+      ok: false,
+      raw: null,
+      reason: result.stderr || result.stdout || `exit ${result.code}`,
+    };
+  }
+  try {
+    const parsed = JSON.parse(result.stdout || "{}");
+    return {
+      ok: Boolean(parsed?.ok),
+      raw: parsed,
+      reason: "",
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      raw: null,
+      reason: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+function buildChecklist(readiness) {
+  const artifactChecks = requiredArtifacts.map((path) => ({
+    id: `artifact:${path}`,
+    ok: existsSync(resolve(repoRoot, path)),
+    detail: path,
+  }));
+  const missingArtifacts = artifactChecks.filter((item) => !item.ok).map((item) => item.detail);
+  const checks = [
+    {
+      id: "roadmap-readiness-contract",
+      ok: readiness.ok,
+      detail: readiness.ok ? "roadmap readiness checker passed" : `checker failed: ${readiness.reason}`,
+    },
+    ...artifactChecks,
+  ];
+  return { checks, missingArtifacts };
+}
+
+function main() {
+  const readiness = readReadinessStatus();
+  const { checks, missingArtifacts } = buildChecklist(readiness);
+  const status = checks.every((check) => check.ok) ? "ready-for-owner-handoff" : "needs-owner-input";
+
+  const result = {
+    generatedAtUtc: new Date().toISOString(),
+    status,
+    checks,
+    missingArtifacts,
+    commands: [
+      "npm run website:ga:data-package:check -- --strict",
+      "npm run website:ga:baseline:report -- --strict",
+      "npm run website:ga:funnel:report -- --strict",
+      "npm run website:ga:experiments:backlog -- --strict",
+      "npm run website:ga:content:opportunities -- --strict",
+      "npm run website:ga:dashboard:weekly -- --strict",
+      "npm run website:ga:roadmap:readiness -- --strict",
+    ],
+  };
+
+  if (asJson) {
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  } else {
+    process.stdout.write(`status=${status}\n`);
+    for (const check of checks) {
+      process.stdout.write(`${check.ok ? "PASS" : "FAIL"} ${check.id}: ${check.detail}\n`);
+    }
+  }
+
+  if (strict && status !== "ready-for-owner-handoff") {
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- suppress non-gating Deploy Preview/build_and_preview style signatures in `portal-automation-issue-loop` so rolling failure triage stays actionable
- add GA handoff runner command `website:ga:roadmap:handoff` via new script `scripts/run-website-ga-roadmap-handoff.mjs`
- guard `daily-improvement` and `daily-interaction` from opening broad aggregate PRs when a focused non-automation PR is already open

## Why
This is the direct follow-through on queue recommendations:
1) reduce #239-style non-gating noise in rolling automation issues
2) provide a one-command GA handoff status surface
3) prevent aggregate automation PR churn like #258/#260