### PR TITLE
chore: retarget automation family coordination issues

### DIFF
--- a/scripts/codex/backlog-autopilot.mjs
+++ b/scripts/codex/backlog-autopilot.mjs
@@ -6,6 +6,7 @@ import { appendFile, mkdir, readFile, readdir, writeFile } from "node:fs/promise
 import { spawnSync } from "node:child_process";
 import { dirname, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { getAutomationFamily } from "../lib/automation-issue-families.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const repoRoot = resolve(dirname(__filename), "..", "..");
@@ -18,7 +19,8 @@ const defaultOutputDir = resolve(repoRoot, "output", "qa");
 const defaultReportJsonPath = resolve(defaultOutputDir, "codex-backlog-autopilot.json");
 const defaultReportMarkdownPath = resolve(defaultOutputDir, "codex-backlog-autopilot.md");
 
-const rollingIssueTitle = "Codex Automation (Rolling)";
+const CODEX_AUTOMATION_FAMILY = getAutomationFamily("codex-automation");
+const rollingIssueTitle = CODEX_AUTOMATION_FAMILY?.title || "Codex Automation Coordination (Rolling)";
 const defaultLendingLibraryExclusionRegex =
   "(lending[ -]?library|tickets/p1-epic-16|tickets/p1-library-|tickets/p2-library-|tickets/p1-lending-library-|tickets/p2-lending-library-)";
 

--- a/scripts/codex/daily-improvement.mjs
+++ b/scripts/codex/daily-improvement.mjs
@@ -7,6 +7,7 @@ import { constants as fsConstants } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { dirname, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { getAutomationFamily } from "../lib/automation-issue-families.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const repoRoot = resolve(dirname(__filename), "..", "..");
@@ -22,7 +23,8 @@ const improvementLogPath = resolve(codexDir, "improvement-log.md");
 const improvementStatePath = resolve(codexDir, "improvement-state.json");
 const improvementReportsDir = resolve(repoRoot, "docs", "runbooks", "codex-improvement");
 
-const rollingIssueTitle = "Codex Automation (Rolling)";
+const CODEX_AUTOMATION_FAMILY = getAutomationFamily("codex-automation");
+const rollingIssueTitle = CODEX_AUTOMATION_FAMILY?.title || "Codex Automation Coordination (Rolling)";
 const ignoreAnalysisFiles = new Set([
   ".codex/improvement-log.md",
   ".codex/improvement-state.json",

--- a/scripts/codex/daily-interaction.mjs
+++ b/scripts/codex/daily-interaction.mjs
@@ -7,6 +7,7 @@ import { constants as fsConstants } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { dirname, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { getAutomationFamily } from "../lib/automation-issue-families.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const repoRoot = resolve(dirname(__filename), "..", "..");
@@ -23,7 +24,8 @@ const interactionLogPath = resolve(codexDir, "interaction-log.md");
 const userDocPath = resolve(codexDir, "user.md");
 const agentsDocPath = resolve(codexDir, "agents.md");
 
-const rollingIssueTitle = "Codex Automation (Rolling)";
+const CODEX_AUTOMATION_FAMILY = getAutomationFamily("codex-automation");
+const rollingIssueTitle = CODEX_AUTOMATION_FAMILY?.title || "Codex Automation Coordination (Rolling)";
 const epicPath = "docs/epics/EPIC-CODEX-INTERACTION-INTERROGATION.md";
 
 const ignoreChurnPaths = new Set([

--- a/scripts/codex/daily-pr-green.mjs
+++ b/scripts/codex/daily-pr-green.mjs
@@ -7,6 +7,7 @@ import { constants as fsConstants } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { dirname, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { getAutomationFamily } from "../lib/automation-issue-families.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const repoRoot = resolve(dirname(__filename), "..", "..");
@@ -16,7 +17,8 @@ const codexDir = resolve(repoRoot, ".codex");
 const toolcallPath = resolve(codexDir, "toolcalls.ndjson");
 const improvementStatePath = resolve(codexDir, "improvement-state.json");
 const prGreenLogPath = resolve(codexDir, "pr-green-log.md");
-const rollingIssueTitle = "Codex Automation (Rolling)";
+const CODEX_AUTOMATION_FAMILY = getAutomationFamily("codex-automation");
+const rollingIssueTitle = CODEX_AUTOMATION_FAMILY?.title || "Codex Automation Coordination (Rolling)";
 
 const secretKeyPattern = /(token|secret|password|authorization|api[_-]?key|cookie|session|private[_-]?key)/i;
 const secretValuePatterns = [

--- a/scripts/github-automation-issue-cleanup.mjs
+++ b/scripts/github-automation-issue-cleanup.mjs
@@ -24,6 +24,30 @@ const DEFAULT_REPORT_PATH = resolve(repoRoot, "output", "qa", "github-automation
 const FAMILY_KEYS = ["portal-qa", "portal-infra", "codex-automation", "governance-tuning"];
 
 const SUPERSeded_ISSUES = [
+  {
+    issueNumber: 116,
+    familyKey: "portal-qa",
+    stateReason: "not_planned",
+    note: "Legacy rolling tracker replaced by the portal QA reliability coordination thread.",
+  },
+  {
+    issueNumber: 103,
+    familyKey: "portal-infra",
+    stateReason: "not_planned",
+    note: "Legacy rolling tracker replaced by the portal infra and security coordination thread.",
+  },
+  {
+    issueNumber: 84,
+    familyKey: "codex-automation",
+    stateReason: "not_planned",
+    note: "Legacy rolling tracker replaced by the Codex automation coordination thread.",
+  },
+  {
+    issueNumber: 309,
+    familyKey: "governance-tuning",
+    stateReason: "not_planned",
+    note: "Legacy rolling tracker replaced by the governance tuning coordination thread.",
+  },
   { issueNumber: 315, familyKey: "portal-qa", stateReason: "not_planned", note: "Load-test rolling failures now aggregate into the portal QA family thread." },
   { issueNumber: 264, familyKey: "portal-qa", stateReason: "not_planned", note: "Older duplicate load-test rolling thread superseded by the portal QA family thread." },
   { issueNumber: 310, familyKey: "portal-qa", stateReason: "not_planned", note: "Smoke-test workflow failures now aggregate into the portal QA family thread." },

--- a/scripts/lib/automation-issue-families.mjs
+++ b/scripts/lib/automation-issue-families.mjs
@@ -34,39 +34,39 @@ export const AUTOMATION_LABELS = {
 export const AUTOMATION_FAMILIES = {
   portalQa: {
     key: "portal-qa",
-    preferredNumber: 116,
-    title: "Portal QA Automation (Rolling)",
+    preferredNumber: 350,
+    title: "Portal QA Reliability (Rolling)",
     marker: "automation-family:portal-qa",
     labels: [AUTOMATION_LABELS.automation, AUTOMATION_LABELS.portalQa],
     body:
-      "Canonical rolling thread for portal QA automation. Use this issue for workflow failures, canary state changes, tuning snapshots, and digest updates.",
+      "Primary rolling thread for portal QA automation and reliability coordination. Replaces legacy tracker #116 and collects workflow failures, canary state changes, tuning snapshots, and digest updates.",
   },
   portalInfra: {
     key: "portal-infra",
-    preferredNumber: 103,
-    title: "Portal Infra and Security Guards (Rolling)",
+    preferredNumber: 349,
+    title: "Portal Infra and Security Coordination (Rolling)",
     marker: "automation-family:portal-infra",
     labels: [AUTOMATION_LABELS.automation, AUTOMATION_LABELS.infra, AUTOMATION_LABELS.security],
     body:
-      "Canonical rolling thread for portal infra and security guard automation. Use this issue for index, credential, and branch integrity updates.",
+      "Primary rolling thread for portal infra and security automation coordination. Replaces legacy tracker #103 and collects index, credential, and branch integrity updates.",
   },
   codexAutomation: {
     key: "codex-automation",
-    preferredNumber: 84,
-    title: "Codex Automation (Rolling)",
+    preferredNumber: 348,
+    title: "Codex Automation Coordination (Rolling)",
     marker: "automation-family:codex-automation",
     labels: [AUTOMATION_LABELS.automation, AUTOMATION_LABELS.codexReporting],
     body:
-      "Canonical rolling thread for Codex automation reporting. Use this issue for improvement, interaction, PR-green, and backlog autopilot updates.",
+      "Primary rolling thread for Codex automation reporting and coordination. Replaces legacy tracker #84 and collects improvement, interaction, PR-green, and backlog autopilot updates.",
   },
   governanceTuning: {
     key: "governance-tuning",
-    preferredNumber: 309,
-    title: "Governance Weekly Tuning (Rolling)",
+    preferredNumber: 351,
+    title: "Governance Tuning Coordination (Rolling)",
     marker: "automation-family:governance-tuning",
     labels: [AUTOMATION_LABELS.governance],
     body:
-      "Canonical rolling thread for weekly governance tuning summaries and threshold proposals.",
+      "Primary rolling thread for weekly governance tuning coordination. Replaces legacy tracker #309 and collects threshold proposals, tuning summaries, and governance follow-through.",
   },
 };
 


### PR DESCRIPTION
## Summary
- retarget the automation family config to the new coordination issues #348, #349, #350, and #351
- stop the Codex rollup scripts from hardcoding the legacy Codex Automation (Rolling) title
- teach the automation issue cleanup script to retire the old rolling trackers once the new coordination threads are active

## Testing
- node --check scripts/lib/automation-issue-families.mjs
- node --check scripts/codex/backlog-autopilot.mjs
- node --check scripts/codex/daily-improvement.mjs
- node --check scripts/codex/daily-interaction.mjs
- node --check scripts/codex/daily-pr-green.mjs
- node --check scripts/github-automation-issue-cleanup.mjs
- node ./scripts/github-automation-issue-cleanup.mjs --json --report C:\\Users\\micah\\AppData\\Local\\Temp\\github-automation-issue-cleanup-retargeted.json

Closes #308
