### PR TITLE
fix(portal): remove horizontal nav divider between sections

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -5000,13 +5000,13 @@ html[data-portal-theme="memoria"] .sidebar.collapsed nav button::after {
   padding: 8px 12px;
 }
 
-html[data-portal-theme="memoria"] .sidebar .nav-primary > .nav-section + .nav-section {
+html[data-portal-theme="memoria"] .app-shell:not(.dock-top):not(.dock-bottom) .sidebar .nav-primary > .nav-section + .nav-section {
   margin-top: 8px;
   padding-top: 10px;
   border-top: 1px solid rgba(255, 255, 255, 0.08);
 }
 
-html[data-portal-theme="memoria"] .sidebar.collapsed .nav-primary > .nav-section + .nav-section {
+html[data-portal-theme="memoria"] .app-shell:not(.dock-top):not(.dock-bottom) .sidebar.collapsed .nav-primary > .nav-section + .nav-section {
   margin-top: 10px;
   padding-top: 12px;
 }


### PR DESCRIPTION
## Summary
- scope the Memoria nav section divider so it only applies in vertical sidebars
- keep portal nav groups level when the nav is docked top or bottom
- avoid touching unrelated work in the main checkout by landing the fix from a clean branch

## Verification
- npm --prefix web run build
- post-deploy cutover verification against https://portal.monsoonfire.com