### PR TITLE
fix(codex): main-branch apply guard + preview channel quota pruning

### DIFF
--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -55,7 +55,7 @@ jobs:
         continue-on-error: true
         env:
           FIREBASE_SERVICE_ACCOUNT_MONSOONFIRE_PORTAL: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_MONSOONFIRE_PORTAL }}
-        run: node ./scripts/prune-firebase-preview-channels.mjs --project monsoonfire-portal --prefix pr --keep 60 --max-delete 30 --json
+        run: node ./scripts/prune-firebase-preview-channels.mjs --project monsoonfire-portal --prefix pr --keep 20 --max-delete 80 --json
       - name: Deploy preview channel
         if: ${{ env.IS_DEPENDABOT_PR != 'true' }}
         uses: FirebaseExtended/action-hosting-deploy@092436dca3ec6dacb231d965ae56f7ff6c09f258

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -50,6 +50,12 @@ jobs:
           export VITE_FIREBASE_API_KEY="$selected_api_key"
           npm --prefix web ci
           npm --prefix web run build
+      - name: Prune stale Firebase preview channels (best effort)
+        if: ${{ env.IS_DEPENDABOT_PR != 'true' }}
+        continue-on-error: true
+        env:
+          FIREBASE_SERVICE_ACCOUNT_MONSOONFIRE_PORTAL: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_MONSOONFIRE_PORTAL }}
+        run: node ./scripts/prune-firebase-preview-channels.mjs --project monsoonfire-portal --prefix pr --keep 60 --max-delete 30 --json
       - name: Deploy preview channel
         if: ${{ env.IS_DEPENDABOT_PR != 'true' }}
         uses: FirebaseExtended/action-hosting-deploy@092436dca3ec6dacb231d965ae56f7ff6c09f258

--- a/scripts/codex/daily-improvement.mjs
+++ b/scripts/codex/daily-improvement.mjs
@@ -2116,15 +2116,26 @@ async function main() {
       if (hasAutomationLabel(pr)) return false;
       return true;
     });
+    const currentBranchForAutomation = runGit(["rev-parse", "--abbrev-ref", "HEAD"]).stdout.trim();
+    const branchGuardTriggered =
+      Boolean(currentBranchForAutomation) &&
+      currentBranchForAutomation !== "main" &&
+      !/^codex\/auto-improve\//i.test(currentBranchForAutomation);
     const shouldCreateRunPr =
       !skipRunPrOnDirtyAllow &&
       !openFocusedPr &&
+      !branchGuardTriggered &&
       (newlyCreatedTicketUrls.length > 0 || scoreDroppedTwice);
     if (openFocusedPr) {
       notes.push(
         `Run PR creation suppressed: focused PR already open (${String(
           openFocusedPr.url || openFocusedPr.headRefName || "unknown"
         )}).`
+      );
+    }
+    if (branchGuardTriggered) {
+      notes.push(
+        `Run PR creation suppressed: current branch is ${currentBranchForAutomation}; switch to main before apply runs.`
       );
     }
     if (!shouldCreateRunPr && recommendations.length > 0 && !scoreDroppedTwice) {

--- a/scripts/codex/daily-improvement.mjs
+++ b/scripts/codex/daily-improvement.mjs
@@ -58,6 +58,21 @@ const ciFailureSignatureSuppressions = [
   /::\s*Deploy Preview$/i,
 ];
 
+const toolFailureSuppressionRules = [
+  {
+    errorType: /^runtime_error$/i,
+    message: /Refusing --apply run on dirty worktree/i,
+  },
+  {
+    errorType: /^runtime_error$/i,
+    message: /would be overwritten by checkout/i,
+  },
+  {
+    errorType: /^runtime_error$/i,
+    message: /Missing value for --(?:help|allow-dirty|state-only|run-id)/i,
+  },
+];
+
 const secretKeyPattern = /(token|secret|password|authorization|api[_-]?key|cookie|session|private[_-]?key)/i;
 const secretValuePatterns = [
   /bearer\s+[a-z0-9._~-]+/gi,
@@ -673,6 +688,19 @@ function shouldSuppressCiFailureSignature(signature) {
   const value = String(signature || "").trim();
   if (!value) return false;
   return ciFailureSignatureSuppressions.some((pattern) => pattern.test(value));
+}
+
+function shouldSuppressToolFailureEntry(entry) {
+  if (!entry || entry.ok !== false) return false;
+  const errorType = String(entry?.errorType || "").trim();
+  const errorMessage = String(entry?.errorMessage || "").trim();
+  if (!errorMessage) return false;
+
+  return toolFailureSuppressionRules.some((rule) => {
+    const typeOk = rule.errorType ? rule.errorType.test(errorType) : true;
+    if (!typeOk) return false;
+    return rule.message.test(errorMessage);
+  });
 }
 
 function ensureRecommendation(recommendations, recommendation) {
@@ -1404,12 +1432,20 @@ async function main() {
   const calls7d = filterByTimeWindow(toolcallData.entries, "tsIso", start7dMs);
 
   const callFailures24 = calls24.filter((entry) => entry?.ok === false);
-  const toolFailureRate24 = calls24.length === 0 ? 0 : callFailures24.length / calls24.length;
-  const errorCounts24 = countByKey(callFailures24, "errorType");
+  const suppressedCallFailures24 = callFailures24.filter((entry) => shouldSuppressToolFailureEntry(entry));
+  const actionableCallFailures24 = callFailures24.filter((entry) => !shouldSuppressToolFailureEntry(entry));
+  const toolFailureRate24 =
+    calls24.length === 0 ? 0 : actionableCallFailures24.length / calls24.length;
+  const errorCounts24 = countByKey(actionableCallFailures24, "errorType");
   const repeatedErrorEntries = Object.entries(errorCounts24).filter(([, count]) => count >= 2);
 
   let githubAvailable = false;
   const notes = [];
+  if (suppressedCallFailures24.length > 0) {
+    notes.push(
+      `Suppressed ${suppressedCallFailures24.length} non-actionable tool failure event(s) from recommendation clustering.`
+    );
+  }
   if (startupMemoryContext.ok && startupMemoryContext.itemCount > 0) {
     notes.push(`Loaded ${startupMemoryContext.itemCount} Open Memory context item(s).`);
   } else if (startupMemoryContext.attempted && startupMemoryContext.error) {
@@ -1547,7 +1583,7 @@ async function main() {
       trigger: `Tool failure rate is ${(toolFailureRate24 * 100).toFixed(1)}% over ${calls24.length} calls (threshold: >10%).`,
       why: "High tool failure rates create avoidable rework and reduce confidence in automation.",
       action: "Prioritize top failing tools, add retries/fallbacks, and improve error classification.",
-      evidence: [`failed calls: ${callFailures24.length}`, `total calls: ${calls24.length}`],
+      evidence: [`failed calls: ${actionableCallFailures24.length}`, `total calls: ${calls24.length}`],
     });
   }
 
@@ -1670,6 +1706,7 @@ async function main() {
         continue;
       }
       if (entry?.ok !== false) continue;
+      if (shouldSuppressToolFailureEntry(entry)) continue;
 
       const errorType = String(entry?.errorType || "unknown").trim() || "unknown";
       const previous = streakBySignature.get(signature);
@@ -1755,7 +1792,7 @@ async function main() {
       )
     ).length,
     metadataConfig: metadataTouchTotal24,
-    tooling: callFailures24.length,
+    tooling: actionableCallFailures24.length,
     workflowPolicy: recommendations.filter((recommendation) =>
       /workflow|branch|policy|guardrail/i.test(
         `${recommendation.id} ${recommendation.title} ${recommendation.trigger}`
@@ -2372,7 +2409,7 @@ async function main() {
     tools: {
       total12h: calls12.length,
       total24h: calls24.length,
-      failed24h: callFailures24.length,
+      failed24h: actionableCallFailures24.length,
       failureRate24h: toolFailureRate24,
       invalidLines: toolcallData.invalidLines,
     },

--- a/scripts/codex/daily-interaction.mjs
+++ b/scripts/codex/daily-interaction.mjs
@@ -2030,8 +2030,21 @@ async function main() {
         )}).`
       );
     }
+    const currentBranchForAutomation = runGit(["rev-parse", "--abbrev-ref", "HEAD"]).stdout.trim();
+    const branchGuardTriggered =
+      Boolean(currentBranchForAutomation) &&
+      currentBranchForAutomation !== "main" &&
+      !/^codex\/interaction-improve\//i.test(currentBranchForAutomation);
+    if (branchGuardTriggered) {
+      notes.push(
+        `Structural PR creation suppressed: current branch is ${currentBranchForAutomation}; switch to main before apply runs.`
+      );
+    }
     const shouldAttemptStructuralPr =
-      structuralDecision.mode === "Triggered" && structuralDocChangesAvailable && !openFocusedPr;
+      structuralDecision.mode === "Triggered" &&
+      structuralDocChangesAvailable &&
+      !openFocusedPr &&
+      !branchGuardTriggered;
 
     if (shouldAttemptStructuralPr) {
       const sharedEntry = sharedCoordination?.automationPrByRunId?.[runInfo.runId];

--- a/scripts/codex/daily-interaction.mjs
+++ b/scripts/codex/daily-interaction.mjs
@@ -56,6 +56,21 @@ const secretValuePatterns = [
   /(sk-[A-Za-z0-9]{20,})/g,
 ];
 
+const toolFailureSuppressionRules = [
+  {
+    errorType: /^runtime_error$/i,
+    message: /Refusing --apply run on dirty worktree/i,
+  },
+  {
+    errorType: /^runtime_error$/i,
+    message: /would be overwritten by checkout/i,
+  },
+  {
+    errorType: /^runtime_error$/i,
+    message: /Missing value for --(?:help|allow-dirty|state-only|run-id)/i,
+  },
+];
+
 const AUTO_START = "<!-- codex-interaction:auto:start -->";
 const AUTO_END = "<!-- codex-interaction:auto:end -->";
 
@@ -1100,6 +1115,19 @@ function countBy(items, keyFn) {
   return counts;
 }
 
+function shouldSuppressToolFailureEntry(entry) {
+  if (!entry || entry.ok !== false) return false;
+  const errorType = String(entry?.errorType || "").trim();
+  const errorMessage = String(entry?.errorMessage || "").trim();
+  if (!errorMessage) return false;
+
+  return toolFailureSuppressionRules.some((rule) => {
+    const typeOk = rule.errorType ? rule.errorType.test(errorType) : true;
+    if (!typeOk) return false;
+    return rule.message.test(errorMessage);
+  });
+}
+
 async function main() {
   const options = parseArgs(process.argv.slice(2));
   const runStartedAt = new Date();
@@ -1228,9 +1256,11 @@ async function main() {
   const toolcallData = await readToolcalls();
   const calls24 = filterByTimeWindow(toolcallData.entries, "tsIso", start24Ms);
   const failures24 = calls24.filter((entry) => entry?.ok === false);
-  const toolFailureRate24 = calls24.length === 0 ? 0 : failures24.length / calls24.length;
+  const suppressedFailures24 = failures24.filter((entry) => shouldSuppressToolFailureEntry(entry));
+  const actionableFailures24 = failures24.filter((entry) => !shouldSuppressToolFailureEntry(entry));
+  const toolFailureRate24 = calls24.length === 0 ? 0 : actionableFailures24.length / calls24.length;
 
-  const retryClusterMap = countBy(failures24, (entry) => {
+  const retryClusterMap = countBy(actionableFailures24, (entry) => {
     const tool = String(entry?.tool || "").trim();
     const action = String(entry?.action || "").trim();
     if (!tool || !action) return "";
@@ -1238,12 +1268,17 @@ async function main() {
   });
   const retryClusters = Array.from(retryClusterMap.entries()).filter(([, count]) => count >= 2);
 
-  const errorClusterMap = countBy(failures24, (entry) => String(entry?.errorType || "").trim());
+  const errorClusterMap = countBy(actionableFailures24, (entry) => String(entry?.errorType || "").trim());
   const repeatedErrorClusters = Array.from(errorClusterMap.entries()).filter(
     ([name, count]) => name && count >= 2
   );
 
   const notes = [];
+  if (suppressedFailures24.length > 0) {
+    notes.push(
+      `Suppressed ${suppressedFailures24.length} non-actionable tool failure event(s) from interaction clustering.`
+    );
+  }
   const repoSlug = parseRepoSlug();
   let githubAvailable = false;
   let prList = [];
@@ -1776,7 +1811,7 @@ async function main() {
     metadataConfig:
       metadataChanges24.reduce((sum, item) => sum + item.touches, 0) +
       textEntries.filter((entry) => /\b(config|metadata|workflow file|github workflow)\b/i.test(entry.text)).length,
-    tooling: failures24.length + retryClusters.length,
+    tooling: actionableFailures24.length + retryClusters.length,
     workflowPolicy:
       branchProtectionPattern.count +
       workflowRestatementCount +

--- a/scripts/prune-firebase-preview-channels.mjs
+++ b/scripts/prune-firebase-preview-channels.mjs
@@ -1,0 +1,310 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+function parseArgs(argv) {
+  const options = {
+    project: "",
+    prefix: "pr",
+    keep: 60,
+    maxDelete: 30,
+    json: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = String(argv[index] || "").trim();
+
+    if (!arg) continue;
+    if (arg === "--json") {
+      options.json = true;
+      continue;
+    }
+    if (arg === "--project") {
+      const next = String(argv[index + 1] || "").trim();
+      if (next) {
+        options.project = next;
+        index += 1;
+      }
+      continue;
+    }
+    if (arg.startsWith("--project=")) {
+      options.project = String(arg.slice("--project=".length)).trim();
+      continue;
+    }
+    if (arg === "--prefix") {
+      const next = String(argv[index + 1] || "").trim();
+      if (next) {
+        options.prefix = next;
+        index += 1;
+      }
+      continue;
+    }
+    if (arg.startsWith("--prefix=")) {
+      options.prefix = String(arg.slice("--prefix=".length)).trim() || options.prefix;
+      continue;
+    }
+    if (arg === "--keep") {
+      const next = Number.parseInt(String(argv[index + 1] || ""), 10);
+      if (Number.isFinite(next) && next >= 0) {
+        options.keep = next;
+        index += 1;
+      }
+      continue;
+    }
+    if (arg.startsWith("--keep=")) {
+      const value = Number.parseInt(String(arg.slice("--keep=".length)).trim(), 10);
+      if (Number.isFinite(value) && value >= 0) {
+        options.keep = value;
+      }
+      continue;
+    }
+    if (arg === "--max-delete") {
+      const next = Number.parseInt(String(argv[index + 1] || ""), 10);
+      if (Number.isFinite(next) && next >= 0) {
+        options.maxDelete = next;
+        index += 1;
+      }
+      continue;
+    }
+    if (arg.startsWith("--max-delete=")) {
+      const value = Number.parseInt(String(arg.slice("--max-delete=".length)).trim(), 10);
+      if (Number.isFinite(value) && value >= 0) {
+        options.maxDelete = value;
+      }
+      continue;
+    }
+  }
+
+  if (!options.project) {
+    throw new Error("Missing required --project <firebase-project-id> argument.");
+  }
+
+  return options;
+}
+
+function runCommand(command, args, extraEnv = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      env: {
+        ...process.env,
+        ...extraEnv,
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code === 0) {
+        resolve({ stdout, stderr, code });
+        return;
+      }
+      const error = new Error(`${command} ${args.join(" ")} exited with code ${code}`);
+      error.stdout = stdout;
+      error.stderr = stderr;
+      error.code = code;
+      reject(error);
+    });
+  });
+}
+
+function parseJsonOutput(raw) {
+  const trimmed = String(raw || "").trim();
+  if (!trimmed) return {};
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    const start = trimmed.indexOf("{");
+    const end = trimmed.lastIndexOf("}");
+    if (start >= 0 && end > start) {
+      return JSON.parse(trimmed.slice(start, end + 1));
+    }
+    throw new Error("Failed to parse firebase-tools JSON output.");
+  }
+}
+
+function getChannelList(payload) {
+  if (Array.isArray(payload?.result?.channels)) {
+    return payload.result.channels;
+  }
+  if (Array.isArray(payload?.channels)) {
+    return payload.channels;
+  }
+  if (Array.isArray(payload?.result)) {
+    return payload.result;
+  }
+  return [];
+}
+
+function getChannelId(channel) {
+  const rawName = String(
+    channel?.channelId || channel?.id || channel?.name || channel?.resource || "",
+  ).trim();
+  if (!rawName) return "";
+  if (rawName.includes("/")) {
+    return rawName.split("/").pop() || "";
+  }
+  return rawName;
+}
+
+function toMs(value) {
+  const parsed = Date.parse(String(value || "").trim());
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function channelFreshnessMs(channel) {
+  return Math.max(
+    toMs(channel?.updateTime),
+    toMs(channel?.release?.createTime),
+    toMs(channel?.release?.releaseTime),
+    toMs(channel?.createTime),
+    toMs(channel?.expireTime),
+  );
+}
+
+async function resolveServiceAccountEnv() {
+  const existing = String(process.env.GOOGLE_APPLICATION_CREDENTIALS || "").trim();
+  if (existing) {
+    return {
+      env: {},
+      cleanup: async () => {},
+      credentialSource: "GOOGLE_APPLICATION_CREDENTIALS",
+    };
+  }
+
+  const serviceAccountJson = String(
+    process.env.FIREBASE_SERVICE_ACCOUNT_MONSOONFIRE_PORTAL ||
+      process.env.FIREBASE_SERVICE_ACCOUNT ||
+      process.env.FIREBASE_SERVICE_ACCOUNT_JSON ||
+      "",
+  ).trim();
+
+  if (!serviceAccountJson) {
+    return {
+      env: {},
+      cleanup: async () => {},
+      credentialSource: "none",
+    };
+  }
+
+  const tmpBase = await mkdtemp(join(tmpdir(), "firebase-sa-"));
+  const credentialPath = join(tmpBase, "service-account.json");
+  await writeFile(credentialPath, serviceAccountJson, "utf8");
+  return {
+    env: { GOOGLE_APPLICATION_CREDENTIALS: credentialPath },
+    cleanup: async () => {
+      await rm(tmpBase, { recursive: true, force: true });
+    },
+    credentialSource: "FIREBASE_SERVICE_ACCOUNT_MONSOONFIRE_PORTAL",
+  };
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const auth = await resolveServiceAccountEnv();
+  const output = {
+    status: "ok",
+    project: options.project,
+    prefix: options.prefix,
+    keep: options.keep,
+    maxDelete: options.maxDelete,
+    credentialSource: auth.credentialSource,
+    totalChannels: 0,
+    prefixedChannels: 0,
+    deleted: [],
+    skipped: [],
+    errors: [],
+  };
+
+  try {
+    const listResp = await runCommand(
+      "npx",
+      ["firebase-tools@latest", "hosting:channel:list", "--project", options.project, "--json"],
+      auth.env,
+    );
+    const payload = parseJsonOutput(listResp.stdout);
+    const channels = getChannelList(payload);
+
+    const prChannels = channels
+      .map((channel) => ({
+        id: getChannelId(channel),
+        freshnessMs: channelFreshnessMs(channel),
+      }))
+      .filter((item) => item.id && item.id.startsWith(options.prefix))
+      .sort((left, right) => right.freshnessMs - left.freshnessMs);
+
+    output.totalChannels = channels.length;
+    output.prefixedChannels = prChannels.length;
+
+    const prunedCandidates = prChannels.slice(options.keep, options.keep + options.maxDelete);
+    for (const channel of prunedCandidates) {
+      try {
+        await runCommand(
+          "npx",
+          [
+            "firebase-tools@latest",
+            "hosting:channel:delete",
+            channel.id,
+            "--project",
+            options.project,
+            "--force",
+          ],
+          auth.env,
+        );
+        output.deleted.push(channel.id);
+      } catch (error) {
+        output.errors.push({
+          channelId: channel.id,
+          message: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
+    if (prChannels.length <= options.keep) {
+      output.skipped.push(`No deletion needed (${prChannels.length} <= keep=${options.keep}).`);
+    }
+    if (prChannels.length > options.keep + options.maxDelete) {
+      output.skipped.push(
+        `Deletion capped by --max-delete=${options.maxDelete}; remaining channels were left untouched.`,
+      );
+    }
+  } finally {
+    await auth.cleanup();
+  }
+
+  if (options.json) {
+    console.log(JSON.stringify(output, null, 2));
+    return;
+  }
+
+  console.log(
+    `firebase-preview-prune: project=${output.project} prefixed=${output.prefixedChannels} deleted=${output.deleted.length}`,
+  );
+  if (output.skipped.length > 0) {
+    for (const note of output.skipped) {
+      console.log(`- ${note}`);
+    }
+  }
+  if (output.errors.length > 0) {
+    for (const entry of output.errors) {
+      console.error(`delete failed for ${entry.channelId}: ${entry.message}`);
+    }
+  }
+}
+
+main().catch((error) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(message);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add non-`main` branch guards in `scripts/codex/daily-improvement.mjs` and `scripts/codex/daily-interaction.mjs` to prevent aggregate/noisy automation PR creation during apply-mode runs
- add Firebase preview-channel quota mitigation by pruning stale `pr*` channels before PR preview deploys

## Why
- keeps automation loops focused when triggered from feature branches
- prevents repeated `build_and_preview` failures caused by Hosting preview-channel quota exhaustion (HTTP 429)