### PR TITLE
fix(codex): route interaction recommendations to rolling issue only

### DIFF
--- a/scripts/codex/daily-improvement.mjs
+++ b/scripts/codex/daily-improvement.mjs
@@ -1934,16 +1934,12 @@ async function main() {
     await ensureGhLabel(repoSlug, "epic:codex-improvement", "5319e7", "Codex continuous improvement epic", true);
     await ensureGhLabel(repoSlug, `run:${runInfo.runSlot}`, "0e8a16", "Codex AM/PM run marker", true);
 
-    const cooldownDefersInteractionTickets =
-      structuralEvolutionDecision.status === "Deferred" &&
-      /cooldown|stability governor/i.test(String(structuralEvolutionDecision.reason || ""));
-    const ticketableRecommendations = recommendations.filter((recommendation) => {
-      if (!cooldownDefersInteractionTickets) return true;
-      return !String(recommendation?.id || "").startsWith("interaction-");
-    });
-    if (cooldownDefersInteractionTickets && ticketableRecommendations.length < recommendations.length) {
+    const ticketableRecommendations = recommendations.filter(
+      (recommendation) => !String(recommendation?.id || "").startsWith("interaction-")
+    );
+    if (ticketableRecommendations.length < recommendations.length) {
       notes.push(
-        "Interaction recommendation tickets were skipped because structural cooldown is active; tracking continues via rolling issue."
+        "Interaction recommendations are tracked through the rolling interaction issue; standalone tickets were skipped."
       );
     }
 


### PR DESCRIPTION
## Summary
- update daily-improvement ticket creation to skip standalone tickets for interaction recommendations
- keep those recommendations tracked in the rolling interaction issue instead
- add a run note when interaction tickets are intentionally skipped

## Why
- prevents repeated one-off interaction tickets for clarification-loop patterns
- keeps interaction remediation in one durable lane instead of noisy ticket churn

Closes #270