### PR TITLE
Close out RC notification evidence

### DIFF
--- a/docs/DRILL_EXECUTION_LOG.md
+++ b/docs/DRILL_EXECUTION_LOG.md
@@ -135,6 +135,73 @@ notificationMetrics/delivery_24h: aggregation endpoint returned ok=true with pop
 
 ---
 
+## Run metadata
+```txt
+dateUtc: 2026-03-18T22:45:24Z
+executedBy: codex (approved by micah)
+baseUrl: https://us-central1-monsoonfire-portal.cloudfunctions.net
+uid: 6qU0XDdJ32e4PUFVvdBfQKuAF7u1
+idTokenSource: local admin service-account JSON outside repo + Firebase Identity Toolkit signInWithCustomToken for the dedicated staff UID
+adminTokenUsed: no
+```
+
+## Command used
+```shell
+node ./scripts/ps1-run.mjs scripts/run-notification-drills.ps1 \
+  -BaseUrl "https://us-central1-monsoonfire-portal.cloudfunctions.net" \
+  -IdToken "<REDACTED_ID_TOKEN>" \
+  -Uid "6qU0XDdJ32e4PUFVvdBfQKuAF7u1" \
+  -LogFile "output/qa/notification-drill-2026-03-18T22-45-24-279Z.jsonl" \
+  -OutputJson
+```
+
+## Captured outputs
+```txt
+runNotificationFailureDrill responses:
+- auth: 200 ok, job queued -> failed after attempt 1 -> dead-lettered
+- provider_4xx: 200 ok, job queued -> failed after attempt 1 -> dead-lettered
+- provider_5xx: 200 ok, job queued -> retried to attempt 5 after queue index remediation -> dead-lettered
+- network: 200 ok, job queued -> retried to attempt 5 after queue index remediation -> dead-lettered
+- success: 200 ok, job queued -> completed with sent telemetry
+- unknown (live runtime proof): seeded separately after the drill run -> failed with `APNS_RELAY_URL not configured` -> retried to attempt 5 -> dead-lettered
+
+runNotificationMetricsAggregationNow response:
+- 200 ok with totalAttempts=5
+- statusCounts={"sent":4,"failed":1}
+- reasonCounts={"DRILL_SUCCESS_SIMULATED":4,"APNS_RELAY_URL not configured":1}
+- providerCounts={"relay":5}
+```
+
+## Firestore checks
+```txt
+notificationJobs:
+- auth -> status=failed, attemptCount=1, lastErrorClass=auth
+- provider_4xx -> status=failed, attemptCount=1, lastErrorClass=provider_4xx
+- provider_5xx -> status=failed, attemptCount=5, lastErrorClass=provider_5xx
+- network -> status=failed, attemptCount=5, lastErrorClass=network
+- success -> status=done, attemptCount=1
+- unknown -> status=failed, attemptCount=5, lastErrorClass=unknown
+
+notificationJobDeadLetters:
+- auth, provider_4xx, provider_5xx, network, and unknown all present in the final drill bundle
+
+notificationDeliveryAttempts:
+- live production proof: sent (`DRILL_SUCCESS_SIMULATED`) and failed (`APNS_RELAY_URL not configured`) recorded
+- local relay-parity proof: `PUSH_PROVIDER_PARTIAL` recorded with provider code `BadDeviceToken`
+
+notificationMetrics/delivery_24h:
+- manual aggregation + scheduler describe confirmed the snapshot is updating and readable
+- final live counters recorded in docs/RELEASE_CANDIDATE_EVIDENCE.md
+```
+
+## Evidence handoff
+- Production drill bundle: `output/qa/notification-evidence-2026-03-18T22-45-24-279Z.json`
+- Production drill raw log: `output/qa/notification-drill-2026-03-18T22-45-24-279Z-raw.txt`
+- Production drill structured JSONL: `output/qa/notification-drill-2026-03-18T22-45-24-279Z.jsonl`
+- Local relay-parity proof: `output/qa/notification-partial-parity-local.json`
+
+---
+
 # Studio OS v3 Drill Execution Log
 
 Use this section for Studio Brain / Studio OS v3 safety drills.

--- a/docs/RELEASE_CANDIDATE_EVIDENCE.md
+++ b/docs/RELEASE_CANDIDATE_EVIDENCE.md
@@ -39,30 +39,49 @@
 - The live portal cutover verifier now confirms `/.well-known/apple-app-site-association` returns `200` from `https://portal.monsoonfire.com`.
 - The website production smoke needed a smoke-runner selector refresh from `pricing` to `payments` to match the current support taxonomy.
 - Local website production smoke required a temporary `STUDIO_BRAIN_INTEGRITY_OVERRIDE` because the smoke runner is coupled to an unrelated Studio Brain integrity manifest; the website behavior itself passed once the unrelated guard was bypassed.
+- Notification reliability evidence was refreshed on 2026-03-18 with a live production drill bundle (`output/qa/notification-evidence-2026-03-18T22-45-24-279Z.json`) plus a local relay-parity proof (`output/qa/notification-partial-parity-local.json`).
+- The production reliability refresh surfaced and fixed missing Firestore indexes for `notificationJobs(status, runAfter)` and `deviceTokens(active, updatedAt)` before the final proof run.
 
 ## Notification Reliability Evidence
 - Owner: `monsoonfirepottery-byte` (`Micah` owner/operator by default until delegated)
 - Blocking close condition: every checkbox below is complete and backed by an artifact or run log before [#350](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/issues/350) can close.
-- [ ] Retry/backoff verified for retryable classes (`provider_5xx`, `network`, `unknown`)
-- [ ] Dead-letter writes verified for exhausted/non-retryable failures
-- [ ] Push telemetry emits sent/partial/failed outcomes
-- [ ] Token invalidation verified on provider invalid-token responses
-- [ ] Stale-token cleanup scheduler verified
-- [ ] Drill script run log captured (`node ./scripts/ps1-run.mjs scripts/run-notification-drills.ps1`)
-- [ ] Drill worksheet completed (`docs/DRILL_EXECUTION_LOG.md`)
+- [x] Retry/backoff verified for retryable classes (`provider_5xx`, `network`, `unknown`)
+- [x] Dead-letter writes verified for exhausted/non-retryable failures
+- [x] Push telemetry emits sent/partial/failed outcomes
+- [x] Token invalidation verified on provider invalid-token responses
+- [x] Stale-token cleanup scheduler verified
+- [x] Drill script run log captured (`node ./scripts/ps1-run.mjs scripts/run-notification-drills.ps1`)
+- [x] Drill worksheet completed (`docs/DRILL_EXECUTION_LOG.md`)
+
+Evidence:
+- Production drill bundle: `output/qa/notification-evidence-2026-03-18T22-45-24-279Z.json`
+- Production drill raw log: `output/qa/notification-drill-2026-03-18T22-45-24-279Z-raw.txt`
+- Production drill structured JSONL: `output/qa/notification-drill-2026-03-18T22-45-24-279Z.jsonl`
+- Local relay-parity proof: `output/qa/notification-partial-parity-local.json`
+- Live proof summary:
+  - `auth` and `provider_4xx` moved to dead-letter after a single non-retryable attempt.
+  - `provider_5xx`, `network`, and `unknown` exhausted after 5 attempts and landed in dead-letter once the missing queue index was deployed.
+  - `success` wrote the sent-path telemetry row.
+  - Local emulator proof with a mocked relay wrote `PUSH_PROVIDER_PARTIAL` telemetry and deactivated the invalid token with `deactivationReason=BadDeviceToken`.
 
 ## Observability Evidence
 - Owner: `monsoonfirepottery-byte` (`Micah` owner/operator by default until delegated)
 - Blocking close condition: the snapshot cadence, threshold review, and current counter values below are complete before [#350](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/issues/350) can close.
-- [ ] `notificationMetrics/delivery_24h` snapshot updates every 30 minutes
-- [ ] Threshold checks reviewed against `docs/NOTIFICATION_ONCALL_RUNBOOK.md`
-- [ ] Current `statusCounts` / `reasonCounts` recorded below:
+- [x] `notificationMetrics/delivery_24h` snapshot updates every 30 minutes
+- [x] Threshold checks reviewed against `docs/NOTIFICATION_ONCALL_RUNBOOK.md`
+- [x] Current `statusCounts` / `reasonCounts` recorded below:
 
 ```txt
-statusCounts:
-reasonCounts:
-providerCounts:
+statusCounts: {"sent":4,"failed":1}
+reasonCounts: {"DRILL_SUCCESS_SIMULATED":4,"APNS_RELAY_URL not configured":1}
+providerCounts: {"relay":5}
 ```
+
+Threshold review:
+- Baseline threshold from `docs/NOTIFICATION_ONCALL_RUNBOOK.md`: failed delivery attempts should remain <= 10% of total over 24h.
+- Current snapshot is intentionally drill-inflated (`1 failed / 5 total = 20%`) because the RC proof injected an `unknown` failure to verify dead-letter handling after the queue index fix.
+- Scheduler state is healthy after index remediation (`processQueuedNotificationJobs`, `cleanupStaleDeviceTokens`, and `aggregateNotificationDeliveryMetrics` all report empty `status` objects in the final describe payload).
+- No newer failing smoke/canary/promotion workflow supersedes the current green mainline evidence in `docs/RELEASE_COMMAND_CENTER.md`.
 
 ## Studio OS v3 Operational Evidence
 - [x] Drill log scaffolding seeded for all quarterly scenarios in `docs/DRILL_EXECUTION_LOG.md`:
@@ -99,6 +118,9 @@ validationStart:
 validationEnd:
 rollbackNeeded: yes/no
 ```
+
+Current blocker note:
+- Live runtime proof on 2026-03-18 still shows the notification processor failing the `unknown` path with `APNS_RELAY_URL not configured`, and the deployed service configs do not currently expose relay runtime bindings. This keeps [#349](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/issues/349) open even though notification reliability evidence is now complete.
 
 ## Risk Register (alpha -> beta gate)
 - [x] Risk ID, owner, mitigation, and rollback path recorded for each open risk

--- a/docs/RELEASE_COMMAND_CENTER.md
+++ b/docs/RELEASE_COMMAND_CENTER.md
@@ -1,6 +1,6 @@
 # Portal + Website Release Command Center
 
-Last reviewed: 2026-03-18 (RC exit hard-gate pass)
+Last reviewed: 2026-03-18 (notification evidence complete; security blocker remains)
 Operating mode: single release candidate consolidation
 
 ## Current posture
@@ -34,6 +34,11 @@ Operating mode: single release candidate consolidation
   - [output/playwright/prod/smoke-summary.json](../output/playwright/prod/smoke-summary.json)
   - Smoke currently passes after aligning the support-topic selector to the live `payments` taxonomy.
   - Local execution required a temporary `STUDIO_BRAIN_INTEGRITY_OVERRIDE` because the smoke runner is coupled to an unrelated Studio Brain integrity guard.
+- Notification reliability proof refreshed on 2026-03-18:
+  - [output/qa/notification-evidence-2026-03-18T22-45-24-279Z.json](../output/qa/notification-evidence-2026-03-18T22-45-24-279Z.json)
+  - [output/qa/notification-partial-parity-local.json](../output/qa/notification-partial-parity-local.json)
+  - Production proof now covers retry exhaustion, dead letters, aggregate metrics, and stale-token cleanup after Firestore index remediation.
+  - Local parity proof covers `PUSH_PROVIDER_PARTIAL` plus invalid-token deactivation (`BadDeviceToken`) against the real notification code path.
 
 ## RC decisions
 
@@ -45,12 +50,12 @@ Operating mode: single release candidate consolidation
 ## Remaining blockers
 
 - RC exit is hard-gated in [docs/RELEASE_CANDIDATE_EVIDENCE.md](RELEASE_CANDIDATE_EVIDENCE.md):
-  - notification reliability proof
   - security rotation proof
   - final operator sign-off must remain populated and current
-- The only hard-blocking issues are:
-  - [#349](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/issues/349)
-  - [#350](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/issues/350)
+- The only remaining hard-blocking issue is [#349](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/issues/349).
+- Current blocker detail:
+  - live runtime proof still shows the push relay path failing with `APNS_RELAY_URL not configured`
+  - APNS relay runtime configuration and rotation evidence remain incomplete
 
 ## Open GitHub issue dispositions
 
@@ -58,7 +63,6 @@ Operating mode: single release candidate consolidation
 | --- | --- | --- |
 | [#348](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/issues/348) | `monsoonfirepottery-byte` (automation owner by default) | Keep open as rolling Codex coordination | Close only if automation coordination is intentionally retired or moved out of GitHub issue tracking | not a ship blocker |
 | [#349](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/issues/349) | `monsoonfirepottery-byte` (infra/security owner by default) | Keep open until infra/security evidence is explicitly signed off | Close after security rotation proof is complete, the evidence pack is updated, and the final ship decision is recorded | hard blocker |
-| [#350](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/issues/350) | `monsoonfirepottery-byte` (QA/release operator by default) | Keep open until QA evidence is explicitly signed off | Close after notification reliability evidence is complete, smoke/canary/promotion evidence is linked, and the final QA sign-off is recorded | hard blocker |
 | [#351](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/issues/351) | `monsoonfirepottery-byte` (governance owner by default) | Keep open as rolling governance tuning | Close only if governance tuning is intentionally moved out of the rolling issue loop | not a ship blocker |
 | [#352](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/issues/352) | `monsoonfirepottery-byte` (backlog/product owner by default) | Defer until after ship | Close only when superseded by smaller implementation tickets or a delivered PR | out of RC scope |
 
@@ -75,5 +79,5 @@ Operating mode: single release candidate consolidation
 - Latest successful `Smoke Tests` on `main` remains current and is not superseded by a newer failing run
 - Release evidence pack reflects current successful runs and current hard blockers only
 - Every open GitHub issue has an explicit owner, RC status, and close condition
-- Only [#349](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/issues/349) and [#350](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/issues/350) remain as ship blockers
+- Only [#349](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/issues/349) remains as a ship blocker
 - Final operator sign-off is recorded in the release evidence pack

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -93,6 +93,14 @@
       ]
     },
     {
+      "collectionGroup": "notificationJobs",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "status", "order": "ASCENDING" },
+        { "fieldPath": "runAfter", "order": "ASCENDING" }
+      ]
+    },
+    {
       "collectionGroup": "batches",
       "queryScope": "COLLECTION",
       "fields": [

--- a/scripts/firestore-index-contract-guard.mjs
+++ b/scripts/firestore-index-contract-guard.mjs
@@ -56,6 +56,26 @@ const requiredIndexes = [
     ],
     reason: "My pieces active batch list",
   },
+  {
+    id: "deviceTokens-active-updatedAt",
+    collectionGroup: "deviceTokens",
+    queryScope: "COLLECTION_GROUP",
+    fields: [
+      { fieldPath: "active", order: "ASCENDING" },
+      { fieldPath: "updatedAt", order: "ASCENDING" },
+    ],
+    reason: "Stale device token cleanup scheduler (collectionGroup active + updatedAt cutoff)",
+  },
+  {
+    id: "notificationJobs-status-runAfter",
+    collectionGroup: "notificationJobs",
+    queryScope: "COLLECTION",
+    fields: [
+      { fieldPath: "status", order: "ASCENDING" },
+      { fieldPath: "runAfter", order: "ASCENDING" },
+    ],
+    reason: "Queued notification processor scheduler (status equality + runAfter cutoff)",
+  },
 ];
 
 function parseArgs(argv) {


### PR DESCRIPTION
## Summary
- record the completed RC notification reliability and observability evidence
- add the missing Firestore index contract for queued notification jobs
- keep the RC command center focused on the one remaining security blocker

## What changed
- update the release evidence and drill log with the 2026-03-18 production drill bundle and local relay-parity proof
- mark notification reliability and observability evidence complete for RC exit
- add the 
otificationJobs(status, runAfter) composite index and guard coverage
- update the release command center so only #349 remains as the ship blocker

## Notes
- #350 is complete after this merges
- #349 stays open because live relay runtime configuration and rotation proof are still incomplete

Closes #350