### PR TITLE
fix(governance): dedupe weekly tuning issues via upsert

### DIFF
--- a/.github/workflows/governance-weekly-tuning.yml
+++ b/.github/workflows/governance-weekly-tuning.yml
@@ -77,10 +77,31 @@ jobs:
               "Notes:",
               ...(report.tuning_notes || []).map((row) => `- ${row}`)
             ].join("\n");
-            await github.rest.issues.create({
+            const openIssues = await github.paginate(github.rest.issues.listForRepo, {
               owner,
               repo,
-              title,
-              body,
-              labels: ["governance-tuning"]
+              state: "open",
+              labels: "governance-tuning",
+              per_page: 100
             });
+            const existing = openIssues.find((issue) => !issue.pull_request && issue.title === title);
+            if (existing) {
+              await github.rest.issues.update({
+                owner,
+                repo,
+                issue_number: existing.number,
+                title,
+                body,
+                labels: ["governance-tuning"]
+              });
+              core.info(`Updated existing governance tuning issue #${existing.number}.`);
+            } else {
+              const created = await github.rest.issues.create({
+                owner,
+                repo,
+                title,
+                body,
+                labels: ["governance-tuning"]
+              });
+              core.info(`Created governance tuning issue #${created.data.number}.`);
+            }


### PR DESCRIPTION
## Summary
- change Governance Weekly Tuning workflow issue emission from create-only to upsert-by-title
- update existing open same-day governance-tuning issue when present
- create a new issue only when no matching open issue exists

## Why
- prevents duplicate same-day governance tuning issues from repeated workflow executions

## Validation
- static workflow logic review; no behavior change outside issue upsert path