### PR TITLE
feat: update ware check-in storage policy

### DIFF
--- a/docs/SCHEMA_RESERVATIONS.md
+++ b/docs/SCHEMA_RESERVATIONS.md
@@ -1,4 +1,4 @@
-# Monsoon Fire Portal — Reservations schema (Feb 2026)
+# Monsoon Fire Portal — Reservations schema (Mar 2026)
 
 ## Firestore: `reservations`
 
@@ -78,7 +78,11 @@ Fields:
   - `rescheduleCount` (number | null)
   - `lastMissedAt` (timestamp | null)
   - `lastRescheduleRequestedAt` (timestamp | null)
-- `storageStatus` (string | null) — `active`, `reminder_pending`, `hold_pending`, `stored_by_policy`
+- `storageStatus` (string | null) — compatibility storage state:
+  - `active` during early grace
+  - `reminder_pending` once late-grace reminders begin
+  - `hold_pending` during billed storage
+  - `stored_by_policy` once the reservation is reclaimed/archived by policy
 - `readyForPickupAt` (timestamp | null)
 - `pickupReminderCount` (number | null)
 - `lastReminderAt` (timestamp | null)
@@ -86,12 +90,27 @@ Fields:
 - `lastReminderFailureAt` (timestamp | null)
 - `storageNoticeHistory` (array<map> | null) — date-ordered notice and escalation trail
   - `at` (timestamp)
-  - `kind` (`pickup_ready` | `pickup_reminder_1` | `pickup_reminder_2` | `pickup_reminder_3` | `pickup_window_opened` | `pickup_window_confirmed` | `pickup_window_missed` | `pickup_window_completed` | `hold_pending` | `stored_by_policy` | `reminder_failed`)
+  - `kind` (`pickup_ready` | `pickup_reminder_1` | `pickup_reminder_2` | `pickup_reminder_3` | `pickup_window_opened` | `pickup_window_confirmed` | `pickup_window_missed` | `pickup_window_completed` | `hold_pending` | `stored_by_policy` | `storage_billing_update` | `reminder_failed`)
   - `detail` (string | null)
   - `status` (`active` | `reminder_pending` | `hold_pending` | `stored_by_policy` | null)
   - `reminderOrdinal` (number | null)
   - `reminderCount` (number | null)
   - `failureCode` (string | null)
+- `storageBilling` (map | null) — server-computed storage billing timeline
+  - `chargeBasis` (`estimatedHalfShelves`)
+  - `chargeBasisHalfShelves` (number)
+  - `prepaidWeeklyRatePerHalfShelf` (number) — currently `2`
+  - `dailyRatePerHalfShelf` (number) — currently `1.5`
+  - `graceEndsAt` (timestamp | null)
+  - `billingStartsAt` (timestamp | null)
+  - `billingEndsAt` (timestamp | null)
+  - `billedDays` (number)
+  - `accruedCost` (number)
+  - `status` (`grace` | `billing` | `reclaimed`)
+  - `reclaimedAt` (timestamp | null)
+  - `reclaimedReason` (string | null)
+- `isArchived` (boolean | null) — set to `true` once reclaimed by policy
+- `archivedAt` (timestamp | null)
 - `staffNotes` (string | null)
 - `notesHistory` (array<object> | null)
 - `pieces` (array<map> | null) — optional piece-level traceability rows
@@ -110,6 +129,17 @@ Fields:
 - `arrivalCheckIns` (array<object> | null) — append-only arrival check-in events (`at`, `byUid`, `byRole`, `via`, `note`, `photoUrl`, `photoPath`).
 - `linkedBatchId` (string | null) — optional batch id for context.
 - `wareType`, `kilnId`, `kilnLabel`, `quantityTier`, `quantityLabel`, `dropOffProfile`, `dropOffQuantity`, `photoUrl`, `photoPath`, `notes`, `addOns` (map | null)
+  - common `addOns` keys written by current reservation flows:
+    - `useStudioGlazes` (boolean)
+    - `glazeAccessCost` (number | null) — `$5` per half-shelf
+    - `selfLoadedKilnRequested` (boolean)
+    - `selfLoadedKilnCost` (number | null) — `$15` flat fee
+    - `prepaidStorageRequested` (boolean)
+    - `prepaidStorageWeeks` (number | null)
+    - `prepaidStorageCost` (number | null) — `$2` per half-shelf per week
+  - legacy `fragileHandlingRequested` / `fragileHandlingCost` may appear on older rows and
+    should be normalized to `selfLoadedKiln*` at read time only. New writes should not persist
+    the legacy field names.
 - `createdByUid`, `createdByRole` (string | null)
 - `createdAt` (timestamp)
 - `updatedAt` (timestamp)
@@ -129,6 +159,26 @@ Fields:
 - Check-in paths:
   - Member/owner check-in: `/v1/reservations.checkIn` with `reservationId`.
   - Staff scanner/lookup: `/v1/reservations.lookupArrival` + `/v1/reservations.checkIn` with `arrivalToken`.
+
+## Storage automation semantics
+
+- `readyForPickupAt` anchors the storage timeline.
+- Grace period: `462 hours` (`19.25 days`) after `readyForPickupAt`.
+- Reminder thresholds:
+  - day `14`
+  - day `17.5`
+  - day `19.25`
+- Billed storage:
+  - starts at `graceEndsAt`
+  - accrues for each fully elapsed 24-hour day
+  - uses `estimatedHalfShelves` as the storage charge basis
+  - caps at `28 billed days`
+- Reclamation:
+  - sets `storageStatus = stored_by_policy`
+  - sets `storageBilling.status = reclaimed`
+  - sets `isArchived = true`
+  - sets `archivedAt`
+- UI may humanize `stored_by_policy` as `Reclaimed by studio` while keeping the stored enum for compatibility.
 
 ## Status lifecycle graph (canonical)
 
@@ -228,6 +278,31 @@ Fields:
   "pickupReminderFailureCount": 0,
   "lastReminderFailureAt": null,
   "storageNoticeHistory": [],
+  "storageBilling": {
+    "chargeBasis": "estimatedHalfShelves",
+    "chargeBasisHalfShelves": 2,
+    "prepaidWeeklyRatePerHalfShelf": 2,
+    "dailyRatePerHalfShelf": 1.5,
+    "graceEndsAt": null,
+    "billingStartsAt": null,
+    "billingEndsAt": null,
+    "billedDays": 0,
+    "accruedCost": 0,
+    "status": "grace",
+    "reclaimedAt": null,
+    "reclaimedReason": null
+  },
+  "isArchived": false,
+  "archivedAt": null,
+  "addOns": {
+    "useStudioGlazes": true,
+    "glazeAccessCost": 10,
+    "selfLoadedKilnRequested": false,
+    "selfLoadedKilnCost": null,
+    "prepaidStorageRequested": true,
+    "prepaidStorageWeeks": 1,
+    "prepaidStorageCost": 4
+  },
   "linkedBatchId": "H3T5...",
   "createdAt": "2026-02-01T02:30:00Z",
   "updatedAt": "2026-02-01T02:30:00Z"
@@ -362,6 +437,9 @@ This keeps queue hint ordering consistent across clients and prevents UI-only or
   - Missing `stageStatus`/`stageHistory` => show stable fallback copy and use `updatedAt`.
   - Missing `estimatedWindow`/`queuePositionHint` => use server recompute when next mutation occurs; UI may show fallback ETA text.
   - Missing `pieces` => treat as no piece-level traceability rows.
+  - Missing `storageBilling` => seed from `estimatedHalfShelves` and current storage timeline.
+  - Missing `isArchived` / `archivedAt` => treat as active/not archived unless policy status says otherwise.
+  - Legacy `fragileHandling*` fields => normalize to `selfLoadedKiln*` when projecting for clients.
 - `assignedStationId`, `requiredResources`, `queueClass`, `queueLaneHint`, `arrivalStatus`, and `arrivalToken*` are included as operational expansion targets to support station-aware capacity, station-specific fairness, and member-assisted check-in.
 - `stageStatus`, `estimatedWindow`, `pickupWindow`, and `storageStatus` are included as expansion targets, currently implemented through phased tickets (P1/P2).
 - `pieces` remains optional for intake compatibility; server-generated piece IDs are only created when piece rows are provided.

--- a/docs/policies/policies-index.json
+++ b/docs/policies/policies-index.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-02-17T05:58:52.185Z",
+  "generatedAt": "2026-03-17T22:09:36.622Z",
   "policies": [
     {
       "slug": "accessibility",
@@ -293,37 +293,38 @@
     {
       "slug": "storage-abandoned-work",
       "title": "Storage limits & abandoned work",
-      "summary": "Storage limits depend on membership tier and available space. Long-abandoned work may move through notice and follow-up steps.",
+      "summary": "Pickup-ready work gets 2.75 weeks of grace, optional prepaid storage at $2 per half-shelf per week, billed storage at $1.50 per half-shelf per day, and studio reclamation after 28 billed days.",
       "status": "active",
       "tags": [
         "storage",
-        "memberships",
+        "pickup",
         "policy"
       ],
-      "effectiveDate": "2026-02-17",
-      "reviewDate": "2026-08-01",
+      "effectiveDate": "2026-03-17",
+      "reviewDate": "2026-09-17",
       "owner": "Studio Operations",
       "sourceUrl": "/policies/storage-abandoned-work/",
       "agent": {
         "canActForSelf": true,
         "canActForOthers": true,
-        "decisionDomain": "Stale-item notification, pickup reminders, and storage hold escalation.",
+        "decisionDomain": "Pickup-ready reminders, prepaid storage quotes, billed storage escalation, and studio reclamation.",
         "defaultActions": [
-          "check piece age and membership tier",
-          "issue/remind pickup and hold-status notification",
-          "route items near retention boundary for review"
+          "confirm the pickup-ready date and current storage timeline",
+          "quote prepaid weekly storage and billed daily storage using half-shelf equivalents",
+          "share the grace-end, billing-end, and reclamation dates before promising exceptions"
         ],
         "requiredSignals": [
-          "last pickup status update",
-          "membership tier and hold duration",
-          "contact method on file"
+          "readyForPickupAt",
+          "estimatedHalfShelves or storageBilling.chargeBasisHalfShelves",
+          "pickupReminderCount and storageNoticeHistory",
+          "contact methods on file"
         ],
         "escalateWhen": [
-          "extended hold beyond policy boundary",
-          "dispute over prior notice",
-          "storage capacity conflict affecting active batches"
+          "artist disputes reclamation, ownership transfer, or notice history",
+          "legal or operations review is requested for abandoned work handling",
+          "staff wants to grant an exception after billed storage has started or reclamation has occurred"
         ],
-        "replyTemplate": "State current hold status, reminder obligations, and next action date before any removal step."
+        "replyTemplate": "Share the pickup-ready date, grace-end date, current storage fees, and reclamation date before quoting next steps."
       }
     },
     {

--- a/docs/policies/storage-abandoned-work.md
+++ b/docs/policies/storage-abandoned-work.md
@@ -2,66 +2,94 @@
 slug: "storage-abandoned-work"
 title: "Storage limits & abandoned work"
 status: "active"
-version: "2026-02-17"
-effectiveDate: "2026-02-17"
-reviewDate: "2026-08-01"
+version: "2026-03-17"
+effectiveDate: "2026-03-17"
+reviewDate: "2026-09-17"
 owner: "Studio Operations"
 sourceUrl: "/policies/storage-abandoned-work/"
-summary: "Storage limits depend on membership tier and available space. Long-abandoned work may move through notice and follow-up steps."
+summary: "Pickup-ready work gets 2.75 weeks of grace, optional prepaid storage at $2 per half-shelf per week, billed storage at $1.50 per half-shelf per day, and studio reclamation after 28 billed days."
 tags:
   - "storage"
-  - "memberships"
+  - "pickup"
   - "policy"
 agent:
   canActForSelf: true
   canActForOthers: true
-  decisionDomain: "Stale-item notification, pickup reminders, and storage hold escalation."
+  decisionDomain: "Pickup-ready reminders, prepaid storage quotes, billed storage escalation, and studio reclamation."
   defaultActions:
-    - "check piece age and membership tier"
-    - "issue/remind pickup and hold-status notification"
-    - "route items near retention boundary for review"
+    - "confirm the pickup-ready date and current storage timeline"
+    - "quote prepaid weekly storage and billed daily storage using half-shelf equivalents"
+    - "share the grace-end, billing-end, and reclamation dates before promising exceptions"
   requiredSignals:
-    - "last pickup status update"
-    - "membership tier and hold duration"
-    - "contact method on file"
+    - "readyForPickupAt"
+    - "estimatedHalfShelves or storageBilling.chargeBasisHalfShelves"
+    - "pickupReminderCount and storageNoticeHistory"
+    - "contact methods on file"
   escalateWhen:
-    - "extended hold beyond policy boundary"
-    - "dispute over prior notice"
-    - "storage capacity conflict affecting active batches"
-  replyTemplate: "State current hold status, reminder obligations, and next action date before any removal step."
+    - "artist disputes reclamation, ownership transfer, or notice history"
+    - "legal or operations review is requested for abandoned work handling"
+    - "staff wants to grant an exception after billed storage has started or reclamation has occurred"
+  replyTemplate: "Share the pickup-ready date, grace-end date, current storage fees, and reclamation date before quoting next steps."
 ---
 
 ## Purpose
 
-To define transparent storage expectations and prevent studio floor crowding.
+Define one clear storage timeline for pickup-ready work so artists know when reminders,
+fees, and reclamation apply.
 
 ## Scope
 
-Completed and in-progress work not yet collected, including work waiting beyond normal
-pickup windows.
+Pickup-ready reservations and any finished work that remains at the studio after an
+artist has been notified it is ready.
 
 ## Policy
 
-- Storage limits vary by membership tier and available shelf capacity.
-- Users should confirm pickup windows before a piece is considered abandoned.
-- The studio will make good-faith efforts to notify before any removal or disposal actions.
-- Extended storage beyond policy windows can move into priority storage tiers or removal
-  workflow.
+- `readyForPickupAt` begins the storage timeline when a reservation reaches pickup-ready status.
+- Artists receive a grace period of `19.25 days` (`462 hours`) after `readyForPickupAt`.
+- During grace, the studio sends pickup reminders at:
+  - `14 days`
+  - `17.5 days`
+  - `19.25 days` (final grace-period reminder)
+- Artists may prepay extra pickup time before billed storage starts. Prepaid storage is
+  charged at `$2 per half-shelf per week`, based on the reservation's half-shelf estimate.
+- Once grace ends, billed storage begins automatically at `$1.50 per half-shelf per day`.
+  Billing accrues only for each fully elapsed 24-hour day.
+- Billed storage is capped at `28 billed days`.
+- Missing a confirmed pickup window does not pause, reset, or shorten the grace or billed
+  storage timeline. The original `readyForPickupAt` date remains the anchor.
+- When a reservation reaches the end of the 28 billed days, the work is considered
+  abandoned and reclaimed by the studio.
+- After reclamation:
+  - ownership transfers to the studio,
+  - the reservation may be archived from active storage workflows,
+  - the studio may destroy, recycle, donate, sell, repurpose, photograph, copy, display,
+    or otherwise use the reclaimed work without further notice or compensation.
 
 ## Automated reminder cadence (portal enforcement)
 
 - `readyForPickupAt` starts when a reservation reaches loaded/pickup-ready state.
-- Reminder 1: ~72 hours after `readyForPickupAt`.
-- Reminder 2: ~120 hours after `readyForPickupAt`.
-- Reminder 3 (final): ~168 hours after `readyForPickupAt`.
+- Reminder 1: `14 days` after `readyForPickupAt`.
+- Reminder 2: `17.5 days` after `readyForPickupAt`.
+- Reminder 3 (final grace reminder): `19.25 days` after `readyForPickupAt`.
 - `storageStatus` escalation:
-  - `active` -> `reminder_pending` once reminders start.
-  - `hold_pending` around ~240 hours.
-  - `stored_by_policy` around ~336 hours (14 days), with staff review required before any disposal action.
+  - `active` during early grace.
+  - `reminder_pending` once reminders begin.
+  - `hold_pending` during the 28-day billed storage window.
+  - `stored_by_policy` once the reservation is reclaimed and archived by policy.
+- `storageBilling` tracks:
+  - `chargeBasis = "estimatedHalfShelves"`
+  - `chargeBasisHalfShelves`
+  - `prepaidWeeklyRatePerHalfShelf = 2`
+  - `dailyRatePerHalfShelf = 1.5`
+  - `graceEndsAt`, `billingStartsAt`, `billingEndsAt`
+  - `billedDays`, `accruedCost`
+  - `status = grace | billing | reclaimed`
+  - `reclaimedAt`, `reclaimedReason`
+- `isArchived` and `archivedAt` are set when reclamation occurs.
 - Pickup-window miss handling:
-  - if a confirmed/open pickup window elapses, status auto-marks `missed`,
-  - first miss moves reservation to `hold_pending`,
-  - repeated misses escalate to `stored_by_policy` without requiring manual queue edits.
+  - if a confirmed/open pickup window elapses, the reservation auto-marks `missed`,
+  - the missed pickup is recorded in notice history and audit logs,
+  - the grace, billing, and reclamation timeline still follows the original pickup-ready date.
 - Every notice/escalation writes an immutable-style entry to `storageNoticeHistory`
   plus audit rows in `reservationStorageAudit`.
 - Reminder failures are tracked (`pickupReminderFailureCount`, `lastReminderFailureAt`) so
@@ -73,19 +101,32 @@ pickup windows.
 
 ## Implementation in portal
 
-- Surface pickup due dates and storage warnings in status views.
-- Route long-stale items to a follow-up path before actions are scheduled.
-- Keep written notices and contact attempts tied to the account record.
+- Surface the grace-end date, billed storage summary, and reclamation state in reservation
+  status views.
+- Offer prepaid extra pickup time in the intake/check-in flow before billed storage begins.
+- Show reclaimed reservations to staff and artists as `Reclaimed by studio`, even though the
+  stored compatibility value remains `stored_by_policy`.
+- Keep reminder history, billing accrual, and contact attempts tied to the reservation record.
 
 ## Enforcement
 
-When notices are exhausted and storage is still needed for operations, removal actions may be
-taken according to active workflow and retention thresholds.
+When the 28 billed storage days are exhausted, the work is reclaimed automatically and removed
+from active storage workflows. Support or staff may review disputes, but exceptions require
+operations approval.
 
 ## Support language
 
 Support should confirm:
 
-- last known status and hold period
-- whether storage notices were delivered
-- collection options and potential fees if applicable
+- the exact `readyForPickupAt` date/time
+- the grace-end date and billed-storage end date
+- whether prepaid storage was purchased
+- the current accrued billed storage amount, if any
+- whether the reservation has already been reclaimed by studio policy
+
+## Implementation notes
+
+- This March 17, 2026 update replaces the old 72h / 120h / 168h reminder cadence and the
+  earlier 14-day removal workflow.
+- Legal and operations review are still required before publishing future changes to storage
+  pricing, abandonment language, or ownership-transfer terms.

--- a/docs/runbooks/STUDIO_RESERVATION_OPERATIONS_PLAYBOOK.md
+++ b/docs/runbooks/STUDIO_RESERVATION_OPERATIONS_PLAYBOOK.md
@@ -79,12 +79,52 @@ When delayed:
 When ready for pickup:
 1. Ready status and next steps.
 2. Pickup timing guidance.
-3. Storage-window reminder if applicable.
+3. Reminder that the grace period lasts 2.75 weeks from the pickup-ready notice.
 
 Storage escalation:
-1. Mention hold status and notice history.
-2. Share latest action date.
-3. Provide recovery/collection path.
+1. Mention the exact pickup-ready date and the current storage status (`active`, `reminder_pending`, `hold_pending`, or reclaimed).
+2. Share the grace-end date, current billed-storage amount if any, and the reclamation date.
+3. Explain that prepaid storage is cheaper than post-grace daily storage.
+4. Provide the next collection path or escalation path.
+
+## Storage and reclamation workflow
+1. `readyForPickupAt` starts the clock when a reservation becomes pickup-ready.
+2. Grace period:
+   - lasts `19.25 days` (`462 hours`),
+   - reminders go out at day `14`, day `17.5`, and day `19.25`.
+3. Prepaid extra pickup time:
+   - can be sold before billed storage begins,
+   - price is `$2 per half-shelf per week`,
+   - use the reservation's estimated half-shelf count as the charge basis.
+4. Billed storage:
+   - begins automatically at the end of grace,
+   - costs `$1.50 per half-shelf per day`,
+   - accrues only after each fully elapsed 24-hour period,
+   - caps at `28 billed days`.
+5. Pickup-window misses:
+   - record the miss,
+   - do not reset the grace or billing clock,
+   - do not fast-track reclamation on their own.
+6. Reclamation:
+   - happens automatically after the 28 billed days are exhausted,
+   - writes `storageStatus = stored_by_policy`,
+   - writes `storageBilling.status = reclaimed`,
+   - sets `isArchived = true`,
+   - is shown in staff/client UI as `Reclaimed by studio`.
+7. Reclaimed work:
+   - is removed from active storage workflows,
+   - transfers ownership to the studio,
+   - may be destroyed, sold, repurposed, copied, displayed, or otherwise used per policy.
+
+## Staff handling guidance for storage cases
+1. Do not promise exceptions after billed storage has begun without operations approval.
+2. Quote storage using the reservation's half-shelf estimate, not ad hoc shelf guesses.
+3. If a member disputes notice history or reclamation timing, review:
+   - `readyForPickupAt`
+   - `pickupReminderCount`
+   - `storageNoticeHistory`
+   - `storageBilling`
+4. If a reservation already shows reclaimed/archive markers, route the case to operations instead of re-opening it manually.
 
 ## Continuity export and restore
 1. Use `apiV1/v1/reservations.exportContinuity` for owner-scoped continuity bundles.
@@ -117,7 +157,7 @@ Run this path in release validation:
 2. Staff confirm (`CONFIRMED`).
 3. Delay/deferral (`WAITLISTED`) with reason note.
 4. Ready-for-pickup reminder path (`loaded` + customer update).
-5. Storage escalation policy handoff path.
+5. Storage escalation path through grace, billed storage, and reclamation/archive.
 
 Station-level scenario (required in QA evidence):
 1. Fill a station to near-capacity.

--- a/functions/src/apiV1.test.ts
+++ b/functions/src/apiV1.test.ts
@@ -75,7 +75,8 @@ function withMockFirestore<T>(
   const db = shared.db as unknown as {
     collection: (path: string) => {
       add: (value: Record<string, unknown>) => Promise<{ id: string }>;
-      doc: (id: string) => {
+      doc: (id?: string) => {
+        id: string;
         __mfCollection: string;
         __mfDocId: string;
       };
@@ -87,7 +88,7 @@ function withMockFirestore<T>(
     doc: (path: string) => {
       exists: boolean;
       get: () => Promise<MockSnapshot>;
-      set: (value: Record<string, unknown>, options?: { merge?: boolean }) => Promise<void>;
+      set: (value?: Record<string, unknown>, options?: { merge?: boolean }) => Promise<void>;
     };
     runTransaction: (cb: (tx: MockTransaction) => Promise<unknown>) => Promise<unknown>;
   };
@@ -146,16 +147,21 @@ function withMockFirestore<T>(
         rows[generatedId] = _doc;
         return { id: generatedId };
       },
-      doc: (id: string) => {
-        const collectionRow = rows[id] ?? null;
+      doc: (id?: string) => {
+        const resolvedId = typeof id === "string" && id.trim().length > 0 ? id : nextGeneratedId(collectionName);
         return {
+          id: resolvedId,
           __mfCollection: collectionName,
-          __mfDocId: id,
-          get: async () => createSnapshot(id, Object.prototype.hasOwnProperty.call(rows, id) ? collectionRow : null),
-          set: async (value: Record<string, unknown>, options?: { merge?: boolean }) => {
-            applySet(collectionName, id, value, options);
+          __mfDocId: resolvedId,
+          get: async () =>
+            createSnapshot(
+              resolvedId,
+              Object.prototype.hasOwnProperty.call(rows, resolvedId) ? rows[resolvedId] : null
+            ),
+          set: async (value?: Record<string, unknown>, options?: { merge?: boolean }) => {
+            applySet(collectionName, resolvedId, value ?? {}, options);
           },
-          collection: (sub: string) => createCollectionRef(`${collectionName}/${id}/${sub}`),
+          collection: (sub: string) => createCollectionRef(`${collectionName}/${resolvedId}/${sub}`),
         };
       },
       where: () => createCollectionQuery(rows),
@@ -184,8 +190,8 @@ function withMockFirestore<T>(
     const raw = Object.prototype.hasOwnProperty.call(rows, docId) ? rows[docId] : null;
     return {
       get: async () => createSnapshot(docId, raw),
-      set: async (value: Record<string, unknown>, options?: { merge?: boolean }) => {
-        applySet(collectionName, docId, value, options);
+      set: async (value?: Record<string, unknown>, options?: { merge?: boolean }) => {
+        applySet(collectionName, docId, value ?? {}, options);
       },
       exists: raw !== null,
     };
@@ -6652,16 +6658,19 @@ test("reservations.create accepts optional piece rows in request payload", async
   assert.equal(data.status, "REQUESTED");
 });
 
-test("reservations.create accepts fragile handling, placement preference, and prepaid storage add-ons", async () => {
+test("reservations.create writes self-loaded kiln, glaze access, and per-half-shelf prepaid storage pricing", async () => {
+  const state: MockDbState = {};
   const response = await invokeApiV1Route(
-    {},
+    state,
     makeApiV1Request({
       path: "/v1/reservations.create",
       body: {
         firingType: "glaze",
-        shelfEquivalent: 1,
+        shelfEquivalent: 1.5,
+        estimatedHalfShelves: 3,
         addOns: {
-          fragileHandlingRequested: true,
+          useStudioGlazes: true,
+          selfLoadedKilnRequested: true,
           placementPreferenceRequested: true,
           placementPreferenceZone: "top",
           prepaidStorageRequested: true,
@@ -6677,6 +6686,57 @@ test("reservations.create accepts fragile handling, placement preference, and pr
   const body = response.body as Record<string, unknown>;
   const data = (body.data ?? {}) as Record<string, unknown>;
   assert.equal(data.status, "REQUESTED");
+  const reservationId = String(data.reservationId ?? "");
+  const reservation = state.reservations?.[reservationId] as Record<string, unknown>;
+  assert.ok(reservation, "reservation should be written to state");
+  const addOns = (reservation.addOns ?? {}) as Record<string, unknown>;
+  const storageBilling = (reservation.storageBilling ?? {}) as Record<string, unknown>;
+  assert.equal(addOns.useStudioGlazes, true);
+  assert.equal(addOns.glazeAccessCost, 15);
+  assert.equal(addOns.selfLoadedKilnRequested, true);
+  assert.equal(addOns.selfLoadedKilnCost, 15);
+  assert.equal(addOns.prepaidStorageRequested, true);
+  assert.equal(addOns.prepaidStorageWeeks, 2);
+  assert.equal(addOns.prepaidStorageCost, 12);
+  assert.equal("fragileHandlingRequested" in addOns, false);
+  assert.equal(storageBilling.chargeBasis, "estimatedHalfShelves");
+  assert.equal(storageBilling.chargeBasisHalfShelves, 3);
+  assert.equal(storageBilling.prepaidWeeklyRatePerHalfShelf, 2);
+  assert.equal(storageBilling.dailyRatePerHalfShelf, 1.5);
+  assert.equal(storageBilling.status, "grace");
+  assert.equal(storageBilling.billedDays, 0);
+  assert.equal(storageBilling.accruedCost, 0);
+  assert.equal(reservation.isArchived, false);
+});
+
+test("reservations.create accepts legacy fragile handling alias and normalizes it to self-loaded kiln", async () => {
+  const state: MockDbState = {};
+  const response = await invokeApiV1Route(
+    state,
+    makeApiV1Request({
+      path: "/v1/reservations.create",
+      body: {
+        firingType: "bisque",
+        shelfEquivalent: 1,
+        estimatedHalfShelves: 2,
+        addOns: {
+          fragileHandlingRequested: true,
+        },
+      },
+      ctx: firebaseContext({ uid: "owner-1" }),
+      routeFamily: "v1",
+    }),
+  );
+
+  assert.equal(response.status, 200, JSON.stringify(response.body));
+  const body = response.body as Record<string, unknown>;
+  const data = (body.data ?? {}) as Record<string, unknown>;
+  const reservationId = String(data.reservationId ?? "");
+  const reservation = state.reservations?.[reservationId] as Record<string, unknown>;
+  const addOns = (reservation.addOns ?? {}) as Record<string, unknown>;
+  assert.equal(addOns.selfLoadedKilnRequested, true);
+  assert.equal(addOns.selfLoadedKilnCost, 15);
+  assert.equal("fragileHandlingRequested" in addOns, false);
 });
 
 test("reservations.create rejects bisque-only profile for non-bisque firings", async () => {
@@ -6965,7 +7025,7 @@ test("reservations.pickupWindow enforces one reschedule request without force", 
   assert.equal(secondBody.code, "CONFLICT");
 });
 
-test("reservations.pickupWindow escalates to stored_by_policy after repeated missed windows", async () => {
+test("reservations.pickupWindow records misses without bypassing the storage grace and billing timeline", async () => {
   const state: MockDbState = {
     reservations: {
       "reservation-pickup-missed": {
@@ -7001,7 +7061,8 @@ test("reservations.pickupWindow escalates to stored_by_policy after repeated mis
   assert.equal(response.status, 200);
   const body = response.body as Record<string, unknown>;
   const data = (body.data ?? {}) as Record<string, unknown>;
-  assert.equal(data.storageStatus, "stored_by_policy");
+  assert.equal(data.storageStatus, "active");
+  assert.equal(data.pickupWindowStatus, "missed");
 });
 
 test("reservations.queueFairness records no-show evidence and updates policy penalty", async () => {

--- a/functions/src/apiV1.ts
+++ b/functions/src/apiV1.ts
@@ -902,6 +902,20 @@ const libraryRatingUpsertSchema = z.object({
   stars: z.number().int().min(1).max(5),
 });
 
+const supportRequestCreateSchema = z.object({
+  subject: z.string().min(1).max(200).trim(),
+  body: z.string().min(1).max(4_000).trim(),
+  category: z.string().min(1).max(80).trim(),
+  eventId: z.string().min(1).max(200).trim().optional().nullable(),
+  sourceEventTitle: z.string().min(1).max(200).trim().optional().nullable(),
+  eventTitle: z.string().min(1).max(200).trim().optional().nullable(),
+  source: z.string().min(1).max(120).trim().optional().nullable(),
+  level: z.string().min(1).max(80).trim().optional().nullable(),
+  schedule: z.string().min(1).max(80).trim().optional().nullable(),
+  buddyMode: z.string().min(1).max(80).trim().optional().nullable(),
+  techniqueIds: z.array(z.string().min(1).max(80).trim()).max(20).optional(),
+});
+
 const libraryReviewCreateSchema = z
   .object({
     itemId: z.string().min(1).max(200).trim(),
@@ -1101,6 +1115,8 @@ const reservationCreateSchema = z.object({
       returnDeliveryRequested: z.boolean().optional().nullable(),
       useStudioGlazes: z.boolean().optional().nullable(),
       glazeAccessCost: z.number().optional().nullable(),
+      selfLoadedKilnRequested: z.boolean().optional().nullable(),
+      selfLoadedKilnCost: z.number().optional().nullable(),
       waxResistAssistRequested: z.boolean().optional().nullable(),
       glazeSanityCheckRequested: z.boolean().optional().nullable(),
       fragileHandlingRequested: z.boolean().optional().nullable(),
@@ -1303,6 +1319,7 @@ type ReservationStatus = "REQUESTED" | "CONFIRMED" | "WAITLISTED" | "CANCELLED" 
 type ReservationLoadStatus = "queued" | "loading" | "loaded" | null;
 type ReservationPieceStatus = "awaiting_placement" | "loaded" | "fired" | "ready" | "picked_up";
 type ReservationStorageStatus = "active" | "reminder_pending" | "hold_pending" | "stored_by_policy";
+type ReservationStorageBillingStatus = "grace" | "billing" | "reclaimed";
 type ReservationPickupWindowStatus = "open" | "confirmed" | "missed" | "expired" | "completed";
 
 type ReservationPieceEntry = {
@@ -1335,6 +1352,21 @@ type ReservationStorageNoticeEntry = {
   reminderOrdinal: number | null;
   reminderCount: number | null;
   failureCode: string | null;
+};
+
+type ReservationStorageBillingEntry = {
+  chargeBasis: "estimatedHalfShelves" | string | null;
+  chargeBasisHalfShelves: number;
+  prepaidWeeklyRatePerHalfShelf: number;
+  dailyRatePerHalfShelf: number;
+  graceEndsAt: Date | null;
+  billingStartsAt: Date | null;
+  billingEndsAt: Date | null;
+  billedDays: number;
+  accruedCost: number;
+  status: ReservationStorageBillingStatus | null;
+  reclaimedAt: Date | null;
+  reclaimedReason: string | null;
 };
 
 type ReservationPickupWindowEntry = {
@@ -1379,6 +1411,8 @@ const RESERVATION_QUEUE_FAIRNESS_POLICY_VERSION = "2026-02-24.v1";
 const RESERVATION_QUEUE_FAIRNESS_NO_SHOW_PENALTY = 2;
 const RESERVATION_QUEUE_FAIRNESS_LATE_PENALTY = 1;
 const RESERVATION_CONTINUITY_EXPORT_SCHEMA_VERSION = "2026-02-24.v1";
+const RESERVATION_STORAGE_PREPAID_WEEKLY_RATE_PER_HALF_SHELF = 2;
+const RESERVATION_STORAGE_DAILY_RATE_PER_HALF_SHELF = 1.5;
 
 const RESERVATION_STORAGE_STATUS_VALUES: ReadonlySet<ReservationStorageStatus> = new Set([
   "active",
@@ -1666,6 +1700,143 @@ function normalizeReservationStorageNoticeHistory(raw: unknown): ReservationStor
     });
   }
   return out.slice(-80);
+}
+
+function roundCurrency(value: number): number {
+  return Number(value.toFixed(2));
+}
+
+function normalizeReservationStorageBillingStatus(
+  value: unknown
+): ReservationStorageBillingStatus | null {
+  const normalized = safeString(value).trim().toLowerCase();
+  if (normalized === "grace" || normalized === "billing" || normalized === "reclaimed") {
+    return normalized;
+  }
+  return null;
+}
+
+function normalizeReservationStorageBilling(
+  value: unknown
+): ReservationStorageBillingEntry | null {
+  const raw = value && typeof value === "object" ? (value as Record<string, unknown>) : null;
+  if (!raw) return null;
+
+  const chargeBasisHalfShelvesRaw = normalizeNumber(raw.chargeBasisHalfShelves);
+  const prepaidWeeklyRateRaw = normalizeNumber(raw.prepaidWeeklyRatePerHalfShelf);
+  const dailyRateRaw = normalizeNumber(raw.dailyRatePerHalfShelf);
+  const billedDaysRaw = normalizeNumber(raw.billedDays);
+  const accruedCostRaw = normalizeNumber(raw.accruedCost);
+
+  return {
+    chargeBasis: trimOrNull(raw.chargeBasis),
+    chargeBasisHalfShelves:
+      typeof chargeBasisHalfShelvesRaw === "number" && chargeBasisHalfShelvesRaw > 0
+        ? chargeBasisHalfShelvesRaw
+        : 0,
+    prepaidWeeklyRatePerHalfShelf:
+      typeof prepaidWeeklyRateRaw === "number" && prepaidWeeklyRateRaw >= 0
+        ? prepaidWeeklyRateRaw
+        : RESERVATION_STORAGE_PREPAID_WEEKLY_RATE_PER_HALF_SHELF,
+    dailyRatePerHalfShelf:
+      typeof dailyRateRaw === "number" && dailyRateRaw >= 0
+        ? dailyRateRaw
+        : RESERVATION_STORAGE_DAILY_RATE_PER_HALF_SHELF,
+    graceEndsAt: parseReservationIsoDate(raw.graceEndsAt),
+    billingStartsAt: parseReservationIsoDate(raw.billingStartsAt),
+    billingEndsAt: parseReservationIsoDate(raw.billingEndsAt),
+    billedDays:
+      typeof billedDaysRaw === "number" && billedDaysRaw >= 0
+        ? Math.max(0, Math.round(billedDaysRaw))
+        : 0,
+    accruedCost:
+      typeof accruedCostRaw === "number" && accruedCostRaw >= 0
+        ? roundCurrency(accruedCostRaw)
+        : 0,
+    status: normalizeReservationStorageBillingStatus(raw.status),
+    reclaimedAt: parseReservationIsoDate(raw.reclaimedAt),
+    reclaimedReason: trimOrNull(raw.reclaimedReason),
+  };
+}
+
+function toReservationStorageBillingWrite(
+  entry: ReservationStorageBillingEntry | null
+): Record<string, unknown> | null {
+  if (!entry) return null;
+  return {
+    chargeBasis: entry.chargeBasis ?? "estimatedHalfShelves",
+    chargeBasisHalfShelves: Math.max(0, entry.chargeBasisHalfShelves),
+    prepaidWeeklyRatePerHalfShelf: roundCurrency(
+      Math.max(0, entry.prepaidWeeklyRatePerHalfShelf)
+    ),
+    dailyRatePerHalfShelf: roundCurrency(Math.max(0, entry.dailyRatePerHalfShelf)),
+    graceEndsAt: entry.graceEndsAt ? Timestamp.fromDate(entry.graceEndsAt) : null,
+    billingStartsAt: entry.billingStartsAt ? Timestamp.fromDate(entry.billingStartsAt) : null,
+    billingEndsAt: entry.billingEndsAt ? Timestamp.fromDate(entry.billingEndsAt) : null,
+    billedDays: Math.max(0, Math.round(entry.billedDays)),
+    accruedCost: roundCurrency(Math.max(0, entry.accruedCost)),
+    status: entry.status ?? "grace",
+    reclaimedAt: entry.reclaimedAt ? Timestamp.fromDate(entry.reclaimedAt) : null,
+    reclaimedReason: entry.reclaimedReason ?? null,
+  };
+}
+
+function seedReservationStorageBilling(
+  chargeBasisHalfShelves: number | null | undefined
+): ReservationStorageBillingEntry {
+  return {
+    chargeBasis: "estimatedHalfShelves",
+    chargeBasisHalfShelves:
+      typeof chargeBasisHalfShelves === "number" && Number.isFinite(chargeBasisHalfShelves)
+        ? Math.max(0, chargeBasisHalfShelves)
+        : 0,
+    prepaidWeeklyRatePerHalfShelf: RESERVATION_STORAGE_PREPAID_WEEKLY_RATE_PER_HALF_SHELF,
+    dailyRatePerHalfShelf: RESERVATION_STORAGE_DAILY_RATE_PER_HALF_SHELF,
+    graceEndsAt: null,
+    billingStartsAt: null,
+    billingEndsAt: null,
+    billedDays: 0,
+    accruedCost: 0,
+    status: "grace",
+    reclaimedAt: null,
+    reclaimedReason: null,
+  };
+}
+
+function normalizeReservationAddOnsForRow(value: unknown): Record<string, unknown> | null {
+  const raw = value && typeof value === "object" ? (value as Record<string, unknown>) : null;
+  if (!raw) return null;
+
+  const selfLoadedKilnRequested = raw.selfLoadedKilnRequested === true || raw.fragileHandlingRequested === true;
+  const selfLoadedKilnCost =
+    normalizeNumber(raw.selfLoadedKilnCost) ?? normalizeNumber(raw.fragileHandlingCost);
+
+  return {
+    rushRequested: raw.rushRequested === true,
+    wholeKilnRequested: raw.wholeKilnRequested === true,
+    communityShelfFillInAllowed: raw.communityShelfFillInAllowed === true,
+    pickupDeliveryRequested: raw.pickupDeliveryRequested === true,
+    returnDeliveryRequested: raw.returnDeliveryRequested === true,
+    useStudioGlazes: raw.useStudioGlazes === true,
+    glazeAccessCost: normalizeNumber(raw.glazeAccessCost),
+    selfLoadedKilnRequested,
+    selfLoadedKilnCost,
+    waxResistAssistRequested: raw.waxResistAssistRequested === true,
+    glazeSanityCheckRequested: raw.glazeSanityCheckRequested === true,
+    placementPreferenceRequested: raw.placementPreferenceRequested === true,
+    placementPreferenceZone:
+      raw.placementPreferenceZone === "top" ||
+      raw.placementPreferenceZone === "middle" ||
+      raw.placementPreferenceZone === "bottom"
+        ? raw.placementPreferenceZone
+        : null,
+    placementPreferenceCost: normalizeNumber(raw.placementPreferenceCost),
+    prepaidStorageRequested: raw.prepaidStorageRequested === true,
+    prepaidStorageWeeks: normalizeNumber(raw.prepaidStorageWeeks),
+    prepaidStorageCost: normalizeNumber(raw.prepaidStorageCost),
+    deliveryAddress: trimOrNull(raw.deliveryAddress),
+    deliveryInstructions: trimOrNull(raw.deliveryInstructions),
+  };
 }
 
 function normalizeReservationWindow(value: unknown): { earliestDate: Date | null; latestDate: Date | null } {
@@ -1994,6 +2165,7 @@ function toReservationRow(id: string, row: Record<string, unknown>) {
       ? (row.queueFairnessPolicy as Record<string, unknown>)
       : {};
   const pieces = normalizeReservationPiecesInput(row.pieces, id);
+  const storageBilling = normalizeReservationStorageBilling(row.storageBilling);
 
   return {
     id,
@@ -2024,7 +2196,7 @@ function toReservationRow(id: string, row: Record<string, unknown>) {
     notes: row.notes ? (row.notes as Record<string, unknown>) : null,
     pieces,
     notesHistory: Array.isArray(row.notesHistory) ? row.notesHistory : null,
-    addOns: row.addOns ? (row.addOns as Record<string, unknown>) : null,
+    addOns: normalizeReservationAddOnsForRow(row.addOns),
     loadStatus,
     queuePositionHint: normalizeNumber(row.queuePositionHint),
     queueFairness: {
@@ -2096,6 +2268,24 @@ function toReservationRow(id: string, row: Record<string, unknown>) {
     pickupReminderFailureCount: normalizeNumber(row.pickupReminderFailureCount),
     lastReminderFailureAt: parseReservationIsoDate(row.lastReminderFailureAt),
     storageNoticeHistory,
+    storageBilling: storageBilling
+      ? {
+          chargeBasis: storageBilling.chargeBasis ?? null,
+          chargeBasisHalfShelves: storageBilling.chargeBasisHalfShelves,
+          prepaidWeeklyRatePerHalfShelf: storageBilling.prepaidWeeklyRatePerHalfShelf,
+          dailyRatePerHalfShelf: storageBilling.dailyRatePerHalfShelf,
+          graceEndsAt: storageBilling.graceEndsAt,
+          billingStartsAt: storageBilling.billingStartsAt,
+          billingEndsAt: storageBilling.billingEndsAt,
+          billedDays: storageBilling.billedDays,
+          accruedCost: storageBilling.accruedCost,
+          status: storageBilling.status ?? null,
+          reclaimedAt: storageBilling.reclaimedAt,
+          reclaimedReason: storageBilling.reclaimedReason,
+        }
+      : null,
+    isArchived: row.isArchived === true,
+    archivedAt: parseReservationIsoDate(row.archivedAt),
     arrivalStatus: safeString(row.arrivalStatus) || null,
     arrivedAt: parseReservationIsoDate(row.arrivedAt),
     arrivalToken: safeString(row.arrivalToken) || null,
@@ -2306,6 +2496,7 @@ const ROUTE_SCOPE_HINTS: Record<string, string | null> = {
   "/v1/library.recommendations.feedback.submit": null,
   "/v1/library.recommendations.moderate": null,
   "/v1/library.recommendations.feedback.moderate": null,
+  "/v1/support.requests.create": null,
   "/v1/library.ratings.upsert": null,
   "/v1/library.reviews.create": null,
   "/v1/library.reviews.update": null,
@@ -2398,6 +2589,7 @@ const ALLOWED_API_V1_ROUTES = new Set<string>([
   "/v1/library.recommendations.feedback.submit",
   "/v1/library.recommendations.moderate",
   "/v1/library.recommendations.feedback.moderate",
+  "/v1/support.requests.create",
   "/v1/library.ratings.upsert",
   "/v1/library.reviews.create",
   "/v1/library.reviews.update",
@@ -5174,9 +5366,10 @@ export async function handleApiV1(req: RequestLike, res: ResponseLike) {
 
       const addOnsInput = body.addOns ?? {};
       const isCommunityShelf = intakeMode === "COMMUNITY_SHELF";
-      const fragileHandlingRatePerHalfShelf = 4;
+      const studioGlazeAccessRatePerHalfShelf = 5;
+      const selfLoadedKilnFlatCost = 15;
       const placementPreferenceFlatCost = 3;
-      const prepaidStorageWeeklyCost = 2;
+      const prepaidStorageWeeklyCostPerHalfShelf = RESERVATION_STORAGE_PREPAID_WEEKLY_RATE_PER_HALF_SHELF;
       const placementPreferenceZoneInput = addOnsInput.placementPreferenceZone;
       const placementPreferenceZone =
         placementPreferenceZoneInput === "top" ||
@@ -5184,6 +5377,9 @@ export async function handleApiV1(req: RequestLike, res: ResponseLike) {
         placementPreferenceZoneInput === "bottom"
           ? placementPreferenceZoneInput
           : "middle";
+      const selfLoadedKilnRequested =
+        !isCommunityShelf &&
+        (addOnsInput.selfLoadedKilnRequested === true || addOnsInput.fragileHandlingRequested === true);
       const prepaidStorageWeeksInput = normalizeNumber(addOnsInput.prepaidStorageWeeks, 1);
       const prepaidStorageWeeks =
         prepaidStorageWeeksInput != null ? clampNumber(Math.round(prepaidStorageWeeksInput), 1, 12) : 1;
@@ -5199,18 +5395,12 @@ export async function handleApiV1(req: RequestLike, res: ResponseLike) {
           resolvedEstimatedHalfShelves &&
           resolvedEstimatedHalfShelves > 0 &&
           addOnsInput.useStudioGlazes === true
-          ? resolvedEstimatedHalfShelves * 3
+          ? resolvedEstimatedHalfShelves * studioGlazeAccessRatePerHalfShelf
           : null,
         waxResistAssistRequested: !isCommunityShelf && addOnsInput.waxResistAssistRequested === true,
         glazeSanityCheckRequested: !isCommunityShelf && addOnsInput.glazeSanityCheckRequested === true,
-        fragileHandlingRequested: !isCommunityShelf && addOnsInput.fragileHandlingRequested === true,
-        fragileHandlingCost:
-          !isCommunityShelf &&
-          addOnsInput.fragileHandlingRequested === true &&
-          resolvedEstimatedHalfShelves &&
-          resolvedEstimatedHalfShelves > 0
-            ? resolvedEstimatedHalfShelves * fragileHandlingRatePerHalfShelf
-            : null,
+        selfLoadedKilnRequested,
+        selfLoadedKilnCost: selfLoadedKilnRequested ? selfLoadedKilnFlatCost : null,
         placementPreferenceRequested: !isCommunityShelf && addOnsInput.placementPreferenceRequested === true,
         placementPreferenceZone:
           !isCommunityShelf && addOnsInput.placementPreferenceRequested === true
@@ -5226,12 +5416,17 @@ export async function handleApiV1(req: RequestLike, res: ResponseLike) {
             ? prepaidStorageWeeks
             : null,
         prepaidStorageCost:
-          !isCommunityShelf && addOnsInput.prepaidStorageRequested === true
-            ? prepaidStorageWeeks * prepaidStorageWeeklyCost
+          !isCommunityShelf &&
+          addOnsInput.prepaidStorageRequested === true &&
+          resolvedEstimatedHalfShelves &&
+          resolvedEstimatedHalfShelves > 0
+            ? prepaidStorageWeeks * resolvedEstimatedHalfShelves * prepaidStorageWeeklyCostPerHalfShelf
             : null,
         deliveryAddress: trimOrNull(addOnsInput.deliveryAddress),
         deliveryInstructions: trimOrNull(addOnsInput.deliveryInstructions),
       };
+
+      const storageBillingSeed = seedReservationStorageBilling(resolvedEstimatedHalfShelves);
 
       if (
         (addOns.pickupDeliveryRequested || addOns.returnDeliveryRequested) &&
@@ -5351,6 +5546,9 @@ export async function handleApiV1(req: RequestLike, res: ResponseLike) {
         pickupReminderFailureCount: 0,
         lastReminderFailureAt: null,
         storageNoticeHistory: [],
+        storageBilling: toReservationStorageBillingWrite(storageBillingSeed),
+        isArchived: false,
+        archivedAt: null,
         createdByUid: ctx.uid,
         createdByRole: isStaff ? "staff" : ctx.mode === "firebase" ? "client" : "dev",
         createdAt: now,
@@ -6697,24 +6895,11 @@ export async function handleApiV1(req: RequestLike, res: ResponseLike) {
             pickupWindow.lastMissedAt = nowDate;
             pickupWindow.confirmedAt = null;
             transitionReason = "pickup_window_missed";
-
-            if (pickupWindow.missedCount >= 2) {
-              storageStatus = "stored_by_policy";
-              updates.storageStatus = storageStatus;
-              storageNotice(
-                "stored_by_policy",
-                "Reservation exceeded pickup-window misses and moved to stored-by-policy.",
-                storageStatus
-              );
-            } else {
-              storageStatus = "hold_pending";
-              updates.storageStatus = storageStatus;
-              storageNotice(
-                "pickup_window_missed",
-                "Pickup window was missed. Reservation moved to hold-pending for follow-up.",
-                storageStatus
-              );
-            }
+            storageNotice(
+              "pickup_window_missed",
+              "Pickup window was missed. Grace, storage billing, and reclamation timers still follow the pickup-ready date.",
+              storageStatus
+            );
           } else if (action === "staff_mark_completed") {
             pickupWindow.status = "completed";
             pickupWindow.completedAt = nowDate;
@@ -9891,6 +10076,50 @@ export async function handleApiV1(req: RequestLike, res: ResponseLike) {
           note: moderationNote,
         },
       });
+      return;
+    }
+
+    if (route === "/v1/support.requests.create") {
+      if (ctx.mode !== "firebase") {
+        jsonError(res, requestId, 403, "FORBIDDEN", "Support request routes require a member firebase session.");
+        return;
+      }
+
+      const parsed = parseBody(supportRequestCreateSchema, req.body);
+      if (!parsed.ok) {
+        jsonError(res, requestId, 400, "INVALID_ARGUMENT", parsed.message);
+        return;
+      }
+
+      const decoded = ctx.decoded as Record<string, unknown>;
+      const displayName = trimOrNull(safeString(decoded.name, null));
+      const email = trimOrNull(safeString(decoded.email, null));
+      const supportRequest = {
+        uid: ctx.uid,
+        subject: parsed.data.subject.trim(),
+        body: parsed.data.body.trim(),
+        category: parsed.data.category.trim(),
+        status: "new",
+        urgency: "non-urgent",
+        channel: "portal",
+        createdAt: nowTs(),
+        displayName,
+        email,
+        ...(trimOrNull(parsed.data.eventId) ? { eventId: trimOrNull(parsed.data.eventId) } : {}),
+        ...(trimOrNull(parsed.data.sourceEventTitle)
+          ? { sourceEventTitle: trimOrNull(parsed.data.sourceEventTitle) }
+          : {}),
+        ...(trimOrNull(parsed.data.eventTitle) ? { eventTitle: trimOrNull(parsed.data.eventTitle) } : {}),
+        ...(trimOrNull(parsed.data.source) ? { source: trimOrNull(parsed.data.source) } : {}),
+        ...(trimOrNull(parsed.data.level) ? { level: trimOrNull(parsed.data.level) } : {}),
+        ...(trimOrNull(parsed.data.schedule) ? { schedule: trimOrNull(parsed.data.schedule) } : {}),
+        ...(trimOrNull(parsed.data.buddyMode) ? { buddyMode: trimOrNull(parsed.data.buddyMode) } : {}),
+        ...(Array.isArray(parsed.data.techniqueIds) && parsed.data.techniqueIds.length > 0
+          ? { techniqueIds: parsed.data.techniqueIds.map((entry) => entry.trim()) }
+          : {}),
+      };
+      const supportRef = await db.collection("supportRequests").add(supportRequest);
+      jsonOk(res, requestId, { supportRequestId: supportRef.id });
       return;
     }
 

--- a/functions/src/notifications.test.ts
+++ b/functions/src/notifications.test.ts
@@ -1,0 +1,346 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import * as shared from "./shared";
+import {
+  computeReservationStorageBilling,
+  nextDueReminderOrdinal,
+  runReservationStorageHoldEvaluation,
+  storageStatusForElapsed,
+} from "./notifications";
+
+type DbRow = Record<string, unknown> | null;
+type MockDbState = Record<string, Record<string, DbRow>>;
+
+type MockDocRef = {
+  id: string;
+  path: string;
+  get: () => Promise<{ id: string; exists: boolean; data: () => Record<string, unknown> | undefined }>;
+  set: (value: Record<string, unknown>, options?: { merge?: boolean }) => Promise<void>;
+  create: (value: Record<string, unknown>) => Promise<void>;
+  collection: (path: string) => MockCollectionRef;
+};
+
+type MockCollectionRef = {
+  doc: (id: string) => MockDocRef;
+  where: (..._args: unknown[]) => MockQuery;
+  limit: (limit: number) => MockQuery;
+  get: () => Promise<{ docs: Array<{ id: string; data: () => Record<string, unknown> | undefined; ref: MockDocRef }> }>;
+};
+
+type MockQuery = {
+  where: (..._args: unknown[]) => MockQuery;
+  limit: (limit: number) => MockQuery;
+  get: () => Promise<{ docs: Array<{ id: string; data: () => Record<string, unknown> | undefined; ref: MockDocRef }> }>;
+};
+
+function cloneRow(row: DbRow): Record<string, unknown> | undefined {
+  if (!row) return undefined;
+  return { ...row };
+}
+
+function mergeRows(existing: DbRow, incoming: Record<string, unknown>): Record<string, unknown> {
+  return {
+    ...(existing ?? {}),
+    ...incoming,
+  };
+}
+
+function withMockFirestore<T>(state: MockDbState, callback: () => Promise<T>): Promise<T> {
+  const db = shared.db as unknown as {
+    collection: (path: string) => MockCollectionRef;
+  };
+  const originalCollection = db.collection;
+
+  const ensureCollection = (collectionPath: string): Record<string, DbRow> => {
+    if (!Object.prototype.hasOwnProperty.call(state, collectionPath)) {
+      state[collectionPath] = {};
+    }
+    return state[collectionPath] as Record<string, DbRow>;
+  };
+
+  const makeDocRef = (collectionPath: string, id: string): MockDocRef => ({
+    id,
+    path: `${collectionPath}/${id}`,
+    get: async () => {
+      const rows = ensureCollection(collectionPath);
+      const row = Object.prototype.hasOwnProperty.call(rows, id) ? rows[id] : null;
+      return {
+        id,
+        exists: row !== null,
+        data: () => cloneRow(row),
+      };
+    },
+    set: async (value, options) => {
+      const rows = ensureCollection(collectionPath);
+      const existing = Object.prototype.hasOwnProperty.call(rows, id) ? rows[id] : null;
+      rows[id] = options?.merge ? mergeRows(existing, value) : { ...value };
+    },
+    create: async (value) => {
+      const rows = ensureCollection(collectionPath);
+      if (Object.prototype.hasOwnProperty.call(rows, id) && rows[id] !== null) {
+        throw new Error("DOC_EXISTS");
+      }
+      rows[id] = { ...value };
+    },
+    collection: (subPath: string) => makeCollectionRef(`${collectionPath}/${id}/${subPath}`),
+  });
+
+  const makeQuery = (collectionPath: string, limitCount?: number): MockQuery => ({
+    where: () => makeQuery(collectionPath, limitCount),
+    limit: (nextLimit) => makeQuery(collectionPath, nextLimit),
+    get: async () => {
+      const rows = ensureCollection(collectionPath);
+      const entries = Object.entries(rows)
+        .filter(([, row]) => row !== null)
+        .slice(0, limitCount ?? Number.MAX_SAFE_INTEGER)
+        .map(([id, row]) => ({
+          id,
+          data: () => cloneRow(row),
+          ref: makeDocRef(collectionPath, id),
+        }));
+      return { docs: entries };
+    },
+  });
+
+  const makeCollectionRef = (collectionPath: string): MockCollectionRef => ({
+    doc: (id: string) => makeDocRef(collectionPath, id),
+    where: () => makeQuery(collectionPath),
+    limit: (limitCount) => makeQuery(collectionPath, limitCount),
+    get: async () => makeQuery(collectionPath).get(),
+  });
+
+  db.collection = (collectionPath) => makeCollectionRef(collectionPath);
+
+  return callback().finally(() => {
+    db.collection = originalCollection;
+  });
+}
+
+function storageSeed(readyIso: string, chargeBasisHalfShelves: number) {
+  const readyForPickupAt = shared.Timestamp.fromDate(new Date(readyIso));
+  return computeReservationStorageBilling({
+    existing: null,
+    readyForPickupAt,
+    chargeBasisHalfShelves,
+    now: readyForPickupAt,
+  });
+}
+
+test("nextDueReminderOrdinal uses the shifted grace-period thresholds", () => {
+  const dayMs = 24 * 60 * 60 * 1000;
+  assert.equal(nextDueReminderOrdinal({ elapsedMs: 13.9 * dayMs, currentCount: 0 }), null);
+  assert.equal(nextDueReminderOrdinal({ elapsedMs: 14 * dayMs, currentCount: 0 }), 1);
+  assert.equal(nextDueReminderOrdinal({ elapsedMs: 17.5 * dayMs, currentCount: 1 }), 2);
+  assert.equal(nextDueReminderOrdinal({ elapsedMs: 19.25 * dayMs, currentCount: 2 }), 3);
+});
+
+test("storageStatusForElapsed maps grace, billing, and reclamation windows", () => {
+  const hourMs = 60 * 60 * 1000;
+  const dayMs = 24 * hourMs;
+  assert.equal(storageStatusForElapsed({ elapsedMs: 13 * dayMs, reminderCount: 0 }), "active");
+  assert.equal(storageStatusForElapsed({ elapsedMs: 14 * dayMs, reminderCount: 1 }), "reminder_pending");
+  assert.equal(storageStatusForElapsed({ elapsedMs: 462 * hourMs, reminderCount: 3 }), "hold_pending");
+  assert.equal(
+    storageStatusForElapsed({ elapsedMs: (462 + 28 * 24) * hourMs, reminderCount: 3 }),
+    "stored_by_policy"
+  );
+});
+
+test("computeReservationStorageBilling accrues full days and caps at reclamation", () => {
+  const readyForPickupAt = shared.Timestamp.fromDate(new Date("2026-03-01T00:00:00.000Z"));
+  const billing = computeReservationStorageBilling({
+    existing: null,
+    readyForPickupAt,
+    chargeBasisHalfShelves: 3,
+    now: shared.Timestamp.fromDate(new Date("2026-03-21T06:00:00.000Z")),
+  });
+  assert.equal(billing.status, "billing");
+  assert.equal(billing.billedDays, 1);
+  assert.equal(billing.accruedCost, 4.5);
+
+  const reclaimed = computeReservationStorageBilling({
+    existing: billing,
+    readyForPickupAt,
+    chargeBasisHalfShelves: 3,
+    now: shared.Timestamp.fromDate(new Date("2026-04-17T06:00:00.000Z")),
+  });
+  assert.equal(reclaimed.status, "reclaimed");
+  assert.equal(reclaimed.billedDays, 28);
+  assert.equal(reclaimed.accruedCost, 126);
+  assert.ok(reclaimed.reclaimedAt);
+});
+
+test("runReservationStorageHoldEvaluation leaves reservations untouched before the first reminder window", async () => {
+  const state: MockDbState = {
+    reservations: {
+      "reservation-early-grace": {
+        ownerUid: "owner-1",
+        status: "CONFIRMED",
+        loadStatus: "loaded",
+        estimatedHalfShelves: 2,
+        readyForPickupAt: shared.Timestamp.fromDate(new Date("2026-03-01T00:00:00.000Z")),
+        storageStatus: "active",
+        pickupReminderCount: 0,
+        storageBilling: storageSeed("2026-03-01T00:00:00.000Z", 2),
+        pickupWindow: {
+          status: "open",
+        },
+      },
+    },
+  };
+
+  const summary = await withMockFirestore(state, () =>
+    runReservationStorageHoldEvaluation(
+      shared.Timestamp.fromDate(new Date("2026-03-13T23:00:00.000Z"))
+    )
+  );
+
+  assert.equal(summary.reminderJobs, 0);
+  assert.equal(summary.updatedReservations, 0);
+  const reservation = state.reservations["reservation-early-grace"] as Record<string, unknown>;
+  assert.equal(reservation.storageStatus, "active");
+});
+
+test("runReservationStorageHoldEvaluation sends the shifted reminders and starts billing at grace cutoff", async () => {
+  const state: MockDbState = {
+    reservations: {
+      "reservation-grace-cutoff": {
+        ownerUid: "owner-1",
+        status: "CONFIRMED",
+        loadStatus: "loaded",
+        estimatedHalfShelves: 2,
+        readyForPickupAt: shared.Timestamp.fromDate(new Date("2026-03-01T00:00:00.000Z")),
+        storageStatus: "reminder_pending",
+        pickupReminderCount: 2,
+        storageNoticeHistory: [],
+        storageBilling: storageSeed("2026-03-01T00:00:00.000Z", 2),
+        pickupWindow: {
+          status: "open",
+        },
+      },
+    },
+  };
+
+  const summary = await withMockFirestore(state, () =>
+    runReservationStorageHoldEvaluation(
+      shared.Timestamp.fromDate(new Date("2026-03-20T06:00:00.000Z"))
+    )
+  );
+
+  assert.equal(summary.reminderJobs, 1);
+  const reservation = state.reservations["reservation-grace-cutoff"] as Record<string, unknown>;
+  assert.equal(reservation.storageStatus, "hold_pending");
+  assert.equal(reservation.pickupReminderCount, 3);
+  const storageBilling = (reservation.storageBilling ?? {}) as Record<string, unknown>;
+  assert.equal(storageBilling.status, "billing");
+  assert.equal(storageBilling.billedDays, 0);
+});
+
+test("runReservationStorageHoldEvaluation stops billing changes after pickup is completed", async () => {
+  const state: MockDbState = {
+    reservations: {
+      "reservation-picked-up": {
+        ownerUid: "owner-1",
+        status: "CONFIRMED",
+        loadStatus: "loaded",
+        estimatedHalfShelves: 4,
+        readyForPickupAt: shared.Timestamp.fromDate(new Date("2026-03-01T00:00:00.000Z")),
+        storageStatus: "hold_pending",
+        pickupReminderCount: 3,
+        storageBilling: {
+          ...storageSeed("2026-03-01T00:00:00.000Z", 4),
+          billedDays: 5,
+          accruedCost: 30,
+          status: "billing",
+        },
+        pickupWindow: {
+          status: "completed",
+        },
+      },
+    },
+  };
+
+  const summary = await withMockFirestore(state, () =>
+    runReservationStorageHoldEvaluation(
+      shared.Timestamp.fromDate(new Date("2026-03-28T06:00:00.000Z"))
+    )
+  );
+
+  assert.equal(summary.updatedReservations, 0);
+  const reservation = state.reservations["reservation-picked-up"] as Record<string, unknown>;
+  const storageBilling = (reservation.storageBilling ?? {}) as Record<string, unknown>;
+  assert.equal(storageBilling.billedDays, 5);
+  assert.equal(storageBilling.accruedCost, 30);
+});
+
+test("runReservationStorageHoldEvaluation archives and reclaims reservations at the end of billed storage", async () => {
+  const state: MockDbState = {
+    reservations: {
+      "reservation-reclaimed": {
+        ownerUid: "owner-1",
+        status: "CONFIRMED",
+        loadStatus: "loaded",
+        estimatedHalfShelves: 3,
+        readyForPickupAt: shared.Timestamp.fromDate(new Date("2026-03-01T00:00:00.000Z")),
+        storageStatus: "hold_pending",
+        pickupReminderCount: 3,
+        storageBilling: storageSeed("2026-03-01T00:00:00.000Z", 3),
+        pickupWindow: {
+          status: "missed",
+          missedCount: 1,
+        },
+      },
+    },
+  };
+
+  const summary = await withMockFirestore(state, () =>
+    runReservationStorageHoldEvaluation(
+      shared.Timestamp.fromDate(new Date("2026-04-17T06:00:00.000Z"))
+    )
+  );
+
+  assert.equal(summary.updatedReservations, 1);
+  const reservation = state.reservations["reservation-reclaimed"] as Record<string, unknown>;
+  assert.equal(reservation.storageStatus, "stored_by_policy");
+  assert.equal(reservation.isArchived, true);
+  assert.ok(reservation.archivedAt);
+  const storageBilling = (reservation.storageBilling ?? {}) as Record<string, unknown>;
+  assert.equal(storageBilling.status, "reclaimed");
+  assert.equal(storageBilling.billedDays, 28);
+});
+
+test("runReservationStorageHoldEvaluation records missed pickup windows without bypassing the grace timeline", async () => {
+  const state: MockDbState = {
+    reservations: {
+      "reservation-window-missed": {
+        ownerUid: "owner-1",
+        status: "CONFIRMED",
+        loadStatus: "loaded",
+        estimatedHalfShelves: 2,
+        readyForPickupAt: shared.Timestamp.fromDate(new Date("2026-03-01T00:00:00.000Z")),
+        storageStatus: "active",
+        pickupReminderCount: 0,
+        storageBilling: storageSeed("2026-03-01T00:00:00.000Z", 2),
+        pickupWindow: {
+          status: "confirmed",
+          confirmedEnd: shared.Timestamp.fromDate(new Date("2026-03-05T00:00:00.000Z")),
+          missedCount: 1,
+        },
+      },
+    },
+  };
+
+  const summary = await withMockFirestore(state, () =>
+    runReservationStorageHoldEvaluation(
+      shared.Timestamp.fromDate(new Date("2026-03-06T00:00:00.000Z"))
+    )
+  );
+
+  assert.equal(summary.reminderJobs, 1);
+  const reservation = state.reservations["reservation-window-missed"] as Record<string, unknown>;
+  assert.equal(reservation.storageStatus, "active");
+  const pickupWindow = (reservation.pickupWindow ?? {}) as Record<string, unknown>;
+  assert.equal(pickupWindow.status, "missed");
+  assert.equal(pickupWindow.missedCount, 2);
+});

--- a/functions/src/notifications.ts
+++ b/functions/src/notifications.ts
@@ -14,15 +14,22 @@ const SMS_MESSAGE_MAX_CHARS = 1200;
 const RESERVATION_DELAY_FOLLOW_UP_INITIAL_MS = 12 * 60 * 60 * 1000;
 const RESERVATION_DELAY_FOLLOW_UP_REPEAT_MS = 24 * 60 * 60 * 1000;
 const RESERVATION_STORAGE_REMINDER_SCHEDULE_MS = [
-  72 * 60 * 60 * 1000,
-  120 * 60 * 60 * 1000,
-  168 * 60 * 60 * 1000,
+  14 * 24 * 60 * 60 * 1000,
+  Math.round(17.5 * 24 * 60 * 60 * 1000),
+  Math.round(19.25 * 24 * 60 * 60 * 1000),
 ] as const;
-const RESERVATION_STORAGE_HOLD_PENDING_MS = 10 * 24 * 60 * 60 * 1000;
-const RESERVATION_STORAGE_STORED_BY_POLICY_MS = 14 * 24 * 60 * 60 * 1000;
+const RESERVATION_STORAGE_GRACE_MS = 462 * 60 * 60 * 1000;
+const RESERVATION_STORAGE_BILLING_DAY_MS = 24 * 60 * 60 * 1000;
+const RESERVATION_STORAGE_BILLING_MAX_DAYS = 28;
+const RESERVATION_STORAGE_STORED_BY_POLICY_MS =
+  RESERVATION_STORAGE_GRACE_MS +
+  RESERVATION_STORAGE_BILLING_DAY_MS * RESERVATION_STORAGE_BILLING_MAX_DAYS;
+const RESERVATION_STORAGE_PREPAID_WEEKLY_RATE_PER_HALF_SHELF = 2;
+const RESERVATION_STORAGE_DAILY_RATE_PER_HALF_SHELF = 1.5;
 const RESERVATION_STORAGE_HISTORY_MAX = 60;
 
 type ReservationStorageStatus = "active" | "reminder_pending" | "hold_pending" | "stored_by_policy";
+type ReservationStorageBillingStatus = "grace" | "billing" | "reclaimed";
 type ReservationPickupWindowStatus = "open" | "confirmed" | "missed" | "expired" | "completed";
 
 function asRecord(value: unknown): value is Record<string, unknown> {
@@ -582,6 +589,21 @@ type ReservationPickupWindowSnapshot = {
   lastRescheduleRequestedAt: Timestamp | null;
 };
 
+type ReservationStorageBillingSnapshot = {
+  chargeBasis: "estimatedHalfShelves" | string | null;
+  chargeBasisHalfShelves: number;
+  prepaidWeeklyRatePerHalfShelf: number;
+  dailyRatePerHalfShelf: number;
+  graceEndsAt: Timestamp | null;
+  billingStartsAt: Timestamp | null;
+  billingEndsAt: Timestamp | null;
+  billedDays: number;
+  accruedCost: number;
+  status: ReservationStorageBillingStatus | null;
+  reclaimedAt: Timestamp | null;
+  reclaimedReason: string | null;
+};
+
 type ReservationNotificationSnapshot = {
   ownerUid: string;
   status: string | null;
@@ -592,6 +614,7 @@ type ReservationNotificationSnapshot = {
   stageReason: string | null;
   stageNotes: string | null;
   staffNotes: string | null;
+  estimatedHalfShelves: number;
   storageStatus: ReservationStorageStatus | null;
   readyForPickupAt: Timestamp | null;
   pickupReminderCount: number;
@@ -599,6 +622,9 @@ type ReservationNotificationSnapshot = {
   pickupReminderFailureCount: number;
   lastReminderFailureAt: Timestamp | null;
   storageNoticeHistory: ReservationStorageNoticeEntry[];
+  storageBilling: ReservationStorageBillingSnapshot | null;
+  isArchived: boolean;
+  archivedAt: Timestamp | null;
   pickupWindow: ReservationPickupWindowSnapshot;
 };
 
@@ -691,6 +717,16 @@ function normalizeReservationStorageStatusValue(value: unknown): ReservationStor
   return null;
 }
 
+function normalizeReservationStorageBillingStatusValue(
+  value: unknown
+): ReservationStorageBillingStatus | null {
+  const normalized = safeString(value).trim().toLowerCase();
+  if (normalized === "grace" || normalized === "billing" || normalized === "reclaimed") {
+    return normalized;
+  }
+  return null;
+}
+
 function normalizeReservationPickupWindowStatusValue(value: unknown): ReservationPickupWindowStatus | null {
   const normalized = safeString(value).trim().toLowerCase();
   if (
@@ -709,6 +745,16 @@ function normalizeReminderCount(value: unknown): number {
   const parsed = Number(value);
   if (!Number.isFinite(parsed) || parsed <= 0) return 0;
   return Math.max(0, Math.trunc(parsed));
+}
+
+function normalizeNonNegativeNumber(value: unknown, fallback = 0): number {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0) return fallback;
+  return parsed;
+}
+
+function roundCurrency(value: number): number {
+  return Number(value.toFixed(2));
 }
 
 function normalizeStorageNoticeHistory(raw: unknown): ReservationStorageNoticeEntry[] {
@@ -730,6 +776,27 @@ function normalizeStorageNoticeHistory(raw: unknown): ReservationStorageNoticeEn
     });
   }
   return rows.slice(-RESERVATION_STORAGE_HISTORY_MAX);
+}
+
+function normalizeStorageBillingForWrite(
+  billing: ReservationStorageBillingSnapshot
+): Record<string, unknown> {
+  return {
+    chargeBasis: billing.chargeBasis ?? "estimatedHalfShelves",
+    chargeBasisHalfShelves: Math.max(0, billing.chargeBasisHalfShelves),
+    prepaidWeeklyRatePerHalfShelf: roundCurrency(
+      Math.max(0, billing.prepaidWeeklyRatePerHalfShelf)
+    ),
+    dailyRatePerHalfShelf: roundCurrency(Math.max(0, billing.dailyRatePerHalfShelf)),
+    graceEndsAt: billing.graceEndsAt ?? null,
+    billingStartsAt: billing.billingStartsAt ?? null,
+    billingEndsAt: billing.billingEndsAt ?? null,
+    billedDays: Math.max(0, Math.trunc(billing.billedDays)),
+    accruedCost: roundCurrency(Math.max(0, billing.accruedCost)),
+    status: billing.status ?? "grace",
+    reclaimedAt: billing.reclaimedAt ?? null,
+    reclaimedReason: billing.reclaimedReason ?? null,
+  };
 }
 
 function normalizeStorageNoticeForWrite(entry: ReservationStorageNoticeEntry): Record<string, unknown> {
@@ -760,6 +827,137 @@ function normalizePickupWindowForWrite(window: ReservationPickupWindowSnapshot):
   };
 }
 
+function normalizeStorageBilling(
+  raw: unknown,
+  chargeBasisHalfShelvesFallback: number
+): ReservationStorageBillingSnapshot | null {
+  if (!asRecord(raw)) return null;
+
+  return {
+    chargeBasis: safeString(raw.chargeBasis).trim() || "estimatedHalfShelves",
+    chargeBasisHalfShelves: Math.max(
+      0,
+      normalizeNonNegativeNumber(raw.chargeBasisHalfShelves, chargeBasisHalfShelvesFallback)
+    ),
+    prepaidWeeklyRatePerHalfShelf: roundCurrency(
+      normalizeNonNegativeNumber(
+        raw.prepaidWeeklyRatePerHalfShelf,
+        RESERVATION_STORAGE_PREPAID_WEEKLY_RATE_PER_HALF_SHELF
+      )
+    ),
+    dailyRatePerHalfShelf: roundCurrency(
+      normalizeNonNegativeNumber(
+        raw.dailyRatePerHalfShelf,
+        RESERVATION_STORAGE_DAILY_RATE_PER_HALF_SHELF
+      )
+    ),
+    graceEndsAt: parseTimestampValue(raw.graceEndsAt),
+    billingStartsAt: parseTimestampValue(raw.billingStartsAt),
+    billingEndsAt: parseTimestampValue(raw.billingEndsAt),
+    billedDays: Math.max(0, Math.trunc(normalizeNonNegativeNumber(raw.billedDays, 0))),
+    accruedCost: roundCurrency(normalizeNonNegativeNumber(raw.accruedCost, 0)),
+    status: normalizeReservationStorageBillingStatusValue(raw.status),
+    reclaimedAt: parseTimestampValue(raw.reclaimedAt),
+    reclaimedReason: safeString(raw.reclaimedReason).trim() || null,
+  };
+}
+
+function timestampFromMillis(ms: number): Timestamp {
+  return Timestamp.fromMillis(ms);
+}
+
+function baselineStorageBilling(
+  readyForPickupAt: Timestamp,
+  chargeBasisHalfShelves: number
+): ReservationStorageBillingSnapshot {
+  const readyMs = readyForPickupAt.toMillis();
+  const graceEndsAt = timestampFromMillis(readyMs + RESERVATION_STORAGE_GRACE_MS);
+  const billingStartsAt = graceEndsAt;
+  const billingEndsAt = timestampFromMillis(
+    billingStartsAt.toMillis() +
+      RESERVATION_STORAGE_BILLING_DAY_MS * RESERVATION_STORAGE_BILLING_MAX_DAYS
+  );
+
+  return {
+    chargeBasis: "estimatedHalfShelves",
+    chargeBasisHalfShelves: Math.max(0, chargeBasisHalfShelves),
+    prepaidWeeklyRatePerHalfShelf: RESERVATION_STORAGE_PREPAID_WEEKLY_RATE_PER_HALF_SHELF,
+    dailyRatePerHalfShelf: RESERVATION_STORAGE_DAILY_RATE_PER_HALF_SHELF,
+    graceEndsAt,
+    billingStartsAt,
+    billingEndsAt,
+    billedDays: 0,
+    accruedCost: 0,
+    status: "grace",
+    reclaimedAt: null,
+    reclaimedReason: null,
+  };
+}
+
+export function computeReservationStorageBilling(params: {
+  existing: ReservationStorageBillingSnapshot | null;
+  readyForPickupAt: Timestamp;
+  chargeBasisHalfShelves: number;
+  now: Timestamp;
+}): ReservationStorageBillingSnapshot {
+  const base = baselineStorageBilling(params.readyForPickupAt, params.chargeBasisHalfShelves);
+  const existing = params.existing;
+  const billingStartsAt = base.billingStartsAt ?? params.readyForPickupAt;
+  const billingEndsAt = base.billingEndsAt ?? params.readyForPickupAt;
+  const nowMs = params.now.toMillis();
+  const billingStartsMs = billingStartsAt.toMillis();
+  const billingEndsMs = billingEndsAt.toMillis();
+  const billedDays =
+    nowMs < billingStartsMs
+      ? 0
+      : Math.min(
+          RESERVATION_STORAGE_BILLING_MAX_DAYS,
+          Math.floor((Math.max(nowMs, billingStartsMs) - billingStartsMs) / RESERVATION_STORAGE_BILLING_DAY_MS)
+        );
+  const status: ReservationStorageBillingStatus =
+    nowMs >= billingEndsMs ? "reclaimed" : nowMs >= billingStartsMs ? "billing" : "grace";
+
+  return {
+    ...base,
+    billedDays,
+    accruedCost: roundCurrency(
+      billedDays * base.chargeBasisHalfShelves * base.dailyRatePerHalfShelf
+    ),
+    status,
+    reclaimedAt:
+      status === "reclaimed"
+        ? existing?.reclaimedAt ?? billingEndsAt
+        : null,
+    reclaimedReason:
+      status === "reclaimed"
+        ? existing?.reclaimedReason ??
+          "No artist response during grace and billed storage windows; studio reclaimed the work."
+        : null,
+  };
+}
+
+function storageBillingEquals(
+  left: ReservationStorageBillingSnapshot | null,
+  right: ReservationStorageBillingSnapshot | null
+): boolean {
+  if (left === right) return true;
+  if (!left || !right) return false;
+  return (
+    left.chargeBasis === right.chargeBasis &&
+    left.chargeBasisHalfShelves === right.chargeBasisHalfShelves &&
+    left.prepaidWeeklyRatePerHalfShelf === right.prepaidWeeklyRatePerHalfShelf &&
+    left.dailyRatePerHalfShelf === right.dailyRatePerHalfShelf &&
+    tsMillis(left.graceEndsAt) === tsMillis(right.graceEndsAt) &&
+    tsMillis(left.billingStartsAt) === tsMillis(right.billingStartsAt) &&
+    tsMillis(left.billingEndsAt) === tsMillis(right.billingEndsAt) &&
+    left.billedDays === right.billedDays &&
+    left.accruedCost === right.accruedCost &&
+    left.status === right.status &&
+    tsMillis(left.reclaimedAt) === tsMillis(right.reclaimedAt) &&
+    left.reclaimedReason === right.reclaimedReason
+  );
+}
+
 function parseReservationSnapshot(value: Record<string, unknown> | undefined): ReservationNotificationSnapshot {
   const estimatedWindow = asRecord(value?.estimatedWindow)
     ? (value.estimatedWindow as Record<string, unknown>)
@@ -770,6 +968,7 @@ function parseReservationSnapshot(value: Record<string, unknown> | undefined): R
   const pickupWindow = asRecord(value?.pickupWindow)
     ? (value.pickupWindow as Record<string, unknown>)
     : {};
+  const estimatedHalfShelves = Math.max(0, normalizeNonNegativeNumber(value?.estimatedHalfShelves, 0));
 
   return {
     ownerUid: safeString(value?.ownerUid),
@@ -787,6 +986,7 @@ function parseReservationSnapshot(value: Record<string, unknown> | undefined): R
     stageReason: safeString(stageStatus.reason).trim() || null,
     stageNotes: safeString(stageStatus.notes).trim() || null,
     staffNotes: safeString(value?.staffNotes).trim() || null,
+    estimatedHalfShelves,
     storageStatus: normalizeReservationStorageStatusValue(value?.storageStatus),
     readyForPickupAt: parseTimestampValue(value?.readyForPickupAt),
     pickupReminderCount: normalizeReminderCount(value?.pickupReminderCount),
@@ -794,6 +994,9 @@ function parseReservationSnapshot(value: Record<string, unknown> | undefined): R
     pickupReminderFailureCount: normalizeReminderCount(value?.pickupReminderFailureCount),
     lastReminderFailureAt: parseTimestampValue(value?.lastReminderFailureAt),
     storageNoticeHistory: normalizeStorageNoticeHistory(value?.storageNoticeHistory),
+    storageBilling: normalizeStorageBilling(value?.storageBilling, estimatedHalfShelves),
+    isArchived: value?.isArchived === true,
+    archivedAt: parseTimestampValue(value?.archivedAt),
     pickupWindow: {
       requestedStart: parseTimestampValue(pickupWindow.requestedStart),
       requestedEnd: parseTimestampValue(pickupWindow.requestedEnd),
@@ -814,18 +1017,18 @@ function currentStorageStatus(snapshot: ReservationNotificationSnapshot): Reserv
   return snapshot.storageStatus ?? "active";
 }
 
-function storageStatusForElapsed(params: {
+export function storageStatusForElapsed(params: {
   elapsedMs: number;
   reminderCount: number;
 }): ReservationStorageStatus {
   const elapsedMs = Math.max(0, params.elapsedMs);
   if (elapsedMs >= RESERVATION_STORAGE_STORED_BY_POLICY_MS) return "stored_by_policy";
-  if (elapsedMs >= RESERVATION_STORAGE_HOLD_PENDING_MS) return "hold_pending";
+  if (elapsedMs >= RESERVATION_STORAGE_GRACE_MS) return "hold_pending";
   if (params.reminderCount > 0) return "reminder_pending";
   return "active";
 }
 
-function nextDueReminderOrdinal(params: {
+export function nextDueReminderOrdinal(params: {
   elapsedMs: number;
   currentCount: number;
 }): number | null {
@@ -837,10 +1040,11 @@ function nextDueReminderOrdinal(params: {
 }
 
 function storagePolicyWindowLabel(reminderOrdinal: number): string {
-  const nextThreshold = RESERVATION_STORAGE_REMINDER_SCHEDULE_MS[reminderOrdinal] ?? RESERVATION_STORAGE_HOLD_PENDING_MS;
+  const nextThreshold =
+    RESERVATION_STORAGE_REMINDER_SCHEDULE_MS[reminderOrdinal] ?? RESERVATION_STORAGE_GRACE_MS;
   const nextHours = Math.round(nextThreshold / (60 * 60 * 1000));
   if (reminderOrdinal >= 3) {
-    return "Final reminder window. Reservation moves to storage hold soon if pickup is still pending.";
+    return "Final grace-period reminder. Billable storage begins at the 19.25-day cutoff if pickup is still pending.";
   }
   return `Next storage policy checkpoint is around ${nextHours} hours after pickup-ready status.`;
 }
@@ -1445,7 +1649,8 @@ export const onReservationLifecycleUpdated = onDocumentWritten(
           previousStorageStatus: currentStorageStatus(before),
           reminderCount: 0,
           readyForPickupAtIso: tsIso(readyForPickupAt),
-          policyWindowLabel: "Pickup-ready notice sent. Storage reminders begin after 72 hours.",
+          policyWindowLabel:
+            "Pickup-ready notice sent. Grace runs for 2.75 weeks, then billed storage begins at $1.50 per half-shelf per day for up to 28 days.",
           estimateWindowLabel,
           suggestedNextUpdateAtIso: null,
           previousWindowStartIso,
@@ -1473,6 +1678,19 @@ export const onReservationLifecycleUpdated = onDocumentWritten(
           pickupReminderFailureCount: 0,
           lastReminderFailureAt: null,
           storageNoticeHistory: nextHistory.map(normalizeStorageNoticeForWrite),
+          storageBilling: normalizeStorageBillingForWrite(
+            computeReservationStorageBilling({
+              existing: after.storageBilling,
+              readyForPickupAt,
+              chargeBasisHalfShelves:
+                after.storageBilling?.chargeBasisHalfShelves && after.storageBilling.chargeBasisHalfShelves > 0
+                  ? after.storageBilling.chargeBasisHalfShelves
+                  : after.estimatedHalfShelves,
+              now: readyForPickupAt,
+            })
+          ),
+          isArchived: false,
+          archivedAt: null,
           updatedAt: nowTs(),
         },
         { merge: true }
@@ -2939,202 +3157,231 @@ export const processQueuedNotificationJobs = onSchedule(
 
 function pickupReminderReason(reminderOrdinal: number): string {
   if (reminderOrdinal >= 3) {
-    return "Final pickup reminder: reservation is nearing storage-hold policy thresholds.";
+    return "Final pickup reminder: grace ends soon, and billable storage starts after the 19.25-day pickup-ready cutoff.";
   }
   if (reminderOrdinal === 2) {
-    return "Second pickup reminder: reservation is still awaiting pickup scheduling.";
+    return "Second pickup reminder: your reservation is still in the grace window, but storage fees are getting closer.";
   }
-  return "Pickup reminder: reservation has been ready for collection for several days.";
+  return "Pickup reminder: your reservation has been ready for pickup for two weeks.";
 }
 
-export const evaluateReservationStorageHolds = onSchedule(
-  { region: REGION, schedule: "every 60 minutes" },
-  async () => {
-    const now = nowTs();
-    const nowMs = now.toMillis();
-    const snap = await db
-      .collection("reservations")
-      .where("loadStatus", "==", "loaded")
-      .limit(200)
-      .get();
+export async function runReservationStorageHoldEvaluation(currentNow: Timestamp = nowTs()) {
+  const now = currentNow;
+  const nowMs = now.toMillis();
+  const snap = await db
+    .collection("reservations")
+    .where("loadStatus", "==", "loaded")
+    .limit(200)
+    .get();
 
-    let scanned = 0;
-    let updatedReservations = 0;
-    let reminderJobs = 0;
-    let statusTransitions = 0;
+  let scanned = 0;
+  let updatedReservations = 0;
+  let reminderJobs = 0;
+  let statusTransitions = 0;
 
-    for (const docSnap of snap.docs) {
-      const reservationId = docSnap.id;
-      const reservation = parseReservationSnapshot(docSnap.data() as Record<string, unknown>);
-      const uid = safeString(reservation.ownerUid).trim();
-      if (!uid) continue;
-      if (reservation.status === "CANCELLED") continue;
-      if (reservation.pickupWindow.status === "completed") continue;
-      scanned += 1;
+  for (const docSnap of snap.docs) {
+    const reservationId = docSnap.id;
+    const reservation = parseReservationSnapshot(docSnap.data() as Record<string, unknown>);
+    const uid = safeString(reservation.ownerUid).trim();
+    if (!uid) continue;
+    if (reservation.status === "CANCELLED") continue;
+    if (reservation.pickupWindow.status === "completed") continue;
+    if (reservation.isArchived && currentStorageStatus(reservation) === "stored_by_policy") continue;
+    scanned += 1;
 
-      const readyAnchor = reservation.readyForPickupAt ?? reservation.updatedAt ?? reservation.createdAt;
-      if (!readyAnchor) continue;
+    const readyAnchor = reservation.readyForPickupAt ?? reservation.updatedAt ?? reservation.createdAt;
+    if (!readyAnchor) continue;
 
-      const elapsedMs = Math.max(0, nowMs - readyAnchor.toMillis());
-      const previousStorageStatus = currentStorageStatus(reservation);
-      let nextStorageStatus = previousStorageStatus;
-      let nextReminderCount = reservation.pickupReminderCount;
-      let nextHistory = reservation.storageNoticeHistory;
-      const updates: Record<string, unknown> = {};
-      let autoMissApplied = false;
+    const elapsedMs = Math.max(0, nowMs - readyAnchor.toMillis());
+    const previousStorageStatus = currentStorageStatus(reservation);
+    let nextStorageStatus = previousStorageStatus;
+    let nextReminderCount = reservation.pickupReminderCount;
+    let nextHistory = reservation.storageNoticeHistory;
+    const updates: Record<string, unknown> = {};
+    let autoMissApplied = false;
 
-      if (!reservation.readyForPickupAt) {
-        updates.readyForPickupAt = readyAnchor;
-      }
+    if (!reservation.readyForPickupAt) {
+      updates.readyForPickupAt = readyAnchor;
+    }
 
-      const pickupWindowStatus = reservation.pickupWindow.status;
-      const pickupWindowEndMs = tsMillis(reservation.pickupWindow.confirmedEnd);
-      if (
-        (pickupWindowStatus === "open" || pickupWindowStatus === "confirmed") &&
-        pickupWindowEndMs !== null &&
-        pickupWindowEndMs <= nowMs
-      ) {
-        const nextMissedCount = reservation.pickupWindow.missedCount + 1;
-        const missedStatus: ReservationStorageStatus =
-          nextMissedCount >= 2 ? "stored_by_policy" : "hold_pending";
-        const missReason =
-          nextMissedCount >= 2
-            ? "Pickup window was missed again and reservation moved to stored-by-policy."
-            : "Pickup window elapsed and reservation moved to hold-pending.";
-        updates.pickupWindow = normalizePickupWindowForWrite({
-          ...reservation.pickupWindow,
-          status: "missed",
-          confirmedAt: null,
-          completedAt: null,
-          missedCount: nextMissedCount,
-          lastMissedAt: now,
-        });
-        updates.storageStatus = missedStatus;
-        nextStorageStatus = missedStatus;
-        autoMissApplied = true;
-        if (previousStorageStatus !== missedStatus) {
-          statusTransitions += 1;
-        }
-        nextHistory = pushStorageNotice(nextHistory, {
-          at: now,
-          kind: "pickup_window_missed",
-          detail: missReason,
-          status: missedStatus,
-          reminderOrdinal: null,
-          reminderCount: nextReminderCount,
-          failureCode: null,
-        });
-        await writeReservationStorageAudit({
-          reservationId,
-          uid,
-          action: "pickup_window_missed",
-          reason: missReason,
-          fromStatus: previousStorageStatus,
-          toStatus: missedStatus,
-          reminderCount: nextReminderCount,
-        });
-        const routing = await readReservationRouting(uid);
-        await enqueueReservationNotificationJob({
-          uid,
-          type: "RESERVATION_PICKUP_REMINDER",
-          routing,
-          payload: {
-            dedupeKey: `RESERVATION_PICKUP_WINDOW_MISSED:${reservationId}:${pickupWindowEndMs}:${nextMissedCount}`,
-            firingId: reservationId,
-            reservationId,
-            reservationStatus: reservation.status,
-            reservationLoadStatus: reservation.loadStatus,
-            eventKind: "pickup_reminder",
-            reason: missReason,
-            storageStatus: missedStatus,
-            previousStorageStatus,
-            reminderCount: nextReminderCount,
-            readyForPickupAtIso: tsIso(readyAnchor),
-            policyWindowLabel: "Pickup window missed. Staff follow-up is now required.",
-            suggestedNextUpdateAtIso: null,
-          },
-        });
-        reminderJobs += 1;
-      }
+    const chargeBasisHalfShelves =
+      reservation.storageBilling?.chargeBasisHalfShelves && reservation.storageBilling.chargeBasisHalfShelves > 0
+        ? reservation.storageBilling.chargeBasisHalfShelves
+        : reservation.estimatedHalfShelves;
+    const existingBilling = reservation.storageBilling;
+    const nextStorageBilling = computeReservationStorageBilling({
+      existing: existingBilling,
+      readyForPickupAt: readyAnchor,
+      chargeBasisHalfShelves,
+      now,
+    });
 
-      const dueReminderOrdinal = nextDueReminderOrdinal({
-        elapsedMs,
-        currentCount: reservation.pickupReminderCount,
+    const pickupWindowStatus = reservation.pickupWindow.status;
+    const pickupWindowEndMs =
+      tsMillis(reservation.pickupWindow.confirmedEnd) ?? tsMillis(reservation.pickupWindow.requestedEnd);
+    if (
+      (pickupWindowStatus === "open" || pickupWindowStatus === "confirmed") &&
+      pickupWindowEndMs !== null &&
+      pickupWindowEndMs <= nowMs
+    ) {
+      const nextMissedCount = reservation.pickupWindow.missedCount + 1;
+      const missReason =
+        "Pickup window elapsed. Grace, billed storage, and studio reclamation still follow the original pickup-ready timeline.";
+      updates.pickupWindow = normalizePickupWindowForWrite({
+        ...reservation.pickupWindow,
+        status: "missed",
+        confirmedAt: null,
+        completedAt: null,
+        missedCount: nextMissedCount,
+        lastMissedAt: now,
       });
-
-      if (dueReminderOrdinal && !autoMissApplied) {
-        const reason = pickupReminderReason(dueReminderOrdinal);
-        const routing = await readReservationRouting(uid);
-        const reminderStatus: ReservationStorageStatus =
-          dueReminderOrdinal >= 3 ? "hold_pending" : "reminder_pending";
-        await enqueueReservationNotificationJob({
-          uid,
-          type: "RESERVATION_PICKUP_REMINDER",
-          routing,
-          payload: {
-            dedupeKey: `RESERVATION_PICKUP_REMINDER:${reservationId}:${tsIso(readyAnchor) ?? readyAnchor.toMillis()}:${dueReminderOrdinal}`,
-            firingId: reservationId,
-            reservationId,
-            reservationStatus: reservation.status,
-            reservationLoadStatus: reservation.loadStatus,
-            eventKind: "pickup_reminder",
-            reason,
-            storageStatus: reminderStatus,
-            previousStorageStatus: previousStorageStatus,
-            reminderOrdinal: dueReminderOrdinal,
-            reminderCount: dueReminderOrdinal,
-            readyForPickupAtIso: tsIso(readyAnchor),
-            policyWindowLabel: storagePolicyWindowLabel(dueReminderOrdinal),
-            suggestedNextUpdateAtIso: null,
-          },
-        });
-        reminderJobs += 1;
-
-        nextReminderCount = Math.max(nextReminderCount, dueReminderOrdinal);
-        nextStorageStatus = reminderStatus;
-        updates.pickupReminderCount = nextReminderCount;
-        updates.lastReminderAt = now;
-        updates.storageStatus = nextStorageStatus;
-        nextHistory = pushStorageNotice(nextHistory, {
-          at: now,
-          kind: `pickup_reminder_${dueReminderOrdinal}`,
-          detail: reason,
-          status: nextStorageStatus,
-          reminderOrdinal: dueReminderOrdinal,
-          reminderCount: nextReminderCount,
-          failureCode: null,
-        });
-        await writeReservationStorageAudit({
-          reservationId,
-          uid,
-          action: "pickup_reminder_enqueued",
-          reason,
-          fromStatus: previousStorageStatus,
-          toStatus: nextStorageStatus,
-          reminderOrdinal: dueReminderOrdinal,
-          reminderCount: nextReminderCount,
-        });
-      }
-
-      const policyStatus = storageStatusForElapsed({
-        elapsedMs,
+      autoMissApplied = true;
+      nextHistory = pushStorageNotice(nextHistory, {
+        at: now,
+        kind: "pickup_window_missed",
+        detail: missReason,
+        status: nextStorageStatus,
+        reminderOrdinal: null,
+        reminderCount: nextReminderCount,
+        failureCode: null,
+      });
+      await writeReservationStorageAudit({
+        reservationId,
+        uid,
+        action: "pickup_window_missed",
+        reason: missReason,
+        fromStatus: previousStorageStatus,
+        toStatus: nextStorageStatus,
         reminderCount: nextReminderCount,
       });
-      if (policyStatus !== nextStorageStatus) {
-        const fromStatus = nextStorageStatus;
-        nextStorageStatus = policyStatus;
-        updates.storageStatus = policyStatus;
-        statusTransitions += 1;
-        const transitionDetail =
-          policyStatus === "stored_by_policy"
-            ? "Reservation reached storage policy threshold and is marked stored by policy."
-            : policyStatus === "hold_pending"
-              ? "Reservation entered storage hold pending status."
+      const routing = await readReservationRouting(uid);
+      await enqueueReservationNotificationJob({
+        uid,
+        type: "RESERVATION_PICKUP_REMINDER",
+        routing,
+        payload: {
+          dedupeKey: `RESERVATION_PICKUP_WINDOW_MISSED:${reservationId}:${pickupWindowEndMs}:${nextMissedCount}`,
+          firingId: reservationId,
+          reservationId,
+          reservationStatus: reservation.status,
+          reservationLoadStatus: reservation.loadStatus,
+          eventKind: "pickup_reminder",
+          reason: missReason,
+          storageStatus: nextStorageStatus,
+          previousStorageStatus,
+          reminderCount: nextReminderCount,
+          readyForPickupAtIso: tsIso(readyAnchor),
+          policyWindowLabel:
+            "Pickup window missed. Billing still begins after the 19.25-day grace period, and the studio reclaims unclaimed work after 28 billed days.",
+          suggestedNextUpdateAtIso: null,
+        },
+      });
+      reminderJobs += 1;
+    }
+
+    const dueReminderOrdinal = nextDueReminderOrdinal({
+      elapsedMs,
+      currentCount: reservation.pickupReminderCount,
+    });
+
+    if (dueReminderOrdinal && !autoMissApplied) {
+      const reason = pickupReminderReason(dueReminderOrdinal);
+      const routing = await readReservationRouting(uid);
+      const reminderStatus: ReservationStorageStatus = "reminder_pending";
+      await enqueueReservationNotificationJob({
+        uid,
+        type: "RESERVATION_PICKUP_REMINDER",
+        routing,
+        payload: {
+          dedupeKey: `RESERVATION_PICKUP_REMINDER:${reservationId}:${tsIso(readyAnchor) ?? readyAnchor.toMillis()}:${dueReminderOrdinal}`,
+          firingId: reservationId,
+          reservationId,
+          reservationStatus: reservation.status,
+          reservationLoadStatus: reservation.loadStatus,
+          eventKind: "pickup_reminder",
+          reason,
+          storageStatus: reminderStatus,
+          previousStorageStatus,
+          reminderOrdinal: dueReminderOrdinal,
+          reminderCount: dueReminderOrdinal,
+          readyForPickupAtIso: tsIso(readyAnchor),
+          policyWindowLabel: storagePolicyWindowLabel(dueReminderOrdinal),
+          suggestedNextUpdateAtIso: null,
+        },
+      });
+      reminderJobs += 1;
+
+      nextReminderCount = Math.max(nextReminderCount, dueReminderOrdinal);
+      nextStorageStatus = reminderStatus;
+      updates.pickupReminderCount = nextReminderCount;
+      updates.lastReminderAt = now;
+      updates.storageStatus = nextStorageStatus;
+      nextHistory = pushStorageNotice(nextHistory, {
+        at: now,
+        kind: `pickup_reminder_${dueReminderOrdinal}`,
+        detail: reason,
+        status: nextStorageStatus,
+        reminderOrdinal: dueReminderOrdinal,
+        reminderCount: nextReminderCount,
+        failureCode: null,
+      });
+      await writeReservationStorageAudit({
+        reservationId,
+        uid,
+        action: "pickup_reminder_enqueued",
+        reason,
+        fromStatus: previousStorageStatus,
+        toStatus: nextStorageStatus,
+        reminderOrdinal: dueReminderOrdinal,
+        reminderCount: nextReminderCount,
+      });
+    }
+
+    const policyStatus = storageStatusForElapsed({
+      elapsedMs,
+      reminderCount: nextReminderCount,
+    });
+    if (policyStatus !== nextStorageStatus) {
+      const fromStatus = nextStorageStatus;
+      nextStorageStatus = policyStatus;
+      updates.storageStatus = policyStatus;
+      statusTransitions += 1;
+      const transitionDetail =
+        policyStatus === "stored_by_policy"
+          ? "Reservation exhausted the 2.75-week grace period and 28 billed storage days. The studio has reclaimed the work."
+          : policyStatus === "hold_pending"
+            ? `Grace ended. Reservation is now in billed storage at $${RESERVATION_STORAGE_DAILY_RATE_PER_HALF_SHELF.toFixed(2)} per half-shelf per day.`
+            : policyStatus === "reminder_pending"
+              ? "Reservation entered the late-grace reminder window."
               : "Reservation storage status returned to active.";
+      nextHistory = pushStorageNotice(nextHistory, {
+        at: now,
+        kind: policyStatus,
+        detail: transitionDetail,
+        status: policyStatus,
+        reminderOrdinal: null,
+        reminderCount: nextReminderCount,
+        failureCode: null,
+      });
+      await writeReservationStorageAudit({
+        reservationId,
+        uid,
+        action: "storage_status_transition",
+        reason: transitionDetail,
+        fromStatus,
+        toStatus: policyStatus,
+        reminderCount: nextReminderCount,
+      });
+    }
+
+    if (!storageBillingEquals(existingBilling, nextStorageBilling)) {
+      updates.storageBilling = normalizeStorageBillingForWrite(nextStorageBilling);
+      if (existingBilling && nextStorageBilling.billedDays !== existingBilling.billedDays) {
+        const billingDetail = `Storage fees now cover ${nextStorageBilling.billedDays} billed day${nextStorageBilling.billedDays === 1 ? "" : "s"} for ${Math.max(0, nextStorageBilling.chargeBasisHalfShelves)} half-shelf equivalents ($${nextStorageBilling.accruedCost.toFixed(2)} accrued).`;
         nextHistory = pushStorageNotice(nextHistory, {
           at: now,
-          kind: policyStatus,
-          detail: transitionDetail,
+          kind: "storage_billing_update",
+          detail: billingDetail,
           status: policyStatus,
           reminderOrdinal: null,
           reminderCount: nextReminderCount,
@@ -3143,30 +3390,46 @@ export const evaluateReservationStorageHolds = onSchedule(
         await writeReservationStorageAudit({
           reservationId,
           uid,
-          action: "storage_status_transition",
-          reason: transitionDetail,
-          fromStatus,
-          toStatus: policyStatus,
+          action: "storage_billing_update",
+          reason: billingDetail,
+          fromStatus: nextStorageStatus,
+          toStatus: nextStorageStatus,
           reminderCount: nextReminderCount,
         });
       }
-
-      if (Object.keys(updates).length === 0) {
-        continue;
-      }
-
-      updates.storageNoticeHistory = nextHistory.map(normalizeStorageNoticeForWrite);
-      updates.updatedAt = now;
-      await docSnap.ref.set(updates, { merge: true });
-      updatedReservations += 1;
     }
 
-    logger.info("reservation_storage_hold_evaluation_complete", {
-      scanned,
-      updatedReservations,
-      reminderJobs,
-      statusTransitions,
-    });
+    if (nextStorageBilling.status === "reclaimed") {
+      updates.storageBilling = normalizeStorageBillingForWrite(nextStorageBilling);
+      updates.storageStatus = "stored_by_policy";
+      updates.isArchived = true;
+      updates.archivedAt = nextStorageBilling.reclaimedAt ?? now;
+      nextStorageStatus = "stored_by_policy";
+    }
+
+    if (Object.keys(updates).length === 0) {
+      continue;
+    }
+
+    updates.storageNoticeHistory = nextHistory.map(normalizeStorageNoticeForWrite);
+    updates.updatedAt = now;
+    await docSnap.ref.set(updates, { merge: true });
+    updatedReservations += 1;
+  }
+
+  return {
+    scanned,
+    updatedReservations,
+    reminderJobs,
+    statusTransitions,
+  };
+}
+
+export const evaluateReservationStorageHolds = onSchedule(
+  { region: REGION, schedule: "every 60 minutes" },
+  async () => {
+    const summary = await runReservationStorageHoldEvaluation();
+    logger.info("reservation_storage_hold_evaluation_complete", summary);
   }
 );
 

--- a/web/src/api/portalContracts.ts
+++ b/web/src/api/portalContracts.ts
@@ -308,6 +308,9 @@ export type CreateReservationRequest = {
     glazeSanityCheckRequested?: boolean;
     staffGlazePrepRequested?: boolean;
     staffGlazePrepRatePerHalfShelf?: number | null;
+    selfLoadedKilnRequested?: boolean;
+    selfLoadedKilnCost?: number | null;
+    // Legacy aliases remain accepted server-side for older clients.
     fragileHandlingRequested?: boolean;
     fragileHandlingCost?: number | null;
     placementPreferenceRequested?: boolean;

--- a/web/src/lib/normalizers/reservations.ts
+++ b/web/src/lib/normalizers/reservations.ts
@@ -93,6 +93,22 @@ export type ReservationRecord = {
     reminderCount?: number | null;
     failureCode?: string | null;
   }> | null;
+  storageBilling?: {
+    chargeBasis?: "estimatedHalfShelves" | string | null;
+    chargeBasisHalfShelves?: number | null;
+    prepaidWeeklyRatePerHalfShelf?: number | null;
+    dailyRatePerHalfShelf?: number | null;
+    graceEndsAt?: { toDate?: () => Date } | null;
+    billingStartsAt?: { toDate?: () => Date } | null;
+    billingEndsAt?: { toDate?: () => Date } | null;
+    billedDays?: number | null;
+    accruedCost?: number | null;
+    status?: "grace" | "billing" | "reclaimed" | string | null;
+    reclaimedAt?: { toDate?: () => Date } | null;
+    reclaimedReason?: string | null;
+  } | null;
+  isArchived?: boolean;
+  archivedAt?: { toDate?: () => Date } | null;
   arrivalStatus?: string | null;
   arrivedAt?: { toDate?: () => Date } | null;
   arrivalToken?: string | null;
@@ -156,6 +172,8 @@ export type ReservationRecord = {
     returnDeliveryRequested?: boolean;
     useStudioGlazes?: boolean;
     glazeAccessCost?: number | null;
+    selfLoadedKilnRequested?: boolean;
+    selfLoadedKilnCost?: number | null;
     waxResistAssistRequested?: boolean;
     glazeSanityCheckRequested?: boolean;
     fragileHandlingRequested?: boolean;
@@ -173,6 +191,98 @@ export type ReservationRecord = {
   createdAt?: { toDate?: () => Date } | null;
   updatedAt?: { toDate?: () => Date } | null;
 };
+
+function normalizeFiniteNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function normalizeBoolean(value: unknown): boolean {
+  return value === true;
+}
+
+function normalizeReservationStorageBilling(
+  raw: ReservationRecord["storageBilling"] | Record<string, unknown> | null | undefined
+): ReservationRecord["storageBilling"] {
+  if (!raw || typeof raw !== "object") return null;
+  const statusRaw =
+    typeof raw.status === "string" && raw.status.trim().length > 0
+      ? raw.status.trim().toLowerCase()
+      : null;
+  const status =
+    statusRaw === "grace" || statusRaw === "billing" || statusRaw === "reclaimed"
+      ? statusRaw
+      : null;
+
+  return {
+    chargeBasis:
+      typeof raw.chargeBasis === "string" && raw.chargeBasis.trim().length > 0
+        ? raw.chargeBasis.trim()
+        : null,
+    chargeBasisHalfShelves: normalizeFiniteNumber(raw.chargeBasisHalfShelves),
+    prepaidWeeklyRatePerHalfShelf: normalizeFiniteNumber(raw.prepaidWeeklyRatePerHalfShelf),
+    dailyRatePerHalfShelf: normalizeFiniteNumber(raw.dailyRatePerHalfShelf),
+    graceEndsAt: raw.graceEndsAt ?? null,
+    billingStartsAt: raw.billingStartsAt ?? null,
+    billingEndsAt: raw.billingEndsAt ?? null,
+    billedDays:
+      typeof raw.billedDays === "number" && Number.isFinite(raw.billedDays)
+        ? Math.max(0, Math.round(raw.billedDays))
+        : null,
+    accruedCost: normalizeFiniteNumber(raw.accruedCost),
+    status,
+    reclaimedAt: raw.reclaimedAt ?? null,
+    reclaimedReason:
+      typeof raw.reclaimedReason === "string" && raw.reclaimedReason.trim().length > 0
+        ? raw.reclaimedReason.trim()
+        : null,
+  };
+}
+
+function normalizeReservationAddOns(
+  raw: ReservationRecord["addOns"] | Record<string, unknown> | null | undefined
+): ReservationRecord["addOns"] {
+  if (!raw || typeof raw !== "object") return null;
+  const selfLoadedKilnRequested =
+    normalizeBoolean(raw.selfLoadedKilnRequested) || normalizeBoolean(raw.fragileHandlingRequested);
+  const selfLoadedKilnCost =
+    normalizeFiniteNumber(raw.selfLoadedKilnCost) ?? normalizeFiniteNumber(raw.fragileHandlingCost);
+
+  return {
+    rushRequested: normalizeBoolean(raw.rushRequested),
+    wholeKilnRequested: normalizeBoolean(raw.wholeKilnRequested),
+    communityShelfFillInAllowed: normalizeBoolean(raw.communityShelfFillInAllowed),
+    pickupDeliveryRequested: normalizeBoolean(raw.pickupDeliveryRequested),
+    returnDeliveryRequested: normalizeBoolean(raw.returnDeliveryRequested),
+    useStudioGlazes: normalizeBoolean(raw.useStudioGlazes),
+    glazeAccessCost: normalizeFiniteNumber(raw.glazeAccessCost),
+    selfLoadedKilnRequested,
+    selfLoadedKilnCost,
+    waxResistAssistRequested: normalizeBoolean(raw.waxResistAssistRequested),
+    glazeSanityCheckRequested: normalizeBoolean(raw.glazeSanityCheckRequested),
+    placementPreferenceRequested: normalizeBoolean(raw.placementPreferenceRequested),
+    placementPreferenceZone:
+      raw.placementPreferenceZone === "top" ||
+      raw.placementPreferenceZone === "middle" ||
+      raw.placementPreferenceZone === "bottom"
+        ? raw.placementPreferenceZone
+        : null,
+    placementPreferenceCost: normalizeFiniteNumber(raw.placementPreferenceCost),
+    prepaidStorageRequested: normalizeBoolean(raw.prepaidStorageRequested),
+    prepaidStorageWeeks:
+      typeof raw.prepaidStorageWeeks === "number" && Number.isFinite(raw.prepaidStorageWeeks)
+        ? Math.max(1, Math.round(raw.prepaidStorageWeeks))
+        : null,
+    prepaidStorageCost: normalizeFiniteNumber(raw.prepaidStorageCost),
+    deliveryAddress:
+      typeof raw.deliveryAddress === "string" && raw.deliveryAddress.trim().length > 0
+        ? raw.deliveryAddress.trim()
+        : null,
+    deliveryInstructions:
+      typeof raw.deliveryInstructions === "string" && raw.deliveryInstructions.trim().length > 0
+        ? raw.deliveryInstructions.trim()
+        : null,
+  };
+}
 
 export function normalizeReservationRecord(
   id: string,
@@ -440,6 +550,9 @@ export function normalizeReservationRecord(
           return acc;
         }, [])
       : null,
+    storageBilling: normalizeReservationStorageBilling(raw.storageBilling),
+    isArchived: raw.isArchived === true,
+    archivedAt: raw.archivedAt ?? null,
     arrivalStatus: typeof raw.arrivalStatus === "string" ? raw.arrivalStatus : null,
     arrivedAt: raw.arrivedAt ?? null,
     arrivalToken: typeof raw.arrivalToken === "string" ? raw.arrivalToken : null,
@@ -492,7 +605,7 @@ export function normalizeReservationRecord(
     staffNotes: raw.staffNotes ?? null,
     stageStatus: raw.stageStatus ?? null,
     stageHistory: Array.isArray(raw.stageHistory) ? raw.stageHistory : null,
-    addOns: raw.addOns ?? null,
+    addOns: normalizeReservationAddOns(raw.addOns),
     createdByRole: raw.createdByRole ?? null,
     createdAt: raw.createdAt ?? null,
     updatedAt: raw.updatedAt ?? null,

--- a/web/src/lib/pricing.test.ts
+++ b/web/src/lib/pricing.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, test } from "vitest";
 import {
-  ADD_ON_HALF_SHELF_CAP,
   HALF_SHELF_BISQUE_PRICE,
   HALF_SHELF_GLAZE_PRICE,
   DELIVERY_PRICE_PER_TRIP,
-  FRAGILE_HANDLING_PER_HALF_SHELF_PRICE,
   FULL_KILN_CUSTOM_PRICE,
   PLACEMENT_PREFERENCE_PRICE,
-  PREPAID_STORAGE_WEEKLY_PRICE,
+  PREPAID_STORAGE_WEEKLY_PRICE_PER_HALF_SHELF,
+  SELF_LOADED_KILN_FLAT_PRICE,
+  STUDIO_GLAZE_ACCESS_PER_HALF_SHELF_PRICE,
   applyHalfKilnPriceBreak,
   applyConservativeBump,
   computeDeliveryCost,
@@ -85,9 +85,10 @@ describe("pricing helpers", () => {
     expect(computeDeliveryCost(2)).toBe(2 * DELIVERY_PRICE_PER_TRIP);
   });
 
-  test("new add-ons stay below 35% of a bisque half-shelf", () => {
-    expect(FRAGILE_HANDLING_PER_HALF_SHELF_PRICE).toBeLessThanOrEqual(ADD_ON_HALF_SHELF_CAP);
-    expect(PLACEMENT_PREFERENCE_PRICE).toBeLessThanOrEqual(ADD_ON_HALF_SHELF_CAP);
-    expect(PREPAID_STORAGE_WEEKLY_PRICE).toBeLessThanOrEqual(ADD_ON_HALF_SHELF_CAP);
+  test("ware add-on pricing matches the published portal rates", () => {
+    expect(STUDIO_GLAZE_ACCESS_PER_HALF_SHELF_PRICE).toBe(5);
+    expect(SELF_LOADED_KILN_FLAT_PRICE).toBe(15);
+    expect(PLACEMENT_PREFERENCE_PRICE).toBe(3);
+    expect(PREPAID_STORAGE_WEEKLY_PRICE_PER_HALF_SHELF).toBe(2);
   });
 });

--- a/web/src/lib/pricing.ts
+++ b/web/src/lib/pricing.ts
@@ -8,9 +8,10 @@ export const GLAZE_SANITY_CHECK_PRICE = 12;
 export const STAFF_GLAZE_PREP_PER_HALF_SHELF_PRICE = 10;
 export const ADD_ON_HALF_SHELF_CAP_RATIO = 0.35;
 export const ADD_ON_HALF_SHELF_CAP = Number((HALF_SHELF_BISQUE_PRICE * ADD_ON_HALF_SHELF_CAP_RATIO).toFixed(2));
-export const FRAGILE_HANDLING_PER_HALF_SHELF_PRICE = 4;
+export const STUDIO_GLAZE_ACCESS_PER_HALF_SHELF_PRICE = 5;
+export const SELF_LOADED_KILN_FLAT_PRICE = 15;
 export const PLACEMENT_PREFERENCE_PRICE = 3;
-export const PREPAID_STORAGE_WEEKLY_PRICE = 2;
+export const PREPAID_STORAGE_WEEKLY_PRICE_PER_HALF_SHELF = 2;
 
 export type FiringType = "bisque" | "glaze" | "other";
 

--- a/web/src/utils/functionsBaseUrl.test.ts
+++ b/web/src/utils/functionsBaseUrl.test.ts
@@ -8,10 +8,15 @@ import {
 
 describe("functions URL resolution", () => {
   it("defaults to production function host when no override is configured", () => {
-    expect(resolveFunctionsBaseUrlWithContext({ browserHostname: "localhost" })).toBe(
+    expect(resolveFunctionsBaseUrlWithContext({ configuredBaseUrl: "", browserHostname: "localhost" })).toBe(
       "https://us-central1-monsoonfire-portal.cloudfunctions.net"
     );
-    expect(resolveFunctionsBaseUrlWithContext({ browserHostname: "monsoonfire-portal.web.app" })).toBe(
+    expect(
+      resolveFunctionsBaseUrlWithContext({
+        configuredBaseUrl: "",
+        browserHostname: "monsoonfire-portal.web.app",
+      })
+    ).toBe(
       "https://us-central1-monsoonfire-portal.cloudfunctions.net"
     );
   });
@@ -43,13 +48,16 @@ describe("functions URL resolution", () => {
 
 describe("resolveFunctionsBaseUrlResolution", () => {
   it("returns default enabled resolution for production and localhost browser contexts", () => {
-    const production = resolveFunctionsBaseUrlResolution({ browserHostname: "monsoonfire-portal.web.app" });
+    const production = resolveFunctionsBaseUrlResolution({
+      configuredBaseUrl: "",
+      browserHostname: "monsoonfire-portal.web.app",
+    });
     expect(production.configured).toBe(false);
     expect(production.enabled).toBe(true);
     expect(production.baseUrl).toBe("https://us-central1-monsoonfire-portal.cloudfunctions.net");
     expect(production.reason).toBe("");
 
-    const local = resolveFunctionsBaseUrlResolution({ browserHostname: "localhost" });
+    const local = resolveFunctionsBaseUrlResolution({ configuredBaseUrl: "", browserHostname: "localhost" });
     expect(local.configured).toBe(false);
     expect(local.enabled).toBe(true);
     expect(local.baseUrl).toBe("https://us-central1-monsoonfire-portal.cloudfunctions.net");

--- a/web/src/views/ReservationsView.test.ts
+++ b/web/src/views/ReservationsView.test.ts
@@ -33,6 +33,9 @@ describe("normalizeReservationRecord", () => {
       pickupReminderFailureCount: null,
       lastReminderFailureAt: null,
       storageNoticeHistory: null,
+      storageBilling: null,
+      isArchived: false,
+      archivedAt: null,
       arrivalStatus: null,
       arrivedAt: null,
       arrivalToken: null,
@@ -52,5 +55,39 @@ describe("normalizeReservationRecord", () => {
       createdAt: null,
       updatedAt: null,
     });
+  });
+
+  it("maps legacy fragile handling fields into the self-loaded kiln add-on shape", () => {
+    const row = normalizeReservationRecord("res-legacy", {
+      addOns: {
+        fragileHandlingRequested: true,
+        fragileHandlingCost: 12,
+      },
+      storageBilling: {
+        chargeBasis: "estimatedHalfShelves",
+        chargeBasisHalfShelves: 3,
+        prepaidWeeklyRatePerHalfShelf: 2,
+        dailyRatePerHalfShelf: 1.5,
+        billedDays: 4,
+        accruedCost: 18,
+        status: "billing",
+      },
+      isArchived: true,
+    });
+
+    expect(row.addOns).toMatchObject({
+      selfLoadedKilnRequested: true,
+      selfLoadedKilnCost: 12,
+    });
+    expect(row.storageBilling).toMatchObject({
+      chargeBasis: "estimatedHalfShelves",
+      chargeBasisHalfShelves: 3,
+      prepaidWeeklyRatePerHalfShelf: 2,
+      dailyRatePerHalfShelf: 1.5,
+      billedDays: 4,
+      accruedCost: 18,
+      status: "billing",
+    });
+    expect(row.isArchived).toBe(true);
   });
 });

--- a/web/src/views/ReservationsView.tsx
+++ b/web/src/views/ReservationsView.tsx
@@ -8,14 +8,14 @@ import { makeRequestId } from "../api/requestId";
 import { parseStaffRoleFromClaims } from "../auth/staffRole";
 import { db } from "../firebase";
 import {
-  ADD_ON_HALF_SHELF_CAP,
   FULL_KILN_CUSTOM_PRICE,
   DELIVERY_PRICE_PER_TRIP,
-  FRAGILE_HANDLING_PER_HALF_SHELF_PRICE,
   PLACEMENT_PREFERENCE_PRICE,
-  PREPAID_STORAGE_WEEKLY_PRICE,
+  PREPAID_STORAGE_WEEKLY_PRICE_PER_HALF_SHELF,
   RUSH_REQUEST_PRICE,
+  SELF_LOADED_KILN_FLAT_PRICE,
   STAFF_GLAZE_PREP_PER_HALF_SHELF_PRICE,
+  STUDIO_GLAZE_ACCESS_PER_HALF_SHELF_PRICE,
   applyHalfKilnPriceBreak,
   computeDeliveryCost,
   computeEstimatedCost,
@@ -135,9 +135,11 @@ const RESERVATION_FILTERS: Array<{ id: ReservationFilter; label: string }> = [
 const STAFF_UNDO_WINDOW_MS = 20_000;
 const PICKUP_WINDOW_RESCHEDULE_LIMIT = 1;
 const FAIRNESS_OVERRIDE_MAX_POINTS = 20;
-const STORAGE_REMINDER_THRESHOLDS_HOURS = [72, 120, 168] as const;
-const STORAGE_HOLD_PENDING_HOURS = 240;
-const STORAGE_POLICY_CAP_HOURS = 336;
+const STORAGE_REMINDER_THRESHOLDS_HOURS = [336, 420, 462] as const;
+const STORAGE_GRACE_HOURS = 462;
+const STORAGE_BILLING_WINDOW_DAYS = 28;
+const STORAGE_BILLING_DAILY_RATE_PER_HALF_SHELF = 1.5;
+const STORAGE_POLICY_CAP_HOURS = STORAGE_GRACE_HOURS + STORAGE_BILLING_WINDOW_DAYS * 24;
 const STAFF_OFFLINE_QUEUE_STORAGE_KEY = "mf_staff_queue_offline_actions_v1";
 const STAFF_OFFLINE_QUEUE_MAX = 80;
 const STAFF_OFFLINE_SYNC_MIN_DELAY_MS = 1200;
@@ -260,8 +262,8 @@ function normalizeStorageStatus(
 function getStorageStatusLabel(record: ReservationRecord): string {
   const status = normalizeStorageStatus(record.storageStatus);
   if (status === "reminder_pending") return "Reminder pending";
-  if (status === "hold_pending") return "Hold pending";
-  if (status === "stored_by_policy") return "Stored by policy";
+  if (status === "hold_pending") return "Billable storage";
+  if (status === "stored_by_policy") return "Reclaimed by studio";
   return "Active";
 }
 
@@ -332,7 +334,7 @@ function isStorageCapApproaching(record: ReservationRecord): boolean {
   if (hours == null) return false;
   const warningStartHours = Math.max(
     STORAGE_REMINDER_THRESHOLDS_HOURS[STORAGE_REMINDER_THRESHOLDS_HOURS.length - 1] ?? 0,
-    STORAGE_HOLD_PENDING_HOURS
+    STORAGE_GRACE_HOURS
   );
   return hours >= warningStartHours && hours < STORAGE_POLICY_CAP_HOURS;
 }
@@ -361,10 +363,42 @@ function formatStorageNoticeKind(kind: string): string {
   if (value === "pickup_reminder_1") return "Reminder 1";
   if (value === "pickup_reminder_2") return "Reminder 2";
   if (value === "pickup_reminder_3") return "Reminder 3";
-  if (value === "hold_pending") return "Hold pending";
-  if (value === "stored_by_policy") return "Stored by policy";
+  if (value === "hold_pending") return "Billable storage";
+  if (value === "stored_by_policy") return "Reclaimed by studio";
+  if (value === "pickup_window_missed") return "Pickup window missed";
+  if (value === "storage_billing_update") return "Storage billing update";
   if (value === "reminder_failed") return "Reminder failed";
   return kind;
+}
+
+function formatStorageBillingSummary(record: ReservationRecord): string | null {
+  const billing = record.storageBilling;
+  if (!billing) return null;
+
+  const graceEndsAt = billing.graceEndsAt?.toDate?.() ?? null;
+  const billingEndsAt = billing.billingEndsAt?.toDate?.() ?? null;
+  const reclaimedAt = billing.reclaimedAt?.toDate?.() ?? billingEndsAt;
+  const billedDays =
+    typeof billing.billedDays === "number" && Number.isFinite(billing.billedDays)
+      ? Math.max(0, Math.round(billing.billedDays))
+      : 0;
+  const accruedCost =
+    typeof billing.accruedCost === "number" && Number.isFinite(billing.accruedCost)
+      ? billing.accruedCost
+      : 0;
+
+  if (billing.status === "reclaimed") {
+    return reclaimedAt
+      ? `Reclaimed ${formatDateTime(reclaimedAt)}${billing.reclaimedReason ? ` · ${billing.reclaimedReason}` : ""}`
+      : "Reclaimed by studio after the billed storage window.";
+  }
+  if (billing.status === "billing") {
+    return `Billed ${billedDays}/${STORAGE_BILLING_WINDOW_DAYS} days · accrued ${formatUsd(accruedCost)}`;
+  }
+  if (graceEndsAt) {
+    return `Grace ends ${formatDateTime(graceEndsAt)} · then ${formatUsd(STORAGE_BILLING_DAILY_RATE_PER_HALF_SHELF)} per half-shelf per day`;
+  }
+  return `Grace window starts at pickup-ready and lasts 2.75 weeks.`;
 }
 
 function normalizeArrivalStatus(value: unknown): "expected" | "arrived" | "overdue" | "no_show" | null {
@@ -803,7 +837,7 @@ export default function ReservationsView({
   const [notesTags, setNotesTags] = useState<string[]>([]);
   const [rushRequested, setRushRequested] = useState(false);
   const [staffGlazePrepRequested, setStaffGlazePrepRequested] = useState(false);
-  const [fragileHandlingRequested, setFragileHandlingRequested] = useState(false);
+  const [selfLoadedKilnRequested, setSelfLoadedKilnRequested] = useState(false);
   const [placementPreferenceRequested, setPlacementPreferenceRequested] = useState(false);
   const [placementPreferenceZone, setPlacementPreferenceZone] = useState<
     (typeof PLACEMENT_PREFERENCE_ZONES)[number]["id"]
@@ -977,14 +1011,13 @@ export default function ReservationsView({
     staffGlazePrepRequested && Number.isFinite(estimatedHalfShelvesRounded)
       ? estimatedHalfShelvesRounded * STAFF_GLAZE_PREP_PER_HALF_SHELF_PRICE
       : 0;
-  const fragileHandlingCost =
-    fragileHandlingRequested && Number.isFinite(estimatedHalfShelvesRounded)
-      ? estimatedHalfShelvesRounded * FRAGILE_HANDLING_PER_HALF_SHELF_PRICE
-      : 0;
+  const selfLoadedKilnCost = selfLoadedKilnRequested ? SELF_LOADED_KILN_FLAT_PRICE : 0;
   const placementPreferenceCost = placementPreferenceRequested ? PLACEMENT_PREFERENCE_PRICE : 0;
   const prepaidStorageWeeksClamped = Math.max(1, Math.min(12, Math.round(prepaidStorageWeeks)));
   const prepaidStorageCost = prepaidStorageRequested
-    ? prepaidStorageWeeksClamped * PREPAID_STORAGE_WEEKLY_PRICE
+    ? prepaidStorageWeeksClamped *
+      estimatedHalfShelvesRounded *
+      PREPAID_STORAGE_WEEKLY_PRICE_PER_HALF_SHELF
     : 0;
   const totalEstimate =
     estimatedCostWithDelivery != null
@@ -992,7 +1025,7 @@ export default function ReservationsView({
         (glazeAccessCost ?? 0) +
         rushCost +
         staffGlazePrepCost +
-        fragileHandlingCost +
+        selfLoadedKilnCost +
         placementPreferenceCost +
         prepaidStorageCost
       : estimatedCostWithDelivery;
@@ -1352,7 +1385,7 @@ export default function ReservationsView({
     setFitsOnOneLayer(null);
     setRushRequested(false);
     setStaffGlazePrepRequested(false);
-    setFragileHandlingRequested(false);
+    setSelfLoadedKilnRequested(false);
     setPlacementPreferenceRequested(false);
     setPlacementPreferenceZone("middle");
     setPrepaidStorageRequested(false);
@@ -1381,7 +1414,7 @@ export default function ReservationsView({
       setGlazeAccessCost(null);
       return;
     }
-    setGlazeAccessCost(estimatedHalfShelvesRounded * 3);
+    setGlazeAccessCost(estimatedHalfShelvesRounded * STUDIO_GLAZE_ACCESS_PER_HALF_SHELF_PRICE);
   }, [useStudioGlazes, estimatedHalfShelvesRounded]);
 
   useEffect(() => {
@@ -2897,7 +2930,7 @@ export default function ReservationsView({
     setNotesGeneral("");
     setRushRequested(false);
     setStaffGlazePrepRequested(false);
-    setFragileHandlingRequested(false);
+    setSelfLoadedKilnRequested(false);
     setPlacementPreferenceRequested(false);
     setPlacementPreferenceZone("middle");
     setPrepaidStorageRequested(false);
@@ -3102,8 +3135,8 @@ export default function ReservationsView({
           staffGlazePrepRequested: !isCommunityShelf && staffGlazePrepRequested,
           staffGlazePrepRatePerHalfShelf:
             !isCommunityShelf && staffGlazePrepRequested ? STAFF_GLAZE_PREP_PER_HALF_SHELF_PRICE : null,
-          fragileHandlingRequested: !isCommunityShelf && fragileHandlingRequested,
-          fragileHandlingCost: !isCommunityShelf && fragileHandlingRequested ? fragileHandlingCost : null,
+          selfLoadedKilnRequested: !isCommunityShelf && selfLoadedKilnRequested,
+          selfLoadedKilnCost: !isCommunityShelf && selfLoadedKilnRequested ? selfLoadedKilnCost : null,
           placementPreferenceRequested: !isCommunityShelf && placementPreferenceRequested,
           placementPreferenceZone:
             !isCommunityShelf && placementPreferenceRequested ? placementPreferenceZone : null,
@@ -3579,7 +3612,7 @@ export default function ReservationsView({
                       {useStudioGlazes ||
                       rushRequested ||
                       staffGlazePrepRequested ||
-                      fragileHandlingRequested ||
+                      selfLoadedKilnRequested ||
                       placementPreferenceRequested ||
                       prepaidStorageRequested
                         ? "Total estimate"
@@ -3599,7 +3632,7 @@ export default function ReservationsView({
                   (useStudioGlazes ||
                     rushRequested ||
                     staffGlazePrepRequested ||
-                    fragileHandlingRequested ||
+                    selfLoadedKilnRequested ||
                     placementPreferenceRequested ||
                     prepaidStorageRequested) ? (
                     <div className="estimate-breakdown">
@@ -3625,10 +3658,10 @@ export default function ReservationsView({
                           <span>{formatUsd(staffGlazePrepCost)}</span>
                         </div>
                       ) : null}
-                      {fragileHandlingRequested ? (
+                      {selfLoadedKilnRequested ? (
                         <div className="estimate-line">
-                          <span>Fragile handling ({formatHalfShelfCount(estimatedHalfShelvesRounded)})</span>
-                          <span>{formatUsd(fragileHandlingCost)}</span>
+                          <span>Self-loaded kiln</span>
+                          <span>{formatUsd(selfLoadedKilnCost)}</span>
                         </div>
                       ) : null}
                       {placementPreferenceRequested ? (
@@ -3643,8 +3676,8 @@ export default function ReservationsView({
                       {prepaidStorageRequested ? (
                         <div className="estimate-line">
                           <span>
-                            Prepaid storage ({prepaidStorageWeeksClamped} week
-                            {prepaidStorageWeeksClamped === 1 ? "" : "s"})
+                            Prepaid storage ({formatHalfShelfCount(estimatedHalfShelvesRounded)} ·{" "}
+                            {prepaidStorageWeeksClamped} week{prepaidStorageWeeksClamped === 1 ? "" : "s"})
                           </span>
                           <span>{formatUsd(prepaidStorageCost)}</span>
                         </div>
@@ -3725,7 +3758,9 @@ export default function ReservationsView({
                     <span className="addon-text">
                       <span className="addon-title">Use Studio Glazes + Kitchen Access</span>
                     </span>
-                    <span className="addon-tag">$3 per half-shelf</span>
+                    <span className="addon-tag">
+                      {formatUsd(STUDIO_GLAZE_ACCESS_PER_HALF_SHELF_PRICE)} per half-shelf
+                    </span>
                   </label>
                 </div>
                 <div className="addon-helper">
@@ -3741,10 +3776,6 @@ export default function ReservationsView({
               </div>
               <div className="addon-section">
                 <div className="addon-subtitle">Firing boosts + handling</div>
-                <div className="addon-helper">
-                  New care add-ons stay under {formatUsd(ADD_ON_HALF_SHELF_CAP)} each (35% cap of one bisque
-                  half-shelf).
-                </div>
                 <div className="addon-grid">
                   <label className="addon-toggle">
                     <input
@@ -3780,18 +3811,17 @@ export default function ReservationsView({
                   <label className="addon-toggle">
                     <input
                       type="checkbox"
-                      checked={fragileHandlingRequested}
-                      onChange={(event) => setFragileHandlingRequested(event.target.checked)}
+                      checked={selfLoadedKilnRequested}
+                      onChange={(event) => setSelfLoadedKilnRequested(event.target.checked)}
                     />
                     <span className="addon-text">
-                      <span className="addon-title">Fragile handling</span>
+                      <span className="addon-title">Self-loaded kiln</span>
                       <span className="addon-copy">
-                        Added care for delicate work during loading and unloading.
+                        You load the kiln entirely yourself. Artists usually choose this for fragile work, but
+                        you can request it for any reason.
                       </span>
                     </span>
-                    <span className="addon-tag">
-                      {formatUsd(FRAGILE_HANDLING_PER_HALF_SHELF_PRICE)} per half-shelf
-                    </span>
+                    <span className="addon-tag">{formatUsd(SELF_LOADED_KILN_FLAT_PRICE)} flat</span>
                   </label>
                   <label className="addon-toggle">
                     <input
@@ -3816,10 +3846,14 @@ export default function ReservationsView({
                     <span className="addon-text">
                       <span className="addon-title">Need extra pickup time?</span>
                       <span className="addon-copy">
-                        Prepay dedicated shelf storage beyond the first 7 days and pause reminder nudges.
+                        Prepay storage at the lower weekly rate now. After the 2.75-week grace period, storage
+                        switches to {formatUsd(STORAGE_BILLING_DAILY_RATE_PER_HALF_SHELF)} per half-shelf per day,
+                        and unclaimed work is reclaimed by the studio after 4 billed weeks.
                       </span>
                     </span>
-                    <span className="addon-tag">{formatUsd(PREPAID_STORAGE_WEEKLY_PRICE)} per week</span>
+                    <span className="addon-tag">
+                      {formatUsd(PREPAID_STORAGE_WEEKLY_PRICE_PER_HALF_SHELF)} per half-shelf per week
+                    </span>
                   </label>
                   <label className="addon-toggle">
                     <input
@@ -3867,7 +3901,7 @@ export default function ReservationsView({
                     ) : null}
                     {prepaidStorageRequested ? (
                       <label>
-                        Extra storage weeks after day 7
+                        Prepaid storage weeks before billing begins
                         <select
                           value={String(prepaidStorageWeeksClamped)}
                           onChange={(event) => {
@@ -3912,7 +3946,7 @@ export default function ReservationsView({
                 ) : null}
                 {(rushRequested ||
                   staffGlazePrepRequested ||
-                  fragileHandlingRequested ||
+                  selfLoadedKilnRequested ||
                   placementPreferenceRequested ||
                   prepaidStorageRequested ||
                   pickupDeliveryRequested ||
@@ -4219,7 +4253,7 @@ export default function ReservationsView({
                 Entering hold: <strong>{storageTriageSummary.enteringHold}</strong>
               </span>
               <span>
-                Stored by policy: <strong>{storageTriageSummary.storedByPolicy}</strong>
+                Reclaimed by studio: <strong>{storageTriageSummary.storedByPolicy}</strong>
               </span>
               <span>
                 Reminder failures: <strong>{storageTriageSummary.reminderFailures}</strong>
@@ -4413,6 +4447,7 @@ export default function ReservationsView({
               const storageHistory = Array.isArray(reservation.storageNoticeHistory)
                 ? reservation.storageNoticeHistory
                 : [];
+              const storageBillingSummary = formatStorageBillingSummary(reservation);
               const pickupWindow = reservation.pickupWindow ?? null;
               const pickupWindowStatus = normalizePickupWindowStatus(pickupWindow?.status);
               const pickupWindowStatusLabel = getPickupWindowStatusLabel(pickupWindowStatus);
@@ -4675,14 +4710,21 @@ export default function ReservationsView({
                         : ""}
                     </span>
                   </div>
+                  {storageBillingSummary ? (
+                    <div className="reservation-note-history">
+                      Storage billing: <strong>{storageBillingSummary}</strong>
+                    </div>
+                  ) : null}
                   {isStorageCapApproaching(reservation) ? (
                     <div className="reservation-storage-warning">
-                      Pickup window is approaching the storage policy cap. Queue staff follow-up now.
+                      Grace has ended or is ending soon. Track billed storage days now so the reservation does not
+                      drift into studio reclamation.
                     </div>
                   ) : null}
                   {storageStatusClass === "stored_by_policy" ? (
                     <div className="reservation-storage-warning critical">
-                      Reservation is marked stored by policy. Coordinate support action before disposal.
+                      Reservation has been reclaimed by the studio. Keep any artist follow-up and disposition notes in
+                      support.
                     </div>
                   ) : null}
                   <div className="reservation-sla-copy">
@@ -4763,7 +4805,7 @@ export default function ReservationsView({
                   {reservation.addOns?.pickupDeliveryRequested ||
                   reservation.addOns?.returnDeliveryRequested ||
                   reservation.addOns?.communityShelfFillInAllowed ||
-                  reservation.addOns?.fragileHandlingRequested ||
+                  reservation.addOns?.selfLoadedKilnRequested ||
                   reservation.addOns?.placementPreferenceRequested ||
                   reservation.addOns?.prepaidStorageRequested ? (
                     <div className="reservation-addons-inline">
@@ -4776,8 +4818,8 @@ export default function ReservationsView({
                       {reservation.addOns?.communityShelfFillInAllowed ? (
                         <span className="reservation-addon-pill">Community shelf fill-in allowed</span>
                       ) : null}
-                      {reservation.addOns?.fragileHandlingRequested ? (
-                        <span className="reservation-addon-pill">Fragile handling</span>
+                      {reservation.addOns?.selfLoadedKilnRequested ? (
+                        <span className="reservation-addon-pill">Self-loaded kiln</span>
                       ) : null}
                       {reservation.addOns?.placementPreferenceRequested ? (
                         <span className="reservation-addon-pill">
@@ -4789,7 +4831,7 @@ export default function ReservationsView({
                       ) : null}
                       {reservation.addOns?.prepaidStorageRequested ? (
                         <span className="reservation-addon-pill">
-                          Storage: {prepaidStorageWeeksLabel} week{prepaidStorageWeeksLabel === 1 ? "" : "s"}
+                          Storage: {prepaidStorageWeeksLabel} week{prepaidStorageWeeksLabel === 1 ? "" : "s"} prepaid
                         </span>
                       ) : null}
                     </div>

--- a/website/data/policies.json
+++ b/website/data/policies.json
@@ -90,14 +90,14 @@
   },
   {
     "title": "Storage limits & abandoned work",
-    "body": "<p>Storage limits depend on membership tier and available space. Long-abandoned work may move through notice and follow-up steps.</p>",
+    "body": "<p>Pickup-ready work gets 2.75 weeks of grace, optional prepaid storage at $2 per half-shelf per week, billed storage at $1.50 per half-shelf per day, and studio reclamation after 28 billed days.</p>",
     "tags": [
       "storage",
-      "memberships",
+      "pickup",
       "policy"
     ],
     "status": "active",
-    "effectiveDate": "2026-02-17"
+    "effectiveDate": "2026-03-17"
   },
   {
     "title": "Studio access & supervision",

--- a/website/ncsitebuilder/policies/storage-abandoned-work/index.html
+++ b/website/ncsitebuilder/policies/storage-abandoned-work/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Storage & Abandoned Work | Monsoon Fire Pottery</title>
-  <meta name="description" content="Storage and abandoned work policy for Monsoon Fire Pottery." />
+  <meta name="description" content="Pickup-ready work gets 2.75 weeks of grace, optional prepaid storage, billed daily storage, and studio reclamation after 28 billed days." />
   <link rel="canonical" href="https://monsoonfire.com/policies/storage-abandoned-work/" />
   <link rel="icon" href="/assets/images/logo-mark-black.png" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -15,7 +15,7 @@
   <script src="/assets/js/analytics.js" defer></script>
   <meta property="og:site_name" content="Monsoon Fire Pottery" />
   <meta property="og:title" content="Storage & Abandoned Work | Monsoon Fire Pottery" />
-  <meta property="og:description" content="Storage and abandoned work policy for Monsoon Fire Pottery." />
+  <meta property="og:description" content="Pickup-ready work gets 2.75 weeks of grace, optional prepaid storage, billed daily storage, and studio reclamation after 28 billed days." />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://monsoonfire.com/policies/storage-abandoned-work/" />
   <meta property="og:image" content="https://monsoonfire.com/assets/images/finished-work-1200.jpg" />
@@ -23,7 +23,7 @@
   <meta property="og:image:height" content="1600" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Storage & Abandoned Work | Monsoon Fire Pottery" />
-  <meta name="twitter:description" content="Storage and abandoned work policy for Monsoon Fire Pottery." />
+  <meta name="twitter:description" content="Pickup-ready work gets 2.75 weeks of grace, optional prepaid storage, billed daily storage, and studio reclamation after 28 billed days." />
   <meta name="twitter:image" content="https://monsoonfire.com/assets/images/finished-work-1200.jpg" />
 </head>
 <body data-nav-parent="/faq/">
@@ -41,7 +41,7 @@
         <a href="/support/">Support</a>
         <a href="/highlights/">Gallery</a></nav>
             <div class="nav-portal-wrap">
-        <a class="nav-portal" href="https://monsoonfire.kilnfire.com" target="_blank" rel="noopener noreferrer">Login</a>
+        <a class="nav-portal" href="https://portal.monsoonfire.com" target="_blank" rel="noopener noreferrer">Login</a>
       </div><button class="menu-toggle" type="button" aria-label="Toggle menu" aria-expanded="false" data-menu-toggle>
         <span></span><span></span><span></span>
       </button>
@@ -54,9 +54,9 @@
         <div class="heading-block">
           <p class="eyebrow">Policy</p>
           <h1 class="section-title">Storage & Abandoned Work.</h1>
-          <p class="lead">Storage is limited, so we keep a clear timeline and communication.</p>
+          <p class="lead">Pickup-ready work gets 2.75 weeks of grace before billed storage and final studio reclamation.</p>
         </div>
-        <p class="hero-note">Effective Feb 1, 2026</p>
+        <p class="hero-note">Effective Mar 17, 2026</p>
       </div>
     </section>
 
@@ -67,7 +67,76 @@
           <h2 class="section-title">What to expect</h2>
         </div>
         <ul class="policy-list">
-          <li>\n            <strong>Standard hold</strong>\n            <p>Finished work is held for 4 weeks after notification.</p>\n          </li>\n          <li>\n            <strong>Two warnings</strong>\n            <p>We send two reminders before work is considered abandoned.</p>\n          </li>\n          <li>\n            <strong>Member storage</strong>\n            <p>Members have access to lockers and long-term storage for active work.</p>\n          </li>\n          <li>\n            <strong>Abandoned work</strong>\n            <p>After the hold period, unclaimed work may be recycled, donated, or discarded.</p>\n          </li>\n          <li>\n            <strong>Label everything</strong>\n            <p>Keep your name and date on storage bins so we can avoid mix-ups.</p>\n          </li>
+          <li>
+            <strong>Grace period</strong>
+            <p>Pickup-ready work gets 19.25 days of grace from the moment we mark it ready for pickup.</p>
+          </li>
+          <li>
+            <strong>Reminder schedule</strong>
+            <p>We send pickup reminders at day 14, day 17.5, and day 19.25.</p>
+          </li>
+          <li>
+            <strong>Prepaid storage</strong>
+            <p>You can prepay extra pickup time at $2 per half-shelf per week before billed storage begins.</p>
+          </li>
+          <li>
+            <strong>Post-grace billing</strong>
+            <p>After grace ends, storage bills at $1.50 per half-shelf per day for up to 28 billed days.</p>
+          </li>
+          <li>
+            <strong>Reclaimed work</strong>
+            <p>After the billed window ends, ownership transfers to the studio and the work may be reused, sold, or destroyed.</p>
+          </li>
+        </ul>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="container">
+        <div class="heading-block">
+          <p class="eyebrow">Timeline</p>
+          <h2 class="section-title">How the clock works</h2>
+        </div>
+        <ul class="policy-list">
+          <li>
+            <strong>Pickup-ready notice</strong>
+            <p>The storage clock starts when your reservation is marked ready for pickup in the portal.</p>
+          </li>
+          <li>
+            <strong>Grace first, billing second</strong>
+            <p>Missing a pickup window does not reset the clock. Grace still runs to day 19.25, and billed storage starts immediately after that.</p>
+          </li>
+          <li>
+            <strong>Daily storage billing</strong>
+            <p>Daily charges only accrue after each fully elapsed 24-hour period and use your reservation's half-shelf estimate as the charge basis.</p>
+          </li>
+          <li>
+            <strong>Automatic reclamation</strong>
+            <p>At the end of the 28 billed days, the reservation is archived and shown as Reclaimed by studio.</p>
+          </li>
+        </ul>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="container">
+        <div class="heading-block">
+          <p class="eyebrow">After reclamation</p>
+          <h2 class="section-title">What abandonment means</h2>
+        </div>
+        <ul class="policy-list">
+          <li>
+            <strong>Ownership transfer</strong>
+            <p>When work is reclaimed, it is treated as abandoned and ownership transfers to Monsoon Fire Pottery.</p>
+          </li>
+          <li>
+            <strong>Studio rights</strong>
+            <p>The studio may destroy, recycle, donate, sell, repurpose, photograph, copy, display, or otherwise use reclaimed work without further notice or compensation.</p>
+          </li>
+          <li>
+            <strong>Questions or disputes</strong>
+            <p>If you believe your reminder history or storage timeline is incorrect, contact support before the reclamation date shown in the portal.</p>
+          </li>
         </ul>
       </div>
     </section>

--- a/website/ncsitebuilder/sitemap.xml
+++ b/website/ncsitebuilder/sitemap.xml
@@ -15,7 +15,7 @@
   <url><loc>https://monsoonfire.com/policies/safety-kiln-rules/</loc><lastmod>2026-02-01</lastmod></url>
   <url><loc>https://monsoonfire.com/policies/clay-materials/</loc><lastmod>2026-02-01</lastmod></url>
   <url><loc>https://monsoonfire.com/policies/firing-scheduling/</loc><lastmod>2026-02-01</lastmod></url>
-  <url><loc>https://monsoonfire.com/policies/storage-abandoned-work/</loc><lastmod>2026-02-01</lastmod></url>
+  <url><loc>https://monsoonfire.com/policies/storage-abandoned-work/</loc><lastmod>2026-03-17</lastmod></url>
   <url><loc>https://monsoonfire.com/policies/damage-responsibility/</loc><lastmod>2026-02-01</lastmod></url>
   <url><loc>https://monsoonfire.com/policies/payments-refunds/</loc><lastmod>2026-02-01</lastmod></url>
   <url><loc>https://monsoonfire.com/policies/community-conduct/</loc><lastmod>2026-02-01</lastmod></url>

--- a/website/policies/storage-abandoned-work/index.html
+++ b/website/policies/storage-abandoned-work/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Storage & Abandoned Work | Monsoon Fire Pottery</title>
-  <meta name="description" content="Storage and abandoned work policy for Monsoon Fire Pottery." />
+  <meta name="description" content="Pickup-ready work gets 2.75 weeks of grace, optional prepaid storage, billed daily storage, and studio reclamation after 28 billed days." />
   <link rel="canonical" href="https://monsoonfire.com/policies/storage-abandoned-work/" />
   <link rel="icon" href="/assets/images/logo-mark-black.png" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -15,7 +15,7 @@
   <script src="/assets/js/analytics.js" defer></script>
   <meta property="og:site_name" content="Monsoon Fire Pottery" />
   <meta property="og:title" content="Storage & Abandoned Work | Monsoon Fire Pottery" />
-  <meta property="og:description" content="Storage and abandoned work policy for Monsoon Fire Pottery." />
+  <meta property="og:description" content="Pickup-ready work gets 2.75 weeks of grace, optional prepaid storage, billed daily storage, and studio reclamation after 28 billed days." />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://monsoonfire.com/policies/storage-abandoned-work/" />
   <meta property="og:image" content="https://monsoonfire.com/assets/images/finished-work-1200.jpg" />
@@ -23,7 +23,7 @@
   <meta property="og:image:height" content="1600" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Storage & Abandoned Work | Monsoon Fire Pottery" />
-  <meta name="twitter:description" content="Storage and abandoned work policy for Monsoon Fire Pottery." />
+  <meta name="twitter:description" content="Pickup-ready work gets 2.75 weeks of grace, optional prepaid storage, billed daily storage, and studio reclamation after 28 billed days." />
   <meta name="twitter:image" content="https://monsoonfire.com/assets/images/finished-work-1200.jpg" />
 </head>
 <body data-nav-parent="/faq/">
@@ -41,7 +41,7 @@
         <a href="/support/">Support</a>
         <a href="/highlights/">Gallery</a></nav>
             <div class="nav-portal-wrap">
-        <a class="nav-portal" href="https://monsoonfire.kilnfire.com" target="_blank" rel="noopener noreferrer">Login</a>
+        <a class="nav-portal" href="https://portal.monsoonfire.com" target="_blank" rel="noopener noreferrer">Login</a>
       </div><button class="menu-toggle" type="button" aria-label="Toggle menu" aria-expanded="false" data-menu-toggle>
         <span></span><span></span><span></span>
       </button>
@@ -54,9 +54,9 @@
         <div class="heading-block">
           <p class="eyebrow">Policy</p>
           <h1 class="section-title">Storage & Abandoned Work.</h1>
-          <p class="lead">Storage is limited, so we keep a clear timeline and communication.</p>
+          <p class="lead">Pickup-ready work gets 2.75 weeks of grace before billed storage and final studio reclamation.</p>
         </div>
-        <p class="hero-note">Effective Feb 1, 2026</p>
+        <p class="hero-note">Effective Mar 17, 2026</p>
       </div>
     </section>
 
@@ -67,7 +67,76 @@
           <h2 class="section-title">What to expect</h2>
         </div>
         <ul class="policy-list">
-          <li>\n            <strong>Standard hold</strong>\n            <p>Finished work is held for 4 weeks after notification.</p>\n          </li>\n          <li>\n            <strong>Two warnings</strong>\n            <p>We send two reminders before work is considered abandoned.</p>\n          </li>\n          <li>\n            <strong>Member storage</strong>\n            <p>Members have access to lockers and long-term storage for active work.</p>\n          </li>\n          <li>\n            <strong>Abandoned work</strong>\n            <p>After the hold period, unclaimed work may be recycled, donated, or discarded.</p>\n          </li>\n          <li>\n            <strong>Label everything</strong>\n            <p>Keep your name and date on storage bins so we can avoid mix-ups.</p>\n          </li>
+          <li>
+            <strong>Grace period</strong>
+            <p>Pickup-ready work gets 19.25 days of grace from the moment we mark it ready for pickup.</p>
+          </li>
+          <li>
+            <strong>Reminder schedule</strong>
+            <p>We send pickup reminders at day 14, day 17.5, and day 19.25.</p>
+          </li>
+          <li>
+            <strong>Prepaid storage</strong>
+            <p>You can prepay extra pickup time at $2 per half-shelf per week before billed storage begins.</p>
+          </li>
+          <li>
+            <strong>Post-grace billing</strong>
+            <p>After grace ends, storage bills at $1.50 per half-shelf per day for up to 28 billed days.</p>
+          </li>
+          <li>
+            <strong>Reclaimed work</strong>
+            <p>After the billed window ends, ownership transfers to the studio and the work may be reused, sold, or destroyed.</p>
+          </li>
+        </ul>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="container">
+        <div class="heading-block">
+          <p class="eyebrow">Timeline</p>
+          <h2 class="section-title">How the clock works</h2>
+        </div>
+        <ul class="policy-list">
+          <li>
+            <strong>Pickup-ready notice</strong>
+            <p>The storage clock starts when your reservation is marked ready for pickup in the portal.</p>
+          </li>
+          <li>
+            <strong>Grace first, billing second</strong>
+            <p>Missing a pickup window does not reset the clock. Grace still runs to day 19.25, and billed storage starts immediately after that.</p>
+          </li>
+          <li>
+            <strong>Daily storage billing</strong>
+            <p>Daily charges only accrue after each fully elapsed 24-hour period and use your reservation's half-shelf estimate as the charge basis.</p>
+          </li>
+          <li>
+            <strong>Automatic reclamation</strong>
+            <p>At the end of the 28 billed days, the reservation is archived and shown as Reclaimed by studio.</p>
+          </li>
+        </ul>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="container">
+        <div class="heading-block">
+          <p class="eyebrow">After reclamation</p>
+          <h2 class="section-title">What abandonment means</h2>
+        </div>
+        <ul class="policy-list">
+          <li>
+            <strong>Ownership transfer</strong>
+            <p>When work is reclaimed, it is treated as abandoned and ownership transfers to Monsoon Fire Pottery.</p>
+          </li>
+          <li>
+            <strong>Studio rights</strong>
+            <p>The studio may destroy, recycle, donate, sell, repurpose, photograph, copy, display, or otherwise use reclaimed work without further notice or compensation.</p>
+          </li>
+          <li>
+            <strong>Questions or disputes</strong>
+            <p>If you believe your reminder history or storage timeline is incorrect, contact support before the reclamation date shown in the portal.</p>
+          </li>
         </ul>
       </div>
     </section>

--- a/website/scripts/policy-docs.mjs
+++ b/website/scripts/policy-docs.mjs
@@ -16,7 +16,7 @@ const parseScalar = (raw) => {
 };
 
 export const parseFrontmatter = (content) => {
-  const match = content.match(/^---\n([\s\S]*?)\n---/);
+  const match = content.match(/^\uFEFF?---\r?\n([\s\S]*?)\r?\n---/);
   if (!match) return null;
 
   const lines = match[1].split(/\r?\n/);

--- a/website/sitemap.xml
+++ b/website/sitemap.xml
@@ -15,7 +15,7 @@
   <url><loc>https://monsoonfire.com/policies/safety-kiln-rules/</loc><lastmod>2026-02-01</lastmod></url>
   <url><loc>https://monsoonfire.com/policies/clay-materials/</loc><lastmod>2026-02-01</lastmod></url>
   <url><loc>https://monsoonfire.com/policies/firing-scheduling/</loc><lastmod>2026-02-01</lastmod></url>
-  <url><loc>https://monsoonfire.com/policies/storage-abandoned-work/</loc><lastmod>2026-02-01</lastmod></url>
+  <url><loc>https://monsoonfire.com/policies/storage-abandoned-work/</loc><lastmod>2026-03-17</lastmod></url>
   <url><loc>https://monsoonfire.com/policies/damage-responsibility/</loc><lastmod>2026-02-01</lastmod></url>
   <url><loc>https://monsoonfire.com/policies/payments-refunds/</loc><lastmod>2026-02-01</lastmod></url>
   <url><loc>https://monsoonfire.com/policies/community-conduct/</loc><lastmod>2026-02-01</lastmod></url>


### PR DESCRIPTION
## Summary
- update ware check-in add-on pricing and rename fragile handling to self-loaded kiln
- add the new grace, billing, reclamation, and archive storage flow across portal, API, and notifications
- refresh storage policy docs, reservation schema docs, and generated website policy outputs

## Verification
- `npm run test:web`
- `npm run test:functions`
- `node website/scripts/sync-policies.mjs`
- `npm run docs:reservations:check`
- `npm run lint:policies`
- `npm run policy:sot:check`
