### PR TITLE
fix(automation): consolidate rolling issue families

### DIFF
--- a/.github/workflows/governance-weekly-tuning.yml
+++ b/.github/workflows/governance-weekly-tuning.yml
@@ -47,61 +47,10 @@ jobs:
           if-no-files-found: ignore
           retention-days: 30
 
-      - name: Open tuning summary issue
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const fs = require("fs");
-            const reportPath = "output/governance/weekly-tune-report.json";
-            if (!fs.existsSync(reportPath)) {
-              core.setFailed("Missing weekly tune report.");
-              return;
-            }
-            const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
-            const { owner, repo } = context.repo;
-            const title = `Governance Weekly Tuning ${String(report.generated_at || "").slice(0, 10)}`;
-            const body = [
-              "Weekly governance tuning summary (proposal-only).",
-              "",
-              `- verification_hold_rate: ${report.metrics.verification_hold_rate}`,
-              `- false_positive_rate: ${report.metrics.false_positive_rate}`,
-              `- ci_failure_loop_rate: ${report.metrics.ci_failure_loop_rate}`,
-              `- audit_workload_per_week: ${report.metrics.audit_workload_per_week}`,
-              "",
-              "Proposed threshold updates:",
-              "```json",
-              JSON.stringify(report.proposed_thresholds, null, 2),
-              "```",
-              "",
-              "Notes:",
-              ...(report.tuning_notes || []).map((row) => `- ${row}`)
-            ].join("\n");
-            const openIssues = await github.paginate(github.rest.issues.listForRepo, {
-              owner,
-              repo,
-              state: "open",
-              labels: "governance-tuning",
-              per_page: 100
-            });
-            const existing = openIssues.find((issue) => !issue.pull_request && issue.title === title);
-            if (existing) {
-              await github.rest.issues.update({
-                owner,
-                repo,
-                issue_number: existing.number,
-                title,
-                body,
-                labels: ["governance-tuning"]
-              });
-              core.info(`Updated existing governance tuning issue #${existing.number}.`);
-            } else {
-              const created = await github.rest.issues.create({
-                owner,
-                repo,
-                title,
-                body,
-                labels: ["governance-tuning"]
-              });
-              core.info(`Created governance tuning issue #${created.data.number}.`);
-            }
+      - name: Update governance rolling issue
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node ./scripts/governance/publish-weekly-tuning-issue.mjs \
+            --report output/governance/weekly-tune-report.json \
+            --output output/governance/weekly-tune-issue.json

--- a/scripts/branch-divergence-guard.mjs
+++ b/scripts/branch-divergence-guard.mjs
@@ -6,12 +6,14 @@ import { mkdir, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawnSync } from "node:child_process";
+import { buildAutomationFamilyBody, getAutomationFamily } from "./lib/automation-issue-families.mjs";
+import { ensureGhLabels, ensureIssueWithMarker, listRepoIssues } from "./lib/github-issues.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const repoRoot = resolve(dirname(__filename), "..");
 
-const ROLLING_ISSUE_TITLE = "Branch Divergence / Force-Push Guard (Rolling)";
 const ALERT_ISSUE_TITLE = "[Branch Guard] Non-fast-forward update detected";
+const PORTAL_INFRA_FAMILY = getAutomationFamily("portal-infra");
 const STATE_START = "<!-- branch-divergence-state:start -->";
 const STATE_END = "<!-- branch-divergence-state:end -->";
 const DEFAULT_REPORT_PATH = resolve(repoRoot, "output", "qa", "branch-divergence-guard.json");
@@ -351,14 +353,31 @@ async function main() {
   };
 
   const repoSlug = options.includeGithub ? parseRepoSlug() : "";
-  const rollingIssue = repoSlug && options.apply
-    ? ensureIssue(
+  let rollingIssue = { number: 0, url: "" };
+  if (repoSlug && options.apply) {
+    const openIssuesResp = listRepoIssues(repoSlug, { state: "open", maxPages: 2, cwd: repoRoot });
+    if (openIssuesResp.ok) {
+      ensureGhLabels(repoSlug, PORTAL_INFRA_FAMILY.labels, { cwd: repoRoot });
+      const ensured = ensureIssueWithMarker(
         repoSlug,
-        ROLLING_ISSUE_TITLE,
-        "Rolling branch divergence and force-push monitoring log.",
-        ["automation", "infra"]
-      )
-    : { number: 0, url: "" };
+        {
+          title: PORTAL_INFRA_FAMILY.title,
+          body: buildAutomationFamilyBody(PORTAL_INFRA_FAMILY),
+          labels: PORTAL_INFRA_FAMILY.labels.map((label) => label.name),
+          marker: PORTAL_INFRA_FAMILY.marker,
+          preferredNumber: PORTAL_INFRA_FAMILY.preferredNumber,
+          openIssues: openIssuesResp.data,
+        },
+        { cwd: repoRoot }
+      );
+      if (ensured.ok && ensured.issue) {
+        rollingIssue = {
+          number: ensured.issue.number,
+          url: ensured.issue.url,
+        };
+      }
+    }
+  }
   summary.rollingIssue = rollingIssue;
 
   const previousState = repoSlug && rollingIssue.number > 0

--- a/scripts/codex/automation-findings-summary.mjs
+++ b/scripts/codex/automation-findings-summary.mjs
@@ -10,7 +10,7 @@ import { fileURLToPath } from "node:url";
 const __filename = fileURLToPath(import.meta.url);
 const repoRoot = resolve(dirname(__filename), "..", "..");
 
-const summaryIssueTitle = "Codex Automation Findings Digest (Rolling)";
+const summaryIssueTitle = "Codex Automation (Rolling)";
 const outputDir = resolve(repoRoot, "output", "qa");
 const markdownArtifactPath = resolve(outputDir, "codex-automation-findings-summary.md");
 const jsonArtifactPath = resolve(outputDir, "codex-automation-findings-summary.json");
@@ -19,26 +19,30 @@ const sources = [
   {
     key: "improvement",
     label: "Continuous Improvement",
-    issueTitle: "Codex Continuous Improvement (Rolling)",
+    issueTitle: summaryIssueTitle,
     workflowName: "Codex Self Improvement",
+    commentMarkers: ["codex-improvement-rollup-run:"],
   },
   {
     key: "interaction",
     label: "Interaction Interrogation",
-    issueTitle: "Codex Interaction Interrogation (Rolling)",
+    issueTitle: summaryIssueTitle,
     workflowName: "Codex Interaction Interrogation",
+    commentMarkers: ["codex-interaction-rollup-run:"],
   },
   {
     key: "prGreen",
     label: "PR Green Daily",
-    issueTitle: "Codex PR Green Daily (Rolling)",
+    issueTitle: summaryIssueTitle,
     workflowName: "Codex PR Green Daily",
+    commentMarkers: ["codex-pr-green-rollup-run:"],
   },
   {
     key: "backlogAutopilot",
     label: "Backlog Autopilot",
-    issueTitle: "Codex Backlog Autopilot (Rolling)",
+    issueTitle: summaryIssueTitle,
     workflowName: "Codex Backlog Autopilot",
+    commentMarkers: ["codex-backlog-rollup-signature:"],
   },
 ];
 
@@ -219,7 +223,7 @@ function findIssueByTitle(repoSlug, title) {
   return response.data.find((issue) => issue.title === title) || null;
 }
 
-function fetchLatestIssueComment(repoSlug, issueNumber) {
+function fetchIssueComments(repoSlug, issueNumber) {
   const response = runGhJson([
     "issue",
     "view",
@@ -230,15 +234,21 @@ function fetchLatestIssueComment(repoSlug, issueNumber) {
     "comments",
   ]);
 
-  if (!response.ok || !response.data || typeof response.data !== "object") return null;
+  if (!response.ok || !response.data || typeof response.data !== "object") return [];
   const comments = Array.isArray(response.data.comments) ? response.data.comments : [];
-  if (comments.length === 0) return null;
-  const latest = comments[comments.length - 1];
-  return {
-    url: String(latest.url || latest.html_url || ""),
-    createdAt: String(latest.createdAt || latest.created_at || ""),
-    body: String(latest.body || ""),
-  };
+  return comments.map((comment) => ({
+    url: String(comment?.url || comment?.html_url || ""),
+    createdAt: String(comment?.createdAt || comment?.created_at || ""),
+    body: String(comment?.body || ""),
+  }));
+}
+
+function findLatestSourceComment(comments, markerPrefixes = []) {
+  const prefixes = Array.isArray(markerPrefixes) ? markerPrefixes.filter(Boolean) : [];
+  const matched = comments.filter((comment) => prefixes.some((prefix) => String(comment?.body || "").includes(prefix)));
+  if (matched.length === 0) return null;
+  matched.sort((left, right) => Date.parse(String(right?.createdAt || 0)) - Date.parse(String(left?.createdAt || 0)));
+  return matched[0];
 }
 
 function fetchLatestWorkflowRun(repoSlug, workflowName) {
@@ -352,6 +362,7 @@ async function main() {
   if (!githubAvailable) notes.push("GitHub CLI unavailable or not authenticated; reporting is local-only.");
 
   const sourceSummaries = [];
+  const sharedIssueCache = new Map();
   for (const source of sources) {
     const summary = {
       key: source.key,
@@ -367,10 +378,17 @@ async function main() {
     };
 
     if (githubAvailable) {
-      const issue = findIssueByTitle(repoSlug, source.issueTitle);
+      const issue = sharedIssueCache.get(source.issueTitle) || findIssueByTitle(repoSlug, source.issueTitle);
       if (issue) {
+        sharedIssueCache.set(source.issueTitle, issue);
         summary.issueUrl = String(issue.url || "");
-        const latestComment = fetchLatestIssueComment(repoSlug, issue.number);
+        const commentsCacheKey = `comments:${issue.number}`;
+        let issueComments = sharedIssueCache.get(commentsCacheKey);
+        if (!issueComments) {
+          issueComments = fetchIssueComments(repoSlug, issue.number);
+          sharedIssueCache.set(commentsCacheKey, issueComments);
+        }
+        const latestComment = findLatestSourceComment(issueComments, source.commentMarkers);
         if (latestComment) {
           summary.latestFindingAt = latestComment.createdAt;
           summary.highlights = extractHighlights(latestComment.body);
@@ -479,7 +497,7 @@ async function main() {
 
     if (digestIssue?.number) {
       digestIssueUrl = digestIssue.url;
-      const latestDigestComment = fetchLatestIssueComment(repoSlug, digestIssue.number);
+      const latestDigestComment = findLatestSourceComment(fetchIssueComments(repoSlug, digestIssue.number), [digestMarker]);
       if (latestDigestComment?.body?.includes(`<!-- ${digestMarker} -->`)) {
         notes.push("Digest unchanged; skipped duplicate rolling digest comment.");
       } else {

--- a/scripts/codex/backlog-autopilot.mjs
+++ b/scripts/codex/backlog-autopilot.mjs
@@ -18,7 +18,7 @@ const defaultOutputDir = resolve(repoRoot, "output", "qa");
 const defaultReportJsonPath = resolve(defaultOutputDir, "codex-backlog-autopilot.json");
 const defaultReportMarkdownPath = resolve(defaultOutputDir, "codex-backlog-autopilot.md");
 
-const rollingIssueTitle = "Codex Backlog Autopilot (Rolling)";
+const rollingIssueTitle = "Codex Automation (Rolling)";
 const defaultLendingLibraryExclusionRegex =
   "(lending[ -]?library|tickets/p1-epic-16|tickets/p1-library-|tickets/p2-library-|tickets/p1-lending-library-|tickets/p2-lending-library-)";
 

--- a/scripts/codex/daily-improvement.mjs
+++ b/scripts/codex/daily-improvement.mjs
@@ -22,7 +22,7 @@ const improvementLogPath = resolve(codexDir, "improvement-log.md");
 const improvementStatePath = resolve(codexDir, "improvement-state.json");
 const improvementReportsDir = resolve(repoRoot, "docs", "runbooks", "codex-improvement");
 
-const rollingIssueTitle = "Codex Continuous Improvement (Rolling)";
+const rollingIssueTitle = "Codex Automation (Rolling)";
 const ignoreAnalysisFiles = new Set([
   ".codex/improvement-log.md",
   ".codex/improvement-state.json",

--- a/scripts/codex/daily-interaction.mjs
+++ b/scripts/codex/daily-interaction.mjs
@@ -23,7 +23,7 @@ const interactionLogPath = resolve(codexDir, "interaction-log.md");
 const userDocPath = resolve(codexDir, "user.md");
 const agentsDocPath = resolve(codexDir, "agents.md");
 
-const rollingIssueTitle = "Codex Interaction Interrogation (Rolling)";
+const rollingIssueTitle = "Codex Automation (Rolling)";
 const epicPath = "docs/epics/EPIC-CODEX-INTERACTION-INTERROGATION.md";
 
 const ignoreChurnPaths = new Set([

--- a/scripts/codex/daily-pr-green.mjs
+++ b/scripts/codex/daily-pr-green.mjs
@@ -16,7 +16,7 @@ const codexDir = resolve(repoRoot, ".codex");
 const toolcallPath = resolve(codexDir, "toolcalls.ndjson");
 const improvementStatePath = resolve(codexDir, "improvement-state.json");
 const prGreenLogPath = resolve(codexDir, "pr-green-log.md");
-const rollingIssueTitle = "Codex PR Green Daily (Rolling)";
+const rollingIssueTitle = "Codex Automation (Rolling)";
 
 const secretKeyPattern = /(token|secret|password|authorization|api[_-]?key|cookie|session|private[_-]?key)/i;
 const secretValuePatterns = [

--- a/scripts/credentials-health-check.mjs
+++ b/scripts/credentials-health-check.mjs
@@ -9,6 +9,13 @@ import { dirname, resolve } from "node:path";
 import { homedir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { spawnSync } from "node:child_process";
+import { buildAutomationFamilyBody, getAutomationFamily } from "./lib/automation-issue-families.mjs";
+import {
+  ensureGhLabels,
+  ensureIssueWithMarker,
+  fetchLatestIssueCommentBody,
+  listRepoIssues,
+} from "./lib/github-issues.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const repoRoot = resolve(dirname(__filename), "..");
@@ -16,7 +23,7 @@ const repoRoot = resolve(dirname(__filename), "..");
 const DEFAULT_PROJECT_ID = "monsoonfire-portal";
 const DEFAULT_BASE_URL = "https://portal.monsoonfire.com";
 const DEFAULT_REPORT_PATH = resolve(repoRoot, "output", "qa", "credential-health-check.json");
-const ROLLING_ISSUE_TITLE = "Portal Credential Health (Rolling)";
+const PORTAL_INFRA_FAMILY = getAutomationFamily("portal-infra");
 const GOOGLE_OAUTH_TOKEN_ENDPOINT = "https://www.googleapis.com/oauth2/v3/token";
 const FIREBASE_CLI_OAUTH_CLIENT_ID =
   "563584335869-fgrhgmd47bqnekij5i8b5pr03ho849e6.apps.googleusercontent.com";
@@ -143,101 +150,12 @@ function parseRepoSlug() {
   return "";
 }
 
-function ensureGhLabel(repoSlug, name, color, description) {
-  runCommand(
-    "gh",
-    ["label", "create", name, "--repo", repoSlug, "--color", color, "--description", description, "--force"],
-    { allowFailure: true }
-  );
-}
-
-function ensureRollingIssue(repoSlug) {
-  const existing = runCommand(
-    "gh",
-    [
-      "issue",
-      "list",
-      "--repo",
-      repoSlug,
-      "--state",
-      "open",
-      "--search",
-      `in:title \"${ROLLING_ISSUE_TITLE}\"`,
-      "--json",
-      "number,title,url",
-    ],
-    { allowFailure: true }
-  );
-
-  if (existing.ok) {
-    try {
-      const parsed = JSON.parse(existing.stdout || "[]");
-      const match = parsed.find((item) => String(item?.title || "") === ROLLING_ISSUE_TITLE);
-      if (match) {
-        return {
-          number: Number(match.number || 0),
-          url: String(match.url || ""),
-        };
-      }
-    } catch {
-      // no-op
-    }
-  }
-
-  const created = runCommand(
-    "gh",
-    [
-      "issue",
-      "create",
-      "--repo",
-      repoSlug,
-      "--title",
-      ROLLING_ISSUE_TITLE,
-      "--body",
-      "Rolling credential and secret-health monitor for portal automation.",
-      "--label",
-      "automation",
-      "--label",
-      "infra",
-      "--label",
-      "security",
-    ],
-    { allowFailure: true }
-  );
-
-  if (!created.ok) return { number: 0, url: "" };
-
-  const issueUrl = created.stdout.split(/\s+/).find((token) => token.startsWith("https://github.com/")) || "";
-  const issueNumberMatch = issueUrl.match(/\/issues\/(\d+)/);
-  return {
-    number: issueNumberMatch ? Number(issueNumberMatch[1]) : 0,
-    url: issueUrl,
-  };
-}
-
 function postIssueComment(repoSlug, issueNumber, body) {
   runCommand(
     "gh",
     ["issue", "comment", String(issueNumber), "--repo", repoSlug, "--body", body],
     { allowFailure: true }
   );
-}
-
-function getLatestIssueCommentBody(repoSlug, issueNumber) {
-  const view = runCommand(
-    "gh",
-    ["issue", "view", String(issueNumber), "--repo", repoSlug, "--json", "comments"],
-    { allowFailure: true }
-  );
-  if (!view.ok) return "";
-  try {
-    const parsed = JSON.parse(view.stdout || "{}");
-    const comments = Array.isArray(parsed?.comments) ? parsed.comments : [];
-    const latest = comments.length > 0 ? comments[comments.length - 1] : null;
-    return String(latest?.body || "");
-  } catch {
-    return "";
-  }
 }
 
 function stableHash(value, len = 20) {
@@ -670,21 +588,40 @@ async function main() {
   if (options.apply && options.includeGithub) {
     const repoSlug = parseRepoSlug();
     if (repoSlug) {
-      ensureGhLabel(repoSlug, "automation", "0e8a16", "Automated monitoring and remediation.");
-      ensureGhLabel(repoSlug, "infra", "5319e7", "Infrastructure and operational controls.");
-      ensureGhLabel(repoSlug, "security", "d73a4a", "Security and credential hygiene.");
+      const openIssuesResp = listRepoIssues(repoSlug, { state: "open", maxPages: 2, cwd: repoRoot });
+      if (openIssuesResp.ok) {
+        ensureGhLabels(repoSlug, PORTAL_INFRA_FAMILY.labels, { cwd: repoRoot });
+        const ensured = ensureIssueWithMarker(
+          repoSlug,
+          {
+            title: PORTAL_INFRA_FAMILY.title,
+            body: buildAutomationFamilyBody(PORTAL_INFRA_FAMILY),
+            labels: PORTAL_INFRA_FAMILY.labels.map((label) => label.name),
+            marker: PORTAL_INFRA_FAMILY.marker,
+            preferredNumber: PORTAL_INFRA_FAMILY.preferredNumber,
+            openIssues: openIssuesResp.data,
+          },
+          { cwd: repoRoot }
+        );
+        if (ensured.ok && ensured.issue) {
+          summary.rollingIssue = {
+            number: ensured.issue.number,
+            url: ensured.issue.url,
+            signature: "",
+            commentSkipped: false,
+          };
+        }
+      }
 
-      const rollingIssue = ensureRollingIssue(repoSlug);
-      summary.rollingIssue = rollingIssue;
-      if (rollingIssue.number > 0) {
+      if (summary.rollingIssue.number > 0) {
         const signature = buildSummarySignature(summary);
         const marker = `<!-- credential-health-signature:${signature} -->`;
-        const latestBody = getLatestIssueCommentBody(repoSlug, rollingIssue.number);
+        const latestBody = fetchLatestIssueCommentBody(repoSlug, summary.rollingIssue.number, { cwd: repoRoot });
         const unchanged = latestBody.includes(marker);
         summary.rollingIssue.signature = signature;
         summary.rollingIssue.commentSkipped = unchanged;
         if (!unchanged) {
-          postIssueComment(repoSlug, rollingIssue.number, buildIssueComment(summary, marker));
+          postIssueComment(repoSlug, summary.rollingIssue.number, buildIssueComment(summary, marker));
         }
       }
     }

--- a/scripts/firestore-index-contract-guard.mjs
+++ b/scripts/firestore-index-contract-guard.mjs
@@ -9,13 +9,20 @@ import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { buildAutomationFamilyBody, getAutomationFamily } from "./lib/automation-issue-families.mjs";
+import {
+  ensureGhLabels,
+  ensureIssueWithMarker,
+  fetchLatestIssueCommentBody,
+  listRepoIssues,
+} from "./lib/github-issues.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const repoRoot = resolve(dirname(__filename), "..");
 const indexesPath = resolve(repoRoot, "firestore.indexes.json");
 const codexDir = resolve(repoRoot, ".codex");
 const logPath = resolve(codexDir, "index-guard-log.md");
-const rollingIssueTitle = "Portal Firestore Index Guard (Rolling)";
+const PORTAL_INFRA_FAMILY = getAutomationFamily("portal-infra");
 
 const requiredIndexes = [
   {
@@ -207,75 +214,6 @@ async function appendLog(summary) {
   await appendFile(logPath, `${lines.join("\n")}\n`, "utf8");
 }
 
-function ensureGhLabel(repoSlug, name, color, description) {
-  runCommand(
-    "gh",
-    ["label", "create", name, "--repo", repoSlug, "--color", color, "--description", description, "--force"],
-    { allowFailure: true }
-  );
-}
-
-function ensureRollingIssue(repoSlug) {
-  const existing = runCommand(
-    "gh",
-    [
-      "issue",
-      "list",
-      "--repo",
-      repoSlug,
-      "--state",
-      "open",
-      "--search",
-      `in:title \"${rollingIssueTitle}\"`,
-      "--json",
-      "number,title,url",
-    ],
-    { allowFailure: true }
-  );
-
-  if (existing.ok) {
-    try {
-      const parsed = JSON.parse(existing.stdout || "[]");
-      const match = parsed.find((item) => String(item?.title || "") === rollingIssueTitle);
-      if (match) {
-        return { number: match.number, url: match.url };
-      }
-    } catch {
-      // fall through to create
-    }
-  }
-
-  const created = runCommand(
-    "gh",
-    [
-      "issue",
-      "create",
-      "--repo",
-      repoSlug,
-      "--title",
-      rollingIssueTitle,
-      "--body",
-      "Rolling index guard findings for portal query stability.",
-      "--label",
-      "automation",
-      "--label",
-      "infra",
-    ],
-    { allowFailure: true }
-  );
-
-  if (!created.ok || !created.stdout) {
-    return { number: 0, url: "" };
-  }
-
-  const issueUrl = created.stdout.split(/\s+/).find((token) => /^https:\/\/github\.com\//.test(token)) || "";
-  const issueNumberMatch = issueUrl.match(/\/issues\/(\d+)/);
-  return {
-    number: issueNumberMatch ? Number(issueNumberMatch[1]) : 0,
-    url: issueUrl,
-  };
-}
-
 function createAlertIssue(repoSlug, summary) {
   const title = "[Index Guard] Missing required Firestore indexes";
   const existing = runCommand(
@@ -359,23 +297,6 @@ function buildRollingCommentSignature(summary) {
   return createHash("sha256").update(JSON.stringify(payload)).digest("hex").slice(0, 20);
 }
 
-function getLatestIssueCommentBody(repoSlug, issueNumber) {
-  const view = runCommand(
-    "gh",
-    ["issue", "view", String(issueNumber), "--repo", repoSlug, "--json", "comments"],
-    { allowFailure: true }
-  );
-  if (!view.ok) return "";
-  try {
-    const parsed = JSON.parse(view.stdout || "{}");
-    const comments = Array.isArray(parsed?.comments) ? parsed.comments : [];
-    const latest = comments.length > 0 ? comments[comments.length - 1] : null;
-    return String(latest?.body || "");
-  } catch {
-    return "";
-  }
-}
-
 function buildRollingComment(summary, marker) {
   const lines = [];
   lines.push(`## ${summary.runAtIso} (Index Guard)`);
@@ -447,25 +368,37 @@ async function main() {
   if (options.apply && options.includeGithub) {
     const repoSlug = parseRepoSlug();
     if (repoSlug) {
-      ensureGhLabel(repoSlug, "automation", "5319e7", "Automation generated task/update.");
-      ensureGhLabel(repoSlug, "infra", "1f6feb", "Infrastructure or platform guardrails.");
-      ensureGhLabel(repoSlug, "firestore", "0e8a16", "Firestore indexes/rules/contracts.");
-
-      const rolling = ensureRollingIssue(repoSlug);
-      if (rolling.number > 0) {
-        summary.rollingIssueUrl = rolling.url;
-        const signature = buildRollingCommentSignature(summary);
-        summary.rollingCommentSignature = signature;
-        const marker = `index-guard-signature:${signature}`;
-        const latestBody = getLatestIssueCommentBody(repoSlug, rolling.number);
-        const unchanged = latestBody.includes(`<!-- ${marker} -->`);
-        summary.rollingCommentSkipped = unchanged;
-        if (!unchanged) {
-          runCommand(
-            "gh",
-            ["issue", "comment", String(rolling.number), "--repo", repoSlug, "--body", buildRollingComment(summary, marker)],
-            { allowFailure: true }
-          );
+      const openIssuesResp = listRepoIssues(repoSlug, { state: "open", maxPages: 2, cwd: repoRoot });
+      if (openIssuesResp.ok) {
+        ensureGhLabels(repoSlug, PORTAL_INFRA_FAMILY.labels, { cwd: repoRoot });
+        const ensured = ensureIssueWithMarker(
+          repoSlug,
+          {
+            title: PORTAL_INFRA_FAMILY.title,
+            body: buildAutomationFamilyBody(PORTAL_INFRA_FAMILY),
+            labels: PORTAL_INFRA_FAMILY.labels.map((label) => label.name),
+            marker: PORTAL_INFRA_FAMILY.marker,
+            preferredNumber: PORTAL_INFRA_FAMILY.preferredNumber,
+            openIssues: openIssuesResp.data,
+          },
+          { cwd: repoRoot }
+        );
+        if (ensured.ok && ensured.issue) {
+          summary.rollingIssueUrl = ensured.issue.url;
+          const rollingNumber = ensured.issue.number;
+          const signature = buildRollingCommentSignature(summary);
+          summary.rollingCommentSignature = signature;
+          const marker = `index-guard-signature:${signature}`;
+          const latestBody = fetchLatestIssueCommentBody(repoSlug, rollingNumber, { cwd: repoRoot });
+          const unchanged = latestBody.includes(`<!-- ${marker} -->`);
+          summary.rollingCommentSkipped = unchanged;
+          if (!unchanged) {
+            runCommand(
+              "gh",
+              ["issue", "comment", String(rollingNumber), "--repo", repoSlug, "--body", buildRollingComment(summary, marker)],
+              { allowFailure: true }
+            );
+          }
         }
       }
 

--- a/scripts/github-automation-issue-cleanup.mjs
+++ b/scripts/github-automation-issue-cleanup.mjs
@@ -1,0 +1,281 @@
+#!/usr/bin/env node
+
+/* eslint-disable no-console */
+
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { buildAutomationFamilyBody, getAutomationFamily } from "./lib/automation-issue-families.mjs";
+import {
+  closeIssue,
+  commentIssue,
+  ensureGhLabels,
+  ensureIssueWithMarker,
+  fetchLatestIssueCommentBody,
+  listRepoIssues,
+  markerComment,
+  parseRepoSlug,
+} from "./lib/github-issues.mjs";
+
+const __filename = fileURLToPath(import.meta.url);
+const repoRoot = resolve(dirname(__filename), "..");
+const DEFAULT_REPORT_PATH = resolve(repoRoot, "output", "qa", "github-automation-issue-cleanup.json");
+
+const FAMILY_KEYS = ["portal-qa", "portal-infra", "codex-automation", "governance-tuning"];
+
+const SUPERSeded_ISSUES = [
+  { issueNumber: 315, familyKey: "portal-qa", stateReason: "not_planned", note: "Load-test rolling failures now aggregate into the portal QA family thread." },
+  { issueNumber: 264, familyKey: "portal-qa", stateReason: "not_planned", note: "Older duplicate load-test rolling thread superseded by the portal QA family thread." },
+  { issueNumber: 310, familyKey: "portal-qa", stateReason: "not_planned", note: "Smoke-test workflow failures now aggregate into the portal QA family thread." },
+  { issueNumber: 115, familyKey: "portal-qa", stateReason: "not_planned", note: "Threshold tuning snapshots now live in the portal QA family thread." },
+  { issueNumber: 140, familyKey: "codex-automation", stateReason: "not_planned", note: "Backlog autopilot reporting now rolls into the shared Codex automation thread." },
+  { issueNumber: 45, familyKey: "codex-automation", stateReason: "not_planned", note: "Continuous improvement reporting now rolls into the shared Codex automation thread." },
+  { issueNumber: 46, familyKey: "codex-automation", stateReason: "not_planned", note: "Interaction interrogation reporting now rolls into the shared Codex automation thread." },
+  { issueNumber: 30, familyKey: "codex-automation", stateReason: "not_planned", note: "PR-green reporting now rolls into the shared Codex automation thread." },
+  { issueNumber: 294, familyKey: "governance-tuning", stateReason: "not_planned", note: "Weekly governance tuning now comments into one rolling thread instead of date-stamped issues." },
+];
+
+const RECOVERED_ISSUES = [
+  {
+    issueNumber: 85,
+    familyKey: "portal-qa",
+    stateReason: "completed",
+    evidencePath: "output/qa/portal-authenticated-canary.json",
+    expectedStatus: "passed",
+    note: "Authenticated canary is green again and future state changes now flow through the portal QA family thread.",
+  },
+  {
+    issueNumber: 87,
+    familyKey: "portal-infra",
+    stateReason: "completed",
+    evidencePath: "output/qa/credential-health-check.json",
+    expectedStatus: "passed",
+    note: "Credential health is currently passing and future updates now flow through the portal infra family thread.",
+  },
+  {
+    issueNumber: 88,
+    familyKey: "portal-infra",
+    stateReason: "completed",
+    evidencePath: "output/qa/branch-divergence-guard.json",
+    expectedStatus: "passed",
+    note: "Branch divergence guard is currently passing and future updates now flow through the portal infra family thread.",
+  },
+];
+
+const FAMILY_SUMMARY_NOTES = {
+  "portal-qa":
+    "Automation cleanup on 2026-03-09 consolidated workflow-failure, canary, tuning, and weekly digest reporting here. Persistent deterministic failures stay open as dedicated child issues.",
+  "portal-infra":
+    "Automation cleanup on 2026-03-09 consolidated credential, index, and branch-integrity reporting here.",
+  "codex-automation":
+    "Automation cleanup on 2026-03-09 consolidated Codex improvement, interaction, PR-green, and backlog rollups here.",
+  "governance-tuning":
+    "Automation cleanup on 2026-03-09 switched governance tuning from date-stamped issues to this rolling thread.",
+};
+
+function parseArgs(argv) {
+  const options = {
+    apply: false,
+    asJson: false,
+    reportPath: DEFAULT_REPORT_PATH,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (!arg || !arg.startsWith("--")) continue;
+
+    if (arg === "--apply") {
+      options.apply = true;
+      continue;
+    }
+    if (arg === "--dry-run") {
+      options.apply = false;
+      continue;
+    }
+    if (arg === "--json") {
+      options.asJson = true;
+      continue;
+    }
+
+    const next = argv[index + 1];
+    if (!next || next.startsWith("--")) {
+      throw new Error(`Missing value for ${arg}`);
+    }
+
+    if (arg === "--report") {
+      options.reportPath = resolve(process.cwd(), String(next).trim());
+      index += 1;
+      continue;
+    }
+  }
+
+  return options;
+}
+
+async function readStatus(pathValue) {
+  try {
+    const raw = await readFile(resolve(repoRoot, pathValue), "utf8");
+    const parsed = JSON.parse(raw);
+    return String(parsed?.status || "").trim().toLowerCase();
+  } catch {
+    return "";
+  }
+}
+
+function buildMigrationComment({ familyIssueNumber, familyTitle, note, evidencePath = "", evidenceStatus = "" }) {
+  const lines = [];
+  lines.push(note);
+  lines.push("");
+  lines.push(`Follow-up lives in #${familyIssueNumber} (${familyTitle}).`);
+  if (evidencePath && evidenceStatus) {
+    lines.push(`Latest local evidence: \`${evidencePath}\` reports status=\`${evidenceStatus}\`.`);
+  }
+  return lines.join("\n");
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const repoSlug = parseRepoSlug({ cwd: repoRoot });
+  if (!repoSlug) {
+    throw new Error("Could not resolve repository slug from environment or git remote.");
+  }
+
+  const openIssuesResp = listRepoIssues(repoSlug, { state: "open", maxPages: 2, cwd: repoRoot });
+  if (!openIssuesResp.ok) {
+    throw new Error(`Could not read open issues: ${openIssuesResp.error}`);
+  }
+  const openIssueMap = new Map(openIssuesResp.data.map((issue) => [issue.number, issue]));
+
+  const report = {
+    status: "ok",
+    generatedAtIso: new Date().toISOString(),
+    mode: options.apply ? "apply" : "dry-run",
+    canonicalIssues: [],
+    closures: [],
+    notes: [],
+  };
+
+  const familyResults = new Map();
+  for (const familyKey of FAMILY_KEYS) {
+    const family = getAutomationFamily(familyKey);
+    if (!family) continue;
+    ensureGhLabels(repoSlug, family.labels, { cwd: repoRoot });
+    const ensured = ensureIssueWithMarker(
+      repoSlug,
+      {
+        title: family.title,
+        body: buildAutomationFamilyBody(family),
+        labels: family.labels.map((label) => label.name),
+        marker: family.marker,
+        preferredNumber: family.preferredNumber,
+        openIssues: openIssuesResp.data,
+      },
+      { cwd: repoRoot }
+    );
+    if (!ensured.ok || !ensured.issue) {
+      throw new Error(`Could not resolve ${familyKey} family issue: ${ensured.error || "unknown error"}`);
+    }
+    familyResults.set(familyKey, ensured.issue);
+
+    const cleanupMarker = `automation-cleanup:family:${family.key}:2026-03-09`;
+    if (options.apply) {
+      const latestComment = fetchLatestIssueCommentBody(repoSlug, ensured.issue.number, { cwd: repoRoot });
+      if (!latestComment.includes(markerComment(cleanupMarker))) {
+        commentIssue(
+          repoSlug,
+          ensured.issue.number,
+          `${FAMILY_SUMMARY_NOTES[family.key]}\n\n${markerComment(cleanupMarker)}\n`,
+          { cwd: repoRoot }
+        );
+      }
+    }
+
+    report.canonicalIssues.push({
+      familyKey,
+      issueNumber: ensured.issue.number,
+      issueUrl: ensured.issue.url,
+      title: ensured.issue.title,
+      created: ensured.created,
+      updated: ensured.updated,
+    });
+  }
+
+  const closePlans = [...SUPERSeded_ISSUES];
+  for (const recovered of RECOVERED_ISSUES) {
+    const evidenceStatus = await readStatus(recovered.evidencePath);
+    closePlans.push({ ...recovered, evidenceStatus });
+  }
+
+  for (const plan of closePlans) {
+    const issue = openIssueMap.get(plan.issueNumber);
+    const familyIssue = familyResults.get(plan.familyKey);
+    if (!issue || !familyIssue) {
+      report.closures.push({
+        issueNumber: plan.issueNumber,
+        result: "skip-missing",
+        familyKey: plan.familyKey,
+      });
+      continue;
+    }
+
+    if ("expectedStatus" in plan && plan.expectedStatus && plan.evidenceStatus !== plan.expectedStatus) {
+      report.closures.push({
+        issueNumber: plan.issueNumber,
+        result: "skip-evidence-mismatch",
+        familyKey: plan.familyKey,
+        evidenceStatus: plan.evidenceStatus,
+      });
+      continue;
+    }
+
+    const commentBody = buildMigrationComment({
+      familyIssueNumber: familyIssue.number,
+      familyTitle: familyIssue.title,
+      note: plan.note,
+      evidencePath: plan.evidencePath || "",
+      evidenceStatus: plan.evidenceStatus || "",
+    });
+
+    if (options.apply) {
+      const closed = closeIssue(
+        repoSlug,
+        plan.issueNumber,
+        {
+          commentBody,
+          stateReason: plan.stateReason,
+        },
+        { cwd: repoRoot }
+      );
+      if (!closed.ok) {
+        throw new Error(`Could not close issue #${plan.issueNumber}.`);
+      }
+    }
+
+    report.closures.push({
+      issueNumber: plan.issueNumber,
+      result: options.apply ? "closed" : "planned-close",
+      familyKey: plan.familyKey,
+      stateReason: plan.stateReason,
+      evidenceStatus: plan.evidenceStatus || "",
+    });
+  }
+
+  await mkdir(dirname(options.reportPath), { recursive: true });
+  await writeFile(options.reportPath, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+
+  if (options.asJson) {
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  } else {
+    process.stdout.write(`status: ${report.status}\n`);
+    process.stdout.write(`mode: ${report.mode}\n`);
+    process.stdout.write(`canonicalIssues: ${String(report.canonicalIssues.length)}\n`);
+    process.stdout.write(`closures: ${String(report.closures.length)}\n`);
+    process.stdout.write(`report: ${options.reportPath}\n`);
+  }
+}
+
+main().catch((error) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`github-automation-issue-cleanup failed: ${message}`);
+  process.exit(1);
+});

--- a/scripts/governance/publish-weekly-tuning-issue.mjs
+++ b/scripts/governance/publish-weekly-tuning-issue.mjs
@@ -1,0 +1,187 @@
+#!/usr/bin/env node
+
+/* eslint-disable no-console */
+
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { buildAutomationFamilyBody, getAutomationFamily } from "../lib/automation-issue-families.mjs";
+import {
+  commentIssue,
+  ensureGhLabels,
+  ensureIssueWithMarker,
+  fetchLatestIssueCommentBody,
+  listRepoIssues,
+  markerComment,
+  parseRepoSlug,
+} from "../lib/github-issues.mjs";
+
+const __filename = fileURLToPath(import.meta.url);
+const repoRoot = resolve(dirname(__filename), "..", "..");
+
+const DEFAULT_REPORT_PATH = resolve(repoRoot, "output", "governance", "weekly-tune-report.json");
+const DEFAULT_OUTPUT_PATH = resolve(repoRoot, "output", "governance", "weekly-tune-issue.json");
+const GOVERNANCE_FAMILY = getAutomationFamily("governance-tuning");
+
+function parseArgs(argv) {
+  const options = {
+    reportPath: DEFAULT_REPORT_PATH,
+    outputPath: DEFAULT_OUTPUT_PATH,
+    apply: true,
+    asJson: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (!arg || !arg.startsWith("--")) continue;
+
+    if (arg === "--json") {
+      options.asJson = true;
+      continue;
+    }
+    if (arg === "--apply") {
+      options.apply = true;
+      continue;
+    }
+    if (arg === "--no-apply") {
+      options.apply = false;
+      continue;
+    }
+
+    const next = argv[index + 1];
+    if (!next || next.startsWith("--")) {
+      throw new Error(`Missing value for ${arg}`);
+    }
+
+    if (arg === "--report") {
+      options.reportPath = resolve(process.cwd(), String(next).trim());
+      index += 1;
+      continue;
+    }
+    if (arg === "--output") {
+      options.outputPath = resolve(process.cwd(), String(next).trim());
+      index += 1;
+      continue;
+    }
+  }
+
+  return options;
+}
+
+function formatRate(value) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return "n/a";
+  return numeric.toFixed(4);
+}
+
+function buildComment(report, marker) {
+  const lines = [];
+  lines.push(`## ${String(report.generated_at || "").slice(0, 10) || new Date().toISOString().slice(0, 10)} — weekly tuning summary`);
+  lines.push("");
+  lines.push("Weekly governance tuning summary (proposal-only).");
+  lines.push("");
+  lines.push(`- verification_hold_rate: ${formatRate(report.metrics?.verification_hold_rate)}`);
+  lines.push(`- false_positive_rate: ${formatRate(report.metrics?.false_positive_rate)}`);
+  lines.push(`- ci_failure_loop_rate: ${formatRate(report.metrics?.ci_failure_loop_rate)}`);
+  lines.push(`- audit_workload_per_week: ${String(report.metrics?.audit_workload_per_week ?? "n/a")}`);
+  lines.push("");
+  lines.push("Proposed threshold updates:");
+  lines.push("```json");
+  lines.push(JSON.stringify(report.proposed_thresholds || {}, null, 2));
+  lines.push("```");
+  lines.push("");
+  lines.push("Notes:");
+  const notes = Array.isArray(report.tuning_notes) ? report.tuning_notes : [];
+  if (notes.length === 0) {
+    lines.push("- No tuning notes recorded.");
+  } else {
+    for (const note of notes) {
+      lines.push(`- ${String(note || "").trim()}`);
+    }
+  }
+  lines.push("");
+  lines.push(markerComment(marker));
+  lines.push("");
+  return lines.join("\n");
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const raw = await readFile(options.reportPath, "utf8");
+  const report = JSON.parse(raw);
+  const repoSlug = parseRepoSlug({ cwd: repoRoot });
+  if (!repoSlug) {
+    throw new Error("Could not resolve repository slug from environment or git remote.");
+  }
+
+  const summary = {
+    status: "ok",
+    generatedAtIso: new Date().toISOString(),
+    reportPath: options.reportPath,
+    outputPath: options.outputPath,
+    issueNumber: 0,
+    issueUrl: "",
+    result: options.apply ? "pending" : "dry-run",
+    marker: `governance-weekly-tuning:${String(report.generated_at || "").slice(0, 10) || "manual"}`,
+    notes: [],
+  };
+
+  if (!options.apply) {
+    summary.result = "dry-run";
+  } else {
+    const openIssuesResp = listRepoIssues(repoSlug, { state: "open", maxPages: 2, cwd: repoRoot });
+    if (!openIssuesResp.ok) {
+      throw new Error(`Could not read open issues: ${openIssuesResp.error}`);
+    }
+
+    ensureGhLabels(repoSlug, GOVERNANCE_FAMILY.labels, { cwd: repoRoot });
+    const ensured = ensureIssueWithMarker(
+      repoSlug,
+      {
+        title: GOVERNANCE_FAMILY.title,
+        body: buildAutomationFamilyBody(GOVERNANCE_FAMILY),
+        labels: GOVERNANCE_FAMILY.labels.map((label) => label.name),
+        marker: GOVERNANCE_FAMILY.marker,
+        preferredNumber: GOVERNANCE_FAMILY.preferredNumber,
+        openIssues: openIssuesResp.data,
+      },
+      { cwd: repoRoot }
+    );
+    if (!ensured.ok || !ensured.issue) {
+      throw new Error(`Could not resolve governance family issue: ${ensured.error || "unknown error"}`);
+    }
+
+    summary.issueNumber = ensured.issue.number;
+    summary.issueUrl = ensured.issue.url;
+    const latestComment = fetchLatestIssueCommentBody(repoSlug, ensured.issue.number, { cwd: repoRoot });
+    if (latestComment.includes(markerComment(summary.marker))) {
+      summary.result = "unchanged-skip";
+    } else {
+      const comment = commentIssue(repoSlug, ensured.issue.number, buildComment(report, summary.marker), {
+        cwd: repoRoot,
+      });
+      if (!comment.ok) {
+        throw new Error("Could not post governance weekly tuning comment.");
+      }
+      summary.result = "commented";
+    }
+  }
+
+  await mkdir(dirname(options.outputPath), { recursive: true });
+  await writeFile(options.outputPath, `${JSON.stringify(summary, null, 2)}\n`, "utf8");
+
+  if (options.asJson) {
+    process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+  } else {
+    process.stdout.write(`status: ${summary.status}\n`);
+    process.stdout.write(`result: ${summary.result}\n`);
+    process.stdout.write(`issue: ${summary.issueUrl || "n/a"}\n`);
+    process.stdout.write(`output: ${summary.outputPath}\n`);
+  }
+}
+
+main().catch((error) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`publish-weekly-tuning-issue failed: ${message}`);
+  process.exit(1);
+});

--- a/scripts/lib/automation-issue-families.mjs
+++ b/scripts/lib/automation-issue-families.mjs
@@ -1,0 +1,94 @@
+export const AUTOMATION_LABELS = {
+  automation: {
+    name: "automation",
+    color: "0e8a16",
+    description: "Automated monitoring and remediation.",
+  },
+  portalQa: {
+    name: "portal-qa",
+    color: "0e8a16",
+    description: "Portal QA automation",
+  },
+  infra: {
+    name: "infra",
+    color: "5319e7",
+    description: "Infrastructure and operational controls.",
+  },
+  security: {
+    name: "security",
+    color: "d73a4a",
+    description: "Security and credential hygiene.",
+  },
+  governance: {
+    name: "governance-tuning",
+    color: "ededed",
+    description: "Governance tuning summaries and threshold proposals.",
+  },
+  codexReporting: {
+    name: "epic:codex-reporting",
+    color: "0e8a16",
+    description: "Codex automation reporting",
+  },
+};
+
+export const AUTOMATION_FAMILIES = {
+  portalQa: {
+    key: "portal-qa",
+    preferredNumber: 116,
+    title: "Portal QA Automation (Rolling)",
+    marker: "automation-family:portal-qa",
+    labels: [AUTOMATION_LABELS.automation, AUTOMATION_LABELS.portalQa],
+    body:
+      "Canonical rolling thread for portal QA automation. Use this issue for workflow failures, canary state changes, tuning snapshots, and digest updates.",
+  },
+  portalInfra: {
+    key: "portal-infra",
+    preferredNumber: 103,
+    title: "Portal Infra and Security Guards (Rolling)",
+    marker: "automation-family:portal-infra",
+    labels: [AUTOMATION_LABELS.automation, AUTOMATION_LABELS.infra, AUTOMATION_LABELS.security],
+    body:
+      "Canonical rolling thread for portal infra and security guard automation. Use this issue for index, credential, and branch integrity updates.",
+  },
+  codexAutomation: {
+    key: "codex-automation",
+    preferredNumber: 84,
+    title: "Codex Automation (Rolling)",
+    marker: "automation-family:codex-automation",
+    labels: [AUTOMATION_LABELS.automation, AUTOMATION_LABELS.codexReporting],
+    body:
+      "Canonical rolling thread for Codex automation reporting. Use this issue for improvement, interaction, PR-green, and backlog autopilot updates.",
+  },
+  governanceTuning: {
+    key: "governance-tuning",
+    preferredNumber: 309,
+    title: "Governance Weekly Tuning (Rolling)",
+    marker: "automation-family:governance-tuning",
+    labels: [AUTOMATION_LABELS.governance],
+    body:
+      "Canonical rolling thread for weekly governance tuning summaries and threshold proposals.",
+  },
+};
+
+export function buildAutomationFamilyBody(family) {
+  return `${family.body}\n\n<!-- ${family.marker} -->\n`;
+}
+
+export function getAutomationFamily(key) {
+  return Object.values(AUTOMATION_FAMILIES).find((family) => family.key === key) || null;
+}
+
+export function getWorkflowFailureFamilyKey(workflowName) {
+  const value = String(workflowName || "").trim();
+  if (
+    /^(Portal Load Test|Smoke Tests|Lighthouse Audit|Portal Fixture Steward|Portal Daily Authenticated Canary|Portal Automation Health Daily|Portal Automation Weekly Digest)$/i.test(
+      value
+    )
+  ) {
+    return "portal-qa";
+  }
+  if (/^Governance Weekly Tuning$/i.test(value)) {
+    return "governance-tuning";
+  }
+  return "";
+}

--- a/scripts/lib/github-issues.mjs
+++ b/scripts/lib/github-issues.mjs
@@ -1,0 +1,381 @@
+import { spawnSync } from "node:child_process";
+
+function shortError(text) {
+  return String(text || "").trim() || "gh command failed";
+}
+
+export function runCommand(command, args, { cwd, env = process.env, allowFailure = false } = {}) {
+  const result = spawnSync(command, args, {
+    cwd,
+    env,
+    encoding: "utf8",
+  });
+  const code = typeof result.status === "number" ? result.status : 1;
+  const stdout = String(result.stdout || "");
+  const stderr = String(result.stderr || "");
+  if (!allowFailure && code !== 0) {
+    throw new Error(`Command failed (${code}): ${command} ${args.join(" ")}\n${stderr || stdout}`);
+  }
+  return {
+    ok: code === 0,
+    code,
+    stdout,
+    stderr,
+  };
+}
+
+export function runGh(args, options = {}) {
+  return runCommand("gh", args, options);
+}
+
+export function runGhJson(args, { allowFailure = true, ...options } = {}) {
+  const response = runGh(args, { allowFailure, ...options });
+  if (!response.ok) {
+    return {
+      ok: false,
+      data: null,
+      error: shortError(response.stderr || response.stdout),
+    };
+  }
+
+  try {
+    return {
+      ok: true,
+      data: response.stdout.trim() ? JSON.parse(response.stdout) : null,
+      error: "",
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      data: null,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+export function parseRepoSlug({ cwd } = {}) {
+  const envSlug = String(process.env.GITHUB_REPOSITORY || "").trim();
+  if (envSlug) return envSlug;
+
+  const remote = runCommand("git", ["config", "--get", "remote.origin.url"], { cwd, allowFailure: true });
+  if (!remote.ok) return "";
+
+  const value = remote.stdout.trim();
+  const sshMatch = value.match(/^git@github\.com:([^/]+\/[^/.]+)(?:\.git)?$/i);
+  if (sshMatch) return sshMatch[1];
+  const httpsMatch = value.match(/^https:\/\/github\.com\/([^/]+\/[^/.]+)(?:\.git)?$/i);
+  if (httpsMatch) return httpsMatch[1];
+  return "";
+}
+
+export function parseIssueNumberFromUrl(url) {
+  const match = String(url || "").match(/\/issues\/(\d+)$/);
+  return match ? Number(match[1]) : 0;
+}
+
+export function normalizeMarker(marker) {
+  return String(marker || "")
+    .replace(/^<!--\s*/, "")
+    .replace(/\s*-->$/, "")
+    .trim();
+}
+
+export function markerComment(marker) {
+  const normalized = normalizeMarker(marker);
+  return normalized ? `<!-- ${normalized} -->` : "";
+}
+
+export function bodyHasMarker(body, marker) {
+  const comment = markerComment(marker);
+  return comment ? String(body || "").includes(comment) : false;
+}
+
+export function appendMarker(body, marker) {
+  const content = String(body || "").trim();
+  const comment = markerComment(marker);
+  if (!comment) return content;
+  if (content.includes(comment)) return content;
+  if (!content) return `${comment}\n`;
+  return `${content}\n\n${comment}\n`;
+}
+
+function normalizeIssue(issue) {
+  return {
+    number: Number(issue?.number || 0),
+    title: String(issue?.title || ""),
+    url: String(issue?.html_url || issue?.url || ""),
+    body: String(issue?.body || ""),
+    state: String(issue?.state || ""),
+    createdAt: String(issue?.created_at || issue?.createdAt || ""),
+    updatedAt: String(issue?.updated_at || issue?.updatedAt || ""),
+    closedAt: String(issue?.closed_at || issue?.closedAt || ""),
+    labels: Array.isArray(issue?.labels) ? issue.labels.map((label) => String(label?.name || label || "")).filter(Boolean) : [],
+  };
+}
+
+export function sortIssuesNewest(issues) {
+  return [...(Array.isArray(issues) ? issues : [])].sort((left, right) => {
+    const leftTime = Date.parse(String(left?.updatedAt || left?.createdAt || 0)) || 0;
+    const rightTime = Date.parse(String(right?.updatedAt || right?.createdAt || 0)) || 0;
+    if (rightTime !== leftTime) return rightTime - leftTime;
+    return Number(right?.number || 0) - Number(left?.number || 0);
+  });
+}
+
+export function findIssuesByExactTitle(issues, title) {
+  const normalizedTitle = String(title || "");
+  return sortIssuesNewest(issues).filter((issue) => issue.title === normalizedTitle);
+}
+
+export function findIssueByMarker(issues, marker) {
+  return sortIssuesNewest(issues).find((issue) => bodyHasMarker(issue.body, marker)) || null;
+}
+
+export function pickCanonicalIssue(issues, { marker = "", title = "", preferredNumber = 0 } = {}) {
+  const sorted = sortIssuesNewest(issues);
+  if (preferredNumber > 0) {
+    const preferred = sorted.find((issue) => issue.number === preferredNumber) || null;
+    if (preferred) {
+      const duplicates = sorted.filter(
+        (issue) =>
+          issue.number !== preferred.number && (issue.title === title || (marker && bodyHasMarker(issue.body, marker)))
+      );
+      return { issue: preferred, duplicates };
+    }
+  }
+
+  const byMarker = marker ? sorted.filter((issue) => bodyHasMarker(issue.body, marker)) : [];
+  if (byMarker.length > 0) {
+    const [issue, ...duplicates] = byMarker;
+    const extraDuplicates = sorted.filter(
+      (candidate) =>
+        candidate.number !== issue.number &&
+        !duplicates.some((duplicate) => duplicate.number === candidate.number) &&
+        title &&
+        candidate.title === title
+    );
+    return { issue, duplicates: [...duplicates, ...extraDuplicates] };
+  }
+
+  const byTitle = title ? findIssuesByExactTitle(sorted, title) : [];
+  if (byTitle.length > 0) {
+    const [issue, ...duplicates] = byTitle;
+    return { issue, duplicates };
+  }
+
+  return { issue: null, duplicates: [] };
+}
+
+export function ensureGhLabel(repoSlug, name, color, description, { cwd } = {}) {
+  return runGh(
+    ["label", "create", name, "--repo", repoSlug, "--color", color, "--description", description, "--force"],
+    { cwd, allowFailure: true }
+  );
+}
+
+export function ensureGhLabels(repoSlug, labels, options = {}) {
+  for (const label of labels || []) {
+    if (!label?.name) continue;
+    ensureGhLabel(repoSlug, label.name, label.color || "ededed", label.description || "", options);
+  }
+}
+
+export function listRepoIssues(
+  repoSlug,
+  { state = "open", labels = "", maxPages = 3, perPage = 100, cwd } = {}
+) {
+  const collected = [];
+  for (let page = 1; page <= maxPages; page += 1) {
+    const query = new URLSearchParams({
+      state,
+      per_page: String(perPage),
+      page: String(page),
+    });
+    if (labels) query.set("labels", labels);
+
+    const response = runGhJson(["api", `repos/${repoSlug}/issues?${query.toString()}`], {
+      allowFailure: true,
+      cwd,
+    });
+    if (!response.ok) {
+      return {
+        ok: false,
+        data: [],
+        error: response.error,
+      };
+    }
+
+    const pageItems = Array.isArray(response.data) ? response.data : [];
+    const issues = pageItems.filter((item) => !item?.pull_request).map(normalizeIssue);
+    collected.push(...issues);
+    if (pageItems.length < perPage) break;
+  }
+
+  return {
+    ok: true,
+    data: sortIssuesNewest(
+      Array.from(new Map(collected.map((issue) => [issue.number, issue])).values())
+    ),
+    error: "",
+  };
+}
+
+export function createIssue(repoSlug, { title, body, labels = [] }, { cwd } = {}) {
+  const args = ["issue", "create", "--repo", repoSlug, "--title", title, "--body", body];
+  for (const label of labels) {
+    args.push("--label", label);
+  }
+  const response = runGh(args, { cwd, allowFailure: true });
+  if (!response.ok) {
+    return {
+      ok: false,
+      issue: null,
+      error: shortError(response.stderr || response.stdout),
+    };
+  }
+
+  const url = response.stdout
+    .split(/\s+/)
+    .map((token) => token.trim())
+    .find((token) => token.startsWith("https://github.com/"));
+
+  return {
+    ok: true,
+    issue: {
+      number: parseIssueNumberFromUrl(url),
+      title,
+      url: url || "",
+      body,
+      labels: [...labels],
+      state: "open",
+      createdAt: "",
+      updatedAt: "",
+      closedAt: "",
+    },
+    error: "",
+  };
+}
+
+export function editIssue(repoSlug, issueNumber, { title, body, addLabels = [] }, { cwd } = {}) {
+  const args = ["issue", "edit", String(issueNumber), "--repo", repoSlug];
+  if (title !== undefined) args.push("--title", title);
+  if (body !== undefined) args.push("--body", body);
+  for (const label of addLabels) {
+    args.push("--add-label", label);
+  }
+  return runGh(args, { cwd, allowFailure: true });
+}
+
+export function commentIssue(repoSlug, issueNumber, body, { cwd } = {}) {
+  return runGh(["issue", "comment", String(issueNumber), "--repo", repoSlug, "--body", body], {
+    cwd,
+    allowFailure: true,
+  });
+}
+
+export function closeIssue(
+  repoSlug,
+  issueNumber,
+  { commentBody = "", stateReason = "not_planned" } = {},
+  { cwd } = {}
+) {
+  if (commentBody) {
+    const commented = commentIssue(repoSlug, issueNumber, commentBody, { cwd });
+    if (!commented.ok) return commented;
+  }
+  return runGh(
+    [
+      "api",
+      "--method",
+      "PATCH",
+      `repos/${repoSlug}/issues/${issueNumber}`,
+      "-f",
+      "state=closed",
+      "-f",
+      `state_reason=${stateReason}`,
+    ],
+    { cwd, allowFailure: true }
+  );
+}
+
+export function fetchLatestIssueCommentBody(repoSlug, issueNumber, { cwd } = {}) {
+  const response = runGhJson(
+    ["issue", "view", String(issueNumber), "--repo", repoSlug, "--json", "comments"],
+    { allowFailure: true, cwd }
+  );
+  if (!response.ok || !response.data || typeof response.data !== "object") return "";
+  const comments = Array.isArray(response.data.comments) ? response.data.comments : [];
+  const latest = comments.length > 0 ? comments[comments.length - 1] : null;
+  return String(latest?.body || "");
+}
+
+export function ensureIssueWithMarker(
+  repoSlug,
+  { title, body, labels = [], marker = "", openIssues = [], preferredNumber = 0, createIfMissing = true },
+  { cwd } = {}
+) {
+  const normalizedBody = appendMarker(body, marker);
+  const issuePool = Array.isArray(openIssues) ? openIssues : [];
+  const { issue, duplicates } = pickCanonicalIssue(issuePool, { marker, title, preferredNumber });
+
+  if (!issue) {
+    if (!createIfMissing) {
+      return {
+        ok: false,
+        issue: null,
+        created: false,
+        updated: false,
+        duplicates: [],
+        error: "issue-not-found",
+      };
+    }
+
+    const created = createIssue(repoSlug, { title, body: normalizedBody, labels }, { cwd });
+    return {
+      ok: created.ok,
+      issue: created.issue,
+      created: created.ok,
+      updated: false,
+      duplicates: [],
+      error: created.error,
+    };
+  }
+
+  const missingLabels = labels.filter((label) => !issue.labels.includes(label));
+  const needsUpdate = issue.title !== title || issue.body !== normalizedBody || missingLabels.length > 0;
+  if (!needsUpdate) {
+    return {
+      ok: true,
+      issue,
+      created: false,
+      updated: false,
+      duplicates,
+      error: "",
+    };
+  }
+
+  const edited = editIssue(
+    repoSlug,
+    issue.number,
+    {
+      title,
+      body: normalizedBody,
+      addLabels: missingLabels,
+    },
+    { cwd }
+  );
+
+  return {
+    ok: edited.ok,
+    issue: {
+      ...issue,
+      title,
+      body: normalizedBody,
+      labels: Array.from(new Set([...issue.labels, ...missingLabels])),
+    },
+    created: false,
+    updated: edited.ok,
+    duplicates,
+    error: edited.ok ? "" : shortError(edited.stderr || edited.stdout),
+  };
+}

--- a/scripts/portal-automation-issue-loop.mjs
+++ b/scripts/portal-automation-issue-loop.mjs
@@ -6,6 +6,8 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawnSync } from "node:child_process";
+import { buildAutomationFamilyBody, getAutomationFamily } from "./lib/automation-issue-families.mjs";
+import { ensureGhLabels, ensureIssueWithMarker, listRepoIssues } from "./lib/github-issues.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const repoRoot = resolve(dirname(__filename), "..");
@@ -13,11 +15,10 @@ const repoRoot = resolve(dirname(__filename), "..");
 const DEFAULT_DASHBOARD_PATH = resolve(repoRoot, "output", "qa", "portal-automation-health-dashboard.json");
 const DEFAULT_REPORT_JSON_PATH = resolve(repoRoot, "output", "qa", "portal-automation-issue-loop.json");
 const DEFAULT_REPORT_MARKDOWN_PATH = resolve(repoRoot, "output", "qa", "portal-automation-issue-loop.md");
-const DEFAULT_REPEATED_THRESHOLD = 2;
-const DEFAULT_MAX_ISSUES = 6;
-const DEFAULT_MAX_PER_WORKFLOW = 2;
-const TUNING_ROLLING_ISSUE = "Portal Automation Threshold Tuning (Rolling)";
-const CANARY_ROLLING_ISSUE = "Portal Authenticated Canary Failures (Rolling)";
+const DEFAULT_REPEATED_THRESHOLD = 3;
+const DEFAULT_MAX_ISSUES = 3;
+const DEFAULT_MAX_PER_WORKFLOW = 1;
+const PORTAL_QA_FAMILY = getAutomationFamily("portal-qa");
 const ROLLING_ONLY_SIGNATURE_KEYS = new Set(["promotion::promotion.risk.high"]);
 const NON_GATING_SIGNATURE_PATTERNS = [
   /deploy to firebase hosting on pr/i,
@@ -722,16 +723,14 @@ async function main() {
 
   const rollingConfigs = [
     {
-      title: TUNING_ROLLING_ISSUE,
-      labels: ["automation", "portal-qa", "self-improvement"],
+      lane: "tuning",
       markerPrefix: "portal-tuning-snapshot-signature",
       markerAliases: ["portal-tuning-signature", "portal-automation-tuning-signature"],
       signaturePayload: dashboard.tuning?.recommendations || {},
       buildComment: (marker) => createTuningComment(dashboard, marker),
     },
     {
-      title: CANARY_ROLLING_ISSUE,
-      labels: ["automation", "portal-qa"],
+      lane: "canary-directives",
       markerPrefix: "portal-canary-directive-signature",
       markerAliases: ["portal-canary-signature", "portal-automation-canary-signature"],
       signaturePayload: extractCanaryDirectiveCandidates(dashboard),
@@ -739,15 +738,42 @@ async function main() {
     },
   ];
 
+  let familyIssue = null;
+  if (options.apply) {
+    const openIssuesResp = listRepoIssues(repoSlug, { state: "open", maxPages: 2, cwd: repoRoot });
+    if (openIssuesResp.ok) {
+      ensureGhLabels(repoSlug, PORTAL_QA_FAMILY.labels, { cwd: repoRoot });
+      const ensured = ensureIssueWithMarker(
+        repoSlug,
+        {
+          title: PORTAL_QA_FAMILY.title,
+          body: buildAutomationFamilyBody(PORTAL_QA_FAMILY),
+          labels: PORTAL_QA_FAMILY.labels.map((item) => item.name),
+          marker: PORTAL_QA_FAMILY.marker,
+          preferredNumber: PORTAL_QA_FAMILY.preferredNumber,
+          openIssues: openIssuesResp.data,
+        },
+        { cwd: repoRoot }
+      );
+      if (ensured.ok) {
+        familyIssue = ensured.issue;
+      } else {
+        report.notes.push(`Could not resolve portal QA family issue: ${ensured.error}`);
+      }
+    } else {
+      report.notes.push(`Could not read portal QA family issue list: ${openIssuesResp.error}`);
+    }
+  }
+
   for (const config of rollingConfigs) {
     const markerCandidates = buildRollingMarkerCandidates(config);
     const marker = markerCandidates[0];
     const commentBody = config.buildComment(marker);
-    const existing = findIssueByTitle(repoSlug, config.title);
     const update = {
-      title: config.title,
+      title: PORTAL_QA_FAMILY.title,
+      lane: config.lane,
       result: options.apply ? "pending" : "dry-run",
-      url: existing?.url || "",
+      url: familyIssue?.url || "",
       marker,
     };
 
@@ -756,50 +782,27 @@ async function main() {
       continue;
     }
 
-    let issueNumber = existing?.number || 0;
-    let issueUrl = existing?.url || "";
-    if (!issueNumber) {
-      const created = runGh(
-        [
-          "issue",
-          "create",
-          "--repo",
-          repoSlug,
-          "--title",
-          config.title,
-          "--body",
-          "Rolling thread for portal automation loop updates.",
-          ...config.labels.flatMap((label) => ["--label", label]),
-        ],
-        { allowFailure: true }
-      );
-      if (created.ok) {
-        issueUrl = created.stdout.trim();
-        issueNumber = parseIssueNumberFromUrl(issueUrl);
-      } else {
-        update.result = "failed-create";
-        report.notes.push(`Could not create rolling issue "${config.title}".`);
-      }
-    }
-
-    if (issueNumber) {
-      const latestComment = fetchLatestIssueCommentBody(repoSlug, issueNumber);
+    if (familyIssue?.number) {
+      const latestComment = fetchLatestIssueCommentBody(repoSlug, familyIssue.number);
       if (markerCandidates.some((candidate) => latestComment.includes(`<!-- ${candidate} -->`))) {
         update.result = "unchanged-skip";
-        update.url = issueUrl || existing?.url || "";
+        update.url = familyIssue.url || "";
       } else {
         const commented = runGh(
-          ["issue", "comment", String(issueNumber), "--repo", repoSlug, "--body", commentBody],
+          ["issue", "comment", String(familyIssue.number), "--repo", repoSlug, "--body", commentBody],
           { allowFailure: true }
         );
         if (commented.ok) {
           update.result = "commented";
-          update.url = issueUrl || existing?.url || "";
+          update.url = familyIssue.url || "";
         } else {
           update.result = "failed-comment";
-          report.notes.push(`Could not comment on rolling issue "${config.title}".`);
+          report.notes.push(`Could not comment on portal QA family issue for lane "${config.lane}".`);
         }
       }
+    } else {
+      update.result = "failed-create";
+      report.notes.push(`Portal QA family issue missing for lane "${config.lane}".`);
     }
 
     report.rollingUpdates.push(update);

--- a/scripts/portal-automation-weekly-digest.mjs
+++ b/scripts/portal-automation-weekly-digest.mjs
@@ -7,6 +7,15 @@ import { tmpdir } from "node:os";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawnSync } from "node:child_process";
+import { buildAutomationFamilyBody, getAutomationFamily } from "./lib/automation-issue-families.mjs";
+import {
+  commentIssue,
+  ensureGhLabels,
+  ensureIssueWithMarker,
+  fetchLatestIssueCommentBody,
+  listRepoIssues,
+  parseRepoSlug,
+} from "./lib/github-issues.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const repoRoot = resolve(dirname(__filename), "..");
@@ -17,7 +26,7 @@ const DEFAULT_RUN_LIMIT = 25;
 const DEFAULT_ARTIFACT_PREFIX = "portal-automation-health-dashboard-";
 const DEFAULT_REPORT_JSON_PATH = resolve(repoRoot, "output", "qa", "portal-automation-weekly-digest.json");
 const DEFAULT_REPORT_MARKDOWN_PATH = resolve(repoRoot, "output", "qa", "portal-automation-weekly-digest.md");
-const ROLLING_DIGEST_ISSUE = "Portal Automation Weekly Digest (Rolling)";
+const PORTAL_QA_FAMILY = getAutomationFamily("portal-qa");
 
 function parseArgs(argv) {
   const options = {
@@ -113,51 +122,6 @@ function runGh(args, options = {}) {
   return runCommand("gh", args, options);
 }
 
-function parseRepoSlug() {
-  const fromEnv = String(process.env.GITHUB_REPOSITORY || "").trim();
-  if (fromEnv && fromEnv.includes("/")) return fromEnv;
-
-  const remote = runCommand("git", ["remote", "get-url", "origin"], { allowFailure: true });
-  if (!remote.ok) return "";
-
-  const raw = remote.stdout.trim();
-  const match = raw.match(/github\.com[:/](.+?)(?:\.git)?$/);
-  return match ? match[1] : "";
-}
-
-function findIssueByTitle(repoSlug, title) {
-  const list = runGh(
-    [
-      "issue",
-      "list",
-      "--repo",
-      repoSlug,
-      "--state",
-      "open",
-      "--search",
-      `"${title}" in:title`,
-      "--limit",
-      "10",
-      "--json",
-      "number,title,url",
-    ],
-    { allowFailure: true }
-  );
-  if (!list.ok) return null;
-  try {
-    const parsed = JSON.parse(list.stdout || "[]");
-    if (!Array.isArray(parsed)) return null;
-    return parsed.find((entry) => String(entry?.title || "") === title) || null;
-  } catch {
-    return null;
-  }
-}
-
-function parseIssueNumberFromUrl(url) {
-  const match = String(url || "").match(/\/issues\/(\d+)$/);
-  return match ? Number(match[1]) : 0;
-}
-
 async function findFilesRecursive(rootPath, fileName) {
   const matches = [];
   async function walk(dir) {
@@ -200,22 +164,6 @@ function stableHash(value) {
     hash = Math.imul(hash, 16777619);
   }
   return `f${(hash >>> 0).toString(16).padStart(8, "0")}`;
-}
-
-function fetchLatestIssueCommentBody(repoSlug, issueNumber) {
-  const view = runGh(
-    ["issue", "view", String(issueNumber), "--repo", repoSlug, "--json", "comments"],
-    { allowFailure: true }
-  );
-  if (!view.ok) return "";
-  try {
-    const parsed = JSON.parse(view.stdout || "{}");
-    const comments = Array.isArray(parsed?.comments) ? parsed.comments : [];
-    const latest = comments.length > 0 ? comments[comments.length - 1] : null;
-    return String(latest?.body || "");
-  } catch {
-    return "";
-  }
 }
 
 function buildDigestSignature(report) {
@@ -544,55 +492,46 @@ async function main() {
   const digestComment = buildDigestComment(report, digestMarker);
   report.digestMarker = digestMarker;
   if (options.apply) {
-    const repoSlug = parseRepoSlug();
+    const repoSlug = parseRepoSlug({ cwd: repoRoot });
     if (!repoSlug) {
       report.notes.push("Could not resolve repository slug; digest issue update skipped.");
     } else {
-      let issue = findIssueByTitle(repoSlug, ROLLING_DIGEST_ISSUE);
-      if (!issue) {
-        const create = runGh(
-          [
-            "issue",
-            "create",
-            "--repo",
-            repoSlug,
-            "--title",
-            ROLLING_DIGEST_ISSUE,
-            "--body",
-            "Rolling weekly digest for portal automation self-improvement loops.",
-            "--label",
-            "automation",
-            "--label",
-            "portal-qa",
-          ],
-          { allowFailure: true }
+      const openIssuesResp = listRepoIssues(repoSlug, { state: "open", maxPages: 2, cwd: repoRoot });
+      if (!openIssuesResp.ok) {
+        report.notes.push(`Could not read portal QA issue list: ${openIssuesResp.error}`);
+      } else {
+        ensureGhLabels(repoSlug, PORTAL_QA_FAMILY.labels, { cwd: repoRoot });
+        const ensured = ensureIssueWithMarker(
+          repoSlug,
+          {
+            title: PORTAL_QA_FAMILY.title,
+            body: buildAutomationFamilyBody(PORTAL_QA_FAMILY),
+            labels: PORTAL_QA_FAMILY.labels.map((label) => label.name),
+            marker: PORTAL_QA_FAMILY.marker,
+            preferredNumber: PORTAL_QA_FAMILY.preferredNumber,
+            openIssues: openIssuesResp.data,
+          },
+          { cwd: repoRoot }
         );
-        if (create.ok) {
-          const url = create.stdout.trim();
-          const number = parseIssueNumberFromUrl(url);
-          issue = { number, url, title: ROLLING_DIGEST_ISSUE };
-        } else {
-          report.notes.push("Could not create weekly digest rolling issue.");
-        }
-      }
 
-      if (issue?.number) {
-        const latestCommentBody = fetchLatestIssueCommentBody(repoSlug, issue.number);
+        if (!ensured.ok || !ensured.issue) {
+          report.notes.push(`Could not resolve portal QA family issue: ${ensured.error || "unknown error"}`);
+        } else {
+          const issue = ensured.issue;
+          const latestCommentBody = fetchLatestIssueCommentBody(repoSlug, issue.number, { cwd: repoRoot });
         const knownDigestMarkers = [digestMarker, legacyDigestMarker];
         if (knownDigestMarkers.some((marker) => latestCommentBody.includes(`<!-- ${marker} -->`))) {
           report.digestIssue = String(issue.url || "");
           report.notes.push("Weekly digest unchanged; skipped duplicate rolling comment.");
         } else {
-          const comment = runGh(
-            ["issue", "comment", String(issue.number), "--repo", repoSlug, "--body", digestComment],
-            { allowFailure: true }
-          );
+          const comment = commentIssue(repoSlug, issue.number, digestComment, { cwd: repoRoot });
           if (comment.ok) {
             report.digestIssue = String(issue.url || "");
           } else {
             report.notes.push("Could not post weekly digest comment.");
           }
         }
+      }
       }
     }
   }

--- a/scripts/portal-canary-escalation.mjs
+++ b/scripts/portal-canary-escalation.mjs
@@ -6,7 +6,15 @@ import { existsSync } from "node:fs";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { spawnSync } from "node:child_process";
+import { buildAutomationFamilyBody, getAutomationFamily } from "./lib/automation-issue-families.mjs";
+import {
+  ensureGhLabels,
+  ensureIssueWithMarker,
+  listRepoIssues,
+  markerComment,
+  parseRepoSlug,
+  runCommand,
+} from "./lib/github-issues.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const repoRoot = resolve(dirname(__filename), "..");
@@ -15,7 +23,7 @@ const DEFAULT_WORKFLOW_NAME = "Portal Daily Authenticated Canary";
 const DEFAULT_THRESHOLD = 2;
 const DEFAULT_REPORT_PATH = resolve(repoRoot, "output", "qa", "portal-authenticated-canary-escalation.json");
 const DEFAULT_CANARY_REPORT = resolve(repoRoot, "output", "qa", "portal-authenticated-canary.json");
-const ROLLING_ISSUE_TITLE = "Portal Authenticated Canary Failures (Rolling)";
+const PORTAL_QA_FAMILY = getAutomationFamily("portal-qa");
 
 function parseArgs(argv) {
   const options = {
@@ -109,37 +117,6 @@ function buildRunUrl() {
   return `${server}/${repo}/actions/runs/${runId}`;
 }
 
-function runCommand(command, args, { allowFailure = false } = {}) {
-  const result = spawnSync(command, args, { cwd: repoRoot, encoding: "utf8" });
-  const code = typeof result.status === "number" ? result.status : 1;
-  const stdout = String(result.stdout || "");
-  const stderr = String(result.stderr || "");
-  if (!allowFailure && code !== 0) {
-    throw new Error(`Command failed (${code}): ${command} ${args.join(" ")}\n${stderr || stdout}`);
-  }
-  return {
-    ok: code === 0,
-    code,
-    stdout,
-    stderr,
-  };
-}
-
-function parseRepoSlug() {
-  const envSlug = String(process.env.GITHUB_REPOSITORY || "").trim();
-  if (envSlug) return envSlug;
-
-  const remote = runCommand("git", ["config", "--get", "remote.origin.url"], { allowFailure: true });
-  if (!remote.ok) return "";
-
-  const value = remote.stdout.trim();
-  const sshMatch = value.match(/^git@github\.com:([^/]+\/[^/.]+)(?:\.git)?$/i);
-  if (sshMatch) return sshMatch[1];
-  const httpsMatch = value.match(/^https:\/\/github\.com\/([^/]+\/[^/.]+)(?:\.git)?$/i);
-  if (httpsMatch) return httpsMatch[1];
-  return "";
-}
-
 async function readJsonSafe(path) {
   if (!existsSync(path)) return null;
   try {
@@ -173,78 +150,6 @@ function countConsecutiveFailures(conclusions) {
     break;
   }
   return count;
-}
-
-function ensureGhLabel(repoSlug, name, color, description) {
-  runCommand(
-    "gh",
-    ["label", "create", name, "--repo", repoSlug, "--color", color, "--description", description, "--force"],
-    { allowFailure: true }
-  );
-}
-
-function ensureRollingIssue(repoSlug) {
-  const existing = runCommand(
-    "gh",
-    [
-      "issue",
-      "list",
-      "--repo",
-      repoSlug,
-      "--state",
-      "open",
-      "--search",
-      `in:title \"${ROLLING_ISSUE_TITLE}\"`,
-      "--json",
-      "number,title,url",
-    ],
-    { allowFailure: true }
-  );
-
-  if (existing.ok) {
-    try {
-      const parsed = JSON.parse(existing.stdout || "[]");
-      const match = parsed.find((item) => String(item?.title || "") === ROLLING_ISSUE_TITLE);
-      if (match) {
-        return {
-          number: Number(match.number || 0),
-          url: String(match.url || ""),
-        };
-      }
-    } catch {
-      // no-op
-    }
-  }
-
-  const created = runCommand(
-    "gh",
-    [
-      "issue",
-      "create",
-      "--repo",
-      repoSlug,
-      "--title",
-      ROLLING_ISSUE_TITLE,
-      "--body",
-      "Rolling alert log for authenticated portal canary outcomes.",
-      "--label",
-      "automation",
-      "--label",
-      "qa",
-      "--label",
-      "oncall",
-    ],
-    { allowFailure: true }
-  );
-
-  if (!created.ok) return { number: 0, url: "" };
-
-  const issueUrl = created.stdout.split(/\s+/).find((token) => token.startsWith("https://github.com/")) || "";
-  const issueNumberMatch = issueUrl.match(/\/issues\/(\d+)/);
-  return {
-    number: issueNumberMatch ? Number(issueNumberMatch[1]) : 0,
-    url: issueUrl,
-  };
 }
 
 function issueHasRunMarker(repoSlug, issueNumber, marker) {
@@ -382,23 +287,42 @@ async function main() {
   };
 
   if (options.apply && options.includeGithub) {
-    const repoSlug = parseRepoSlug();
+    const repoSlug = parseRepoSlug({ cwd: repoRoot });
     if (repoSlug) {
-      ensureGhLabel(repoSlug, "automation", "0e8a16", "Automated monitoring and remediation.");
-      ensureGhLabel(repoSlug, "qa", "1d76db", "Quality assurance automation coverage.");
-      ensureGhLabel(repoSlug, "oncall", "d73a4a", "Operational attention required.");
+      const openIssuesResp = listRepoIssues(repoSlug, { state: "open", maxPages: 2, cwd: repoRoot });
+      if (openIssuesResp.ok) {
+        ensureGhLabels(repoSlug, PORTAL_QA_FAMILY.labels, { cwd: repoRoot });
+        const ensured = ensureIssueWithMarker(
+          repoSlug,
+          {
+            title: PORTAL_QA_FAMILY.title,
+            body: buildAutomationFamilyBody(PORTAL_QA_FAMILY),
+            labels: PORTAL_QA_FAMILY.labels.map((label) => label.name),
+            marker: PORTAL_QA_FAMILY.marker,
+            preferredNumber: PORTAL_QA_FAMILY.preferredNumber,
+            openIssues: openIssuesResp.data,
+          },
+          { cwd: repoRoot }
+        );
+        if (ensured.ok && ensured.issue) {
+          summary.rollingIssue = {
+            number: ensured.issue.number,
+            url: ensured.issue.url,
+          };
+        }
+      }
 
-      const rollingIssue = ensureRollingIssue(repoSlug);
-      summary.rollingIssue = rollingIssue;
-
-      if (rollingIssue.number > 0 && (shouldEscalate || shouldPostRecovery)) {
-        const marker = `<!-- portal-canary-run:${options.runId || "manual"} -->`;
-        const alreadyPosted = issueHasRunMarker(repoSlug, rollingIssue.number, marker);
+      if (summary.rollingIssue.number > 0 && (shouldEscalate || shouldPostRecovery)) {
+        const marker = markerComment(`portal-canary-run:${options.runId || "manual"}`);
+        const alreadyPosted = issueHasRunMarker(repoSlug, summary.rollingIssue.number, marker);
         if (!alreadyPosted) {
           const body = shouldEscalate
             ? buildEscalationComment(summary, marker)
             : buildRecoveryComment(summary, marker);
-          postIssueComment(repoSlug, rollingIssue.number, body);
+          runCommand("gh", ["issue", "comment", String(summary.rollingIssue.number), "--repo", repoSlug, "--body", body], {
+            cwd: repoRoot,
+            allowFailure: true,
+          });
         }
       }
     }

--- a/scripts/portal-canary-feedback-loop.mjs
+++ b/scripts/portal-canary-feedback-loop.mjs
@@ -8,6 +8,8 @@ import { tmpdir } from "node:os";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawnSync } from "node:child_process";
+import { getAutomationFamily } from "./lib/automation-issue-families.mjs";
+import { listRepoIssues, parseRepoSlug as parseGhRepoSlug, pickCanonicalIssue } from "./lib/github-issues.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const repoRoot = resolve(dirname(__filename), "..");
@@ -17,7 +19,7 @@ const DEFAULT_REPORT_PATH = resolve(repoRoot, "output", "qa", "portal-authentica
 const DEFAULT_ARTIFACT_PREFIX = "portal-authenticated-canary-";
 const DEFAULT_LIMIT = 12;
 const DEFAULT_RECOVERY_WINDOW = 2;
-const ROLLING_ISSUE_TITLE = "Portal Authenticated Canary Failures (Rolling)";
+const PORTAL_QA_FAMILY = getAutomationFamily("portal-qa");
 const MY_PIECES_CHECK = "dashboard piece click-through opens my pieces detail";
 const NOTIFICATIONS_CHECK = "notifications mark read gives user feedback";
 
@@ -121,21 +123,6 @@ function clampInteger(value, min, max, fallback) {
   return rounded;
 }
 
-function parseRepoSlug() {
-  const envSlug = String(process.env.GITHUB_REPOSITORY || "").trim();
-  if (envSlug) return envSlug;
-
-  const remote = runCommand("git", ["config", "--get", "remote.origin.url"], { allowFailure: true });
-  if (!remote.ok) return "";
-  const value = remote.stdout.trim();
-
-  const sshMatch = value.match(/^git@github\.com:([^/]+\/[^/.]+)(?:\.git)?$/i);
-  if (sshMatch) return sshMatch[1];
-  const httpsMatch = value.match(/^https:\/\/github\.com\/([^/]+\/[^/.]+)(?:\.git)?$/i);
-  if (httpsMatch) return httpsMatch[1];
-  return "";
-}
-
 function normalizeConclusion(value) {
   const normalized = String(value || "").trim().toLowerCase();
   if (!normalized) return "unknown";
@@ -194,33 +181,17 @@ function extractEmptyStatePatternsFromWarnings(warnings) {
   return Array.from(new Set(patterns)).slice(0, 20);
 }
 
-function findRollingIssue(repoSlug) {
+function findPortalQaIssue(repoSlug) {
   if (!repoSlug) return { number: 0, url: "", comments: [] };
-  const list = runCommand(
-    "gh",
-    [
-      "issue",
-      "list",
-      "--repo",
-      repoSlug,
-      "--state",
-      "open",
-      "--search",
-      `in:title \"${ROLLING_ISSUE_TITLE}\"`,
-      "--json",
-      "number,title,url",
-    ],
-    { allowFailure: true }
-  );
-  if (!list.ok) return { number: 0, url: "", comments: [] };
-
-  let issue = null;
-  try {
-    const parsed = JSON.parse(list.stdout || "[]");
-    issue = parsed.find((item) => String(item?.title || "") === ROLLING_ISSUE_TITLE) || null;
-  } catch {
+  const openIssuesResp = listRepoIssues(repoSlug, { state: "open", maxPages: 2, cwd: repoRoot });
+  if (!openIssuesResp.ok) {
     return { number: 0, url: "", comments: [] };
   }
+  const { issue } = pickCanonicalIssue(openIssuesResp.data, {
+    marker: PORTAL_QA_FAMILY.marker,
+    title: PORTAL_QA_FAMILY.title,
+    preferredNumber: PORTAL_QA_FAMILY.preferredNumber,
+  });
   if (!issue?.number) return { number: 0, url: "", comments: [] };
 
   const view = runCommand(
@@ -530,8 +501,8 @@ async function main() {
     }
   }
 
-  const repoSlug = options.includeGithub ? parseRepoSlug() : "";
-  const rollingIssue = options.includeGithub && repoSlug ? findRollingIssue(repoSlug) : { number: 0, url: "", comments: [] };
+  const repoSlug = options.includeGithub ? parseGhRepoSlug({ cwd: repoRoot }) : "";
+  const rollingIssue = options.includeGithub && repoSlug ? findPortalQaIssue(repoSlug) : { number: 0, url: "", comments: [] };
   const directives = extractCanaryFeedbackDirectives(rollingIssue.comments);
   report.agenticFeedback.rollingIssue.number = rollingIssue.number;
   report.agenticFeedback.rollingIssue.url = rollingIssue.url;

--- a/scripts/workflow-failure-ticket.mjs
+++ b/scripts/workflow-failure-ticket.mjs
@@ -5,7 +5,21 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { spawnSync } from "node:child_process";
+import {
+  buildAutomationFamilyBody,
+  getAutomationFamily,
+  getWorkflowFailureFamilyKey,
+} from "./lib/automation-issue-families.mjs";
+import {
+  closeIssue,
+  commentIssue,
+  ensureGhLabels,
+  ensureIssueWithMarker,
+  fetchLatestIssueCommentBody,
+  listRepoIssues,
+  markerComment,
+  parseRepoSlug,
+} from "./lib/github-issues.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const repoRoot = resolve(dirname(__filename), "..");
@@ -69,32 +83,6 @@ function parseArgs(argv) {
   return options;
 }
 
-function runCommand(command, args, { allowFailure = false } = {}) {
-  const result = spawnSync(command, args, { cwd: repoRoot, encoding: "utf8" });
-  const code = typeof result.status === "number" ? result.status : 1;
-  const stdout = String(result.stdout || "");
-  const stderr = String(result.stderr || "");
-  if (!allowFailure && code !== 0) {
-    throw new Error(`Command failed (${code}): ${command} ${args.join(" ")}\n${stderr || stdout}`);
-  }
-  return { ok: code === 0, code, stdout, stderr };
-}
-
-function runGh(args, options = {}) {
-  return runCommand("gh", args, options);
-}
-
-function parseRepoSlug() {
-  const fromEnv = String(process.env.GITHUB_REPOSITORY || "").trim();
-  if (fromEnv && fromEnv.includes("/")) return fromEnv;
-
-  const remote = runCommand("git", ["remote", "get-url", "origin"], { allowFailure: true });
-  if (!remote.ok) return "";
-  const raw = remote.stdout.trim();
-  const match = raw.match(/github\.com[:/](.+?)(?:\.git)?$/);
-  return match ? match[1] : "";
-}
-
 function normalizeTitle(workflowName, overrideTitle) {
   if (overrideTitle) return overrideTitle;
   return `${workflowName} Failures (Rolling)`;
@@ -105,46 +93,6 @@ function short(value, max = 280) {
   if (!normalized) return "";
   if (normalized.length <= max) return normalized;
   return `${normalized.slice(0, Math.max(0, max - 3)).trim()}...`;
-}
-
-function parseIssueNumberFromUrl(url) {
-  const match = String(url || "").match(/\/issues\/(\d+)$/);
-  return match ? Number(match[1]) : 0;
-}
-
-function findOpenIssueByTitle(repoSlug, title) {
-  const list = runGh(
-    [
-      "issue",
-      "list",
-      "--repo",
-      repoSlug,
-      "--state",
-      "open",
-      "--search",
-      `"${title}" in:title`,
-      "--limit",
-      "10",
-      "--json",
-      "number,title,url,updatedAt",
-    ],
-    { allowFailure: true }
-  );
-  if (!list.ok) return null;
-  try {
-    const parsed = JSON.parse(list.stdout || "[]");
-    if (!Array.isArray(parsed)) return null;
-    return parsed.find((entry) => String(entry?.title || "") === title) || null;
-  } catch {
-    return null;
-  }
-}
-
-function ensureLabel(repoSlug, name, color, description) {
-  runGh(
-    ["label", "create", name, "--repo", repoSlug, "--color", color, "--description", description, "--force"],
-    { allowFailure: true }
-  );
 }
 
 function createIssueBody({ workflowName, runUrl, runId }) {
@@ -171,7 +119,7 @@ function createIssueBody({ workflowName, runUrl, runId }) {
   return lines.join("\n");
 }
 
-function createFailureComment({ workflowName, runUrl, runId }) {
+function createFailureComment({ workflowName, runUrl, runId, runMarker }) {
   const lines = [];
   lines.push(`## ${new Date().toISOString()} — workflow failure`);
   lines.push("");
@@ -188,80 +136,97 @@ function createFailureComment({ workflowName, runUrl, runId }) {
   lines.push("- Inspect failing step logs and artifacts.");
   lines.push("- Capture root-cause + mitigation in this thread.");
   lines.push("");
+  lines.push(markerComment(runMarker));
+  lines.push("");
   return lines.join("\n");
+}
+
+function slugify(text) {
+  return String(text || "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
 }
 
 async function main() {
   const options = parseArgs(process.argv.slice(2));
-  const repoSlug = parseRepoSlug();
+  const repoSlug = parseRepoSlug({ cwd: repoRoot });
   if (!repoSlug) {
     throw new Error("Could not resolve repository slug from environment or git remote.");
   }
-
-  const auth = runGh(["auth", "status"], { allowFailure: true });
-  if (!auth.ok) {
-    throw new Error("GitHub CLI auth is required.");
+  const title = normalizeTitle(options.workflowName, options.title);
+  const openIssuesResp = listRepoIssues(repoSlug, { state: "open", maxPages: 2, cwd: repoRoot });
+  if (!openIssuesResp.ok) {
+    throw new Error(`Could not read open issues: ${openIssuesResp.error}`);
   }
 
-  ensureLabel(repoSlug, "automation", "1d76db", "Automation-generated work");
-  ensureLabel(repoSlug, "portal-qa", "0e8a16", "Portal QA automation");
-  ensureLabel(repoSlug, "self-improvement", "5319e7", "Self-improving feedback loops");
+  const familyKey = getWorkflowFailureFamilyKey(options.workflowName);
+  const family = familyKey ? getAutomationFamily(familyKey) : null;
+  const marker = family ? family.marker : `workflow-failure-title:${slugify(title)}`;
+  const runMarker = `workflow-failure-run:${slugify(options.workflowName)}:${options.runId || "manual"}`;
 
-  const title = normalizeTitle(options.workflowName, options.title);
-  const existing = findOpenIssueByTitle(repoSlug, title);
+  const labels = family
+    ? family.labels
+    : [
+        { name: "automation", color: "0e8a16", description: "Automated monitoring and remediation." },
+        { name: "portal-qa", color: "0e8a16", description: "Portal QA automation" },
+      ];
+  ensureGhLabels(repoSlug, labels, { cwd: repoRoot });
+
+  const issueBody = family ? buildAutomationFamilyBody(family) : `${createIssueBody(options)}\n\n${markerComment(marker)}\n`;
+  const ensured = ensureIssueWithMarker(
+    repoSlug,
+    {
+      title: family ? family.title : title,
+      body: issueBody,
+      labels: labels.map((item) => item.name),
+      marker,
+      preferredNumber: family?.preferredNumber || 0,
+      openIssues: openIssuesResp.data,
+    },
+    { cwd: repoRoot }
+  );
+  if (!ensured.ok || !ensured.issue) {
+    throw new Error(`Could not resolve issue target: ${ensured.error || "unknown error"}`);
+  }
+
+  for (const duplicate of ensured.duplicates) {
+    closeIssue(
+      repoSlug,
+      duplicate.number,
+      {
+        commentBody: `Superseded by #${ensured.issue.number} (${ensured.issue.title}). Closing duplicate rolling thread.`,
+        stateReason: "not_planned",
+      },
+      { cwd: repoRoot }
+    );
+  }
 
   const report = {
     status: "ok",
     generatedAtIso: new Date().toISOString(),
     repo: repoSlug,
     workflowName: options.workflowName,
-    issueTitle: title,
+    issueTitle: ensured.issue.title,
     runId: options.runId,
     runUrl: options.runUrl,
-    action: existing ? "comment" : "create",
-    issueUrl: existing?.url || "",
-    issueNumber: existing?.number || 0,
+    action: "comment",
+    issueUrl: ensured.issue.url || "",
+    issueNumber: ensured.issue.number || 0,
     notes: [],
+    familyKey: family?.key || "",
+    duplicatesClosed: ensured.duplicates.map((duplicate) => duplicate.url),
   };
 
-  if (!existing) {
-    const created = runGh(
-      [
-        "issue",
-        "create",
-        "--repo",
-        repoSlug,
-        "--title",
-        title,
-        "--body",
-        createIssueBody(options),
-        "--label",
-        "automation",
-        "--label",
-        "portal-qa",
-        "--label",
-        "self-improvement",
-      ],
-      { allowFailure: true }
-    );
-    if (!created.ok) {
-      throw new Error(`Issue create failed: ${short(created.stderr || created.stdout, 400)}`);
-    }
-    report.issueUrl = created.stdout.trim();
-    report.issueNumber = parseIssueNumberFromUrl(report.issueUrl);
-    report.result = "created";
+  const latestComment = fetchLatestIssueCommentBody(repoSlug, ensured.issue.number, { cwd: repoRoot });
+  if (latestComment.includes(markerComment(runMarker))) {
+    report.result = "unchanged-skip";
   } else {
-    const commented = runGh(
-      [
-        "issue",
-        "comment",
-        String(existing.number),
-        "--repo",
-        repoSlug,
-        "--body",
-        createFailureComment(options),
-      ],
-      { allowFailure: true }
+    const commented = commentIssue(
+      repoSlug,
+      ensured.issue.number,
+      createFailureComment({ ...options, runMarker }),
+      { cwd: repoRoot }
     );
     if (!commented.ok) {
       throw new Error(`Issue comment failed: ${short(commented.stderr || commented.stdout, 400)}`);

--- a/web/src/views/StaffView.tsx
+++ b/web/src/views/StaffView.tsx
@@ -814,22 +814,28 @@ const AUTOMATION_WORKFLOW_SOURCES: AutomationWorkflowSource[] = [
 ];
 const AUTOMATION_ISSUE_SOURCES: AutomationIssueSource[] = [
   {
-    key: "thresholdTuning",
-    title: "Portal Automation Threshold Tuning (Rolling)",
-    issueNumber: 115,
-    purpose: "loop threshold recommendations",
-  },
-  {
-    key: "weeklyDigest",
-    title: "Portal Automation Weekly Digest (Rolling)",
+    key: "portalQa",
+    title: "Portal QA Automation (Rolling)",
     issueNumber: 116,
-    purpose: "weekly trend digest for loops",
+    purpose: "portal workflow failures, canary state changes, tuning, and digest updates",
   },
   {
-    key: "canaryRolling",
-    title: "Portal Authenticated Canary Failures (Rolling)",
-    issueNumber: 85,
-    purpose: "canary incident history and directives",
+    key: "portalInfra",
+    title: "Portal Infra and Security Guards (Rolling)",
+    issueNumber: 103,
+    purpose: "credential, index, and branch-integrity guard updates",
+  },
+  {
+    key: "governanceTuning",
+    title: "Governance Weekly Tuning (Rolling)",
+    issueNumber: 309,
+    purpose: "weekly governance tuning summaries and threshold proposals",
+  },
+  {
+    key: "codexAutomation",
+    title: "Codex Automation (Rolling)",
+    issueNumber: 84,
+    purpose: "Codex improvement, interaction, PR-green, and backlog reporting",
   },
 ];
 const WORKSHOP_PROGRAMMING_TECHNIQUES: WorkshopProgrammingTechnique[] = [


### PR DESCRIPTION
## Summary
- consolidate portal, infra, codex, and governance automation into canonical rolling issue families
- add shared GitHub issue helpers plus a one-shot cleanup script for duplicate/superseded automation issues
- reduce portal repeated-failure fan-out and switch governance weekly tuning to a rolling thread

## Verification
- node --check on updated automation scripts
- npm --prefix web run build
- applied GitHub cleanup and verified the open issue queue dropped to 9 canonical/action issues