### PR TITLE
fix(harness): dedupe unchanged signature issue comments

### DIFF
--- a/scripts/portal-automation-issue-loop.mjs
+++ b/scripts/portal-automation-issue-loop.mjs
@@ -284,6 +284,7 @@ function createIssueBody(signature, dashboard) {
 
 function createIssueComment(signature, dashboard) {
   const lines = [];
+  const marker = signatureUpdateMarker(signature);
   lines.push(`## ${dashboard.generatedAtIso} (Repeated Signature Update)`);
   lines.push("");
   lines.push(`- Signature: **${signature.label}**`);
@@ -291,6 +292,8 @@ function createIssueComment(signature, dashboard) {
   lines.push(`- Latest run: ${signature.runUrl || "n/a"}`);
   if (signature.evidence) lines.push(`- Evidence: ${short(signature.evidence, 280)}`);
   if (signature.suggestion) lines.push(`- Suggested remediation: ${signature.suggestion}`);
+  lines.push("");
+  lines.push(`<!-- ${marker} -->`);
   lines.push("");
   return lines.join("\n");
 }
@@ -376,6 +379,16 @@ function signatureKey(signature) {
   const workflowKey = String(signature?.workflowKey || "").trim();
   const key = String(signature?.key || "").trim();
   return `${workflowKey}::${key}`;
+}
+
+function signatureUpdateMarker(signature) {
+  return `portal-signature-update-${stableHash({
+    signatureKey: signatureKey(signature),
+    runUrl: String(signature?.runUrl || ""),
+    count: Number(signature?.count || 0),
+    evidence: short(signature?.evidence || "", 200),
+    suggestion: short(signature?.suggestion || "", 200),
+  })}`;
 }
 
 function isRollingOnlySignature(signature) {
@@ -675,6 +688,14 @@ async function main() {
       }
     } else {
       const commentBody = createIssueComment(signature, dashboard);
+      const latestComment = fetchLatestIssueCommentBody(repoSlug, existing.number);
+      const marker = signatureUpdateMarker(signature);
+      if (latestComment.includes(`<!-- ${marker} -->`)) {
+        action.result = "unchanged-skip";
+        action.url = existing.url;
+        report.signatureActions.push(action);
+        continue;
+      }
       const commented = runGh(
         [
           "issue",


### PR DESCRIPTION
## Summary
- add deterministic signature-update markers to repeated-failure issue comments
- skip posting updates when the latest issue comment already carries the same marker/evidence payload
- keep existing behavior for genuinely new signature evidence

## Why
- prevents noisy repeated comments on open signature issues (for example promotion risk) when the evidence has not changed