### PR TITLE
feat(portal): ship task-first staff home

### DIFF
--- a/.github/workflows/ci-smoke.yml
+++ b/.github/workflows/ci-smoke.yml
@@ -213,7 +213,7 @@ jobs:
 
       - name: Portal Playwright deep smoke (manual)
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.run_deep_playwright == 'true' || github.event_name == 'schedule' }}
-        run: npm run functions:smoke:cors -- --base-url https://us-central1-monsoonfire-portal.cloudfunctions.net --origin https://monsoonfire-portal.web.app && npm run test:automation:ui:deep
+        run: npm run functions:smoke:cors -- --base-url https://us-central1-monsoonfire-portal.cloudfunctions.net --origin https://portal.monsoonfire.com && npm run test:automation:ui:deep
 
       - name: Journey deep lane (manual/scheduled)
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.run_deep_playwright == 'true' || github.event_name == 'schedule' }}

--- a/.github/workflows/ci-smoke.yml
+++ b/.github/workflows/ci-smoke.yml
@@ -219,7 +219,7 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.run_deep_playwright == 'true' || github.event_name == 'schedule' }}
         env:
           MF_REQUIRE_RESERVATIONS_PLAYWRIGHT: "1"
-          PORTAL_URL: ${{ vars.PORTAL_JOURNEY_BASE_URL || 'https://monsoonfire-portal.web.app' }}
+          PORTAL_URL: ${{ vars.PORTAL_JOURNEY_BASE_URL || 'https://portal.monsoonfire.com' }}
           PORTAL_CLIENT_EMAIL: ${{ secrets.PORTAL_CLIENT_EMAIL }}
           PORTAL_CLIENT_PASSWORD: ${{ secrets.PORTAL_CLIENT_PASSWORD }}
           PORTAL_STAFF_EMAIL: ${{ secrets.PORTAL_STAFF_EMAIL }}

--- a/.github/workflows/portal-prod-smoke.yml
+++ b/.github/workflows/portal-prod-smoke.yml
@@ -61,6 +61,12 @@ jobs:
           FIREBASE_WEB_API_KEY: ${{ secrets.FIREBASE_WEB_API_KEY }}
         run: node ./scripts/resolve-firebase-api-key.mjs --github-output --json
 
+      - name: Verify deployed bundle and auth bootstrap
+        run: |
+          node ./web/deploy/namecheap/verify-cutover.mjs \
+            --portal-url "${{ steps.base_url.outputs.value }}" \
+            --report-path output/qa/portal-prod-cutover-verify.json
+
       - name: Build production smoke feedback profile
         continue-on-error: true
         env:
@@ -160,6 +166,15 @@ jobs:
         with:
           name: portal-virtual-staff-regression
           path: output/qa/portal-virtual-staff-regression-prod.json
+          if-no-files-found: ignore
+          retention-days: 14
+
+      - name: Upload production cutover verify report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: portal-prod-cutover-verify
+          path: output/qa/portal-prod-cutover-verify.json
           if-no-files-found: ignore
           retention-days: 14
 

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -16,3 +16,6 @@ paths = [
   '''^studio-brain/src/config/env\.test\.ts$''',
   '''^studio-brain/lib/config/env\.test\.js$'''
 ]
+regexes = [
+  '''AIzaSyC7ynej0nGJas9me9M5oW6jHfLsWe5gHbU'''
+]

--- a/docs/EMULATOR_RUNBOOK.md
+++ b/docs/EMULATOR_RUNBOOK.md
@@ -145,7 +145,7 @@ Acceptable backend status codes for proxy checks depend on auth/runtime state (`
   - `npm run studio:network:check:gate -- --strict`
   - `npm run guardrails:check -- --strict`
   - `npm run studio:cutover:gate -- --no-smoke`
-  - `npm run studio:cutover:gate -- --portal-deep` (or `npm run studio:cutover:gate -- --portal-deep --portal-base-url https://monsoonfire-portal.web.app` for production-aligned API target)
+  - `npm run studio:cutover:gate -- --portal-deep` (or `npm run studio:cutover:gate -- --portal-deep --portal-base-url https://portal.monsoonfire.com` for production-aligned API target)
   - `npm run integrity:check`
 
 #### Expected runtime (cutover gate)

--- a/docs/runbooks/PORTAL_PLAYWRIGHT_SMOKE.md
+++ b/docs/runbooks/PORTAL_PLAYWRIGHT_SMOKE.md
@@ -52,7 +52,7 @@ flows are not reached), `/readyz` probe is still recorded as skipped and non-aut
 You can also pass custom endpoints explicitly:
 ```bash
 node ./scripts/portal-playwright-smoke.mjs \
-  --base-url https://monsoonfire-portal.web.app \
+  --base-url https://portal.monsoonfire.com \
   --deep \
   --functions-base-url https://us-central1-monsoonfire-portal.cloudfunctions.net \
   --studio-brain-base-url https://monsoonfire-studio-brain.example.com \
@@ -62,7 +62,7 @@ node ./scripts/portal-playwright-smoke.mjs \
 If you need endpoint probes to include explicit auth context:
 ```bash
 node ./scripts/portal-playwright-smoke.mjs \
-  --base-url https://monsoonfire-portal.web.app \
+  --base-url https://portal.monsoonfire.com \
   --deep \
   --probe-bearer "$ID_TOKEN" \
   --probe-admin-token "$X_ADMIN_TOKEN" \
@@ -73,7 +73,7 @@ node ./scripts/portal-playwright-smoke.mjs \
 If you need to force the deep probe against an observed studio-brain local URL (for reproducing `127.0.0.1`/`localhost` regressions), pass it explicitly:
 ```bash
 node ./scripts/portal-playwright-smoke.mjs \
-  --base-url https://monsoonfire-portal.web.app \
+  --base-url https://portal.monsoonfire.com \
   --deep \
   --studio-brain-base-url http://127.0.0.1:8787 \
   --probe-credential-mode same-origin \
@@ -83,7 +83,7 @@ node ./scripts/portal-playwright-smoke.mjs \
 For full browser parity (login-gated staff routes) run with real credentials:
 ```bash
 node ./scripts/portal-playwright-smoke.mjs \
-  --base-url https://monsoonfire-portal.web.app \
+  --base-url https://portal.monsoonfire.com \
   --deep \
   --with-auth \
   --staff-email "$STAFF_EMAIL" \

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "test:automation:ui:deep": "npm run portal:smoke:playwright:deep",
     "test:automation:bundle": "npm run build:web && npm run studio:host:contract:scan && npm run check:studio-brain:bundle",
     "test:automation": "npm run test:automation:unit && npm run test:automation:gateway && npm run test:automation:checks && npm run test:automation:ui && npm run test:automation:bundle",
-    "test:automation:deep": "npm run test:automation && npm run functions:smoke:cors -- --base-url https://us-central1-monsoonfire-portal.cloudfunctions.net --origin https://monsoonfire-portal.web.app && npm run test:automation:ui:deep",
+    "test:automation:deep": "npm run test:automation && npm run functions:smoke:cors -- --base-url https://us-central1-monsoonfire-portal.cloudfunctions.net --origin https://portal.monsoonfire.com && npm run test:automation:ui:deep",
     "test:stripe:negative": "npm --prefix functions run build && node --test functions/lib/stripeConfig.test.js",
     "test:journey:contracts": "node ./scripts/check-continue-journey-contract.mjs --strict --json && node ./scripts/check-journey-fixtures.mjs --strict --json",
     "test:journey:fast": "node ./scripts/run-journey-suite.mjs --mode fast --strict --json --artifact output/journey-tests/fast.json",

--- a/scripts/deploy-firebase-safe.mjs
+++ b/scripts/deploy-firebase-safe.mjs
@@ -20,7 +20,7 @@ const DEFAULT_QUOTA_RETRIES = 1;
 
 const FIREBASE_WEB_APP_ID = "1:667865114946:web:7275b02c9345aa975200db";
 const FIREBASE_API_KEY_REGEX = /^AIza[0-9A-Za-z_-]{20,}$/;
-const FIREBASE_EMBEDDED_KEY_REGEX = /VITE_FIREBASE_API_KEY["']?\s*:\s*["']AIza[0-9A-Za-z_-]{20,}["']/;
+const FIREBASE_COMPILED_KEY_REGEX = /AIza[0-9A-Za-z_-]{20,}/;
 const FIREBASE_MISSING_KEY_TOKEN = "MISSING_VITE_FIREBASE_API_KEY";
 
 const QUOTA_SENSITIVE_FUNCTIONS = new Set([
@@ -362,7 +362,7 @@ function inspectFirebaseBuildArtifacts(jsAssets) {
     if (content.includes(FIREBASE_MISSING_KEY_TOKEN)) {
       placeholderTokenFiles.push(path);
     }
-    if (FIREBASE_EMBEDDED_KEY_REGEX.test(content)) {
+    if (FIREBASE_COMPILED_KEY_REGEX.test(content)) {
       compiledApiKeyFiles.push(path);
     }
   }
@@ -376,8 +376,8 @@ function inspectFirebaseBuildArtifacts(jsAssets) {
           : "firebase_api_key_not_embedded",
       message:
         placeholderTokenFiles.length > 0
-          ? `Build output contains ${FIREBASE_MISSING_KEY_TOKEN} without an embedded VITE_FIREBASE_API_KEY value.`
-          : "Build output does not contain a compiled VITE_FIREBASE_API_KEY value.",
+          ? `Build output contains ${FIREBASE_MISSING_KEY_TOKEN} without a compiled Firebase API key value.`
+          : "Build output does not contain a compiled Firebase API key value.",
       placeholderTokenFiles,
       compiledApiKeyFiles,
     };
@@ -385,9 +385,9 @@ function inspectFirebaseBuildArtifacts(jsAssets) {
 
   if (placeholderTokenFiles.length > 0) {
     return {
-      ok: true,
-      code: "firebase_api_key_embedded_with_fallback_token",
-      message: `Build output embeds a Firebase API key; ${FIREBASE_MISSING_KEY_TOKEN} is present as a fallback literal.`,
+      ok: false,
+      code: "firebase_api_key_placeholder_token_detected",
+      message: `Build output still contains ${FIREBASE_MISSING_KEY_TOKEN}.`,
       placeholderTokenFiles,
       compiledApiKeyFiles,
     };

--- a/scripts/deploy-firebase-safe.test.mjs
+++ b/scripts/deploy-firebase-safe.test.mjs
@@ -62,22 +62,22 @@ test("inspectFirebaseBuildArtifacts passes when key is embedded", () => {
   const result = inspectFirebaseBuildArtifacts([
     {
       path: "/tmp/index.js",
-      content: `const ENV={VITE_FIREBASE_API_KEY:"${SAMPLE_KEY}"};`,
+      content: `const firebaseConfig={apiKey:"${SAMPLE_KEY}"};`,
     },
   ]);
   assert.equal(result.ok, true);
   assert.equal(result.code, "firebase_api_key_embedded");
 });
 
-test("inspectFirebaseBuildArtifacts allows fallback token when key is embedded", () => {
+test("inspectFirebaseBuildArtifacts blocks placeholder token even when key is embedded", () => {
   const result = inspectFirebaseBuildArtifacts([
     {
       path: "/tmp/index.js",
-      content: `const ENV={VITE_FIREBASE_API_KEY:"${SAMPLE_KEY}"};const x="MISSING_VITE_FIREBASE_API_KEY";`,
+      content: `const firebaseConfig={apiKey:"${SAMPLE_KEY}"};const x="MISSING_VITE_FIREBASE_API_KEY";`,
     },
   ]);
-  assert.equal(result.ok, true);
-  assert.equal(result.code, "firebase_api_key_embedded_with_fallback_token");
+  assert.equal(result.ok, false);
+  assert.equal(result.code, "firebase_api_key_placeholder_token_detected");
 });
 
 test("parseJsonObjectFromMixedOutput tolerates prefixed logs", () => {

--- a/scripts/deploy-namecheap-portal.mjs
+++ b/scripts/deploy-namecheap-portal.mjs
@@ -44,7 +44,8 @@ if (options.help) {
 const FIREBASE_WEB_APP_ID = "1:667865114946:web:7275b02c9345aa975200db";
 const FIREBASE_PROJECT_ID = "monsoonfire-portal";
 const FIREBASE_API_KEY_REGEX = /^AIza[0-9A-Za-z_-]{20,}$/;
-const FIREBASE_EMBEDDED_KEY_REGEX = /VITE_FIREBASE_API_KEY["']?\s*:\s*["']AIza[0-9A-Za-z_-]{20,}["']/;
+const FIREBASE_COMPILED_KEY_REGEX = /AIza[0-9A-Za-z_-]{20,}/g;
+const FIREBASE_MISSING_KEY_TOKEN = "MISSING_VITE_FIREBASE_API_KEY";
 
 if (!options.server.trim()) {
   fail("Missing --server (or WEBSITE_DEPLOY_SERVER).");
@@ -468,11 +469,34 @@ function shellQuote(raw) {
   return `'${String(raw).replace(/'/g, "'\"'\"'")}'`;
 }
 
+function resolveCommand(command) {
+  if (process.platform !== "win32") {
+    return command;
+  }
+  if (command === "npm" || command === "npx") {
+    return `${command}.cmd`;
+  }
+  if (command === "rsync") {
+    const candidates = [
+      "C:/msys64/usr/bin/rsync.exe",
+      "C:/Program Files/Git/usr/bin/rsync.exe",
+      "C:/Program Files/Git/bin/rsync.exe",
+    ];
+    for (const candidate of candidates) {
+      if (existsSync(candidate)) {
+        return candidate;
+      }
+    }
+  }
+  return command;
+}
+
 function run(command, args, options = {}) {
   if (options.label) {
     process.stdout.write(`${options.label}...\n`);
   }
-  const result = spawnSync(command, args, {
+  const resolvedCommand = resolveCommand(command);
+  const result = spawnSync(resolvedCommand, args, {
     stdio: "inherit",
     shell: false,
     env: options.env || process.env,
@@ -485,12 +509,12 @@ function run(command, args, options = {}) {
         status: 1,
       };
     }
-    throw new Error(`${command} failed: ${result.error.message}`);
+    throw new Error(`${resolvedCommand} failed: ${result.error.message}`);
   }
 
   const status = typeof result.status === "number" ? result.status : 1;
   if (status !== 0 && !options.allowFailure) {
-    throw new Error(`${command} exited with status ${status}`);
+    throw new Error(`${resolvedCommand} exited with status ${status}`);
   }
 
   return {
@@ -500,7 +524,8 @@ function run(command, args, options = {}) {
 }
 
 function runCapture(command, args, options = {}) {
-  return spawnSync(command, args, {
+  const resolvedCommand = resolveCommand(command);
+  return spawnSync(resolvedCommand, args, {
     stdio: ["ignore", "pipe", "pipe"],
     shell: false,
     encoding: "utf8",
@@ -586,23 +611,36 @@ function collectFiles(rootDir, includeFile) {
 
 function assertFirebaseApiKeyIsEmbedded(distDir) {
   const buildFiles = collectFiles(distDir, (filePath) => filePath.endsWith(".js"));
-  const matchingFiles = [];
+  const compiledApiKeyFiles = [];
+  const placeholderTokenFiles = [];
 
   for (const filePath of buildFiles) {
     const text = readFileSync(filePath, "utf8");
-    if (FIREBASE_EMBEDDED_KEY_REGEX.test(text)) {
-      matchingFiles.push(filePath);
+    if (extractCompiledFirebaseApiKeys(text).length > 0) {
+      compiledApiKeyFiles.push(filePath);
+    }
+    if (text.includes(FIREBASE_MISSING_KEY_TOKEN)) {
+      placeholderTokenFiles.push(filePath);
     }
   }
 
-  if (matchingFiles.length > 0) {
-    return;
+  if (placeholderTokenFiles.length > 0) {
+    fail(
+      `Build output still contains ${FIREBASE_MISSING_KEY_TOKEN}; refusing deploy.\n` +
+        `Affected files:\n - ${placeholderTokenFiles.join("\n - ")}`
+    );
   }
+  if (compiledApiKeyFiles.length === 0) {
+    fail(
+      "Build output does not include a compiled Firebase API key value; refusing deploy.\n" +
+        "Set VITE_FIREBASE_API_KEY (or ensure web build injects it) before deploy."
+    );
+  }
+}
 
-  fail(
-    "Build output does not include a compiled VITE_FIREBASE_API_KEY value; refusing deploy.\n" +
-      "Set VITE_FIREBASE_API_KEY (or ensure web build injects it) before deploy."
-  );
+function extractCompiledFirebaseApiKeys(text) {
+  const matches = String(text || "").match(FIREBASE_COMPILED_KEY_REGEX) || [];
+  return [...new Set(matches)];
 }
 
 function writeJson(path, payload) {

--- a/scripts/phased-smoke-gate.mjs
+++ b/scripts/phased-smoke-gate.mjs
@@ -595,7 +595,7 @@ function createPhaseProfiles() {
       },
       {
         id: "production-portal-smoke-command",
-        command: "node ./scripts/portal-playwright-smoke.mjs --base-url https://monsoonfire-portal.web.app --output-dir output/playwright/prod-smoke",
+        command: "node ./scripts/portal-playwright-smoke.mjs --base-url https://portal.monsoonfire.com --output-dir output/playwright/prod-smoke",
         severity: "error",
         category: "smoke",
         commandExists: true,

--- a/scripts/portal-authenticated-canary.mjs
+++ b/scripts/portal-authenticated-canary.mjs
@@ -46,6 +46,7 @@ const NAV_DOCK_SWEEP_TARGETS = [
   },
 ];
 const STAFF_PATHS = {
+  home: "/staff",
   cockpit: "/staff/cockpit",
   workshops: "/staff/workshops",
   system: "/staff/system",
@@ -53,6 +54,7 @@ const STAFF_PATHS = {
 const STAFF_PATHS_CASE_NOISE = "/STAFF/Workshops";
 const STAFF_FALLBACK_PATH = "/staff";
 const STAFF_CANONICAL_TARGETS = {
+  [STAFF_PATHS.home]: "/staff",
   [STAFF_PATHS.cockpit]: "/staff/cockpit",
   [STAFF_PATHS.workshops]: "/staff/cockpit/operations",
   [STAFF_PATHS.system]: "/staff/cockpit/platform",
@@ -1861,6 +1863,25 @@ async function run() {
             : "Skipped strict staff-route assertions in theme-only mode.",
       });
     } else {
+      await check(summary, "staff home path resolves to the task-first landing", async () => {
+        await assertStaffWorkspaceRoute(
+          page,
+          summary,
+          options.baseUrl,
+          STAFF_PATHS.home,
+          STAFF_PATHS.home,
+          "Staff tasks",
+          "Needs attention now",
+        );
+        await takeScreenshot(
+          page,
+          options.outputDir,
+          "canary-02c-staff-home.png",
+          summary,
+          "staff task home"
+        );
+      });
+
       await check(summary, "staff dedicated cockpit path resolves to cockpit workspace", async () => {
         await assertStaffWorkspaceRoute(
           page,
@@ -1872,7 +1893,7 @@ async function run() {
         await takeScreenshot(
           page,
           options.outputDir,
-          "canary-02c-staff-cockpit.png",
+          "canary-02d-staff-cockpit.png",
           summary,
           "staff cockpit workspace"
         );
@@ -1889,7 +1910,7 @@ async function run() {
         await takeScreenshot(
           page,
           options.outputDir,
-          "canary-02d-staff-workshops.png",
+          "canary-02e-staff-workshops.png",
           summary,
           "staff workshops workspace"
         );
@@ -1906,7 +1927,7 @@ async function run() {
         await takeScreenshot(
           page,
           options.outputDir,
-          "canary-02e-staff-system.png",
+          "canary-02f-staff-system.png",
           summary,
           "staff system workspace"
         );
@@ -1944,7 +1965,7 @@ async function run() {
           `${STAFF_UNKNOWN_FALLBACK_PATH}/?from=legacy`,
           STAFF_FALLBACK_PATH,
         );
-        await takeScreenshot(page, options.outputDir, "canary-02f-staff-recovery.png", summary, "staff path fallback");
+        await takeScreenshot(page, options.outputDir, "canary-02g-staff-recovery.png", summary, "staff path fallback");
       });
     }
 

--- a/scripts/portal-playwright-smoke.mjs
+++ b/scripts/portal-playwright-smoke.mjs
@@ -14,7 +14,7 @@ import { resolveStudioBrainNetworkProfile } from "./studio-network-profile.mjs";
 const __filename = fileURLToPath(import.meta.url);
 const repoRoot = resolve(__filename, "..", "..");
 
-const DEFAULT_BASE_URL = "https://monsoonfire-portal.web.app";
+const DEFAULT_BASE_URL = "https://portal.monsoonfire.com";
 const defaultOutputRoot = resolve(repoRoot, "output", "playwright", "portal");
 const DEFAULT_FUNCTIONS_BASE_URL = "https://us-central1-monsoonfire-portal.cloudfunctions.net";
 const DEFAULT_STUDIO_BRAIN_READYZ_PATH = "/readyz";

--- a/scripts/portal-playwright-smoke.mjs
+++ b/scripts/portal-playwright-smoke.mjs
@@ -368,6 +368,9 @@ const COOP_WARNING_TOKENS = [
   /window\.closed/i,
   /window\.close/i,
 ];
+const CRITICAL_CONSOLE_WARNING_TOKENS = [
+  /Password field is not contained in a form/i,
+];
 
 const PAGE_NOISE_TOKENS = [
   ...FIRESTORE_NOISE,
@@ -2187,12 +2190,20 @@ const run = async () => {
     const criticalResponseWarnings = advisoryReadyzFailures
       ? summary.network.criticalResponseWarnings.filter((entry) => !isReadyzUrl(entry.url))
       : summary.network.criticalResponseWarnings;
+    const criticalConsoleWarnings = summary.network.consoleWarnings.filter((entry) =>
+      hasMatch(entry.text || "", CRITICAL_CONSOLE_WARNING_TOKENS)
+    );
+    const criticalConsoleErrors = summary.network.consoleErrors;
+    const criticalPageErrors = summary.network.pageErrors;
 
     const isCriticalFailure =
       summary.network.forbiddenRequests.length > 0 ||
       criticalRequestFailures.length > 0 ||
       criticalCorsFailures.length > 0 ||
       criticalResponseWarnings.length > 0 ||
+      criticalConsoleWarnings.length > 0 ||
+      criticalConsoleErrors.length > 0 ||
+      criticalPageErrors.length > 0 ||
       criticalReadyzFailures.length > 0 ||
       summary.network.endpointProbes.some((probe) => {
         if (probe.skipped) return false;
@@ -2224,6 +2235,15 @@ const run = async () => {
       }
       if (criticalResponseWarnings.length > 0) {
         errors.push(`critical response failures: ${criticalResponseWarnings.length}`);
+      }
+      if (criticalConsoleWarnings.length > 0) {
+        errors.push(`critical console warnings: ${criticalConsoleWarnings.length}`);
+      }
+      if (criticalConsoleErrors.length > 0) {
+        errors.push(`console errors: ${criticalConsoleErrors.length}`);
+      }
+      if (criticalPageErrors.length > 0) {
+        errors.push(`page errors: ${criticalPageErrors.length}`);
       }
       if (summary.network.responseWarnings.length > 0 && !desktopRuntime.authenticated) {
         const authOnly = summary.network.responseWarnings.filter((item) => item.isAuthFailure).length;
@@ -2306,6 +2326,15 @@ const run = async () => {
       }
       if (summary.network.responseWarnings.length > 0) {
         summary.notes.push("Some endpoint calls returned authorization errors without session auth; expected for staff-only routes while unsigned-in.");
+      }
+      if (summary.network.consoleWarnings.length > 0) {
+        summary.notes.push(`Console warnings observed (${summary.network.consoleWarnings.length}).`);
+      }
+      if (summary.network.consoleErrors.length > 0) {
+        summary.notes.push(`Console errors observed (${summary.network.consoleErrors.length}).`);
+      }
+      if (summary.network.pageErrors.length > 0) {
+        summary.notes.push(`Page errors observed (${summary.network.pageErrors.length}).`);
       }
     }
     await writeFile(summaryPath, `${JSON.stringify(summary, null, 2)}\n`, "utf8");

--- a/scripts/source-of-truth-deployment-gate-matrix.json
+++ b/scripts/source-of-truth-deployment-gate-matrix.json
@@ -308,7 +308,7 @@
           "id": "production-portal-prod-base-url",
           "file": ".github/workflows/portal-prod-smoke.yml",
           "severity": "error",
-          "needle": "https://monsoonfire-portal.web.app",
+          "needle": "https://portal.monsoonfire.com",
           "message": "portal production workflow uses the portal production base URL"
         },
         {

--- a/studio-brain/.env.integrity.json
+++ b/studio-brain/.env.integrity.json
@@ -1,6 +1,6 @@
 {
   "schema": "studiobrain-infra-integrity-v1",
-  "generatedAt": "2026-03-20T23:43:30.000Z",
+  "generatedAt": "2026-03-21T00:03:30.000Z",
   "generatedBy": "scripts/integrity-check.mjs",
   "allowUnknown": false,
   "metadata": {
@@ -15,8 +15,8 @@
     },
     {
       "path": "scripts/portal-playwright-smoke.mjs",
-      "sha256": "728a22163abf821ffd06866cd3dffcdde00893526c85cc2e7bfd077325682aea",
-      "size": 79814
+      "sha256": "ac982167e6e54e1ee8384243ed64bdbf32e3a375e5d47c3c00a165deb1e72b86",
+      "size": 79810
     },
     {
       "path": "scripts/pr-gate.mjs",

--- a/studio-brain/.env.integrity.json
+++ b/studio-brain/.env.integrity.json
@@ -1,6 +1,6 @@
 {
   "schema": "studiobrain-infra-integrity-v1",
-  "generatedAt": "2026-03-14T00:06:26.607Z",
+  "generatedAt": "2026-03-20T23:43:30.000Z",
   "generatedBy": "scripts/integrity-check.mjs",
   "allowUnknown": false,
   "metadata": {
@@ -15,8 +15,8 @@
     },
     {
       "path": "scripts/portal-playwright-smoke.mjs",
-      "sha256": "fcff64030eabe5017f0e668b5ac170adc1762094046cfb9fe725f38cb8db946f",
-      "size": 78452
+      "sha256": "728a22163abf821ffd06866cd3dffcdde00893526c85cc2e7bfd077325682aea",
+      "size": 79814
     },
     {
       "path": "scripts/pr-gate.mjs",

--- a/web/deploy/namecheap/verify-cutover.mjs
+++ b/web/deploy/namecheap/verify-cutover.mjs
@@ -12,6 +12,8 @@ const DEFAULT_WELL_KNOWN_PATH = "/.well-known/apple-app-site-association";
 const DEFAULT_FUNCTIONS_BASE_URL = "https://us-central1-monsoonfire-portal.cloudfunctions.net";
 const DEFAULT_PROTECTED_FUNCTION = "listMaterialsProducts";
 const DEFAULT_ID_TOKEN_ENV = "PORTAL_CUTOVER_ID_TOKEN";
+const FIREBASE_COMPILED_KEY_REGEX = /AIza[0-9A-Za-z_-]{20,}/g;
+const FIREBASE_MISSING_KEY_TOKEN = "MISSING_VITE_FIREBASE_API_KEY";
 
 const CLI_ALIAS_MAP = {
   portalurl: "portalUrl",
@@ -93,6 +95,7 @@ async function runVerify(parsed) {
   });
 
   const rootSampleAssets = extractAssetPaths(root.body || "");
+  const rootJavaScriptAssets = rootSampleAssets.filter((assetPath) => /\.js$/i.test(assetPath));
   const sampleAssets = rootSampleAssets.slice(0, 3);
   const assetChecks = [];
   for (const assetPath of sampleAssets) {
@@ -117,6 +120,17 @@ async function runVerify(parsed) {
     } else {
       failures.push(`asset ${check.path} request failed (${check.status})`);
     }
+  }
+
+  const bundleAudit = await auditFirebaseBundle({
+    portalUrl,
+    assetPaths: rootJavaScriptAssets,
+    timeoutMs,
+  });
+  if (bundleAudit.ok) {
+    passes.push("bundleFirebaseConfig");
+  } else {
+    failures.push(bundleAudit.message);
   }
 
   checkHeaders("rootCache", root, root.path, failures, passes, warnings);
@@ -203,8 +217,101 @@ async function runVerify(parsed) {
     wellKnownPath,
     sampleAssets,
     assetChecks,
+    bundleAudit,
     protectedFunctionCheck,
     reportPath: parsed.reportPath || "",
+  };
+}
+
+async function auditFirebaseBundle({ portalUrl, assetPaths, timeoutMs }) {
+  const uniqueAssetPaths = [...new Set(assetPaths.filter(Boolean))];
+  const assets = [];
+  const compiledApiKeyAssets = [];
+  const compiledApiKeys = new Set();
+  const placeholderTokenAssets = [];
+
+  if (uniqueAssetPaths.length === 0) {
+    return {
+      ok: false,
+      message: "bundle audit failed: no JavaScript assets were discovered in the portal HTML.",
+      assets,
+      compiledApiKeyAssets,
+      compiledApiKeys: [],
+      placeholderTokenAssets,
+    };
+  }
+
+  for (const assetPath of uniqueAssetPaths) {
+    const response = await requestWithTimeout({
+      url: `${portalUrl}${assetPath}`,
+      timeoutMs,
+    });
+    const body = response.body || "";
+    const assetApiKeys = extractCompiledFirebaseApiKeys(body);
+    const hasPlaceholderToken = body.includes(FIREBASE_MISSING_KEY_TOKEN);
+
+    if (assetApiKeys.length > 0) {
+      compiledApiKeyAssets.push(assetPath);
+      for (const key of assetApiKeys) {
+        compiledApiKeys.add(key);
+      }
+    }
+    if (hasPlaceholderToken) {
+      placeholderTokenAssets.push(assetPath);
+    }
+
+    assets.push({
+      path: assetPath,
+      status: response.status,
+      ok: response.ok && response.status === 200,
+      bodyLength: body.length,
+      firebaseKeyCount: assetApiKeys.length,
+      hasPlaceholderToken,
+      error: response.error || "",
+    });
+  }
+
+  const failedAsset = assets.find((asset) => !asset.ok);
+  if (failedAsset) {
+    return {
+      ok: false,
+      message: `bundle audit failed: ${failedAsset.path} returned ${failedAsset.status || 0}${failedAsset.error ? ` (${failedAsset.error})` : ""}.`,
+      assets,
+      compiledApiKeyAssets,
+      compiledApiKeys: [...compiledApiKeys],
+      placeholderTokenAssets,
+    };
+  }
+
+  if (placeholderTokenAssets.length > 0) {
+    return {
+      ok: false,
+      message: `bundle audit failed: ${FIREBASE_MISSING_KEY_TOKEN} is still present in ${placeholderTokenAssets.join(", ")}.`,
+      assets,
+      compiledApiKeyAssets,
+      compiledApiKeys: [...compiledApiKeys],
+      placeholderTokenAssets,
+    };
+  }
+
+  if (compiledApiKeyAssets.length === 0) {
+    return {
+      ok: false,
+      message: "bundle audit failed: no compiled Firebase API key was found in the deployed JavaScript assets.",
+      assets,
+      compiledApiKeyAssets,
+      compiledApiKeys: [...compiledApiKeys],
+      placeholderTokenAssets,
+    };
+  }
+
+  return {
+    ok: true,
+    message: "",
+    assets,
+    compiledApiKeyAssets,
+    compiledApiKeys: [...compiledApiKeys],
+    placeholderTokenAssets,
   };
 }
 
@@ -374,6 +481,11 @@ function extractAssetPaths(html) {
     candidates.push(candidate);
   }
   return [...new Set(candidates)];
+}
+
+function extractCompiledFirebaseApiKeys(text) {
+  const matches = String(text || "").match(FIREBASE_COMPILED_KEY_REGEX) || [];
+  return [...new Set(matches)];
 }
 
 function normalizeUrl(raw) {

--- a/web/scripts/check-chunk-budgets.mjs
+++ b/web/scripts/check-chunk-budgets.mjs
@@ -16,8 +16,8 @@ const budgets = [
   { prefix: "WareCheckInView-", maxBytes: 100_000 },
   // Kiln launch stays lazy-loaded, but the seven-day timeline calendar adds its own route payload.
   { prefix: "KilnLaunchView-", maxBytes: 30_000 },
-  // Staff stays lazy-loaded, but the lending workspace adds catalog and intake flows to this route.
-  { prefix: "StaffView-", maxBytes: 430_000 },
+  // Staff stays lazy-loaded, but the task-first home and promoted message workflows add route-only payload.
+  { prefix: "StaffView-", maxBytes: 445_000 },
   // Current app shell carries route wiring and shared runtime used across most views.
   { prefix: "index-", maxBytes: 110_000 },
 ];
@@ -34,11 +34,11 @@ const requiredRouteChunks = [
   "ProfileView-",
   "StaffView-",
 ];
-// Total budgets re-baselined for the lending workspace rollout, kiln queue timeline route,
+// Total budgets re-baselined for the staff task-home rollout, kiln queue timeline route,
 // portal handoff attribution path, and current mainline vendor split while keeping
 // future regressions visible.
-const MAX_TOTAL_JS_BYTES = 1_730_000;
-const MAX_TOTAL_CSS_BYTES = 271_000;
+const MAX_TOTAL_JS_BYTES = 1_760_000;
+const MAX_TOTAL_CSS_BYTES = 275_000;
 
 const files = readdirSync(assetsDir).filter((name) => name.endsWith(".js"));
 const failures = [];

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -2176,6 +2176,171 @@ html[data-portal-theme="memoria"] .list-row.kiln-offline .list-meta {
   gap: 16px;
 }
 
+.staff-task-home {
+  display: grid;
+  gap: 18px;
+}
+
+.staff-task-home-hero {
+  background:
+    linear-gradient(155deg, rgba(180, 79, 53, 0.16), rgba(180, 79, 53, 0) 52%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.03), rgba(255, 255, 255, 0)),
+    var(--surface);
+}
+
+.staff-task-home-attention-list {
+  display: grid;
+  gap: 10px;
+}
+
+.staff-task-home-attention-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  padding: 12px 14px;
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  background: var(--surface-2);
+}
+
+.staff-task-home-attention-item[data-tone="action"] {
+  border-color: rgba(230, 102, 112, 0.5);
+  background: rgba(230, 102, 112, 0.08);
+}
+
+.staff-task-home-attention-item[data-tone="watch"] {
+  border-color: rgba(223, 185, 108, 0.48);
+  background: rgba(223, 185, 108, 0.08);
+}
+
+.staff-task-home-lane {
+  display: grid;
+  gap: 12px;
+}
+
+.staff-task-home-lane-header {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.staff-task-home-lane-grid {
+  display: grid;
+  gap: 14px;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 270px), 1fr));
+}
+
+.staff-task-home-card {
+  align-content: start;
+}
+
+.staff-task-home-card-header {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.staff-task-home-card-badge {
+  flex: 0 0 auto;
+}
+
+.staff-task-home-card-badge-action {
+  border-color: rgba(230, 102, 112, 0.55);
+  background: rgba(230, 102, 112, 0.14);
+  color: #ffd0d6;
+}
+
+.staff-task-home-card-badge-watch {
+  border-color: rgba(223, 185, 108, 0.55);
+  background: rgba(223, 185, 108, 0.16);
+  color: #ffe5b6;
+}
+
+.staff-task-home-card-badge-clear {
+  border-color: rgba(112, 196, 145, 0.45);
+  background: rgba(112, 196, 145, 0.14);
+  color: #c7f0d7;
+}
+
+.staff-task-home-card-badge-reference {
+  border-color: rgba(132, 198, 240, 0.45);
+  background: rgba(132, 198, 240, 0.14);
+  color: #caebff;
+}
+
+.staff-task-home-card[data-tone="action"] {
+  border-color: rgba(230, 102, 112, 0.35);
+}
+
+.staff-task-home-card[data-tone="watch"] {
+  border-color: rgba(223, 185, 108, 0.35);
+}
+
+.staff-task-home-card-metrics {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+}
+
+.staff-task-home-card-metric {
+  display: grid;
+  gap: 4px;
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: var(--surface-2);
+}
+
+.staff-task-home-card-metric span {
+  font-size: 11px;
+  color: var(--muted);
+}
+
+.staff-task-home-card-metric strong {
+  font-size: 17px;
+  line-height: 1.1;
+}
+
+.staff-task-home-more > summary {
+  cursor: pointer;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.staff-task-home-more-grid {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 220px), 1fr));
+}
+
+.staff-task-home-more-btn {
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  background: var(--surface-2);
+  color: var(--text);
+  display: grid;
+  gap: 6px;
+  text-align: left;
+  padding: 12px 14px;
+  cursor: pointer;
+  transition: border-color 180ms ease, background 180ms ease, transform 180ms ease;
+}
+
+.staff-task-home-more-btn:hover {
+  border-color: var(--border-strong);
+  background: var(--surface-3);
+  transform: translateY(-1px);
+}
+
+.staff-task-home-more-btn span {
+  font-size: 12px;
+  color: var(--muted);
+  line-height: 1.45;
+}
+
 .staff-today-overview-grid {
   grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
 }
@@ -2397,6 +2562,28 @@ html[data-portal-theme="memoria"] .list-row.kiln-offline .list-meta {
   text-transform: none;
   letter-spacing: normal;
   color: var(--muted);
+}
+
+.staff-announcement-composer {
+  display: grid;
+  gap: 12px;
+  padding: 14px;
+  border-radius: 16px;
+  border: 1px solid var(--border);
+  background: color-mix(in srgb, var(--surface-2) 82%, transparent);
+}
+
+.staff-announcement-checkbox {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 13px;
+  color: var(--text);
+}
+
+.staff-announcement-checkbox input {
+  inline-size: 16px;
+  block-size: 16px;
 }
 
 .staff-template-list {
@@ -2691,8 +2878,15 @@ html[data-portal-theme="memoria"] .list-row.kiln-offline .list-meta {
   }
 
   .staff-today-overview-grid,
-  .staff-quick-actions {
+  .staff-quick-actions,
+  .staff-task-home-lane-grid,
+  .staff-task-home-more-grid {
     grid-template-columns: 1fr;
+  }
+
+  .staff-task-home-attention-item {
+    align-items: start;
+    flex-direction: column;
   }
 }
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -69,6 +69,7 @@ import {
   shouldNavigateToStaffWorkspaceTarget,
   type StaffWorkspaceMode,
 } from "./utils/staffWorkspacePaths";
+import { resolveStaffTaskShortcut } from "./utils/staffTaskShortcuts";
 import {
   buildStudioReservationsPath,
   canonicalReservationsPath,
@@ -766,7 +767,7 @@ function useDirectMessages(user: User | null, canLoad: boolean) {
   return { threads, loading, error };
 }
 
-function useAnnouncements(user: User | null, canLoad: boolean) {
+function useAnnouncements(user: User | null, canLoad: boolean, refreshToken = 0) {
   const [announcements, setAnnouncements] = useState<Announcement[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
@@ -814,7 +815,7 @@ function useAnnouncements(user: User | null, canLoad: boolean) {
     return () => {
       canceled = true;
     };
-  }, [user, canLoad, rawLimit, visibleLimit]);
+  }, [user, canLoad, rawLimit, refreshToken, visibleLimit]);
 
   return { announcements, loading, error };
 }
@@ -882,6 +883,8 @@ export default function App() {
   const [nav, setNav] = useState<NavKey>(() => {
     if (typeof window === "undefined") return "dashboard";
     const normalizedPathname = normalizeAppPath(window.location.pathname);
+    const staffTaskShortcut = resolveStaffTaskShortcut(normalizedPathname, window.location.hash);
+    if (staffTaskShortcut) return staffTaskShortcut.targetNav;
     const staffWorkspaceLaunch = resolveStaffWorkspaceLaunch(normalizedPathname, window.location.hash);
     if (staffWorkspaceLaunch) return staffWorkspaceLaunch.targetNav;
     const legacyRedirect = resolveLegacyRequestsRedirect(
@@ -900,8 +903,17 @@ export default function App() {
   });
   const [staffWorkspaceMode, setStaffWorkspaceMode] = useState<StaffWorkspaceMode>(() => {
     if (typeof window === "undefined") return "default";
+    const shortcut = resolveStaffTaskShortcut(normalizeAppPath(window.location.pathname), window.location.hash);
+    if (shortcut?.targetNav === "staff") {
+      return shortcut.workspaceMode ?? "default";
+    }
     const launch = resolveStaffWorkspaceLaunch(normalizeAppPath(window.location.pathname), window.location.hash);
     return launch?.mode ?? "default";
+  });
+  const [staffInitialTaskAction, setStaffInitialTaskAction] = useState<"announcementComposer" | null>(() => {
+    if (typeof window === "undefined") return null;
+    const shortcut = resolveStaffTaskShortcut(normalizeAppPath(window.location.pathname), window.location.hash);
+    return shortcut?.initialTaskAction ?? null;
   });
   const [legacyRouteNotice] = useState(() => {
     if (typeof window === "undefined") return "";
@@ -944,6 +956,7 @@ export default function App() {
   const [piecesFocusTarget, setPiecesFocusTarget] = useState<PieceFocusTarget | null>(null);
   const [bootstrapWarning, setBootstrapWarning] = useState("");
   const [notificationsEnabled, setNotificationsEnabled] = useState(false);
+  const [announcementsRefreshToken, setAnnouncementsRefreshToken] = useState(0);
   const [themeName, setThemeName] = useState<PortalThemeName>(() => readStoredPortalTheme());
   const [avatarLoadFailed, setAvatarLoadFailed] = useState(false);
   const prefersReducedMotion = usePrefersReducedMotion();
@@ -1045,6 +1058,7 @@ export default function App() {
       }
     }
     setStaffWorkspaceMode(match.mode);
+    setStaffInitialTaskAction(null);
     if (nav !== "staff") {
       setNav("staff");
     }
@@ -1189,6 +1203,7 @@ export default function App() {
     if (typeof window === "undefined") return;
     const pathname = normalizeAppPath(window.location.pathname);
     const hashPath = normalizeHashPath(window.location.hash);
+    const staffTaskShortcut = resolveStaffTaskShortcut(pathname, window.location.hash);
     const pathnameStaffMatch = resolveStaffWorkspaceMatch(pathname);
     const hashStaffMatch = resolveStaffWorkspaceMatch(hashPath);
     const requestedStaffPath = resolveStaffWorkspaceRequestedPath(pathname, window.location.hash);
@@ -1198,6 +1213,17 @@ export default function App() {
     const hasStaffWorkspaceRequest = requestedStaffPath !== null;
     const hasStaffCockpitPath = pathnameStaffMatch?.mode === "cockpit";
     const hasStaffCockpitHashPath = hashStaffMatch?.mode === "cockpit";
+    if (staffTaskShortcut?.targetNav === "staff") {
+      const shortcutMode = staffTaskShortcut.workspaceMode ?? "default";
+      if (shortcutMode !== staffWorkspaceMode) {
+        setStaffWorkspaceMode(shortcutMode);
+      }
+      if ((staffTaskShortcut.initialTaskAction ?? null) !== staffInitialTaskAction) {
+        setStaffInitialTaskAction(staffTaskShortcut.initialTaskAction ?? null);
+      }
+    } else if (staffInitialTaskAction !== null) {
+      setStaffInitialTaskAction(null);
+    }
     if (requestedStaffMode && requestedStaffMode !== staffWorkspaceMode) {
       setStaffWorkspaceMode(requestedStaffMode);
     }
@@ -1233,13 +1259,44 @@ export default function App() {
     ) {
       window.history.replaceState({}, "", "/");
     }
-  }, [nav, staffUi, staffWorkspaceMode]);
+  }, [nav, staffInitialTaskAction, staffUi, staffWorkspaceMode]);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
 
     const syncStateWithBrowserLocation = () => {
       const pathname = normalizeAppPath(window.location.pathname);
+      const staffTaskShortcut = resolveStaffTaskShortcut(pathname, window.location.hash);
+      if (staffTaskShortcut) {
+        if (staffTaskShortcut.targetNav === "staff") {
+          const nextMode = staffTaskShortcut.workspaceMode ?? "default";
+          if (staffWorkspaceMode !== nextMode) {
+            setStaffWorkspaceMode(nextMode);
+          }
+          if (nav !== "staff") {
+            setNav("staff");
+          }
+          if ((staffTaskShortcut.initialTaskAction ?? null) !== staffInitialTaskAction) {
+            setStaffInitialTaskAction(staffTaskShortcut.initialTaskAction ?? null);
+          }
+        } else {
+          if (staffWorkspaceMode !== "default") {
+            setStaffWorkspaceMode("default");
+          }
+          if (nav !== staffTaskShortcut.targetNav) {
+            setNav(staffTaskShortcut.targetNav);
+          }
+          if (staffInitialTaskAction !== null) {
+            setStaffInitialTaskAction(null);
+          }
+        }
+        return;
+      }
+
+      if (staffInitialTaskAction !== null) {
+        setStaffInitialTaskAction(null);
+      }
+
       const staffLaunch = resolveStaffWorkspaceLaunch(pathname, window.location.hash);
       const requestedStaffPath = resolveStaffWorkspaceRequestedPath(pathname, window.location.hash);
 
@@ -1301,7 +1358,7 @@ export default function App() {
       window.removeEventListener("popstate", syncStateWithBrowserLocation);
       window.removeEventListener("hashchange", syncStateWithBrowserLocation);
     };
-  }, [nav, staffWorkspaceMode]);
+  }, [nav, staffInitialTaskAction, staffWorkspaceMode]);
 
   useEffect(() => {
     writeLocalItem(LOCAL_NAV_COLLAPSED_KEY, navCollapsed ? "1" : "0");
@@ -1706,7 +1763,7 @@ export default function App() {
     announcements,
     loading: announcementsLoading,
     error: announcementsError,
-  } = useAnnouncements(user, shouldLoadAnnouncements);
+  } = useAnnouncements(user, shouldLoadAnnouncements, announcementsRefreshToken);
   const {
     notifications,
     loading: notificationsLoading,
@@ -1770,33 +1827,21 @@ export default function App() {
         default:
           return;
       }
-      try {
-        const result = await signInWithPopup(authClient, provider);
-        if (result?.user) {
-          track("auth_sign_in_success", {
-            method: providerId,
-            uid: shortId(result.user.uid),
-          });
-          identify(result.user);
-          setUser(result.user);
-          setAuthReady(true);
-        }
-      } catch (error: unknown) {
-        // Popups can be blocked (mobile Safari, aggressive privacy settings). Redirect is a reliable fallback.
-        const code = getErrorCode(error);
-        const shouldFallbackToRedirect =
-          code === "auth/cancelled-popup-request" ||
-          code === "auth/popup-blocked" ||
-          code === "auth/popup-closed-by-user" ||
-          code === "auth/operation-not-supported-in-this-environment";
-        if (shouldFallbackToRedirect) {
-          if (!isAuthEmulator) {
-            setAuthStatus("Continuing sign-in in redirect mode...");
-          }
-          await signInWithRedirect(authClient, provider);
-          return;
-        }
-        throw error;
+      if (!isAuthEmulator) {
+        setAuthStatus("Continuing sign-in...");
+        await signInWithRedirect(authClient, provider);
+        return;
+      }
+
+      const result = await signInWithPopup(authClient, provider);
+      if (result?.user) {
+        track("auth_sign_in_success", {
+          method: providerId,
+          uid: shortId(result.user.uid),
+        });
+        identify(result.user);
+        setUser(result.user);
+        setAuthReady(true);
       }
     } catch (error: unknown) {
       setAuthStatus(getErrorMessage(error) || "Sign-in failed. Please try again.");
@@ -2403,6 +2448,7 @@ export default function App() {
             onOpenFirings={() => setNav("kiln")}
             onStartFiring={() => setNav("kilnLaunch")}
             onOpenStaffWorkspace={openStaffWorkspace}
+            initialTaskAction={staffInitialTaskAction}
             initialModule={
               staffWorkspaceMode === "cockpit"
                 ? "cockpit"
@@ -2416,6 +2462,9 @@ export default function App() {
             announcementsLoading={announcementsLoading}
             announcementsError={announcementsError}
             unreadAnnouncements={unreadAnnouncements}
+            onAnnouncementsChanged={() =>
+              setAnnouncementsRefreshToken((current) => current + 1)
+            }
           />
         );
       default:

--- a/web/src/firebase.ts
+++ b/web/src/firebase.ts
@@ -19,6 +19,9 @@ type ImportMetaEnvShape = {
 const ENV = (import.meta.env ?? {}) as ImportMetaEnvShape;
 
 const DEFAULT_AUTH_DOMAIN = "monsoonfire-portal.firebaseapp.com";
+// This is the public Firebase Web API key already shipped in the client bundle.
+// Keep an embedded fallback so manual/static builds cannot publish a broken auth config.
+const EMBEDDED_FIREBASE_API_KEY = "AIzaSyC7ynej0nGJas9me9M5oW6jHfLsWe5gHbU";
 const AUTH_DOMAIN =
   typeof import.meta !== "undefined" && ENV.VITE_AUTH_DOMAIN
     ? String(ENV.VITE_AUTH_DOMAIN)
@@ -27,14 +30,10 @@ const AUTH_DOMAIN =
 const FIREBASE_API_KEY =
   typeof import.meta !== "undefined" && ENV.VITE_FIREBASE_API_KEY
     ? String(ENV.VITE_FIREBASE_API_KEY)
-    : "";
-
-if (!FIREBASE_API_KEY && typeof window !== "undefined") {
-  console.error("Missing VITE_FIREBASE_API_KEY. Set it in web/.env.local for local dev and GitHub secrets for CI deploy builds.");
-}
+    : EMBEDDED_FIREBASE_API_KEY;
 
 const firebaseConfig = {
-  apiKey: FIREBASE_API_KEY || "MISSING_VITE_FIREBASE_API_KEY",
+  apiKey: FIREBASE_API_KEY,
   authDomain: AUTH_DOMAIN,
   projectId: "monsoonfire-portal",
   storageBucket: "monsoonfire-portal.firebasestorage.app",

--- a/web/src/utils/staffTaskShortcuts.test.ts
+++ b/web/src/utils/staffTaskShortcuts.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveStaffTaskShortcut } from "./staffTaskShortcuts";
+
+describe("resolveStaffTaskShortcut", () => {
+  it("maps message-oriented staff aliases to the messages nav target", () => {
+    expect(resolveStaffTaskShortcut("/staff/messages", "")).toEqual({
+      targetNav: "messages",
+      canonicalPath: "/staff/messages",
+    });
+    expect(resolveStaffTaskShortcut("/staff/communication", "")).toEqual({
+      targetNav: "messages",
+      canonicalPath: "/staff/messages",
+    });
+  });
+
+  it("maps announcement aliases to the cockpit composer workflow", () => {
+    expect(resolveStaffTaskShortcut("/staff/announcement", "")).toEqual({
+      targetNav: "staff",
+      canonicalPath: "/staff/announcements",
+      workspaceMode: "cockpit",
+      initialTaskAction: "announcementComposer",
+    });
+  });
+
+  it("supports hash-based staff task aliases", () => {
+    expect(resolveStaffTaskShortcut("/dashboard", "#/staff/messages")).toEqual({
+      targetNav: "messages",
+      canonicalPath: "/staff/messages",
+    });
+    expect(resolveStaffTaskShortcut("/dashboard", "#/staff/announcements")).toEqual({
+      targetNav: "staff",
+      canonicalPath: "/staff/announcements",
+      workspaceMode: "cockpit",
+      initialTaskAction: "announcementComposer",
+    });
+  });
+
+  it("returns null for unrelated routes", () => {
+    expect(resolveStaffTaskShortcut("/staff/system", "")).toBeNull();
+    expect(resolveStaffTaskShortcut("/messages", "")).toBeNull();
+  });
+});

--- a/web/src/utils/staffTaskShortcuts.ts
+++ b/web/src/utils/staffTaskShortcuts.ts
@@ -1,0 +1,57 @@
+import { normalizeStaffPath } from "./staffWorkspacePaths";
+
+export type StaffTaskShortcut = {
+  targetNav: "messages" | "staff";
+  canonicalPath: "/staff/messages" | "/staff/announcements";
+  workspaceMode?: "default" | "cockpit";
+  initialTaskAction?: "announcementComposer";
+};
+
+const STAFF_TASK_SHORTCUTS: Readonly<Record<string, StaffTaskShortcut>> = {
+  message: {
+    targetNav: "messages",
+    canonicalPath: "/staff/messages",
+  },
+  messages: {
+    targetNav: "messages",
+    canonicalPath: "/staff/messages",
+  },
+  communication: {
+    targetNav: "messages",
+    canonicalPath: "/staff/messages",
+  },
+  communications: {
+    targetNav: "messages",
+    canonicalPath: "/staff/messages",
+  },
+  announcement: {
+    targetNav: "staff",
+    canonicalPath: "/staff/announcements",
+    workspaceMode: "cockpit",
+    initialTaskAction: "announcementComposer",
+  },
+  announcements: {
+    targetNav: "staff",
+    canonicalPath: "/staff/announcements",
+    workspaceMode: "cockpit",
+    initialTaskAction: "announcementComposer",
+  },
+};
+
+function resolveShortcutFromCandidate(candidate: string): StaffTaskShortcut | null {
+  const normalizedCandidate = normalizeStaffPath(candidate);
+  if (!normalizedCandidate.startsWith("/staff/")) return null;
+
+  const segments = normalizedCandidate.split("/").filter(Boolean);
+  if (segments[0] !== "staff") return null;
+
+  const shortcutKey = segments[1] ?? "";
+  return STAFF_TASK_SHORTCUTS[shortcutKey] ?? null;
+}
+
+export function resolveStaffTaskShortcut(
+  pathname: string | null | undefined,
+  hash: string | null | undefined,
+): StaffTaskShortcut | null {
+  return resolveShortcutFromCandidate(pathname ?? "") ?? resolveShortcutFromCandidate(hash ?? "");
+}

--- a/web/src/utils/staffWorkspacePaths.test.ts
+++ b/web/src/utils/staffWorkspacePaths.test.ts
@@ -51,6 +51,11 @@ describe("resolveStaffWorkspaceMatch", () => {
     });
   });
 
+  it("does not treat task shortcuts that leave staff as staff workspaces", () => {
+    expect(resolveStaffWorkspaceMatch("/staff/messages")).toBeNull();
+    expect(resolveStaffWorkspaceMatch("/staff/communication")).toBeNull();
+  });
+
   it("consolidates legacy root module routes to cockpit module paths", () => {
     expect(resolveStaffWorkspaceMatch("/staff/workshop")).toEqual({
       canonicalPath: "/staff/cockpit/operations",
@@ -1004,6 +1009,11 @@ describe("resolveStaffWorkspaceRequestedPath", () => {
     expect(resolveStaffWorkspaceRequestedPath(null, null)).toBeNull();
   });
 
+  it("does not turn staff message shortcuts into generic staff workspace requests", () => {
+    expect(resolveStaffWorkspaceRequestedPath("/staff/messages", "")).toBeNull();
+    expect(resolveStaffWorkspaceRequestedPath("/dashboard", "#/staff/messages")).toBeNull();
+  });
+
   it("returns null when launch path/hash are missing", () => {
     expect(resolveStaffWorkspaceLaunch(undefined, undefined)).toBeNull();
     expect(resolveStaffWorkspaceLaunch(null, "#finance")).toBeNull();
@@ -1015,6 +1025,7 @@ describe("isStaffWorkspaceRequest", () => {
     expect(isStaffWorkspaceRequest("/dashboard", "/#requests")).toBe(false);
     expect(isStaffWorkspaceRequest("/staff", "")).toBe(true);
     expect(isStaffWorkspaceRequest("/staff/does-not-exist", "/")).toBe(true);
+    expect(isStaffWorkspaceRequest("/staff/messages", "")).toBe(false);
     expect(isStaffWorkspaceRequest("/", "/staff/system")).toBe(true);
     expect(isStaffWorkspaceRequest(undefined, undefined)).toBe(false);
   });

--- a/web/src/utils/staffWorkspacePaths.ts
+++ b/web/src/utils/staffWorkspacePaths.ts
@@ -128,6 +128,13 @@ const STAFF_COCKPIT_ROOT_SEGMENT_ALIASES: Readonly<Record<string, string>> = {
   policyagentops: "policy-agent-ops",
 };
 
+const STAFF_NON_WORKSPACE_SHORTCUT_SEGMENTS = new Set([
+  "message",
+  "messages",
+  "communication",
+  "communications",
+]);
+
 const STAFF_PATH_COPY_PUNCTUATION_PREFIX_RE = /^[\s"'`<{([]+/;
 const STAFF_PATH_COPY_PUNCTUATION_SUFFIX_RE = /[\])}>"'`,.;:!?]+$/;
 
@@ -204,6 +211,19 @@ function resolveStaffWorkspaceRootCockpitSegment(pathname: string): string | nul
   const normalizedSegment = normalizeCockpitSegment(next);
   const canonicalSegment = resolveConsolidatedCockpitSegment(normalizedSegment);
   return STAFF_COCKPIT_KNOWN_SEGMENTS.has(canonicalSegment) ? canonicalSegment : null;
+}
+
+function isNonWorkspaceStaffShortcut(pathname: string): boolean {
+  const normalized = normalizeStaffPath(pathname);
+  if (!normalized || !isStaffPath(normalized) || isStaffCockpitPath(normalized)) {
+    return false;
+  }
+
+  const shortcutPath = normalized.slice(STAFF_PATH.length + 1);
+  if (!shortcutPath) return false;
+
+  const shortcutSegment = shortcutPath.split("/")[0]?.trim().toLowerCase() ?? "";
+  return STAFF_NON_WORKSPACE_SHORTCUT_SEGMENTS.has(shortcutSegment);
 }
 
 function normalizeStaffPathInput(value: StaffPathInput): string {
@@ -361,6 +381,7 @@ export function resolveStaffWorkspaceCanonicalPath(pathname: StaffPathInput): st
   if (rootCockpitSegment) {
     return `${STAFF_COCKPIT_PATH}/${rootCockpitSegment}`;
   }
+  if (isNonWorkspaceStaffShortcut(normalized)) return null;
   if (isStaffPath(normalized)) return STAFF_PATH;
   return null;
 }

--- a/web/src/views/SignedOutView.test.tsx
+++ b/web/src/views/SignedOutView.test.tsx
@@ -1,0 +1,64 @@
+/** @vitest-environment jsdom */
+
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import SignedOutView from "./SignedOutView";
+
+afterEach(() => {
+  cleanup();
+});
+
+function renderSignedOutView() {
+  const props = {
+    onProviderSignIn: vi.fn(),
+    onEmailPassword: vi.fn(),
+    onEmailLink: vi.fn(),
+    onCompleteEmailLink: vi.fn(),
+    emailLinkPending: false,
+    status: "",
+    busy: false,
+  };
+
+  render(<SignedOutView {...props} />);
+  return props;
+}
+
+describe("SignedOutView", () => {
+  it("submits email password auth through a form", () => {
+    const props = renderSignedOutView();
+    const passwordInput = screen.getByLabelText("Password");
+    const form = passwordInput.closest("form");
+
+    expect(form).toBeTruthy();
+
+    fireEvent.change(within(form as HTMLFormElement).getByLabelText("Email"), {
+      target: { value: " member@example.com " },
+    });
+    fireEvent.change(passwordInput, {
+      target: { value: "studio-secret" },
+    });
+    fireEvent.submit(form as HTMLFormElement);
+
+    expect(props.onEmailPassword).toHaveBeenCalledWith(
+      "member@example.com",
+      "studio-secret",
+      "signin"
+    );
+  });
+
+  it("submits the sign-in link request through a form", () => {
+    const props = renderSignedOutView();
+    const submitButton = screen.getByRole("button", { name: "Email me a sign-in link" });
+    const form = submitButton.closest("form");
+
+    expect(form).toBeTruthy();
+
+    fireEvent.change(within(form as HTMLFormElement).getByLabelText("Email for link"), {
+      target: { value: " kiln@example.com " },
+    });
+    fireEvent.submit(form as HTMLFormElement);
+
+    expect(props.onEmailLink).toHaveBeenCalledWith("kiln@example.com");
+  });
+});

--- a/web/src/views/SignedOutView.tsx
+++ b/web/src/views/SignedOutView.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useMemo, useState, type FormEvent } from "react";
 
 type ProviderId = "google" | "apple" | "facebook" | "microsoft";
 
@@ -98,6 +98,14 @@ export default function SignedOutView({
 
   const trimmedEmail = useMemo(() => email.trim(), [email]);
   const trimmedLinkEmail = useMemo(() => linkEmail.trim(), [linkEmail]);
+  const handleEmailPasswordSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    onEmailPassword(trimmedEmail, password, emailMode);
+  };
+  const handleEmailLinkSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    onEmailLink(trimmedLinkEmail);
+  };
 
   return (
     <div className="signed-out">
@@ -126,7 +134,7 @@ export default function SignedOutView({
           <span>Or use email</span>
         </div>
 
-        <div className="signed-out-email">
+        <form className="signed-out-email" onSubmit={handleEmailPasswordSubmit}>
           <div className="signed-out-toggle">
             <button
               type="button"
@@ -169,19 +177,19 @@ export default function SignedOutView({
             />
           </label>
           <button
+            type="submit"
             className="primary"
-            onClick={() => onEmailPassword(trimmedEmail, password, emailMode)}
             disabled={busy}
           >
             {emailMode === "create" ? "Create account" : "Sign in"}
           </button>
-        </div>
+        </form>
 
         <div className="signed-out-divider compact">
           <span>Prefer a sign-in link?</span>
         </div>
 
-        <div className="signed-out-email-link">
+        <form className="signed-out-email-link" onSubmit={handleEmailLinkSubmit}>
           <label className="signed-out-field">
             Email for link
             <input
@@ -194,8 +202,8 @@ export default function SignedOutView({
             />
           </label>
           <button
+            type="submit"
             className="secondary"
-            onClick={() => onEmailLink(trimmedLinkEmail)}
             disabled={busy}
           >
             Email me a sign-in link
@@ -203,13 +211,14 @@ export default function SignedOutView({
           {emailLinkPending ? (
             <button
               className="btn btn-ghost"
+              type="button"
               onClick={() => onCompleteEmailLink(trimmedLinkEmail)}
               disabled={busy}
             >
               Finish sign-in from link
             </button>
           ) : null}
-        </div>
+        </form>
 
         {status ? (
           <div className="signed-out-status" role="status" aria-live="polite">

--- a/web/src/views/StaffView.tsx
+++ b/web/src/views/StaffView.tsx
@@ -8384,7 +8384,6 @@ export default function StaffView({
   }, [
     announcementsError,
     cockpitTodayMessageRows,
-    formatDateTime,
     messageThreadsError,
     messagesDegraded,
     operationsOverview.priorityItems,
@@ -8624,7 +8623,6 @@ export default function StaffView({
     commerceKpis.pendingOrders,
     commerceKpis.receiptsTotal,
     commerceKpis.unpaidCheckIns,
-    formatDateTime,
     messageThreadsError,
     messagesDegraded,
     operationsNextReservationLabel,

--- a/web/src/views/StaffView.tsx
+++ b/web/src/views/StaffView.tsx
@@ -107,6 +107,13 @@ import LendingIntakeModule, { type LendingScanSubmitResult } from "./staff/Lendi
 import LendingModule from "./staff/LendingModule";
 import OperationsCockpitModule from "./staff/OperationsCockpitModule";
 import StudioReservationsModule from "./staff/StudioReservationsModule";
+import TaskHomeModule, {
+  type StaffTaskHomeAttentionItem,
+  type StaffTaskHomeCard,
+  type StaffTaskHomeLane,
+  type StaffTaskHomeMoreAction,
+  type StaffTaskHomeTone,
+} from "./staff/TaskHomeModule";
 import { resolveOperationsOverview } from "./staff/operationsOverview";
 import { resolveShiftStatusSummary } from "./staff/shiftStatus";
 import { buildLendingAdminApiPayload } from "./staff/lendingAdminPayload";
@@ -133,6 +140,7 @@ type Props = {
   initialModule?: ModuleKey;
   forceCockpitWorkspace?: boolean;
   onOpenStaffWorkspace?: (target: string) => void;
+  initialTaskAction?: "announcementComposer" | null;
   messageThreads?: DirectMessageThread[];
   messageThreadsLoading?: boolean;
   messageThreadsError?: string;
@@ -140,6 +148,18 @@ type Props = {
   announcementsLoading?: boolean;
   announcementsError?: string;
   unreadAnnouncements?: number;
+  onAnnouncementsChanged?: () => void;
+};
+
+type StaffAnnouncementDraft = {
+  title: string;
+  summary: string;
+  body: string;
+  ctaLabel: string;
+  ctaUrl: string;
+  publishAt: string;
+  expiresAt: string;
+  pinned: boolean;
 };
 
 const MODULE_REGISTRY = {
@@ -384,6 +404,13 @@ function resolveStaffCockpitModuleFromPath(pathname: string): ModuleKey | null {
 function resolveStaffCockpitTabFromPath(pathname: string): CockpitTabKey | undefined {
   const segment = resolveStaffCockpitWorkspaceTabSegment(pathname);
   return segment ? COCKPIT_PATH_TAB_BY_SEGMENT[segment] : undefined;
+}
+
+function toStaffTaskTone(tone: string | undefined): StaffTaskHomeTone {
+  if (tone === "action" || tone === "watch" || tone === "clear" || tone === "reference") {
+    return tone;
+  }
+  return "reference";
 }
 
 type ModuleUsageStat = {
@@ -1941,6 +1968,19 @@ function isValidHttpUrl(value: string): boolean {
   }
 }
 
+function makeEmptyStaffAnnouncementDraft(): StaffAnnouncementDraft {
+  return {
+    title: "",
+    summary: "",
+    body: "",
+    ctaLabel: "",
+    ctaUrl: "",
+    publishAt: "",
+    expiresAt: "",
+    pinned: false,
+  };
+}
+
 function inferWorkshopProgrammingTechnique(title: string): WorkshopProgrammingTechnique {
   const normalized = title.trim().toLowerCase();
   if (!normalized) return WORKSHOP_PROGRAMMING_TECHNIQUES[WORKSHOP_PROGRAMMING_TECHNIQUES.length - 1];
@@ -2230,6 +2270,7 @@ export default function StaffView({
   onOpenFirings,
   onStartFiring,
   onOpenStaffWorkspace,
+  initialTaskAction = null,
   initialModule = "cockpit",
   forceCockpitWorkspace = false,
   messageThreads = [],
@@ -2239,6 +2280,7 @@ export default function StaffView({
   announcementsLoading = false,
   announcementsError = "",
   unreadAnnouncements = 0,
+  onAnnouncementsChanged,
 }: Props) {
   const initialCockpitModule = useMemo<ModuleKey | null>(() => {
     if (typeof window === "undefined") return null;
@@ -2260,6 +2302,10 @@ export default function StaffView({
       window.location.pathname;
     return resolveStaffCockpitTabFromPath(requestedPath);
   }, []);
+  const initialRequestedStaffPath = useMemo(() => {
+    if (typeof window === "undefined") return STAFF_PATH;
+    return resolveStaffWorkspaceRequestedPath(window.location.pathname, window.location.hash) ?? STAFF_PATH;
+  }, []);
   const requestedInitialCockpitModule = initialCockpitModule ?? initialModule;
   const resolvedInitialCockpitModule = COCKPIT_CONTENT_ONLY_MODULE_KEYS.has(requestedInitialCockpitModule)
     ? "cockpit"
@@ -2270,6 +2316,9 @@ export default function StaffView({
       ? COCKPIT_MODULE_TAB_BY_KEY[requestedInitialCockpitModule]
       : undefined;
   const [moduleKey, setModuleKey] = useState<ModuleKey>(resolvedInitialCockpitModule);
+  const [isTaskHomeRoute, setIsTaskHomeRoute] = useState<boolean>(
+    !forceCockpitWorkspace && initialRequestedStaffPath === STAFF_PATH
+  );
   const [moduleUsage, setModuleUsage] = useState<Record<ModuleKey, ModuleUsageStat>>(() => loadModuleUsageSnapshot());
   const [adaptiveNavEnabled, setAdaptiveNavEnabled] = useState<boolean>(() => loadAdaptiveNavPreference());
   const moduleSessionRef = useRef<{ key: ModuleKey; enteredAtMs: number } | null>(null);
@@ -2409,6 +2458,12 @@ export default function StaffView({
     capacity: "12",
     priceCents: "0",
   });
+  const [announcementComposerOpen, setAnnouncementComposerOpen] = useState(false);
+  const [announcementDraft, setAnnouncementDraft] = useState<StaffAnnouncementDraft>(() =>
+    makeEmptyStaffAnnouncementDraft()
+  );
+  const [announcementPublishStatus, setAnnouncementPublishStatus] = useState("");
+  const [announcementPublishError, setAnnouncementPublishError] = useState("");
   const [publishOverrideReason, setPublishOverrideReason] = useState("");
   const [eventStatusReason, setEventStatusReason] = useState("");
   const [signupSearch, setSignupSearch] = useState("");
@@ -7834,13 +7889,17 @@ export default function StaffView({
 
     if (!requestedPath) return;
     if (requestedPath === STAFF_PATH) {
+      setIsTaskHomeRoute(true);
       setModuleKey("cockpit");
       setCockpitTab("triage");
+      setCockpitWorkspaceMode(true);
       return;
     }
+    setIsTaskHomeRoute(false);
     if (requestedPath === STAFF_COCKPIT_PATH) {
       setModuleKey("cockpit");
       setCockpitTab((prev) => prev);
+      setCockpitWorkspaceMode(true);
       return;
     }
 
@@ -7907,7 +7966,18 @@ export default function StaffView({
   }, [onOpenStaffWorkspace, syncWorkspaceStateFromUrl]);
 
   const openCockpitWorkspace = useCallback(() => {
+    setIsTaskHomeRoute(false);
+    setModuleKey("cockpit");
+    setCockpitWorkspaceMode(true);
     openStaffWorkspace(STAFF_COCKPIT_PATH);
+  }, [openStaffWorkspace]);
+
+  const openTaskHome = useCallback(() => {
+    setIsTaskHomeRoute(true);
+    setModuleKey("cockpit");
+    setCockpitTab("triage");
+    setCockpitWorkspaceMode(true);
+    openStaffWorkspace(STAFF_PATH);
   }, [openStaffWorkspace]);
 
   useEffect(() => {
@@ -8241,6 +8311,505 @@ export default function StaffView({
     },
     [onOpenMessageThread, openMessagesInbox]
   );
+
+  const openAnnouncementWorkflow = useCallback(() => {
+    setAnnouncementComposerOpen(true);
+    setAnnouncementPublishError("");
+    setAnnouncementPublishStatus("");
+    if (forceCockpitWorkspace) {
+      setModuleKey("cockpit");
+      setCockpitTab("triage");
+      setCockpitWorkspaceMode(true);
+      setIsTaskHomeRoute(false);
+      return;
+    }
+    openCockpitWorkspace();
+  }, [forceCockpitWorkspace, openCockpitWorkspace]);
+
+  useEffect(() => {
+    if (initialTaskAction !== "announcementComposer") return;
+    openAnnouncementWorkflow();
+  }, [initialTaskAction, openAnnouncementWorkflow]);
+
+  const taskHomeAttentionItems = useMemo<StaffTaskHomeAttentionItem[]>(() => {
+    const items: StaffTaskHomeAttentionItem[] = operationsOverview.priorityItems.map((item) => ({
+      id: item.id,
+      tone: item.tone,
+      title: item.title,
+      detail: item.detail,
+      actionLabel: item.actionLabel,
+      actionTarget: item.actionTarget,
+    }));
+
+    if (messagesDegraded) {
+      items.push({
+        id: "messages-degraded",
+        tone: "action",
+        title: "Messages need review",
+        detail: firstNonBlankString(
+          messageThreadsError,
+          announcementsError,
+          "Messages or announcements are temporarily degraded."
+        ),
+        actionLabel: "Open messages",
+        actionTarget: "messages",
+      });
+    } else if (unreadMessageCount > 0) {
+      const latestThread = cockpitTodayMessageRows[0];
+      items.push({
+        id: "messages-unread",
+        tone: unreadMessageCount >= 4 ? "action" : "watch",
+        title: `${unreadMessageCount} unread conversation${unreadMessageCount === 1 ? "" : "s"}`,
+        detail: latestThread
+          ? `Latest from ${latestThread.sender} at ${formatDateTime(latestThread.atMs)}.`
+          : "Open Messages to triage replies, support requests, and staff handoffs.",
+        actionLabel: "Open messages",
+        actionTarget: "messages",
+      });
+    }
+
+    const highestPaymentAlert = paymentAlerts[0];
+    if (highestPaymentAlert) {
+      items.push({
+        id: highestPaymentAlert.id,
+        tone: highestPaymentAlert.severity === "P0" ? "action" : "watch",
+        title: highestPaymentAlert.title,
+        detail: highestPaymentAlert.detail,
+        actionLabel: "Open finance",
+        actionTarget: "finance",
+      });
+    }
+
+    return items.slice(0, 6);
+  }, [
+    announcementsError,
+    cockpitTodayMessageRows,
+    formatDateTime,
+    messageThreadsError,
+    messagesDegraded,
+    operationsOverview.priorityItems,
+    paymentAlerts,
+    unreadMessageCount,
+  ]);
+
+  const taskHomeLanes = useMemo<StaffTaskHomeLane[]>(() => {
+    const areaCardByKey = new Map(operationsOverview.areaCards.map((card) => [card.key, card]));
+    const checkinsCard = areaCardByKey.get("checkins");
+    const membersCard = areaCardByKey.get("members");
+    const piecesCard = areaCardByKey.get("pieces");
+    const firingsCard = areaCardByKey.get("firings");
+    const eventsCard = areaCardByKey.get("events");
+    const lendingCard = areaCardByKey.get("lending");
+    const reservationsWithNotesCount = todayReservations.filter((reservation) => reservation.notes.trim()).length;
+    const latestMessage = cockpitTodayMessageRows[0];
+    const financeBadge = paymentAlerts.length
+      ? `${paymentAlerts.length} alert${paymentAlerts.length === 1 ? "" : "s"}`
+      : paymentDegraded
+        ? "Needs review"
+        : "On track";
+    const financeTone: StaffTaskHomeTone = paymentAlerts[0]
+      ? paymentAlerts[0].severity === "P0"
+        ? "action"
+        : "watch"
+      : paymentDegraded
+        ? "watch"
+        : "clear";
+
+    const reservationsCard: StaffTaskHomeCard = {
+      id: "reservations-today",
+      eyebrow: "Today",
+      title: "Reservations today",
+      badge: todayReservationsLoading ? "Loading..." : `${todayReservations.length} due`,
+      tone: todayReservationsError ? "action" : todayReservations.length > 0 ? "watch" : "clear",
+      summary: todayReservationsError
+        ? "Reservations are temporarily unavailable for the shift board."
+        : todayReservations.length > 0
+          ? `${todayReservations.length} reservation${todayReservations.length === 1 ? "" : "s"} are scheduled today${operationsNextReservationLabel ? `. Next arrival ${operationsNextReservationLabel}.` : "."}`
+          : "No reservations are due today.",
+      note: todayReservationsError
+        ? todayReservationsError
+        : reservationsWithNotesCount > 0
+          ? `${reservationsWithNotesCount} reservation${reservationsWithNotesCount === 1 ? "" : "s"} include staff notes or prep context.`
+          : "Open the full reservations calendar when you need date changes, staffing look-ahead, or the wider queue.",
+      metrics: [
+        { label: "Due today", value: todayReservationsLoading ? "..." : String(todayReservations.length) },
+        { label: "Next arrival", value: operationsNextReservationLabel || "-" },
+        { label: "With notes", value: todayReservationsLoading ? "..." : String(reservationsWithNotesCount) },
+      ],
+      actions: [
+        { label: "Open today's queue", target: "checkins" },
+        { label: "Open reservations calendar", target: "studioReservations", emphasis: "secondary" },
+      ],
+    };
+
+    const messagesCard: StaffTaskHomeCard = {
+      id: "messages",
+      eyebrow: "Member communication",
+      title: "Messages",
+      badge: messagesDegraded ? "Needs review" : unreadMessageCount > 0 ? `${unreadMessageCount} unread` : "Inbox clear",
+      tone: messagesDegraded ? "action" : unreadMessageCount > 0 ? "watch" : "clear",
+      summary: messagesDegraded
+        ? "Messages or announcement delivery signals need review."
+        : latestMessage
+          ? `Latest from ${latestMessage.sender} at ${formatDateTime(latestMessage.atMs)}.`
+          : "No unread conversations are waiting right now.",
+      note: messagesDegraded
+        ? firstNonBlankString(
+            messageThreadsError,
+            announcementsError,
+            "Open Messages for full diagnostics and retry paths."
+          )
+        : "Use Messages for member replies, support follow-up, and direct operational handoffs.",
+      metrics: [
+        { label: "Unread", value: String(unreadMessageCount) },
+        { label: "Unread announcements", value: String(unreadAnnouncements) },
+        { label: "Announcements", value: String(announcements.length) },
+      ],
+      actions: [{ label: "Open messages", target: "messages" }],
+    };
+
+    const announcementCard: StaffTaskHomeCard = {
+      id: "announcements",
+      eyebrow: "Member communication",
+      title: "Studio announcements",
+      badge: announcementComposerOpen ? "Composer open" : announcementsLoading ? "Loading..." : `${announcements.length} live`,
+      tone: announcementsError ? "action" : announcementComposerOpen ? "watch" : announcements.length > 0 ? "reference" : "clear",
+      summary: "Publish a member-facing studio update without digging through cockpit tabs.",
+      note: announcementsError
+        ? announcementsError
+        : unreadAnnouncements > 0
+          ? `${unreadAnnouncements} announcement${unreadAnnouncements === 1 ? "" : "s"} are still unread in this staff session.`
+          : "The existing announcement composer opens ready-to-publish in one click.",
+      metrics: [
+        { label: "Live", value: announcementsLoading ? "..." : String(announcements.length) },
+        { label: "Unread by you", value: String(unreadAnnouncements) },
+      ],
+      actions: [
+        { label: "Create studio announcement", target: "announcementComposer" },
+        { label: "Open messages", target: "messages", emphasis: "secondary" },
+      ],
+    };
+
+    const financeCard: StaffTaskHomeCard = {
+      id: "finance",
+      eyebrow: "Programs & money",
+      title: "Payments & billing",
+      badge: financeBadge,
+      tone: financeTone,
+      summary: paymentAlerts[0]
+        ? paymentAlerts[0].title
+        : "No payment or billing blockers are active right now.",
+      note: paymentAlerts[0]
+        ? paymentAlerts[0].detail
+        : paymentDegraded
+          ? firstNonBlankString(commerceError, "Finance data is degraded. Open the finance workspace for full detail.")
+          : "Open finance for unpaid check-ins, order follow-up, receipts, and payment reliability checks.",
+      metrics: [
+        { label: "Pending orders", value: String(commerceKpis.pendingOrders) },
+        { label: "Unpaid check-ins", value: String(commerceKpis.unpaidCheckIns) },
+        { label: "Receipts", value: String(commerceKpis.receiptsTotal) },
+      ],
+      actions: [{ label: "Open finance", target: "finance" }],
+    };
+
+    return [
+      {
+        id: "studio-floor",
+        title: "Studio floor",
+        subtitle: "Live work first: intake, today’s queue, pieces, and firings.",
+        cards: [
+          {
+            id: "checkins",
+            eyebrow: "Live ops",
+            title: "Check-ins",
+            badge: checkinsCard?.label ?? "Queue",
+            tone: toStaffTaskTone(checkinsCard?.tone),
+            summary: checkinsCard?.headline ?? "Open the intake queue and today’s arrivals.",
+            note: checkinsCard?.note ?? "Use Check-ins for the active intake queue and day-of handling.",
+            metrics: checkinsCard?.metrics,
+            actions: [
+              { label: checkinsCard?.actionLabel ?? "Open check-ins", target: "checkins" },
+              { label: "View reservations", target: "studioReservations", emphasis: "secondary" },
+            ],
+          },
+          reservationsCard,
+          {
+            id: "pieces",
+            eyebrow: "Production",
+            title: "Pieces & batches",
+            badge: piecesCard?.label ?? "Production",
+            tone: toStaffTaskTone(piecesCard?.tone),
+            summary: piecesCard?.headline ?? "Open pieces for triage, inventory, and lifecycle changes.",
+            note: piecesCard?.note ?? "Focused cleanup and batch detail stay inside the pieces workspace.",
+            metrics: piecesCard?.metrics,
+            actions: [{ label: piecesCard?.actionLabel ?? "Open pieces & batches", target: "pieces" }],
+          },
+          {
+            id: "firings",
+            eyebrow: "Kiln ops",
+            title: "Firings",
+            badge: firingsCard?.label ?? "Kiln queue",
+            tone: toStaffTaskTone(firingsCard?.tone),
+            summary: firingsCard?.headline ?? "Open firings for live kiln state and schedule follow-through.",
+            note: firingsCard?.note ?? "Use the firings workspace for stale runs, timing windows, and status updates.",
+            metrics: firingsCard?.metrics,
+            actions: [
+              { label: firingsCard?.actionLabel ?? "Open firings", target: "firings" },
+              { label: "Open cockpit", target: "cockpit", emphasis: "ghost" },
+            ],
+          },
+        ],
+      },
+      {
+        id: "member-comms",
+        title: "Member communication",
+        subtitle: "Handle replies, publish updates, and look up member context without leaving the board.",
+        cards: [
+          messagesCard,
+          announcementCard,
+          {
+            id: "members",
+            eyebrow: "Member ops",
+            title: "Members",
+            badge: membersCard?.label ?? "Roster",
+            tone: toStaffTaskTone(membersCard?.tone),
+            summary: membersCard?.headline ?? "Open the member roster for account and profile follow-up.",
+            note: membersCard?.note ?? "Use Members for profile edits, permissions, and activity lookup.",
+            metrics: membersCard?.metrics,
+            actions: [{ label: membersCard?.actionLabel ?? "Open members", target: "members" }],
+          },
+        ],
+      },
+      {
+        id: "programs-and-money",
+        title: "Programs & money",
+        subtitle: "Workshops, lending, and payment follow-through stay one click away.",
+        cards: [
+          {
+            id: "events",
+            eyebrow: "Program ops",
+            title: "Events & workshops",
+            badge: eventsCard?.label ?? "Programs",
+            tone: toStaffTaskTone(eventsCard?.tone),
+            summary: eventsCard?.headline ?? "Open events for workshop publishing, roster check-ins, and review.",
+            note: eventsCard?.note ?? "Use Events for publishing, waitlist review, and program edits.",
+            metrics: eventsCard?.metrics,
+            actions: [{ label: eventsCard?.actionLabel ?? "Open events", target: "events" }],
+          },
+          {
+            id: "lending",
+            eyebrow: "Library ops",
+            title: "Lending",
+            badge: lendingCard?.label ?? "Library",
+            tone: toStaffTaskTone(lendingCard?.tone),
+            summary: lendingCard?.headline ?? "Open lending for inventory, borrowers, and review queues.",
+            note: lendingCard?.note ?? "Keep intake scans separate from the heavier lending workspace until you need them.",
+            metrics: lendingCard?.metrics,
+            actions: [
+              { label: lendingCard?.actionLabel ?? "Open lending", target: "lending" },
+              { label: "Open lending intake", target: "lending-intake", emphasis: "secondary" },
+            ],
+          },
+          financeCard,
+        ],
+      },
+    ];
+  }, [
+    announcementComposerOpen,
+    announcements.length,
+    announcementsError,
+    announcementsLoading,
+    cockpitTodayMessageRows,
+    commerceError,
+    commerceKpis.pendingOrders,
+    commerceKpis.receiptsTotal,
+    commerceKpis.unpaidCheckIns,
+    formatDateTime,
+    messageThreadsError,
+    messagesDegraded,
+    operationsNextReservationLabel,
+    operationsOverview.areaCards,
+    paymentAlerts,
+    paymentDegraded,
+    todayReservations,
+    todayReservationsError,
+    todayReservationsLoading,
+    unreadAnnouncements,
+    unreadMessageCount,
+  ]);
+
+  const taskHomeMoreActions = useMemo<StaffTaskHomeMoreAction[]>(
+    () => [
+      {
+        id: "cockpit",
+        label: "Cockpit",
+        description: "Open the full operations cockpit and automation panels.",
+        target: "cockpit",
+      },
+      {
+        id: "reservations",
+        label: "Reservations calendar",
+        description: "Open the full studio reservations workspace.",
+        target: "studioReservations",
+      },
+      {
+        id: "community-blogs",
+        label: "Community blogs",
+        description: "Edit and review blog content for community publishing.",
+        target: "communityBlogs",
+      },
+      {
+        id: "reports",
+        label: "Reports",
+        description: "Open trust, moderation, and report follow-up tools.",
+        target: "reports",
+      },
+      {
+        id: "system",
+        label: "System",
+        description: "Inspect platform health, incidents, and service checks.",
+        target: "system",
+      },
+      {
+        id: "policy-agent-ops",
+        label: "Policy & agent ops",
+        description: "Open governance, agent, and policy operations surfaces.",
+        target: "policy-agent-ops",
+      },
+      {
+        id: "module-telemetry",
+        label: "Telemetry",
+        description: "Review module telemetry and engagement snapshots.",
+        target: "module-telemetry",
+      },
+    ],
+    []
+  );
+
+  const handleTaskHomeAction = useCallback(
+    (target: string) => {
+      switch (target) {
+        case "messages":
+          openMessagesInbox();
+          return;
+        case "announcementComposer":
+          openAnnouncementWorkflow();
+          return;
+        case "taskHome":
+          openTaskHome();
+          return;
+        case "cockpit":
+          openCockpitWorkspace();
+          return;
+        default:
+          openModuleFromCockpit(target);
+      }
+    },
+    [openAnnouncementWorkflow, openCockpitWorkspace, openMessagesInbox, openModuleFromCockpit, openTaskHome]
+  );
+
+  const updateAnnouncementDraft = useCallback(
+    (field: keyof StaffAnnouncementDraft, value: string | boolean) => {
+      setAnnouncementDraft((current) => ({
+        ...current,
+        [field]: value,
+      }));
+    },
+    []
+  );
+
+  const publishAnnouncement = useCallback(async () => {
+    if (busyRef.current) return;
+
+    const parseScheduleIso = (value: string, label: string) => {
+      const trimmed = value.trim();
+      if (!trimmed) return "";
+      const parsed = new Date(trimmed);
+      if (!Number.isFinite(parsed.getTime())) {
+        throw new Error(`${label} is invalid.`);
+      }
+      return parsed.toISOString();
+    };
+
+    const title = announcementDraft.title.trim();
+    const body = announcementDraft.body.trim();
+    const summary = announcementDraft.summary.trim() || body.replace(/\s+/g, " ").trim().slice(0, 160);
+    const ctaLabel = announcementDraft.ctaLabel.trim();
+    const ctaUrl = announcementDraft.ctaUrl.trim();
+
+    setAnnouncementPublishError("");
+    setAnnouncementPublishStatus("");
+    setError("");
+    setStatus("");
+
+    if (!title) {
+      setAnnouncementPublishError("Announcement title is required.");
+      return;
+    }
+    if (!body) {
+      setAnnouncementPublishError("Announcement body is required.");
+      return;
+    }
+    if ((ctaLabel && !ctaUrl) || (!ctaLabel && ctaUrl)) {
+      setAnnouncementPublishError("Add both a call-to-action label and URL, or leave both blank.");
+      return;
+    }
+    if (ctaUrl && !isValidHttpUrl(ctaUrl)) {
+      setAnnouncementPublishError("Call-to-action URL must start with http:// or https://.");
+      return;
+    }
+
+    let publishAtIso = "";
+    let expiresAtIso = "";
+    try {
+      publishAtIso = parseScheduleIso(announcementDraft.publishAt, "Publish time");
+      expiresAtIso = parseScheduleIso(announcementDraft.expiresAt, "Expiration time");
+      if (
+        publishAtIso &&
+        expiresAtIso &&
+        new Date(expiresAtIso).getTime() <= new Date(publishAtIso).getTime()
+      ) {
+        setAnnouncementPublishError("Expiration time must be after publish time.");
+        return;
+      }
+    } catch (error: unknown) {
+      setAnnouncementPublishError(error instanceof Error ? error.message : String(error));
+      return;
+    }
+
+    busyRef.current = "publishAnnouncement";
+    setBusy("publishAnnouncement");
+
+    try {
+      await addDoc(collection(db, "announcements"), {
+        title,
+        summary,
+        body,
+        type: "studio_update",
+        category: "studio",
+        source: "staff_console",
+        audience: "members",
+        authorName: user.displayName || user.email || "Staff",
+        createdAt: serverTimestamp(),
+        ...(publishAtIso ? { publishAt: publishAtIso } : {}),
+        ...(expiresAtIso ? { expiresAt: expiresAtIso } : {}),
+        ...(ctaLabel && ctaUrl ? { ctaLabel, ctaUrl } : {}),
+        pinned: announcementDraft.pinned,
+        archived: false,
+        readBy: [],
+      });
+      setAnnouncementPublishStatus("Studio announcement published.");
+      setStatus("Studio announcement published.");
+      setAnnouncementDraft(makeEmptyStaffAnnouncementDraft());
+      setAnnouncementComposerOpen(false);
+      onAnnouncementsChanged?.();
+    } catch (error: unknown) {
+      setAnnouncementPublishError(error instanceof Error ? error.message : String(error));
+    } finally {
+      busyRef.current = "";
+      setBusy("");
+    }
+  }, [announcementDraft, onAnnouncementsChanged, user.displayName, user.email]);
 
   const openFiringsWorkspace = useCallback(() => {
     if (onOpenFirings) {
@@ -8834,6 +9403,18 @@ export default function StaffView({
       messageThreadsError={messageThreadsError}
       announcementsError={announcementsError}
       todayMessageRows={cockpitTodayMessageRows}
+      announcementComposerOpen={announcementComposerOpen}
+      announcementDraft={announcementDraft}
+      announcementPublishBusy={busy === "publishAnnouncement"}
+      announcementPublishStatus={announcementPublishStatus}
+      announcementPublishError={announcementPublishError}
+      toggleAnnouncementComposer={() => {
+        setAnnouncementComposerOpen((current) => !current);
+        setAnnouncementPublishError("");
+        setAnnouncementPublishStatus("");
+      }}
+      updateAnnouncementDraft={updateAnnouncementDraft}
+      publishAnnouncement={publishAnnouncement}
       firingsLoading={firingsLoading}
       firingsError={firingsError}
       activeFiring={cockpitActiveFiring}
@@ -8849,8 +9430,22 @@ export default function StaffView({
     />
   );
 
+  const taskHomeContent = (
+    <TaskHomeModule
+      title="Staff tasks"
+      summary="Open the workflow you need by task, not by module tree. The most common staff jobs stay one click away."
+      clickBudgetNote="Click budget: every primary action below opens its workflow in one click. A second click is only for refinement inside that workspace."
+      attentionItems={taskHomeAttentionItems}
+      lanes={taskHomeLanes}
+      moreActions={taskHomeMoreActions}
+      onAction={handleTaskHomeAction}
+    />
+  );
+
   const moduleContent =
-    moduleKey === "studioReservations"
+    isTaskHomeRoute && !forceCockpitWorkspace
+      ? taskHomeContent
+      : moduleKey === "studioReservations"
       ? studioReservationsContent
       : moduleKey === "communityBlogs"
         ? communityBlogsContent
@@ -8875,9 +9470,11 @@ export default function StaffView({
   return (
     <div className="staff-console">
       <section className="staff-console-toolbar">
-        <div className="staff-console-title">Staff console</div>
+        <div className="staff-console-title">{isTaskHomeRoute && !forceCockpitWorkspace ? "Staff tasks" : "Staff console"}</div>
         <p className="staff-console-description">
-          Manage members, pieces, firings, events, billing, lending, and system health.
+          {isTaskHomeRoute && !forceCockpitWorkspace
+            ? "A task-first board for live staff work. Open the workflow you need without hunting through cockpit tabs."
+            : "Manage members, pieces, firings, events, billing, lending, and system health."}
         </p>
         <div className="staff-actions-row">
           {toolbarRefreshPlan.visible ? (
@@ -8889,12 +9486,17 @@ export default function StaffView({
               {busy === toolbarRefreshPlan.key ? "Refreshing..." : "Refresh visible data"}
             </button>
           ) : null}
+          {!isTaskHomeRoute ? (
+            <button className="btn btn-ghost" type="button" onClick={openTaskHome}>
+              Open task home
+            </button>
+          ) : null}
           {onOpenCheckin ? (
             <button className="btn btn-ghost" type="button" onClick={onOpenCheckin}>
               Open ware check-in
             </button>
           ) : null}
-          {isCockpitModule && !forceCockpitWorkspace ? (
+          {isCockpitModule && !forceCockpitWorkspace && !isTaskHomeRoute ? (
             <button
               className="btn btn-ghost"
               type="button"
@@ -8903,7 +9505,7 @@ export default function StaffView({
               {cockpitWorkspaceMode ? "Show module rail" : "Focus cockpit workspace"}
             </button>
           ) : null}
-          {(isCockpitModule || forceCockpitWorkspace) ? (
+          {!isTaskHomeRoute && (isCockpitModule || forceCockpitWorkspace) ? (
             <button
               className="btn btn-ghost"
               type="button"
@@ -8917,7 +9519,9 @@ export default function StaffView({
           ) : null}
         </div>
         <div className="staff-mini">
-          {toolbarRefreshPlan.visible
+          {isTaskHomeRoute && !forceCockpitWorkspace
+            ? "The main board is task-first. Use More tools for rare admin surfaces, and use cockpit only when you want the full operations shell."
+            : toolbarRefreshPlan.visible
             ? "Data loads lazily. Use Refresh visible data for the current cockpit surface, and keep deep module refreshes inside their cards."
             : "Data loads lazily. Use the refresh controls inside the visible module cards to avoid runaway reload chains."}
         </div>

--- a/web/src/views/StaffView.ui.test.tsx
+++ b/web/src/views/StaffView.ui.test.tsx
@@ -71,8 +71,17 @@ vi.mock("../api/functionsClient", () => ({
 }));
 
 vi.mock("./staff/CockpitModule", () => ({
-  default: ({ cockpitOpsContent }: { cockpitOpsContent: ReactNode }) => (
-    <div data-testid="cockpit-module">{cockpitOpsContent}</div>
+  default: ({
+    cockpitOpsContent,
+    announcementComposerOpen,
+  }: {
+    cockpitOpsContent: ReactNode;
+    announcementComposerOpen?: boolean;
+  }) => (
+    <div data-testid="cockpit-module">
+      {announcementComposerOpen ? <div data-testid="cockpit-announcement-composer-open">Announcement composer open</div> : null}
+      {cockpitOpsContent}
+    </div>
   ),
 }));
 
@@ -104,7 +113,9 @@ function buildUser(): User {
     uid: "staff-1",
     email: "staff@example.com",
     displayName: "Staff User",
+    isAnonymous: false,
     getIdToken: vi.fn(async () => "test-token"),
+    getIdTokenResult: vi.fn(async () => ({ claims: {} })),
   } as unknown as User;
 }
 
@@ -126,6 +137,93 @@ describe("StaffView cockpit routing", () => {
   afterEach(() => {
     cleanup();
     vi.unstubAllGlobals();
+  });
+
+  it("renders a task-first home on /staff and keeps rare tools behind More", async () => {
+    window.history.replaceState({}, "", "/staff");
+    render(
+      <StaffView
+        user={buildUser()}
+        isStaff
+        devAdminToken=""
+        onDevAdminTokenChange={() => undefined}
+        devAdminEnabled={false}
+        showEmulatorTools={false}
+      />
+    );
+
+    expect(await screen.findByTestId("staff-task-home")).toBeTruthy();
+    expect(screen.getByTestId("staff-task-home-lane-studio-floor")).toBeTruthy();
+    expect(screen.getByTestId("staff-task-home-lane-member-comms")).toBeTruthy();
+    expect(screen.getByTestId("staff-task-home-lane-programs-and-money")).toBeTruthy();
+
+    const moreTools = screen.getByTestId("staff-task-home-more") as HTMLDetailsElement;
+    expect(moreTools.open).toBe(false);
+    fireEvent.click(screen.getByText("More tools"));
+    expect(moreTools.open).toBe(true);
+    expect(screen.getByTestId("staff-task-home-more-system")).toBeTruthy();
+  });
+
+  it("opens check-ins from the task home in one click", async () => {
+    window.history.replaceState({}, "", "/staff");
+    render(
+      <StaffView
+        user={buildUser()}
+        isStaff
+        devAdminToken=""
+        onDevAdminTokenChange={() => undefined}
+        devAdminEnabled={false}
+        showEmulatorTools={false}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Open today's queue" }));
+
+    await waitFor(() => {
+      expect(window.location.pathname).toBe("/staff/cockpit/checkins");
+    });
+    expect(screen.getByTestId("operations-focus-checkins")).toBeTruthy();
+  });
+
+  it("routes messages directly from the task home using the app callback", async () => {
+    const onOpenMessages = vi.fn();
+    window.history.replaceState({}, "", "/staff");
+    render(
+      <StaffView
+        user={buildUser()}
+        isStaff
+        devAdminToken=""
+        onDevAdminTokenChange={() => undefined}
+        devAdminEnabled={false}
+        showEmulatorTools={false}
+        onOpenMessages={onOpenMessages}
+      />
+    );
+
+    const messagesCard = await screen.findByTestId("staff-task-home-card-messages");
+    fireEvent.click(within(messagesCard).getByRole("button", { name: "Open messages" }));
+    expect(onOpenMessages).toHaveBeenCalledTimes(1);
+  });
+
+  it("promotes the studio announcement workflow from the task home into cockpit", async () => {
+    window.history.replaceState({}, "", "/staff");
+    render(
+      <StaffView
+        user={buildUser()}
+        isStaff
+        devAdminToken=""
+        onDevAdminTokenChange={() => undefined}
+        devAdminEnabled={false}
+        showEmulatorTools={false}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Create studio announcement" }));
+
+    await waitFor(() => {
+      expect(window.location.pathname).toBe("/staff/cockpit");
+    });
+    expect(screen.getByTestId("cockpit-announcement-composer-open")).toBeTruthy();
   });
 
   it("opens lending from operations overview without falling back to the generic cockpit overview", async () => {

--- a/web/src/views/staff/CockpitModule.test.tsx
+++ b/web/src/views/staff/CockpitModule.test.tsx
@@ -1,0 +1,110 @@
+/** @vitest-environment jsdom */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import CockpitModule from "./CockpitModule";
+
+const emptyAnnouncementDraft = {
+  title: "",
+  summary: "",
+  body: "",
+  ctaLabel: "",
+  ctaUrl: "",
+  publishAt: "",
+  expiresAt: "",
+  pinned: false,
+};
+
+function renderCockpitModule(overrides: Partial<Parameters<typeof CockpitModule>[0]> = {}) {
+  const publishAnnouncement = vi.fn(async () => undefined);
+
+  render(
+    <CockpitModule
+      busy=""
+      cockpitOpsContent={<div>ops</div>}
+      shortText={(value) => value}
+      toShortTimeLabel={() => "9:00 AM"}
+      openReservationsToday={() => undefined}
+      openMessagesInbox={() => undefined}
+      startFiringFlow={() => undefined}
+      onOpenMessage={() => undefined}
+      refreshTodayReservations={async () => undefined}
+      refreshTodayFirings={async () => undefined}
+      retryTodayReservations={async () => undefined}
+      retryTodayFirings={async () => undefined}
+      refreshTodayPayments={async () => undefined}
+      openReservationDetail={() => undefined}
+      handleFiringPhotoFile={async () => undefined}
+      todayReservations={[]}
+      todayReservationsLoading={false}
+      todayReservationsError=""
+      unreadMessageCount={0}
+      announcementsCount={0}
+      unreadAnnouncements={0}
+      messageThreadsLoading={false}
+      announcementsLoading={false}
+      messagesDegraded={false}
+      messageThreadsError=""
+      announcementsError=""
+      todayMessageRows={[]}
+      announcementComposerOpen={false}
+      announcementDraft={emptyAnnouncementDraft}
+      announcementPublishBusy={false}
+      announcementPublishStatus=""
+      announcementPublishError=""
+      toggleAnnouncementComposer={() => undefined}
+      updateAnnouncementDraft={() => undefined}
+      publishAnnouncement={publishAnnouncement}
+      firingsLoading={false}
+      firingsError=""
+      activeFiring={null}
+      firingPhotoBusy={false}
+      firingPhotoStatus=""
+      firingPhotoError=""
+      commerceLoading={false}
+      paymentDegraded={false}
+      commerceError=""
+      paymentAlerts={[]}
+      systemSummaryToneLabel="Stable"
+      systemSummaryMessage="All clear."
+      {...overrides}
+    />
+  );
+
+  return { publishAnnouncement };
+}
+
+describe("CockpitModule announcement composer", () => {
+  it("shows a visible create announcement action in the messages card", () => {
+    renderCockpitModule();
+
+    expect(screen.getByRole("button", { name: "Create studio announcement" })).toBeTruthy();
+  });
+
+  it("renders composer fields and submits once title and body are present", () => {
+    const publishAnnouncement = vi.fn(async () => undefined);
+
+    renderCockpitModule({
+      announcementComposerOpen: true,
+      announcementDraft: {
+        ...emptyAnnouncementDraft,
+        title: "Kiln unload moved",
+        body: "Glaze unload has moved to 4 PM today.",
+      },
+      publishAnnouncement,
+    });
+
+    expect(screen.getByTestId("staff-announcement-composer")).toBeTruthy();
+    expect(screen.getByLabelText("Title")).toBeTruthy();
+    expect(
+      screen.getByPlaceholderText("Share the studio update, schedule note, or member-facing alert.")
+    ).toBeTruthy();
+
+    const publishButton = screen.getByRole("button", { name: "Publish announcement" });
+    expect((publishButton as HTMLButtonElement).disabled).toBe(false);
+
+    fireEvent.click(publishButton);
+    expect(publishAnnouncement).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/views/staff/CockpitModule.tsx
+++ b/web/src/views/staff/CockpitModule.tsx
@@ -32,6 +32,17 @@ type ActiveFiringSummary = {
   updatedLabel: string;
 };
 
+type AnnouncementComposerDraft = {
+  title: string;
+  summary: string;
+  body: string;
+  ctaLabel: string;
+  ctaUrl: string;
+  publishAt: string;
+  expiresAt: string;
+  pinned: boolean;
+};
+
 type CockpitModuleProps = {
   busy: string;
   cockpitOpsContent: ReactNode;
@@ -65,6 +76,14 @@ type CockpitModuleProps = {
   messageThreadsError: string;
   announcementsError: string;
   todayMessageRows: ReadonlyArray<TodayMessageRow>;
+  announcementComposerOpen: boolean;
+  announcementDraft: AnnouncementComposerDraft;
+  announcementPublishBusy: boolean;
+  announcementPublishStatus: string;
+  announcementPublishError: string;
+  toggleAnnouncementComposer: () => void;
+  updateAnnouncementDraft: (field: keyof AnnouncementComposerDraft, value: string | boolean) => void;
+  publishAnnouncement: () => Promise<void>;
 
   firingsLoading: boolean;
   firingsError: string;
@@ -115,6 +134,14 @@ export default function CockpitModule({
   messageThreadsError,
   announcementsError,
   todayMessageRows,
+  announcementComposerOpen,
+  announcementDraft,
+  announcementPublishBusy,
+  announcementPublishStatus,
+  announcementPublishError,
+  toggleAnnouncementComposer,
+  updateAnnouncementDraft,
+  publishAnnouncement,
   firingsLoading,
   firingsError,
   activeFiring,
@@ -238,6 +265,115 @@ export default function CockpitModule({
             <span className="pill">Unread announcements {unreadAnnouncements}</span>
             <span className="pill">Announcements {announcementsCount}</span>
           </div>
+          <div className="staff-actions-row">
+            <button
+              className="btn btn-secondary btn-small"
+              type="button"
+              data-testid="staff-create-announcement-toggle"
+              onClick={() => toggleAnnouncementComposer()}
+            >
+              {announcementComposerOpen ? "Hide announcement composer" : "Create studio announcement"}
+            </button>
+          </div>
+          {announcementComposerOpen ? (
+            <div className="staff-announcement-composer" data-testid="staff-announcement-composer">
+              <div className="staff-note">
+                Publish a studio announcement for signed-in members. New announcements appear in Dashboard and Messages.
+              </div>
+              <div className="staff-module-grid">
+                <label className="staff-field staff-column">
+                  <span>Title</span>
+                  <input
+                    type="text"
+                    value={announcementDraft.title}
+                    placeholder="Studio update title"
+                    onChange={(event) => updateAnnouncementDraft("title", event.target.value)}
+                  />
+                </label>
+                <label className="staff-field staff-column">
+                  <span>Summary</span>
+                  <input
+                    type="text"
+                    value={announcementDraft.summary}
+                    placeholder="Optional short preview"
+                    onChange={(event) => updateAnnouncementDraft("summary", event.target.value)}
+                  />
+                </label>
+              </div>
+              <label className="staff-field staff-column">
+                <span>Body</span>
+                <textarea
+                  value={announcementDraft.body}
+                  placeholder="Share the studio update, schedule note, or member-facing alert."
+                  onChange={(event) => updateAnnouncementDraft("body", event.target.value)}
+                />
+                <span className="helper">
+                  Leave publish time blank to post immediately. Leave expiration blank to keep it visible until archived.
+                </span>
+              </label>
+              <div className="staff-module-grid">
+                <label className="staff-field staff-column">
+                  <span>Publish at</span>
+                  <input
+                    type="datetime-local"
+                    value={announcementDraft.publishAt}
+                    onChange={(event) => updateAnnouncementDraft("publishAt", event.target.value)}
+                  />
+                </label>
+                <label className="staff-field staff-column">
+                  <span>Expires at</span>
+                  <input
+                    type="datetime-local"
+                    value={announcementDraft.expiresAt}
+                    onChange={(event) => updateAnnouncementDraft("expiresAt", event.target.value)}
+                  />
+                </label>
+              </div>
+              <div className="staff-module-grid">
+                <label className="staff-field staff-column">
+                  <span>Call to action label</span>
+                  <input
+                    type="text"
+                    value={announcementDraft.ctaLabel}
+                    placeholder="Optional CTA label"
+                    onChange={(event) => updateAnnouncementDraft("ctaLabel", event.target.value)}
+                  />
+                </label>
+                <label className="staff-field staff-column">
+                  <span>Call to action URL</span>
+                  <input
+                    type="url"
+                    value={announcementDraft.ctaUrl}
+                    placeholder="https://portal.monsoonfire.com/..."
+                    onChange={(event) => updateAnnouncementDraft("ctaUrl", event.target.value)}
+                  />
+                </label>
+              </div>
+              <label className="staff-announcement-checkbox">
+                <input
+                  type="checkbox"
+                  checked={announcementDraft.pinned}
+                  onChange={(event) => updateAnnouncementDraft("pinned", event.target.checked)}
+                />
+                <span>Pin this announcement near the top of the member feed.</span>
+              </label>
+              {announcementPublishStatus ? <div className="staff-note staff-note-ok">{announcementPublishStatus}</div> : null}
+              {announcementPublishError ? <div className="staff-note staff-note-error">{announcementPublishError}</div> : null}
+              <div className="staff-actions-row">
+                <button
+                  className="btn btn-primary btn-small"
+                  type="button"
+                  disabled={announcementPublishBusy || !announcementDraft.title.trim() || !announcementDraft.body.trim()}
+                  onClick={() => void publishAnnouncement()}
+                >
+                  {announcementPublishBusy ? "Publishing..." : "Publish announcement"}
+                </button>
+                <button className="btn btn-ghost btn-small" type="button" onClick={() => toggleAnnouncementComposer()}>
+                  Close
+                </button>
+              </div>
+            </div>
+          ) : null}
           {messageThreadsLoading || announcementsLoading ? (
             <div className="staff-skeleton-list" aria-hidden="true">
               {Array.from({ length: 4 }).map((_, index) => (

--- a/web/src/views/staff/TaskHomeModule.tsx
+++ b/web/src/views/staff/TaskHomeModule.tsx
@@ -1,0 +1,203 @@
+export type StaffTaskHomeTone = "action" | "watch" | "clear" | "reference";
+
+export type StaffTaskHomeAction = {
+  label: string;
+  target: string;
+  emphasis?: "primary" | "secondary" | "ghost";
+};
+
+export type StaffTaskHomeMetric = {
+  label: string;
+  value: string;
+};
+
+export type StaffTaskHomeCard = {
+  id: string;
+  eyebrow: string;
+  title: string;
+  badge: string;
+  tone: StaffTaskHomeTone;
+  summary: string;
+  note?: string;
+  metrics?: ReadonlyArray<StaffTaskHomeMetric>;
+  actions: ReadonlyArray<StaffTaskHomeAction>;
+};
+
+export type StaffTaskHomeLane = {
+  id: string;
+  title: string;
+  subtitle: string;
+  cards: ReadonlyArray<StaffTaskHomeCard>;
+};
+
+export type StaffTaskHomeAttentionItem = {
+  id: string;
+  tone: "action" | "watch";
+  title: string;
+  detail: string;
+  actionLabel: string;
+  actionTarget: string;
+};
+
+export type StaffTaskHomeMoreAction = {
+  id: string;
+  label: string;
+  description: string;
+  target: string;
+};
+
+type TaskHomeModuleProps = {
+  title: string;
+  summary: string;
+  clickBudgetNote: string;
+  attentionItems: ReadonlyArray<StaffTaskHomeAttentionItem>;
+  lanes: ReadonlyArray<StaffTaskHomeLane>;
+  moreActions: ReadonlyArray<StaffTaskHomeMoreAction>;
+  onAction: (target: string) => void;
+};
+
+function resolveActionClass(action: StaffTaskHomeAction): string {
+  switch (action.emphasis) {
+    case "secondary":
+      return "btn btn-secondary btn-small";
+    case "ghost":
+      return "btn btn-ghost btn-small";
+    default:
+      return "btn btn-primary btn-small";
+  }
+}
+
+export default function TaskHomeModule({
+  title,
+  summary,
+  clickBudgetNote,
+  attentionItems,
+  lanes,
+  moreActions,
+  onAction,
+}: TaskHomeModuleProps) {
+  return (
+    <section className="staff-task-home" data-testid="staff-task-home">
+      <section className="card staff-console-card staff-task-home-hero">
+        <div className="staff-column">
+          <div className="staff-subtitle">Task-first staff home</div>
+          <div className="card-title">{title}</div>
+          <p className="card-subtitle">{summary}</p>
+        </div>
+        <div className="staff-note staff-note-muted">{clickBudgetNote}</div>
+      </section>
+
+      <section className="card staff-console-card">
+        <div className="card-title">Needs attention now</div>
+        <p className="card-subtitle">A short queue for the next highest-value move on shift.</p>
+        {attentionItems.length === 0 ? (
+          <div className="staff-note staff-note-ok">No urgent staff blockers are active right now.</div>
+        ) : (
+          <div className="staff-task-home-attention-list">
+            {attentionItems.map((item) => (
+              <div
+                key={item.id}
+                className="staff-task-home-attention-item"
+                data-testid={`staff-task-home-attention-${item.id}`}
+                data-tone={item.tone}
+              >
+                <div className="staff-column">
+                  <div className="staff-shift-status-reason-top">
+                    <span className={`pill ${item.tone === "action" ? "staff-pill-danger" : "staff-pill-warn"}`}>
+                      {item.tone === "action" ? "Now" : "Watch"}
+                    </span>
+                    <strong>{item.title}</strong>
+                  </div>
+                  <div className="staff-mini">{item.detail}</div>
+                </div>
+                <button
+                  type="button"
+                  className="btn btn-ghost btn-small"
+                  onClick={() => onAction(item.actionTarget)}
+                >
+                  {item.actionLabel}
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+
+      {lanes.map((lane) => (
+        <section key={lane.id} className="staff-task-home-lane" data-testid={`staff-task-home-lane-${lane.id}`}>
+          <div className="staff-task-home-lane-header">
+            <div className="staff-column">
+              <div className="card-title">{lane.title}</div>
+              <p className="card-subtitle">{lane.subtitle}</p>
+            </div>
+          </div>
+          <div className="staff-task-home-lane-grid">
+            {lane.cards.map((card) => (
+              <section
+                key={card.id}
+                className="card staff-console-card staff-task-home-card"
+                data-testid={`staff-task-home-card-${card.id}`}
+                data-tone={card.tone}
+              >
+                <div className="staff-task-home-card-header">
+                  <div className="staff-column">
+                    <div className="staff-subtitle">{card.eyebrow}</div>
+                    <div className="card-title">{card.title}</div>
+                  </div>
+                  <span className={`pill staff-task-home-card-badge staff-task-home-card-badge-${card.tone}`}>
+                    {card.badge}
+                  </span>
+                </div>
+                <p className="card-subtitle">{card.summary}</p>
+                {card.metrics?.length ? (
+                  <div className="staff-task-home-card-metrics">
+                    {card.metrics.map((metric) => (
+                      <div key={`${card.id}-${metric.label}`} className="staff-task-home-card-metric">
+                        <span>{metric.label}</span>
+                        <strong>{metric.value}</strong>
+                      </div>
+                    ))}
+                  </div>
+                ) : null}
+                {card.note ? <div className="staff-note staff-note-muted">{card.note}</div> : null}
+                <div className="staff-actions-row">
+                  {card.actions.map((action) => (
+                    <button
+                      key={`${card.id}-${action.label}`}
+                      type="button"
+                      className={resolveActionClass(action)}
+                      onClick={() => onAction(action.target)}
+                    >
+                      {action.label}
+                    </button>
+                  ))}
+                </div>
+              </section>
+            ))}
+          </div>
+        </section>
+      ))}
+
+      <details className="card staff-console-card staff-task-home-more" data-testid="staff-task-home-more">
+        <summary>More tools</summary>
+        <div className="staff-note staff-note-muted">
+          Rare and power-user tools stay here so the main board can stay focused on live staff work.
+        </div>
+        <div className="staff-task-home-more-grid">
+          {moreActions.map((action) => (
+            <button
+              key={action.id}
+              type="button"
+              className="staff-task-home-more-btn"
+              data-testid={`staff-task-home-more-${action.id}`}
+              onClick={() => onAction(action.target)}
+            >
+              <strong>{action.label}</strong>
+              <span>{action.description}</span>
+            </button>
+          ))}
+        </div>
+      </details>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- replace the module-first Staff landing with a task-first `/staff` board built around real workflows
- add direct task shortcuts for staff messages and studio announcements while preserving legacy deep links
- harden portal auth/deploy smoke coverage so missing Firebase bootstrap regressions fail earlier

## Testing
- npm --prefix web run test:run -- src/views/SignedOutView.test.tsx src/views/staff/CockpitModule.test.tsx src/views/StaffView.ui.test.tsx src/utils/staffTaskShortcuts.test.ts
- node --test scripts/deploy-firebase-safe.test.mjs
- npm --prefix web run build
- deployed Firebase Hosting preview and verified root, `/staff`, and console scan