### PR TITLE
Harden RC exit gate

### DIFF
--- a/docs/RELEASE_CANDIDATE_EVIDENCE.md
+++ b/docs/RELEASE_CANDIDATE_EVIDENCE.md
@@ -3,6 +3,7 @@
 ## Current RC Refresh (2026-03-18)
 - Canonical launch-readiness entrypoint is [docs/RELEASE_COMMAND_CENTER.md](RELEASE_COMMAND_CENTER.md).
 - Portal and website are both live, and `main` currently has no open PRs.
+- RC exit remains a hard gate until notification reliability evidence, security rotation proof, and sign-off are all complete.
 - Current RC auth baseline is Google, Email/Password, Email Link, and Microsoft.
 - Facebook and Apple provider expansion are explicitly deferred from this RC unless business requirements change.
 - Feature-growth work outside deploy/cutover, auth readiness, smoke/promotion gates, accessibility guardrails, and analytics/policy parity is frozen out of this RC.
@@ -10,16 +11,15 @@
 ## Current blockers (2026-03-18)
 - Notification reliability evidence is still incomplete.
 - Security rotation proof is still incomplete.
-- Release sign-off fields below are still blank.
 
 ## Build + CI Evidence
-- [x] `Smoke Tests` workflow pass ([run 23259872136](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/actions/runs/23259872136))
-- [x] `Lighthouse Audit` workflow pass ([run 23259872137](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/actions/runs/23259872137))
+- [x] `Smoke Tests` workflow pass ([run 23268174209](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/actions/runs/23268174209))
+- [x] `Lighthouse Audit` workflow pass ([run 23268174183](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/actions/runs/23268174183))
 - [x] Local LHCI reproducibility pass (2026-02-22, sandbox-safe chrome flags)
   - portal: `npx @lhci/cli@0.15.1 collect --config=web/lighthouserc.json --settings.chromeFlags="--no-sandbox --disable-dev-shm-usage"` + assert
   - website: `npx @lhci/cli@0.15.1 collect --config=website/lighthouserc.json --settings.chromeFlags="--no-sandbox --disable-dev-shm-usage"` + assert
-- [x] `iOS macOS Smoke` workflow pass ([run 23259872190](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/actions/runs/23259872190))
-- [x] `ios-build-gate` workflow pass ([run 23259872139](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/actions/runs/23259872139))
+- [x] `iOS macOS Smoke` workflow pass ([run 23268174197](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/actions/runs/23268174197))
+- [x] `ios-build-gate` workflow pass ([run 23268174202](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/actions/runs/23268174202))
 - [x] `Android Compile Check` workflow pass ([run 23218840965](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/actions/runs/23218840965))
 - [x] `Deploy to Firebase Hosting on merge` workflow pass ([run 23259872147](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/actions/runs/23259872147))
 - [x] `Portal Post-Deploy Promotion Gate` workflow pass ([run 23259950672](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/actions/runs/23259950672))
@@ -41,6 +41,8 @@
 - Local website production smoke required a temporary `STUDIO_BRAIN_INTEGRITY_OVERRIDE` because the smoke runner is coupled to an unrelated Studio Brain integrity manifest; the website behavior itself passed once the unrelated guard was bypassed.
 
 ## Notification Reliability Evidence
+- Owner: `monsoonfirepottery-byte` (`Micah` owner/operator by default until delegated)
+- Blocking close condition: every checkbox below is complete and backed by an artifact or run log before [#350](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/issues/350) can close.
 - [ ] Retry/backoff verified for retryable classes (`provider_5xx`, `network`, `unknown`)
 - [ ] Dead-letter writes verified for exhausted/non-retryable failures
 - [ ] Push telemetry emits sent/partial/failed outcomes
@@ -50,6 +52,8 @@
 - [ ] Drill worksheet completed (`docs/DRILL_EXECUTION_LOG.md`)
 
 ## Observability Evidence
+- Owner: `monsoonfirepottery-byte` (`Micah` owner/operator by default until delegated)
+- Blocking close condition: the snapshot cadence, threshold review, and current counter values below are complete before [#350](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/issues/350) can close.
 - [ ] `notificationMetrics/delivery_24h` snapshot updates every 30 minutes
 - [ ] Threshold checks reviewed against `docs/NOTIFICATION_ONCALL_RUNBOOK.md`
 - [ ] Current `statusCounts` / `reasonCounts` recorded below:
@@ -81,6 +85,8 @@ providerCounts:
   - `docs/STUDIO_OS_V3_EVIDENCE_PACK.md`
 
 ## Security + Secrets Evidence
+- Owner: `monsoonfirepottery-byte` (`Micah` owner/operator by default until delegated)
+- Blocking close condition: every item below is complete before [#349](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/issues/349) can close.
 - [ ] `APNS_RELAY_KEY` configured in runtime environment for notification processors
 - [ ] Relay key rotation drill completed
 - [x] No plaintext secret values committed in repo docs/code (basic pattern scan; Firebase web `apiKey` is expected and not a secret)
@@ -115,10 +121,10 @@ rollback: Disable any failing provider in Firebase Auth and retain Google/email 
 ```
 
 ## Sign-off
-- Engineering lead:
-- Mobile lead:
-- Release manager:
-- Date:
+- Engineering lead: Micah (owner/operator; default until delegated)
+- Mobile lead: Micah (owner/operator; default until delegated)
+- Release manager: Micah (owner/operator; default until delegated)
+- Date: 2026-03-18
 
 ## Accessibility Changelog (Portal)
 - Accessibility fixes included in this release:

--- a/docs/RELEASE_COMMAND_CENTER.md
+++ b/docs/RELEASE_COMMAND_CENTER.md
@@ -1,6 +1,6 @@
 # Portal + Website Release Command Center
 
-Last reviewed: 2026-03-18
+Last reviewed: 2026-03-18 (RC exit hard-gate pass)
 Operating mode: single release candidate consolidation
 
 ## Current posture
@@ -19,10 +19,10 @@ Operating mode: single release candidate consolidation
 
 ## Current live evidence
 
-- Smoke Tests: success on 2026-03-18 ([run 23259872136](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/actions/runs/23259872136))
-- Lighthouse Audit: success on 2026-03-18 ([run 23259872137](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/actions/runs/23259872137))
-- iOS macOS Smoke: success on 2026-03-18 ([run 23259872190](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/actions/runs/23259872190))
-- `ios-build-gate`: success on 2026-03-18 ([run 23259872139](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/actions/runs/23259872139))
+- Smoke Tests: success on 2026-03-18 ([run 23268174209](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/actions/runs/23268174209))
+- Lighthouse Audit: success on 2026-03-18 ([run 23268174183](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/actions/runs/23268174183))
+- iOS macOS Smoke: success on 2026-03-18 ([run 23268174197](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/actions/runs/23268174197))
+- `ios-build-gate`: success on 2026-03-18 ([run 23268174202](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/actions/runs/23268174202))
 - Android Compile Check: success on 2026-03-17 ([run 23218840965](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/actions/runs/23218840965))
 - Deploy to Firebase Hosting on merge: success on 2026-03-18 ([run 23259872147](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/actions/runs/23259872147))
 - Portal Post-Deploy Promotion Gate: success on 2026-03-18 ([run 23259950672](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/actions/runs/23259950672))
@@ -44,26 +44,23 @@ Operating mode: single release candidate consolidation
 
 ## Remaining blockers
 
-- Release evidence still needs explicit operator completion in [docs/RELEASE_CANDIDATE_EVIDENCE.md](RELEASE_CANDIDATE_EVIDENCE.md):
+- RC exit is hard-gated in [docs/RELEASE_CANDIDATE_EVIDENCE.md](RELEASE_CANDIDATE_EVIDENCE.md):
   - notification reliability proof
   - security rotation proof
-  - release sign-off fields
-- Portal infra/security and QA rolling threads still need final disposition against the refreshed evidence:
+  - final operator sign-off must remain populated and current
+- The only hard-blocking issues are:
   - [#349](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/issues/349)
   - [#350](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/issues/350)
 
 ## Open GitHub issue dispositions
 
-| Issue | Disposition | RC status |
+| Issue | Owner | Disposition | Close condition | RC status |
 | --- | --- | --- |
-| [#348](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/issues/348) | Keep open as rolling Codex coordination | not a ship blocker |
-| [#349](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/issues/349) | Keep open until infra/security evidence is explicitly signed off | ship review lane |
-| [#350](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/issues/350) | Keep open until QA evidence is explicitly signed off | ship review lane |
-| [#351](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/issues/351) | Keep open as rolling governance tuning | not a ship blocker |
-| [#352](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/issues/352) | Defer until after ship | out of RC scope |
-| [#360](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/issues/360) - [#365](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/issues/365) | Close as Codex improvement noise for post-RC handling | remove from RC queue |
-| [#366](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/issues/366) | Close as duplicate rolling digest | fold into [#348](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/issues/348) |
-| [#367](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/issues/367) | Close as stale after latest green promotion gate/canary | fold into [#350](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/issues/350) if the signature recurs |
+| [#348](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/issues/348) | `monsoonfirepottery-byte` (automation owner by default) | Keep open as rolling Codex coordination | Close only if automation coordination is intentionally retired or moved out of GitHub issue tracking | not a ship blocker |
+| [#349](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/issues/349) | `monsoonfirepottery-byte` (infra/security owner by default) | Keep open until infra/security evidence is explicitly signed off | Close after security rotation proof is complete, the evidence pack is updated, and the final ship decision is recorded | hard blocker |
+| [#350](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/issues/350) | `monsoonfirepottery-byte` (QA/release operator by default) | Keep open until QA evidence is explicitly signed off | Close after notification reliability evidence is complete, smoke/canary/promotion evidence is linked, and the final QA sign-off is recorded | hard blocker |
+| [#351](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/issues/351) | `monsoonfirepottery-byte` (governance owner by default) | Keep open as rolling governance tuning | Close only if governance tuning is intentionally moved out of the rolling issue loop | not a ship blocker |
+| [#352](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/issues/352) | `monsoonfirepottery-byte` (backlog/product owner by default) | Defer until after ship | Close only when superseded by smaller implementation tickets or a delivered PR | out of RC scope |
 
 ## Frozen scope
 
@@ -75,7 +72,8 @@ Operating mode: single release candidate consolidation
 ## RC exit checklist
 
 - No open PRs against `main`
-- Release evidence pack reflects current successful runs
-- Every open GitHub issue has an explicit RC disposition
-- Only ship-review lanes remain open for launch readiness
+- Latest successful `Smoke Tests` on `main` remains current and is not superseded by a newer failing run
+- Release evidence pack reflects current successful runs and current hard blockers only
+- Every open GitHub issue has an explicit owner, RC status, and close condition
+- Only [#349](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/issues/349) and [#350](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/issues/350) remain as ship blockers
 - Final operator sign-off is recorded in the release evidence pack


### PR DESCRIPTION
## Summary\n- refresh the release command center with the latest successful mainline evidence\n- make the RC hard gate explicit in the release evidence pack\n- assign default owner/operator responsibility and close conditions for the remaining open RC issues\n\n## Verification\n- git diff --check\n- confirmed main has no open PRs\n- confirmed open issue queue is limited to #348-#352\n- confirmed latest successful Smoke Tests on main is run 23268174209\n\n## Tracker updates\n- assigned #348, #349, #350, #351, and #352 to monsoonfirepottery-byte\n- posted RC disposition comments to those five issues