### PR TITLE
Prune scheduled GitHub Actions

### DIFF
--- a/.github/workflows/branch-divergence-guard.yml
+++ b/.github/workflows/branch-divergence-guard.yml
@@ -2,9 +2,6 @@ name: Branch Divergence Guard
 
 on:
   workflow_dispatch:
-  schedule:
-    # Every 6 hours to detect non-fast-forward branch rewrites quickly.
-    - cron: "35 */6 * * *"
 
 permissions:
   contents: read

--- a/.github/workflows/ci-smoke.yml
+++ b/.github/workflows/ci-smoke.yml
@@ -15,8 +15,6 @@ on:
         options:
           - "false"
           - "true"
-  schedule:
-    - cron: "0 15 * * 1"
 
 permissions:
   contents: read

--- a/.github/workflows/codex-pr-green-daily.yml
+++ b/.github/workflows/codex-pr-green-daily.yml
@@ -13,9 +13,6 @@ on:
         required: false
         default: false
         type: boolean
-  schedule:
-    # 07:10 America/Phoenix (MST year-round) = 14:10 UTC
-    - cron: "10 14 * * *"
 
 permissions:
   contents: write

--- a/.github/workflows/codex-self-improvement.yml
+++ b/.github/workflows/codex-self-improvement.yml
@@ -13,9 +13,6 @@ on:
         required: false
         default: false
         type: boolean
-  schedule:
-    # 06:10 America/Phoenix (MST year-round) = 13:10 UTC
-    - cron: "10 13 * * *"
 
 permissions:
   contents: write

--- a/.github/workflows/firestore-index-contract-guard.yml
+++ b/.github/workflows/firestore-index-contract-guard.yml
@@ -8,10 +8,6 @@ on:
         required: false
         default: true
         type: boolean
-  schedule:
-    # 06:20 and 15:20 America/Phoenix (MST year-round) = 13:20 and 22:20 UTC
-    - cron: "20 13 * * *"
-    - cron: "20 22 * * *"
 
 permissions:
   actions: read

--- a/.github/workflows/functions-coldstart-regression.yml
+++ b/.github/workflows/functions-coldstart-regression.yml
@@ -23,8 +23,6 @@ on:
         options:
           - "true"
           - "false"
-  schedule:
-    - cron: "50 16 * * *"
 
 permissions:
   contents: read

--- a/.github/workflows/governance-weekly-tuning.yml
+++ b/.github/workflows/governance-weekly-tuning.yml
@@ -1,8 +1,6 @@
 name: Governance Weekly Tuning
 
 on:
-  schedule:
-    - cron: "15 9 * * 1"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/intent-runner-daily.yml
+++ b/.github/workflows/intent-runner-daily.yml
@@ -1,8 +1,6 @@
 name: Intent Runner Daily
 
 on:
-  schedule:
-    - cron: "30 6 * * *"
   workflow_dispatch:
     inputs:
       mode:

--- a/.github/workflows/open-memory-context-sync.yml
+++ b/.github/workflows/open-memory-context-sync.yml
@@ -1,8 +1,6 @@
 name: Open Memory Context Sync
 
 on:
-  schedule:
-    - cron: "45 7 * * *"
   workflow_dispatch:
     inputs:
       include_resumable:

--- a/.github/workflows/policy-single-source-of-truth-parity.yml
+++ b/.github/workflows/policy-single-source-of-truth-parity.yml
@@ -2,8 +2,6 @@ name: Policy Single Source Of Truth Parity
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "11 6 * * *"
   push:
     paths:
       - "docs/policies/**"

--- a/.github/workflows/portal-automation-health-daily.yml
+++ b/.github/workflows/portal-automation-health-daily.yml
@@ -13,9 +13,6 @@ on:
         required: false
         default: 48
         type: number
-  schedule:
-    # Daily snapshot keeps trends visible without turning health checks into issue churn.
-    - cron: "15 14 * * *"
 
 permissions:
   actions: read

--- a/.github/workflows/portal-community-layout-canary.yml
+++ b/.github/workflows/portal-community-layout-canary.yml
@@ -7,9 +7,6 @@ on:
         description: "Portal base URL"
         required: false
         default: "https://portal.monsoonfire.com"
-  schedule:
-    # Hourly guard for intermittent community sidebar/chiplet layout regressions.
-    - cron: "17 * * * *"
 
 permissions:
   contents: read

--- a/.github/workflows/portal-credential-health.yml
+++ b/.github/workflows/portal-credential-health.yml
@@ -2,9 +2,6 @@ name: Portal Credential Health
 
 on:
   workflow_dispatch:
-  schedule:
-    # Daily credential drift check is enough once the canary cadence is reduced.
-    - cron: "20 13 * * *"
 
 permissions:
   contents: read

--- a/.github/workflows/portal-daily-authenticated-canary.yml
+++ b/.github/workflows/portal-daily-authenticated-canary.yml
@@ -7,9 +7,6 @@ on:
         description: "Portal base URL"
         required: false
         default: "https://portal.monsoonfire.com"
-  schedule:
-    # Every 4 hours balances regression coverage with workflow cost.
-    - cron: "15 */4 * * *"
 
 permissions:
   actions: read

--- a/.github/workflows/portal-fixture-steward.yml
+++ b/.github/workflows/portal-fixture-steward.yml
@@ -7,9 +7,6 @@ on:
         description: "Fixture TTL days"
         required: false
         default: "21"
-  schedule:
-    # 06:55 America/Phoenix (MST year-round) = 13:55 UTC
-    - cron: "55 13 * * *"
 
 permissions:
   contents: read

--- a/.github/workflows/portal-studio-digest.yml
+++ b/.github/workflows/portal-studio-digest.yml
@@ -13,9 +13,6 @@ on:
         required: false
         default: false
         type: boolean
-  schedule:
-    # 07:10 America/Phoenix (MST year-round) = 14:10 UTC
-    - cron: "10 14 * * *"
 
 permissions:
   contents: read

--- a/.github/workflows/portal-theme-contrast-regression.yml
+++ b/.github/workflows/portal-theme-contrast-regression.yml
@@ -11,9 +11,6 @@ on:
         description: "Minimum contrast ratio threshold"
         required: false
         default: "4.2"
-  schedule:
-    # 15:40 America/Phoenix (MST year-round) = 22:40 UTC
-    - cron: "40 22 * * *"
 
 permissions:
   contents: read

--- a/.github/workflows/real-estate-quarterly-cadence.yml
+++ b/.github/workflows/real-estate-quarterly-cadence.yml
@@ -1,8 +1,6 @@
 name: Real Estate Quarterly Cadence
 
 on:
-  schedule:
-    - cron: "0 9 1 1,4,7,10 *"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/security-daily-scan.yml
+++ b/.github/workflows/security-daily-scan.yml
@@ -2,8 +2,6 @@ name: Daily Security Scan
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "20 9 * * *"
 
 permissions:
   contents: read

--- a/.github/workflows/security-key-rotation.yml
+++ b/.github/workflows/security-key-rotation.yml
@@ -23,8 +23,6 @@ on:
         description: Resolve provided alert number as revoked.
         required: false
         default: "false"
-  schedule:
-    - cron: "17 * * * *"
 
 permissions:
   contents: read

--- a/.github/workflows/website-prod-smoke.yml
+++ b/.github/workflows/website-prod-smoke.yml
@@ -7,8 +7,6 @@ on:
         description: "Website base URL"
         required: false
         default: "https://monsoonfire.com"
-  schedule:
-    - cron: "0 17 * * 2"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- remove cron schedules from older background GitHub Actions workflows
- keep manual, push, and pull_request triggers intact so checks stay available on demand
- reduce recurring workflow spend from hourly, daily, weekly, and quarterly jobs that are better handled manually or via Codex automation

## Validation
- verified .github/workflows no longer contains schedule or cron entries
- confirmed the change only trims top-level triggers and does not alter workflow jobs or permissions
- left active worktrees and local WIP checkouts untouched