### PR TITLE
hardening(canary): retry daily authenticated canary once on failure

### DIFF
--- a/.github/workflows/portal-daily-authenticated-canary.yml
+++ b/.github/workflows/portal-daily-authenticated-canary.yml
@@ -119,12 +119,26 @@ jobs:
           PORTAL_STAFF_PASSWORD: ${{ secrets.PORTAL_STAFF_PASSWORD }}
           PORTAL_AGENT_STAFF_CREDENTIALS_JSON: ${{ secrets.PORTAL_AGENT_STAFF_CREDENTIALS_JSON }}
         run: |
+          set +e
           node ./scripts/portal-authenticated-canary.mjs \
             --base-url "${{ steps.base_url.outputs.value }}" \
             --output-dir output/qa/portal-authenticated-canary \
             --report output/qa/portal-authenticated-canary.json \
             --feedback output/qa/portal-authenticated-canary-feedback.json \
             --json
+          status=$?
+          if [ "$status" -ne 0 ]; then
+            echo "First canary attempt failed; retrying once after cooldown."
+            sleep 20
+            node ./scripts/portal-authenticated-canary.mjs \
+              --base-url "${{ steps.base_url.outputs.value }}" \
+              --output-dir output/qa/portal-authenticated-canary \
+              --report output/qa/portal-authenticated-canary.json \
+              --feedback output/qa/portal-authenticated-canary-feedback.json \
+              --json
+            status=$?
+          fi
+          exit "$status"
 
       - name: Escalate after consecutive failures
         if: always()


### PR DESCRIPTION
## Summary
- add single retry pass to the daily authenticated canary execution step
- preserve existing output/report paths and escalation logic

## Why
- reduce false negatives from transient production timeouts/navigation flake
- keep failing signal if retry also fails

## Scope
- .github/workflows/portal-daily-authenticated-canary.yml only