### PR TITLE
feat(studio-brain): add synthetic thread scrubber

### DIFF
--- a/scripts/open-memory.mjs
+++ b/scripts/open-memory.mjs
@@ -205,6 +205,7 @@ async function main() {
         "  node ./scripts/open-memory.mjs backfill-email-threading [--tenant-id ...] [--limit 2000] [--dry-run true] [--source-prefixes mail:,email]",
         "  node ./scripts/open-memory.mjs backfill-email-intelligence [--tenant-id ...] [--limit 2000] [--dry-run true] [--source-prefixes mail:,email]",
         "  node ./scripts/open-memory.mjs backfill-signal-indexing [--tenant-id ...] [--limit 2000] [--dry-run true] [--source-prefixes mail:,email] [--min-signals 2]",
+        "  node ./scripts/open-memory.mjs scrub-thread-metadata [--tenant-id ...] [--limit 2000] [--dry-run true] [--source-prefixes import,replay:,repo-markdown]",
         "  node ./scripts/open-memory.mjs ingest --text \"...\" --source discord --client-request-id msg-123 [--discord-guild-id ...] [--discord-channel-id ...]",
         "",
         "Optional flags:",
@@ -220,11 +221,12 @@ async function main() {
         "  --relationship-preview-max-chars <n> Search mode: context payload chars per seed (default: 10000).",
         "  --disable-run-burst-limit true|false  Disable run-write burst limiter for this import batch (default: false).",
         "  --post-import-briefing true|false  Generate loop/action briefing after import (default: auto for mail-like sources).",
-        "  --dry-run true|false  For backfill-email-threading/backfill-signal-indexing, preview changes without writing.",
-        "  --max-writes <n>  For backfill-email-threading/backfill-signal-indexing, cap write operations per run (default: 500).",
+        "  --dry-run true|false  For backfill-email-threading/backfill-signal-indexing/scrub-thread-metadata, preview changes without writing.",
+        "  --max-writes <n>  For backfill-email-threading/backfill-signal-indexing/scrub-thread-metadata, cap write operations per run (default: 500).",
         "  --write-delay-ms <n>  Delay between backfill writes to reduce load (default: 20).",
         "  --stop-after-timeout-errors <n>  Stop backfill after consecutive timeout errors (default: 5).",
         "  --include-non-mail-like true|false  Include non-mail sources in backfill-signal-indexing (default: false).",
+        "  --include-mail-like true|false  Include mail-like rows in scrub-thread-metadata (default: false).",
         "  --min-signals <n>  For backfill-signal-indexing, minimum derived signal items per memory (default: 1).",
         "  --skip-already-indexed true|false  For backfill-signal-indexing, skip rows whose signal index already appears populated (default: true).",
         "  --infer-relationships true|false  For backfill-signal-indexing, infer high-signal edges using related-memory probes (default: true).",
@@ -946,6 +948,22 @@ async function main() {
       stopAfterTimeoutErrors: intFlag(flags["stop-after-timeout-errors"], 5),
     };
     const result = await request("/api/memory/backfill-signal-indexing", "POST", payload);
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    return;
+  }
+
+  if (command === "scrub-thread-metadata") {
+    const payload = {
+      tenantId: flags["tenant-id"] ? String(flags["tenant-id"]).trim() : undefined,
+      limit: intFlag(flags.limit, 2000),
+      dryRun: boolFlag(flags["dry-run"], false),
+      sourcePrefixes: flags["source-prefixes"] ? parseCsv(flags["source-prefixes"]) : undefined,
+      includeMailLike: boolFlag(flags["include-mail-like"], false),
+      maxWrites: intFlag(flags["max-writes"], 500),
+      writeDelayMs: intFlag(flags["write-delay-ms"], 20),
+      stopAfterTimeoutErrors: intFlag(flags["stop-after-timeout-errors"], 5),
+    };
+    const result = await request("/api/memory/scrub-thread-metadata", "POST", payload);
     process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
     return;
   }

--- a/studio-brain/lib/http/server.js
+++ b/studio-brain/lib/http/server.js
@@ -2475,6 +2475,75 @@ function startHttpServer(params) {
                 }
                 return;
             }
+            if (memoryService && method === "POST" && url.pathname === "/api/memory/scrub-thread-metadata") {
+                const auth = await assertCapabilityAuth(req);
+                if (!auth.ok) {
+                    statusCode = 401;
+                    res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+                    res.end(JSON.stringify({ ok: false, message: auth.message }));
+                    return;
+                }
+                const pressure = memoryPressureSnapshot();
+                if (pressure.activeImportRequests >= memoryPressureConfig.maxActiveImportsBeforeBackfill ||
+                    pressure.activeBackfillRequests >= memoryPressureConfig.maxConcurrentBackfills) {
+                    const reason = pressure.activeImportRequests >= memoryPressureConfig.maxActiveImportsBeforeBackfill
+                        ? "active-import-pressure"
+                        : "backfill-concurrency-limit";
+                    statusCode = 503;
+                    res.writeHead(statusCode, withSecurityHeaders({
+                        "content-type": "application/json",
+                        ...corsHeaders,
+                        "x-request-id": requestId,
+                        "retry-after": String(memoryPressureConfig.retryAfterSeconds),
+                    }));
+                    res.end(JSON.stringify({
+                        ok: false,
+                        message: "Backfill deferred due current memory ingest pressure.",
+                        reason,
+                        retryAfterSeconds: memoryPressureConfig.retryAfterSeconds,
+                        pressure,
+                    }));
+                    return;
+                }
+                try {
+                    const payload = await readJsonBody(req);
+                    let result;
+                    activeBackfillRequests += 1;
+                    try {
+                        result = await memoryService.scrubSyntheticThreadMetadata(payload);
+                    }
+                    finally {
+                        activeBackfillRequests = Math.max(0, activeBackfillRequests - 1);
+                    }
+                    logger.info("memory_scrub_thread_metadata_summary", {
+                        requestId,
+                        tenantId: result.tenantId ?? null,
+                        dryRun: result.dryRun,
+                        scanned: result.scanned,
+                        eligible: result.eligible,
+                        updated: result.updated,
+                        skipped: result.skipped,
+                        failed: result.failed,
+                        writesAttempted: result.writesAttempted ?? 0,
+                        maxWrites: result.maxWrites ?? 0,
+                        timeoutErrors: result.timeoutErrors ?? 0,
+                        stopReason: result.stopReason ?? null,
+                        convergence: result.convergence ?? null,
+                        pressure: memoryPressureSnapshot(),
+                    });
+                    statusCode = 200;
+                    res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+                    res.end(JSON.stringify({ ok: true, result }));
+                }
+                catch (error) {
+                    const message = error instanceof Error ? error.message : String(error);
+                    const isValidation = error instanceof service_1.MemoryValidationError;
+                    statusCode = isValidation ? 400 : 500;
+                    res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+                    res.end(JSON.stringify({ ok: false, message }));
+                }
+                return;
+            }
             if (capabilityRuntime && method === "GET" && url.pathname === "/api/capabilities") {
                 const auth = await assertCapabilityAuth(req);
                 if (!auth.ok) {

--- a/studio-brain/lib/memory/contracts.js
+++ b/studio-brain/lib/memory/contracts.js
@@ -1,6 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.memoryLoopAutomationTickRequestSchema = exports.memoryLoopActionPlanRequestSchema = exports.memoryLoopOwnerQueuesRequestSchema = exports.memoryLoopFeedbackStatsRequestSchema = exports.memoryLoopIncidentActionBatchRequestSchema = exports.memoryLoopIncidentActionRequestSchema = exports.memoryLoopsRequestSchema = exports.memorySignalIndexBackfillRequestSchema = exports.memoryEmailThreadBackfillRequestSchema = exports.memoryImportRequestSchema = exports.memoryContextRequestSchema = exports.memoryStatsRequestSchema = exports.memoryRecentRequestSchema = exports.memorySearchRequestSchema = exports.memoryCaptureRequestSchema = exports.memoryLoopSortSchema = exports.memoryLoopActionPrioritySchema = exports.memoryLoopIncidentActionTypeSchema = exports.memoryLoopLaneSchema = exports.memoryLoopStateSchema = exports.memoryTypeSchema = exports.memoryStatusSchema = exports.memoryQueryLaneSchema = exports.retrievalModeSchema = exports.embeddingSchema = exports.MAX_MEMORY_IMPORT_ITEMS = exports.MAX_MEMORY_LIMIT = exports.MAX_MEMORY_CONTENT_CHARS = void 0;
+exports.memoryLoopAutomationTickRequestSchema = exports.memoryLoopActionPlanRequestSchema = exports.memoryLoopOwnerQueuesRequestSchema = exports.memoryLoopFeedbackStatsRequestSchema = exports.memoryLoopIncidentActionBatchRequestSchema = exports.memoryLoopIncidentActionRequestSchema = exports.memoryLoopsRequestSchema = exports.memoryThreadMetadataScrubRequestSchema = exports.memorySignalIndexBackfillRequestSchema = exports.memoryEmailThreadBackfillRequestSchema = exports.memoryImportRequestSchema = exports.memoryContextRequestSchema = exports.memoryStatsRequestSchema = exports.memoryRecentRequestSchema = exports.memorySearchRequestSchema = exports.memoryCaptureRequestSchema = exports.memoryLoopSortSchema = exports.memoryLoopActionPrioritySchema = exports.memoryLoopIncidentActionTypeSchema = exports.memoryLoopLaneSchema = exports.memoryLoopStateSchema = exports.memoryTypeSchema = exports.memoryStatusSchema = exports.memoryQueryLaneSchema = exports.retrievalModeSchema = exports.embeddingSchema = exports.MAX_MEMORY_IMPORT_ITEMS = exports.MAX_MEMORY_LIMIT = exports.MAX_MEMORY_CONTENT_CHARS = void 0;
 const zod_1 = require("zod");
 exports.MAX_MEMORY_CONTENT_CHARS = 65_536;
 exports.MAX_MEMORY_LIMIT = 100;
@@ -128,6 +128,16 @@ exports.memorySignalIndexBackfillRequestSchema = zod_1.z.object({
     relationshipProbeLimit: zod_1.z.number().int().min(2).max(128).default(24),
     maxInferredEdgesPerMemory: zod_1.z.number().int().min(0).max(128).default(16),
     minRelatedSignalScore: zod_1.z.number().min(0).max(2).default(0.12),
+    maxWrites: zod_1.z.number().int().min(1).max(20_000).default(500),
+    writeDelayMs: zod_1.z.number().int().min(0).max(60_000).default(20),
+    stopAfterTimeoutErrors: zod_1.z.number().int().min(1).max(100).default(5),
+});
+exports.memoryThreadMetadataScrubRequestSchema = zod_1.z.object({
+    tenantId: zod_1.z.string().trim().min(1).max(128).nullable().optional(),
+    limit: zod_1.z.number().int().min(1).max(20_000).default(2_000),
+    dryRun: zod_1.z.boolean().default(false),
+    sourcePrefixes: zod_1.z.array(zod_1.z.string().trim().min(1).max(64)).max(24).default([]),
+    includeMailLike: zod_1.z.boolean().default(false),
     maxWrites: zod_1.z.number().int().min(1).max(20_000).default(500),
     writeDelayMs: zod_1.z.number().int().min(0).max(60_000).default(20),
     stopAfterTimeoutErrors: zod_1.z.number().int().min(1).max(100).default(5),

--- a/studio-brain/lib/memory/inMemoryAdapter.js
+++ b/studio-brain/lib/memory/inMemoryAdapter.js
@@ -311,6 +311,24 @@ function createInMemoryMemoryStoreAdapter() {
                 .filter((row) => (excludedStatuses.size > 0 ? !excludedStatuses.has(row.status) : true))
                 .slice(0, Math.max(1, input.limit));
         },
+        async recentCreated(input) {
+            const normalizedAllow = new Set((input.sourceAllowlist ?? []).map((value) => value.trim()).filter(Boolean));
+            const normalizedDeny = new Set((input.sourceDenylist ?? []).map((value) => value.trim()).filter(Boolean));
+            const excludedStatuses = new Set((input.excludeStatuses ?? []).map((value) => String(value ?? "").trim()).filter(Boolean));
+            return toArray()
+                .filter((row) => (input.tenantId === undefined ? true : row.tenantId === input.tenantId))
+                .filter((row) => (input.agentId ? row.agentId === input.agentId : true))
+                .filter((row) => (input.runId ? row.runId === input.runId : true))
+                .filter((row) => (normalizedAllow.size > 0 ? normalizedAllow.has(row.source) : true))
+                .filter((row) => (normalizedDeny.size > 0 ? !normalizedDeny.has(row.source) : true))
+                .filter((row) => (excludedStatuses.size > 0 ? !excludedStatuses.has(row.status) : true))
+                .sort((left, right) => {
+                const rightCreated = Date.parse(right.createdAt || "") || 0;
+                const leftCreated = Date.parse(left.createdAt || "") || 0;
+                return rightCreated - leftCreated;
+            })
+                .slice(0, Math.max(1, input.limit));
+        },
         async stats(input) {
             return stats(input.tenantId);
         },

--- a/studio-brain/lib/memory/postgresAdapter.js
+++ b/studio-brain/lib/memory/postgresAdapter.js
@@ -507,6 +507,61 @@ function createPostgresMemoryStoreAdapter(params) {
             const result = await pool.query(query, values);
             return result.rows.map(mapRowToRecord);
         },
+        async recentCreated(input) {
+            const values = [];
+            const predicates = [];
+            if (input.tenantId !== undefined) {
+                values.push(input.tenantId);
+                predicates.push(`tenant_id IS NOT DISTINCT FROM $${values.length}`);
+            }
+            const agentId = String(input.agentId ?? "").trim();
+            if (agentId) {
+                values.push(agentId);
+                predicates.push(`agent_id = $${values.length}`);
+            }
+            const runId = String(input.runId ?? "").trim();
+            if (runId) {
+                values.push(runId);
+                predicates.push(`run_id = $${values.length}`);
+            }
+            const allow = sanitizeSourceList(input.sourceAllowlist);
+            if (allow.length > 0) {
+                values.push(allow);
+                predicates.push(`COALESCE(metadata->>'source', 'manual') = ANY($${values.length}::text[])`);
+            }
+            const deny = sanitizeSourceList(input.sourceDenylist);
+            if (deny.length > 0) {
+                values.push(deny);
+                predicates.push(`COALESCE(metadata->>'source', 'manual') <> ALL($${values.length}::text[])`);
+            }
+            const excludedStatuses = sanitizeStatusList(input.excludeStatuses);
+            if (excludedStatuses.length > 0) {
+                values.push(excludedStatuses);
+                predicates.push(`status <> ALL($${values.length}::text[])`);
+            }
+            values.push(input.limit);
+            const query = `
+        SELECT
+          memory_id,
+          agent_id,
+          run_id,
+          tenant_id,
+          content,
+          metadata,
+          created_at,
+          occurred_at,
+          status,
+          memory_type,
+          source_confidence,
+          importance
+          FROM ${tableName}
+         ${predicates.length ? `WHERE ${predicates.join(" AND ")}` : ""}
+         ORDER BY created_at DESC
+         LIMIT $${values.length}
+      `;
+            const result = await pool.query(query, values);
+            return result.rows.map(mapRowToRecord);
+        },
         async getByIds(input) {
             const ids = Array.from(new Set((input.ids ?? []).map((value) => String(value ?? "").trim()).filter(Boolean)));
             if (!ids.length)

--- a/studio-brain/lib/memory/service.js
+++ b/studio-brain/lib/memory/service.js
@@ -462,14 +462,22 @@ function enrichCaptureMetadata(payload) {
         normalizeText(enriched.thread) ||
         normalizeText(enriched.thread_id) ||
         normalizeText(enriched.conversationId);
+    const supportsDerivedThreading = Boolean(isEmailLike || normalizedMessageId || inReplyToNormalized || referenceMessageIds.length > 0);
     const inferredThreadKey = existingThreadKey ||
-        normalizePatternKey([
-            "mail-thread",
-            subjectKey.slice(0, 80) || participantDomains[0] || "unknown",
-            referenceMessageIds[0] || inReplyToNormalized || normalizedMessageId || "",
-        ]
-            .filter(Boolean)
-            .join(":"));
+        (supportsDerivedThreading
+            ? normalizePatternKey([
+                "mail-thread",
+                subjectKey.slice(0, 80) || participantDomains[0] || "unknown",
+                referenceMessageIds[0] || inReplyToNormalized || normalizedMessageId || "",
+            ]
+                .filter(Boolean)
+                .join(":"))
+            : "");
+    const threadEvidence = existingThreadKey
+        ? "explicit"
+        : inferredThreadKey
+            ? "derived"
+            : "none";
     const tickets = mergeUniqueStrings(enriched.mentionedTickets, `${subject}\n${payload.content}`.match(TICKET_PATTERN) ?? [], 24).map((value) => String(value).toUpperCase());
     const urls = mergeUniqueStrings(enriched.mentionedUrls, `${subject}\n${payload.content}`.match(URL_PATTERN) ?? [], 24).map((value) => String(value).toLowerCase());
     const topicTokens = mergeUniqueStrings(enriched.topicTokens, subjectKey
@@ -478,14 +486,18 @@ function enrichCaptureMetadata(payload) {
         .filter((token) => token.length >= 4)
         .slice(0, 18), 32).map((value) => String(value).toLowerCase());
     const inferredLoopState = inferLoopStateFromContent(subject, payload.content.slice(0, 14_000));
-    const loopClusterKey = inferLoopClusterKeyFromEmail({
-        existing: normalizeText(enriched.loopClusterKey),
-        threadKey: inferredThreadKey,
-        subjectKey,
-        tickets,
-        participantDomains,
-    });
+    const loopClusterKey = threadEvidence !== "none"
+        ? inferLoopClusterKeyFromEmail({
+            existing: normalizeText(enriched.loopClusterKey),
+            threadKey: inferredThreadKey,
+            subjectKey,
+            tickets,
+            participantDomains,
+        })
+        : "";
     const deterministicThreadSignature = (() => {
+        if (threadEvidence === "none")
+            return "";
         const signatureBasis = [
             inferredThreadKey,
             normalizedMessageId,
@@ -521,9 +533,9 @@ function enrichCaptureMetadata(payload) {
     }
     if (inReplyToNormalized || referenceMessageIds.length > 0)
         patternHints.add("structure:has-references");
-    if (inferredThreadKey)
+    if (threadEvidence !== "none" && inferredThreadKey)
         patternHints.add("structure:has-thread");
-    if (deterministicThreadSignature)
+    if (threadEvidence !== "none" && deterministicThreadSignature)
         patternHints.add(`thread-signature:${deterministicThreadSignature}`);
     if (normalizedMessageId && (inReplyToNormalized || referenceMessageIds.length > 0)) {
         patternHints.add("structure:deterministic-thread-link");
@@ -534,9 +546,9 @@ function enrichCaptureMetadata(payload) {
         entityHints.add(`message-ref:${inReplyToNormalized}`);
     for (const ref of referenceMessageIds.slice(0, 16))
         entityHints.add(`message-ref:${ref}`);
-    if (inferredThreadKey)
+    if (threadEvidence !== "none" && inferredThreadKey)
         entityHints.add(`thread:${inferredThreadKey}`);
-    if (deterministicThreadSignature)
+    if (threadEvidence !== "none" && deterministicThreadSignature)
         entityHints.add(`thread-signature:${deterministicThreadSignature}`);
     if (participantKey)
         entityHints.add(`participants:${participantKey}`);
@@ -559,6 +571,8 @@ function enrichCaptureMetadata(payload) {
     messageStructure.hasReplyTo = Boolean(inReplyToNormalized);
     messageStructure.hasReferences = referenceMessageIds.length > 0;
     messageStructure.hasThreadKey = Boolean(inferredThreadKey);
+    messageStructure.sourceFamily = isEmailLike ? "mail" : "generic";
+    messageStructure.threadEvidence = threadEvidence;
     const structureSignalCount = Number(messageStructure.hasMessageId === true) +
         Number(messageStructure.hasReplyTo === true) +
         Number(messageStructure.hasReferences === true) +
@@ -592,12 +606,13 @@ function enrichCaptureMetadata(payload) {
         enriched.inReplyToNormalized = inReplyToNormalized;
     if (referenceMessageIds.length > 0)
         enriched.referenceMessageIds = referenceMessageIds;
-    if (inferredThreadKey)
+    if (threadEvidence !== "none" && inferredThreadKey)
         enriched.threadKey = inferredThreadKey;
-    if (loopClusterKey)
+    if (threadEvidence !== "none" && loopClusterKey)
         enriched.loopClusterKey = loopClusterKey;
-    if (deterministicThreadSignature)
+    if (threadEvidence !== "none" && deterministicThreadSignature)
         enriched.threadDeterministicSignature = deterministicThreadSignature;
+    enriched.threadEvidence = threadEvidence;
     if (!normalizeText(enriched.loopState) && inferredLoopState)
         enriched.loopState = inferredLoopState;
     if (tickets.length > 0)
@@ -628,6 +643,7 @@ function enrichCaptureMetadata(payload) {
         hasMessageId: Boolean(normalizedMessageId),
         inferredLoopState: inferredLoopState ?? null,
         sourceFamily: isEmailLike ? "mail" : "generic",
+        threadEvidence,
     };
     return enriched;
 }
@@ -967,7 +983,7 @@ function deriveSignalIndex(payload) {
     for (const tag of payload.tags.slice(0, 24)) {
         appendEntity(entities, entitySeen, "tag", tag, tag, 0.55);
     }
-    const threadKey = normalizeText(metadata.threadKey || metadata.thread || metadata.conversationId || metadata.thread_id);
+    const threadKey = threadKeyFromMetadata(metadata);
     if (threadKey)
         appendEntity(entities, entitySeen, "thread", threadKey, threadKey, 0.9);
     if (threadKey)
@@ -982,7 +998,7 @@ function deriveSignalIndex(payload) {
         appendEntity(entities, entitySeen, "participants", participantKey, participantKey, 0.82);
     if (participantKey)
         appendPattern(patterns, patternSeen, "participants", participantKey, participantKey, 0.78);
-    const loopClusterKey = normalizeText(metadata.loopClusterKey);
+    const loopClusterKey = loopClusterKeyFromMetadata(metadata);
     if (loopClusterKey)
         appendPattern(patterns, patternSeen, "loop-cluster", loopClusterKey, loopClusterKey, 0.92);
     const normalizedMessageId = normalizeMessageReferenceList([metadata.normalizedMessageId, metadata.messageId, metadata.rawMessageId], 1)[0] ?? "";
@@ -1258,8 +1274,175 @@ function extractRelationIds(metadata) {
     }
     return Array.from(ids).filter((value) => value.length > 0 && value.length <= 128);
 }
+function metadataHasThreadSignals(metadata) {
+    const messageStructure = normalizeMetadata(metadata.messageStructure);
+    if (messageStructure.hasMessageId === true ||
+        messageStructure.hasReplyTo === true ||
+        messageStructure.hasReferences === true) {
+        return true;
+    }
+    const normalizedMessageId = normalizeMessageReferenceList([metadata.normalizedMessageId, metadata.messageId, metadata.rawMessageId], 1)[0] ?? "";
+    if (normalizedMessageId)
+        return true;
+    return normalizeMessageReferenceList([metadata.referenceMessageIds, metadata.inReplyToNormalized, metadata.inReplyTo, metadata.replyTo, metadata.references], 2).length > 0;
+}
+function normalizeThreadEvidence(metadata) {
+    const explicit = normalizeText(metadata.threadEvidence);
+    if (explicit === "explicit" || explicit === "derived" || explicit === "none") {
+        return explicit;
+    }
+    const emailSignalSummary = normalizeMetadata(metadata.emailSignalSummary);
+    const sourceFamily = normalizeText(emailSignalSummary.sourceFamily) ||
+        normalizeText(normalizeMetadata(metadata.messageStructure).sourceFamily) ||
+        normalizeText(metadata.sourceFamily);
+    if (sourceFamily === "mail" || metadataHasThreadSignals(metadata)) {
+        return "derived";
+    }
+    return "none";
+}
+function threadRelationshipsAllowed(metadata) {
+    const evidence = normalizeThreadEvidence(metadata);
+    if (evidence === "explicit")
+        return true;
+    if (evidence !== "derived")
+        return false;
+    const emailSignalSummary = normalizeMetadata(metadata.emailSignalSummary);
+    const sourceFamily = normalizeText(emailSignalSummary.sourceFamily) ||
+        normalizeText(normalizeMetadata(metadata.messageStructure).sourceFamily) ||
+        normalizeText(metadata.sourceFamily);
+    return sourceFamily === "mail" || metadataHasThreadSignals(metadata);
+}
 function threadKeyFromMetadata(metadata) {
-    return normalizeText(metadata.threadKey) || normalizeText(metadata.thread) || normalizeText(metadata.thread_id);
+    if (!threadRelationshipsAllowed(metadata))
+        return "";
+    return (normalizeText(metadata.threadKey) ||
+        normalizeText(metadata.thread) ||
+        normalizeText(metadata.thread_id) ||
+        normalizeText(metadata.conversationId));
+}
+function loopClusterKeyFromMetadata(metadata) {
+    if (!threadRelationshipsAllowed(metadata))
+        return "";
+    return normalizeText(metadata.loopClusterKey);
+}
+function isMailLikeThreadSource(source, metadata) {
+    const normalized = normalizeSource(source);
+    if (normalized.startsWith("mail:") || normalized.includes("email") || normalized.startsWith("message-signal:")) {
+        return true;
+    }
+    const emailSignalSummary = normalizeMetadata(metadata.emailSignalSummary);
+    const sourceFamily = normalizeText(emailSignalSummary.sourceFamily) ||
+        normalizeText(normalizeMetadata(metadata.messageStructure).sourceFamily) ||
+        normalizeText(metadata.sourceFamily);
+    return sourceFamily === "mail";
+}
+function isThreadEntityHint(value) {
+    const normalized = normalizeText(value);
+    return normalized.startsWith("thread:") || normalized.startsWith("thread-signature:");
+}
+function isThreadPatternHint(value) {
+    const normalized = normalizeText(value);
+    return (normalized === "structure:has-thread" ||
+        normalized === "thread:shallow" ||
+        normalized.startsWith("thread:") ||
+        normalized.startsWith("thread-signature:") ||
+        normalized.startsWith("loop-cluster:") ||
+        normalized.startsWith("loop-state:") ||
+        normalized.startsWith("loop:thread:"));
+}
+function scrubThreadMetadata(metadata) {
+    const before = normalizeMetadata(metadata);
+    const beforeThreadKey = normalizeText(before.threadKey) || null;
+    const beforeLoopClusterKey = normalizeText(before.loopClusterKey) || null;
+    const beforeThreadSignature = normalizeText(before.threadDeterministicSignature);
+    const beforeThreadEvidence = normalizeThreadEvidence(before);
+    const entityHints = readStringValues(before.entityHints, 128);
+    const patternHints = readStringValues(before.patternHints, 192);
+    const hadThreadHints = entityHints.some(isThreadEntityHint) || patternHints.some(isThreadPatternHint);
+    const hadThreadArtifacts = Boolean(beforeThreadKey || beforeLoopClusterKey || beforeThreadSignature || hadThreadHints);
+    const hasUnknownThreadKey = (beforeThreadKey?.includes("mail-thread:unknown") ?? false) ||
+        (beforeThreadKey?.endsWith(":unknown") ?? false) ||
+        (beforeLoopClusterKey?.includes("mail-thread:unknown") ?? false) ||
+        (beforeLoopClusterKey?.endsWith(":unknown") ?? false);
+    const relationshipsAllowed = threadRelationshipsAllowed(before);
+    if (!hadThreadArtifacts || (beforeThreadEvidence === "explicit" && !hasUnknownThreadKey) || (relationshipsAllowed && !hasUnknownThreadKey)) {
+        return {
+            changed: false,
+            reason: "",
+            metadata: before,
+            beforeThreadKey,
+            afterThreadKey: beforeThreadKey,
+            beforeLoopClusterKey,
+            afterLoopClusterKey: beforeLoopClusterKey,
+            beforeThreadEvidence,
+            afterThreadEvidence: beforeThreadEvidence,
+        };
+    }
+    const next = { ...before };
+    delete next.threadKey;
+    delete next.thread;
+    delete next.thread_id;
+    delete next.loopClusterKey;
+    delete next.threadDeterministicSignature;
+    next.threadEvidence = "none";
+    const filteredEntityHints = entityHints.filter((value) => !isThreadEntityHint(value));
+    if (filteredEntityHints.length > 0)
+        next.entityHints = filteredEntityHints;
+    else
+        delete next.entityHints;
+    const filteredPatternHints = patternHints.filter((value) => !isThreadPatternHint(value));
+    if (filteredPatternHints.length > 0)
+        next.patternHints = filteredPatternHints;
+    else
+        delete next.patternHints;
+    const workstreamKey = normalizeText(next.workstreamKey);
+    if (workstreamKey.startsWith("thread:")) {
+        delete next.workstreamKey;
+    }
+    const messageStructure = normalizeMetadata(next.messageStructure);
+    if (Object.keys(messageStructure).length > 0) {
+        messageStructure.hasThreadKey = false;
+        messageStructure.threadEvidence = "none";
+        if (messageStructure.sourceFamily === "mail" && !metadataHasThreadSignals(before)) {
+            messageStructure.sourceFamily = "generic";
+        }
+        next.messageStructure = messageStructure;
+    }
+    const threadSignals = normalizeMetadata(next.threadReconstructionSignals);
+    if (Object.keys(threadSignals).length > 0) {
+        threadSignals.deterministicSignature = "";
+        threadSignals.hasLinkableMessagePath = false;
+        if (!metadataHasThreadSignals(before)) {
+            threadSignals.messageIdCount = 0;
+            threadSignals.replyReferenceCount = 0;
+            threadSignals.participantCount = 0;
+        }
+        next.threadReconstructionSignals = threadSignals;
+    }
+    const after = normalizeMetadata(next);
+    const afterThreadEvidence = normalizeThreadEvidence(after);
+    const reasons = [];
+    if (hasUnknownThreadKey)
+        reasons.push("unknown-thread-key");
+    if (!relationshipsAllowed)
+        reasons.push("unsupported-thread-source");
+    if (beforeThreadSignature)
+        reasons.push("thread-signature");
+    if (hadThreadHints)
+        reasons.push("thread-hints");
+    if (workstreamKey.startsWith("thread:"))
+        reasons.push("thread-workstream");
+    return {
+        changed: stableStringify(before) !== stableStringify(after),
+        reason: reasons.join(",") || "synthetic-thread-metadata",
+        metadata: after,
+        beforeThreadKey,
+        afterThreadKey: normalizeText(after.threadKey) || null,
+        beforeLoopClusterKey,
+        afterLoopClusterKey: normalizeText(after.loopClusterKey) || null,
+        beforeThreadEvidence,
+        afterThreadEvidence,
+    };
 }
 function halfLifeDays(memoryType) {
     if (memoryType === "working")
@@ -1330,14 +1513,11 @@ function inferImportance(tags, metadata) {
 }
 function buildContextualizedContent(payload) {
     const metadata = normalizeMetadata(payload.metadata);
-    const threadKey = normalizeText(metadata.threadKey) ||
-        normalizeText(metadata.conversationId) ||
-        normalizeText(metadata.thread) ||
-        normalizeText(metadata.thread_id);
+    const threadKey = threadKeyFromMetadata(metadata);
     const subject = normalizeText(metadata.subject);
     const from = normalizeText(metadata.from);
     const participantKey = normalizeText(metadata.participantKey);
-    const loopClusterKey = normalizeText(metadata.loopClusterKey);
+    const loopClusterKey = loopClusterKeyFromMetadata(metadata);
     const loopState = normalizeText(metadata.loopState);
     const contextSignals = normalizeMetadata(metadata.contextSignals);
     const signalKeys = Object.entries(contextSignals)
@@ -1542,7 +1722,7 @@ function computeSignalBoost(row, query) {
             participantKey.includes("|");
         if (hasManyParticipants)
             boost += 0.07;
-        if (normalizeText(metadata.threadKey))
+        if (threadKeyFromMetadata(metadata))
             boost += 0.04;
         if (participantDomains.length >= 2)
             boost += Math.min(0.06, participantDomains.length * 0.018);
@@ -1585,7 +1765,7 @@ function computeSignalBoost(row, query) {
             boost += Math.min(0.04, emailThreadDepth * 0.007);
     }
     if (querySignals.relationship) {
-        const hasThread = normalizeText(metadata.threadKey) ||
+        const hasThread = threadKeyFromMetadata(metadata) ||
             normalizeText(metadata.conversationId) ||
             normalizeText(metadata.inReplyTo) ||
             normalizeText(metadata.references);
@@ -1652,7 +1832,7 @@ function applyRelatedBoost(row, hit) {
 }
 function loopKeyFromRow(row) {
     const metadata = normalizeMetadata(row.metadata);
-    return normalizeText(metadata.loopClusterKey);
+    return loopClusterKeyFromMetadata(metadata);
 }
 function applyLoopStateBoost(row, loopState, query) {
     if (!loopState)
@@ -2178,7 +2358,7 @@ function computeLoopFeedbackAdjustment(feedback, query) {
 }
 function diversityGroupForRow(row) {
     const metadata = normalizeMetadata(row.metadata);
-    const threadKey = normalizeText(metadata.threadKey);
+    const threadKey = threadKeyFromMetadata(metadata);
     if (threadKey)
         return `thread:${threadKey}`;
     const subjectKey = normalizeText(metadata.subjectKey);
@@ -3312,7 +3492,7 @@ function createMemoryService(options) {
             if (!pointer)
                 continue;
             const metadata = normalizeMetadata(pointer.metadata);
-            const threadKey = normalizeText(metadata.threadKey);
+            const threadKey = threadKeyFromMetadata(metadata);
             const participantKey = normalizeText(metadata.participantKey);
             const actorTokens = Array.from(new Set([
                 ...readStringTokens(metadata.participantKey, 12),
@@ -3367,7 +3547,7 @@ function createMemoryService(options) {
             const pointerMemoryId = pointerMemoryIdForLoopState(row);
             const pointerRow = pointerMemoryId ? pointerRowsById.get(pointerMemoryId) : undefined;
             const metadata = normalizeMetadata(pointerRow?.metadata);
-            const threadKey = normalizeText(metadata.threadKey);
+            const threadKey = threadKeyFromMetadata(metadata);
             const participantKey = normalizeText(metadata.participantKey);
             const actorTokens = Array.from(new Set([
                 ...readStringTokens(metadata.participantKey, 12),
@@ -3739,7 +3919,7 @@ function createMemoryService(options) {
                 const pointerId = String(entry.pointerMemoryId ?? "").trim();
                 const pointer = pointerId ? pointerRowsById.get(pointerId) : undefined;
                 const metadata = normalizeMetadata(pointer?.metadata);
-                const threadKey = normalizeText(metadata.threadKey);
+                const threadKey = threadKeyFromMetadata(metadata);
                 const actorTokens = Array.from(new Set([
                     ...readStringTokens(metadata.participantKey, 12),
                     ...readStringTokens(metadata.participants, 16),
@@ -6262,6 +6442,169 @@ function createMemoryService(options) {
             errors,
         };
     };
+    const scrubSyntheticThreadMetadata = async (raw) => {
+        let parsed;
+        try {
+            parsed = contracts_1.memoryThreadMetadataScrubRequestSchema.parse(raw ?? {});
+        }
+        catch (error) {
+            throw normalizeError(error);
+        }
+        const startedAt = new Date().toISOString();
+        const tenantId = normalizeTenant(parsed.tenantId);
+        const sourcePrefixes = sanitizeStringList(parsed.sourcePrefixes).slice(0, 24);
+        const rows = await (options.store.recentCreated
+            ? options.store.recentCreated({
+                tenantId,
+                limit: parsed.limit,
+            })
+            : options.store.recent({
+                tenantId,
+                limit: parsed.limit,
+            }));
+        let scanned = 0;
+        let eligible = 0;
+        let updated = 0;
+        let skipped = 0;
+        let failed = 0;
+        let writesAttempted = 0;
+        let timeoutErrors = 0;
+        let consecutiveTimeoutErrors = 0;
+        let stopReason = null;
+        const maxWrites = Math.max(1, Math.min(parsed.maxWrites, parsed.limit));
+        const writeDelayMs = Math.max(0, parsed.writeDelayMs);
+        const stopAfterTimeoutErrors = Math.max(1, parsed.stopAfterTimeoutErrors);
+        const sample = [];
+        const errors = [];
+        const pushSample = (entry) => {
+            if (sample.length >= 40)
+                return;
+            sample.push(entry);
+        };
+        const sleep = async (ms) => new Promise((resolve) => {
+            setTimeout(resolve, Math.max(0, ms));
+        });
+        for (const row of rows) {
+            if (!parsed.dryRun && writesAttempted >= maxWrites) {
+                stopReason = "max-writes-reached";
+                break;
+            }
+            scanned += 1;
+            const metadataBefore = normalizeMetadata(row.metadata);
+            const normalizedSource = normalizeSource(row.source);
+            if (sourcePrefixes.length > 0 && !sourcePrefixes.some((prefix) => normalizedSource.startsWith(prefix))) {
+                skipped += 1;
+                continue;
+            }
+            if (!parsed.includeMailLike && isMailLikeThreadSource(normalizedSource, metadataBefore)) {
+                skipped += 1;
+                continue;
+            }
+            const scrubbed = scrubThreadMetadata(metadataBefore);
+            if (!scrubbed.changed) {
+                skipped += 1;
+                continue;
+            }
+            eligible += 1;
+            if (parsed.dryRun) {
+                pushSample({
+                    id: row.id,
+                    source: row.source,
+                    reason: scrubbed.reason,
+                    beforeThreadKey: scrubbed.beforeThreadKey,
+                    afterThreadKey: scrubbed.afterThreadKey,
+                    beforeLoopClusterKey: scrubbed.beforeLoopClusterKey,
+                    afterLoopClusterKey: scrubbed.afterLoopClusterKey,
+                    beforeThreadEvidence: scrubbed.beforeThreadEvidence,
+                    afterThreadEvidence: scrubbed.afterThreadEvidence,
+                });
+                continue;
+            }
+            try {
+                writesAttempted += 1;
+                await capture({
+                    id: row.id,
+                    tenantId: row.tenantId ?? undefined,
+                    agentId: row.agentId,
+                    runId: row.runId,
+                    content: row.content,
+                    source: row.source,
+                    tags: row.tags,
+                    metadata: scrubbed.metadata,
+                    clientRequestId: `thread-scrub:${row.id}`.slice(0, 120),
+                    occurredAt: row.occurredAt ?? undefined,
+                    status: row.status,
+                    memoryType: row.memoryType,
+                    sourceConfidence: row.sourceConfidence,
+                    importance: row.importance,
+                }, {
+                    bypassRunWriteBurstLimit: true,
+                });
+                updated += 1;
+                consecutiveTimeoutErrors = 0;
+                pushSample({
+                    id: row.id,
+                    source: row.source,
+                    reason: scrubbed.reason,
+                    beforeThreadKey: scrubbed.beforeThreadKey,
+                    afterThreadKey: scrubbed.afterThreadKey,
+                    beforeLoopClusterKey: scrubbed.beforeLoopClusterKey,
+                    afterLoopClusterKey: scrubbed.afterLoopClusterKey,
+                    beforeThreadEvidence: scrubbed.beforeThreadEvidence,
+                    afterThreadEvidence: scrubbed.afterThreadEvidence,
+                });
+            }
+            catch (error) {
+                failed += 1;
+                if (isTransientStoreTimeoutError(error)) {
+                    timeoutErrors += 1;
+                    consecutiveTimeoutErrors += 1;
+                }
+                else {
+                    consecutiveTimeoutErrors = 0;
+                }
+                errors.push({
+                    id: row.id,
+                    message: error instanceof Error ? error.message : String(error),
+                });
+                if (consecutiveTimeoutErrors >= stopAfterTimeoutErrors) {
+                    stopReason = "timeout-error-threshold";
+                    break;
+                }
+            }
+            if (!parsed.dryRun && writeDelayMs > 0) {
+                await sleep(writeDelayMs);
+            }
+        }
+        return {
+            tenantId,
+            dryRun: parsed.dryRun,
+            startedAt,
+            finishedAt: new Date().toISOString(),
+            scanned,
+            eligible,
+            updated,
+            skipped,
+            failed,
+            writesAttempted,
+            maxWrites,
+            stoppedEarly: stopReason !== null,
+            stopReason,
+            timeoutErrors,
+            convergence: {
+                windowScanned: scanned,
+                windowEligible: eligible,
+                windowUpdated: updated,
+                windowRemainingEligible: Math.max(0, eligible - updated),
+                windowRemainingRatio: scanned > 0 ? Math.max(0, eligible - updated) / scanned : 0,
+                writeUtilization: maxWrites > 0 ? Math.min(1, writesAttempted / maxWrites) : 0,
+                timeoutRate: writesAttempted > 0 ? timeoutErrors / writesAttempted : 0,
+                exhaustedWithinWindow: Math.max(0, eligible - updated) === 0,
+            },
+            sample,
+            errors,
+        };
+    };
     const importBatch = async (raw) => {
         let parsed;
         try {
@@ -6422,6 +6765,7 @@ function createMemoryService(options) {
         context,
         backfillEmailThreading,
         backfillSignalIndexing,
+        scrubSyntheticThreadMetadata,
         importBatch,
     };
 }

--- a/studio-brain/lib/memory/service.test.js
+++ b/studio-brain/lib/memory/service.test.js
@@ -106,6 +106,133 @@ const inMemoryAdapter_1 = require("./inMemoryAdapter");
     });
     strict_1.default.equal(row?.source, "import");
 });
+(0, node_test_1.default)("repo markdown rows do not synthesize thread lineage without real thread evidence", async () => {
+    const service = (0, service_1.createMemoryService)({
+        store: (0, inMemoryAdapter_1.createInMemoryMemoryStoreAdapter)(),
+        defaultTenantId: "tenant-thread-evidence",
+    });
+    const row = await service.capture({
+        content: "Portal dashboard documentation notes and implementation outline.",
+        source: "repo-markdown",
+        metadata: {
+            subject: "Portal dashboard docs",
+        },
+    });
+    const metadata = (row.metadata ?? {});
+    strict_1.default.equal(metadata.threadEvidence, "none");
+    strict_1.default.equal(typeof metadata.threadKey, "undefined");
+    strict_1.default.equal(Array.isArray(metadata.patternHints), true);
+    strict_1.default.equal(metadata.patternHints.includes("structure:has-thread"), false);
+});
+(0, node_test_1.default)("mail-like rows retain derived thread evidence for relationship indexing", async () => {
+    const service = (0, service_1.createMemoryService)({
+        store: (0, inMemoryAdapter_1.createInMemoryMemoryStoreAdapter)(),
+        defaultTenantId: "tenant-mail-thread-evidence",
+    });
+    const row = await service.capture({
+        content: "Re: kiln queue blocker follow-up with references and next action.",
+        source: "email",
+        metadata: {
+            subject: "Re: Kiln queue blocker",
+            from: "owner@example.com",
+            to: "team@example.com",
+            normalizedMessageId: "<msg-2@example.com>",
+            inReplyToNormalized: "<msg-1@example.com>",
+            referenceMessageIds: ["<msg-1@example.com>"],
+        },
+    });
+    const metadata = (row.metadata ?? {});
+    strict_1.default.equal(metadata.threadEvidence, "derived");
+    strict_1.default.equal(typeof metadata.threadKey, "string");
+    strict_1.default.notEqual(String(metadata.threadKey || "").length, 0);
+});
+(0, node_test_1.default)("synthetic thread metadata scrubber rewrites legacy non-threaded rows", async () => {
+    const store = (0, inMemoryAdapter_1.createInMemoryMemoryStoreAdapter)();
+    const service = (0, service_1.createMemoryService)({
+        store,
+        defaultTenantId: "tenant-thread-scrub",
+    });
+    await store.upsert({
+        id: "mem-legacy-thread-noise",
+        tenantId: "tenant-thread-scrub",
+        agentId: "agent:import",
+        runId: "import:legacy",
+        content: "Imported repo notes that should not behave like an email thread.",
+        source: "repo-markdown",
+        tags: ["import"],
+        metadata: {
+            source: "repo-markdown",
+            threadKey: "mail-thread:unknown",
+            loopClusterKey: "thread:mail-thread:unknown",
+            threadDeterministicSignature: "threadsig_legacy_noise",
+            threadEvidence: "derived",
+            entityHints: ["thread:mail-thread:unknown", "thread-signature:threadsig_legacy_noise"],
+            patternHints: ["loop-cluster:thread:mail-thread:unknown", "structure:has-thread"],
+            workstreamKey: "thread:mail-thread:unknown",
+            messageStructure: {
+                hasThreadKey: true,
+                sourceFamily: "generic",
+            },
+            threadReconstructionSignals: {
+                deterministicSignature: "threadsig_legacy_noise",
+                hasLinkableMessagePath: false,
+            },
+        },
+        embedding: null,
+        occurredAt: null,
+        clientRequestId: "legacy-thread-noise-1",
+        status: "accepted",
+        memoryType: "semantic",
+        sourceConfidence: 0.75,
+        importance: 0.6,
+        contextualizedContent: "Imported repo notes that should not behave like an email thread.",
+        fingerprint: null,
+        embeddingModel: null,
+        embeddingVersion: 1,
+    });
+    const result = await service.scrubSyntheticThreadMetadata({
+        dryRun: false,
+        limit: 10,
+    });
+    strict_1.default.equal(result.updated, 1);
+    strict_1.default.equal(result.sample[0]?.beforeThreadKey, "mail-thread:unknown");
+    strict_1.default.equal(result.sample[0]?.afterThreadKey, null);
+    const [row] = await service.getByIds({
+        ids: ["mem-legacy-thread-noise"],
+        includeArchived: true,
+    });
+    const metadata = (row?.metadata ?? {});
+    strict_1.default.equal(metadata.threadEvidence, "none");
+    strict_1.default.equal(typeof metadata.threadKey, "undefined");
+    strict_1.default.equal(typeof metadata.loopClusterKey, "undefined");
+    strict_1.default.equal(typeof metadata.threadDeterministicSignature, "undefined");
+    strict_1.default.equal(metadata.patternHints.includes("structure:has-thread"), false);
+});
+(0, node_test_1.default)("synthetic thread metadata scrubber leaves legitimate mail threading alone", async () => {
+    const service = (0, service_1.createMemoryService)({
+        store: (0, inMemoryAdapter_1.createInMemoryMemoryStoreAdapter)(),
+        defaultTenantId: "tenant-thread-scrub-mail",
+    });
+    await service.capture({
+        content: "Re: real thread with actual message references.",
+        source: "email",
+        metadata: {
+            subject: "Re: Kiln notice",
+            from: "owner@example.com",
+            to: "team@example.com",
+            normalizedMessageId: "<msg-10@example.com>",
+            inReplyToNormalized: "<msg-9@example.com>",
+            referenceMessageIds: ["<msg-9@example.com>"],
+        },
+    });
+    const result = await service.scrubSyntheticThreadMetadata({
+        dryRun: true,
+        limit: 10,
+        includeMailLike: true,
+    });
+    strict_1.default.equal(result.eligible, 0);
+    strict_1.default.equal(result.updated, 0);
+});
 (0, node_test_1.default)("memory nanny reroutes non-allowlisted tenant and derives stable namespace", async () => {
     const service = (0, service_1.createMemoryService)({
         store: (0, inMemoryAdapter_1.createInMemoryMemoryStoreAdapter)(),

--- a/studio-brain/src/http/server.ts
+++ b/studio-brain/src/http/server.ts
@@ -2741,6 +2741,82 @@ export function startHttpServer(params: {
         return;
       }
 
+      if (memoryService && method === "POST" && url.pathname === "/api/memory/scrub-thread-metadata") {
+        const auth = await assertCapabilityAuth(req);
+        if (!auth.ok) {
+          statusCode = 401;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: auth.message }));
+          return;
+        }
+        const pressure = memoryPressureSnapshot();
+        if (
+          pressure.activeImportRequests >= memoryPressureConfig.maxActiveImportsBeforeBackfill ||
+          pressure.activeBackfillRequests >= memoryPressureConfig.maxConcurrentBackfills
+        ) {
+          const reason =
+            pressure.activeImportRequests >= memoryPressureConfig.maxActiveImportsBeforeBackfill
+              ? "active-import-pressure"
+              : "backfill-concurrency-limit";
+          statusCode = 503;
+          res.writeHead(
+            statusCode,
+            withSecurityHeaders({
+              "content-type": "application/json",
+              ...corsHeaders,
+              "x-request-id": requestId,
+              "retry-after": String(memoryPressureConfig.retryAfterSeconds),
+            })
+          );
+          res.end(
+            JSON.stringify({
+              ok: false,
+              message: "Backfill deferred due current memory ingest pressure.",
+              reason,
+              retryAfterSeconds: memoryPressureConfig.retryAfterSeconds,
+              pressure,
+            })
+          );
+          return;
+        }
+        try {
+          const payload = await readJsonBody(req);
+          let result;
+          activeBackfillRequests += 1;
+          try {
+            result = await memoryService.scrubSyntheticThreadMetadata(payload);
+          } finally {
+            activeBackfillRequests = Math.max(0, activeBackfillRequests - 1);
+          }
+          logger.info("memory_scrub_thread_metadata_summary", {
+            requestId,
+            tenantId: result.tenantId ?? null,
+            dryRun: result.dryRun,
+            scanned: result.scanned,
+            eligible: result.eligible,
+            updated: result.updated,
+            skipped: result.skipped,
+            failed: result.failed,
+            writesAttempted: result.writesAttempted ?? 0,
+            maxWrites: result.maxWrites ?? 0,
+            timeoutErrors: result.timeoutErrors ?? 0,
+            stopReason: result.stopReason ?? null,
+            convergence: result.convergence ?? null,
+            pressure: memoryPressureSnapshot(),
+          });
+          statusCode = 200;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: true, result }));
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          const isValidation = error instanceof MemoryValidationError;
+          statusCode = isValidation ? 400 : 500;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message }));
+        }
+        return;
+      }
+
       if (capabilityRuntime && method === "GET" && url.pathname === "/api/capabilities") {
         const auth = await assertCapabilityAuth(req);
         if (!auth.ok) {

--- a/studio-brain/src/memory/adapters.ts
+++ b/studio-brain/src/memory/adapters.ts
@@ -238,6 +238,7 @@ export type MemoryStoreAdapter = {
   upsert: (input: MemoryUpsertInput) => Promise<MemoryRecord>;
   search: (input: MemorySearchInput) => Promise<MemorySearchResult[]>;
   recent: (input: MemoryRecentInput) => Promise<MemoryRecord[]>;
+  recentCreated?: (input: MemoryRecentInput) => Promise<MemoryRecord[]>;
   getByIds: (input: MemoryGetByIdsInput) => Promise<MemoryRecord[]>;
   stats: (input: MemoryStatsInput) => Promise<MemoryStats>;
   indexSignals?: (input: MemoryIndexInput) => Promise<void>;

--- a/studio-brain/src/memory/contracts.ts
+++ b/studio-brain/src/memory/contracts.ts
@@ -141,6 +141,17 @@ export const memorySignalIndexBackfillRequestSchema = z.object({
   stopAfterTimeoutErrors: z.number().int().min(1).max(100).default(5),
 });
 
+export const memoryThreadMetadataScrubRequestSchema = z.object({
+  tenantId: z.string().trim().min(1).max(128).nullable().optional(),
+  limit: z.number().int().min(1).max(20_000).default(2_000),
+  dryRun: z.boolean().default(false),
+  sourcePrefixes: z.array(z.string().trim().min(1).max(64)).max(24).default([]),
+  includeMailLike: z.boolean().default(false),
+  maxWrites: z.number().int().min(1).max(20_000).default(500),
+  writeDelayMs: z.number().int().min(0).max(60_000).default(20),
+  stopAfterTimeoutErrors: z.number().int().min(1).max(100).default(5),
+});
+
 export const memoryLoopsRequestSchema = z.object({
   tenantId: z.string().trim().min(1).max(128).nullable().optional(),
   loopKeys: stringList.default([]),
@@ -259,6 +270,7 @@ export type MemoryContextRequest = z.infer<typeof memoryContextRequestSchema>;
 export type MemoryImportRequest = z.infer<typeof memoryImportRequestSchema>;
 export type MemoryEmailThreadBackfillRequest = z.infer<typeof memoryEmailThreadBackfillRequestSchema>;
 export type MemorySignalIndexBackfillRequest = z.infer<typeof memorySignalIndexBackfillRequestSchema>;
+export type MemoryThreadMetadataScrubRequest = z.infer<typeof memoryThreadMetadataScrubRequestSchema>;
 export type MemoryLoopsRequest = z.infer<typeof memoryLoopsRequestSchema>;
 export type MemoryLoopIncidentActionRequest = z.infer<typeof memoryLoopIncidentActionRequestSchema>;
 export type MemoryLoopIncidentActionBatchRequest = z.infer<typeof memoryLoopIncidentActionBatchRequestSchema>;
@@ -405,6 +417,36 @@ export type MemorySignalIndexBackfillResult = {
     patternCount: number;
     signalCount: number;
     loopKeys: string[];
+  }>;
+  errors: Array<{ id: string; message: string }>;
+};
+
+export type MemoryThreadMetadataScrubResult = {
+  tenantId: string | null;
+  dryRun: boolean;
+  startedAt: string;
+  finishedAt: string;
+  scanned: number;
+  eligible: number;
+  updated: number;
+  skipped: number;
+  failed: number;
+  writesAttempted?: number;
+  maxWrites?: number;
+  stoppedEarly?: boolean;
+  stopReason?: string | null;
+  timeoutErrors?: number;
+  convergence?: MemoryBackfillConvergenceTelemetry;
+  sample: Array<{
+    id: string;
+    source: string;
+    reason: string;
+    beforeThreadKey: string | null;
+    afterThreadKey: string | null;
+    beforeLoopClusterKey: string | null;
+    afterLoopClusterKey: string | null;
+    beforeThreadEvidence: "explicit" | "derived" | "none";
+    afterThreadEvidence: "explicit" | "derived" | "none";
   }>;
   errors: Array<{ id: string; message: string }>;
 };

--- a/studio-brain/src/memory/inMemoryAdapter.ts
+++ b/studio-brain/src/memory/inMemoryAdapter.ts
@@ -423,6 +423,25 @@ export function createInMemoryMemoryStoreAdapter(): MemoryStoreAdapter {
         .slice(0, Math.max(1, input.limit));
     },
 
+    async recentCreated(input): Promise<MemoryRecord[]> {
+      const normalizedAllow = new Set((input.sourceAllowlist ?? []).map((value) => value.trim()).filter(Boolean));
+      const normalizedDeny = new Set((input.sourceDenylist ?? []).map((value) => value.trim()).filter(Boolean));
+      const excludedStatuses = new Set((input.excludeStatuses ?? []).map((value) => String(value ?? "").trim()).filter(Boolean));
+      return toArray()
+        .filter((row) => (input.tenantId === undefined ? true : row.tenantId === input.tenantId))
+        .filter((row) => (input.agentId ? row.agentId === input.agentId : true))
+        .filter((row) => (input.runId ? row.runId === input.runId : true))
+        .filter((row) => (normalizedAllow.size > 0 ? normalizedAllow.has(row.source) : true))
+        .filter((row) => (normalizedDeny.size > 0 ? !normalizedDeny.has(row.source) : true))
+        .filter((row) => (excludedStatuses.size > 0 ? !excludedStatuses.has(row.status) : true))
+        .sort((left, right) => {
+          const rightCreated = Date.parse(right.createdAt || "") || 0;
+          const leftCreated = Date.parse(left.createdAt || "") || 0;
+          return rightCreated - leftCreated;
+        })
+        .slice(0, Math.max(1, input.limit));
+    },
+
     async stats(input): Promise<MemoryStats> {
       return stats(input.tenantId);
     },

--- a/studio-brain/src/memory/postgresAdapter.ts
+++ b/studio-brain/src/memory/postgresAdapter.ts
@@ -575,6 +575,62 @@ export function createPostgresMemoryStoreAdapter(params: AdapterParams): MemoryS
       return result.rows.map(mapRowToRecord);
     },
 
+    async recentCreated(input): Promise<MemoryRecord[]> {
+      const values: unknown[] = [];
+      const predicates: string[] = [];
+      if (input.tenantId !== undefined) {
+        values.push(input.tenantId);
+        predicates.push(`tenant_id IS NOT DISTINCT FROM $${values.length}`);
+      }
+      const agentId = String(input.agentId ?? "").trim();
+      if (agentId) {
+        values.push(agentId);
+        predicates.push(`agent_id = $${values.length}`);
+      }
+      const runId = String(input.runId ?? "").trim();
+      if (runId) {
+        values.push(runId);
+        predicates.push(`run_id = $${values.length}`);
+      }
+      const allow = sanitizeSourceList(input.sourceAllowlist);
+      if (allow.length > 0) {
+        values.push(allow);
+        predicates.push(`COALESCE(metadata->>'source', 'manual') = ANY($${values.length}::text[])`);
+      }
+      const deny = sanitizeSourceList(input.sourceDenylist);
+      if (deny.length > 0) {
+        values.push(deny);
+        predicates.push(`COALESCE(metadata->>'source', 'manual') <> ALL($${values.length}::text[])`);
+      }
+      const excludedStatuses = sanitizeStatusList(input.excludeStatuses);
+      if (excludedStatuses.length > 0) {
+        values.push(excludedStatuses);
+        predicates.push(`status <> ALL($${values.length}::text[])`);
+      }
+      values.push(input.limit);
+      const query = `
+        SELECT
+          memory_id,
+          agent_id,
+          run_id,
+          tenant_id,
+          content,
+          metadata,
+          created_at,
+          occurred_at,
+          status,
+          memory_type,
+          source_confidence,
+          importance
+          FROM ${tableName}
+         ${predicates.length ? `WHERE ${predicates.join(" AND ")}` : ""}
+         ORDER BY created_at DESC
+         LIMIT $${values.length}
+      `;
+      const result = await pool.query(query, values);
+      return result.rows.map(mapRowToRecord);
+    },
+
     async getByIds(input): Promise<MemoryRecord[]> {
       const ids = Array.from(new Set((input.ids ?? []).map((value) => String(value ?? "").trim()).filter(Boolean)));
       if (!ids.length) return [];

--- a/studio-brain/src/memory/service.test.ts
+++ b/studio-brain/src/memory/service.test.ts
@@ -118,6 +118,149 @@ test("memory service importBatch honors explicit sourceOverride when intentional
   assert.equal(row?.source, "import");
 });
 
+test("repo markdown rows do not synthesize thread lineage without real thread evidence", async () => {
+  const service = createMemoryService({
+    store: createInMemoryMemoryStoreAdapter(),
+    defaultTenantId: "tenant-thread-evidence",
+  });
+
+  const row = await service.capture({
+    content: "Portal dashboard documentation notes and implementation outline.",
+    source: "repo-markdown",
+    metadata: {
+      subject: "Portal dashboard docs",
+    },
+  });
+
+  const metadata = (row.metadata ?? {}) as Record<string, unknown>;
+  assert.equal(metadata.threadEvidence, "none");
+  assert.equal(typeof metadata.threadKey, "undefined");
+  assert.equal(Array.isArray(metadata.patternHints), true);
+  assert.equal((metadata.patternHints as string[]).includes("structure:has-thread"), false);
+});
+
+test("mail-like rows retain derived thread evidence for relationship indexing", async () => {
+  const service = createMemoryService({
+    store: createInMemoryMemoryStoreAdapter(),
+    defaultTenantId: "tenant-mail-thread-evidence",
+  });
+
+  const row = await service.capture({
+    content: "Re: kiln queue blocker follow-up with references and next action.",
+    source: "email",
+    metadata: {
+      subject: "Re: Kiln queue blocker",
+      from: "owner@example.com",
+      to: "team@example.com",
+      normalizedMessageId: "<msg-2@example.com>",
+      inReplyToNormalized: "<msg-1@example.com>",
+      referenceMessageIds: ["<msg-1@example.com>"],
+    },
+  });
+
+  const metadata = (row.metadata ?? {}) as Record<string, unknown>;
+  assert.equal(metadata.threadEvidence, "derived");
+  assert.equal(typeof metadata.threadKey, "string");
+  assert.notEqual(String(metadata.threadKey || "").length, 0);
+});
+
+test("synthetic thread metadata scrubber rewrites legacy non-threaded rows", async () => {
+  const store = createInMemoryMemoryStoreAdapter();
+  const service = createMemoryService({
+    store,
+    defaultTenantId: "tenant-thread-scrub",
+  });
+
+  await store.upsert({
+    id: "mem-legacy-thread-noise",
+    tenantId: "tenant-thread-scrub",
+    agentId: "agent:import",
+    runId: "import:legacy",
+    content: "Imported repo notes that should not behave like an email thread.",
+    source: "repo-markdown",
+    tags: ["import"],
+    metadata: {
+      source: "repo-markdown",
+      threadKey: "mail-thread:unknown",
+      loopClusterKey: "thread:mail-thread:unknown",
+      threadDeterministicSignature: "threadsig_legacy_noise",
+      threadEvidence: "derived",
+      entityHints: ["thread:mail-thread:unknown", "thread-signature:threadsig_legacy_noise"],
+      patternHints: ["loop-cluster:thread:mail-thread:unknown", "structure:has-thread"],
+      workstreamKey: "thread:mail-thread:unknown",
+      messageStructure: {
+        hasThreadKey: true,
+        sourceFamily: "generic",
+      },
+      threadReconstructionSignals: {
+        deterministicSignature: "threadsig_legacy_noise",
+        hasLinkableMessagePath: false,
+      },
+    },
+    embedding: null,
+    occurredAt: null,
+    clientRequestId: "legacy-thread-noise-1",
+    status: "accepted",
+    memoryType: "semantic",
+    sourceConfidence: 0.75,
+    importance: 0.6,
+    contextualizedContent: "Imported repo notes that should not behave like an email thread.",
+    fingerprint: null,
+    embeddingModel: null,
+    embeddingVersion: 1,
+  });
+
+  const result = await service.scrubSyntheticThreadMetadata({
+    dryRun: false,
+    limit: 10,
+  });
+
+  assert.equal(result.updated, 1);
+  assert.equal(result.sample[0]?.beforeThreadKey, "mail-thread:unknown");
+  assert.equal(result.sample[0]?.afterThreadKey, null);
+
+  const [row] = await service.getByIds({
+    ids: ["mem-legacy-thread-noise"],
+    includeArchived: true,
+  });
+
+  const metadata = (row?.metadata ?? {}) as Record<string, unknown>;
+  assert.equal(metadata.threadEvidence, "none");
+  assert.equal(typeof metadata.threadKey, "undefined");
+  assert.equal(typeof metadata.loopClusterKey, "undefined");
+  assert.equal(typeof metadata.threadDeterministicSignature, "undefined");
+  assert.equal((metadata.patternHints as string[]).includes("structure:has-thread"), false);
+});
+
+test("synthetic thread metadata scrubber leaves legitimate mail threading alone", async () => {
+  const service = createMemoryService({
+    store: createInMemoryMemoryStoreAdapter(),
+    defaultTenantId: "tenant-thread-scrub-mail",
+  });
+
+  await service.capture({
+    content: "Re: real thread with actual message references.",
+    source: "email",
+    metadata: {
+      subject: "Re: Kiln notice",
+      from: "owner@example.com",
+      to: "team@example.com",
+      normalizedMessageId: "<msg-10@example.com>",
+      inReplyToNormalized: "<msg-9@example.com>",
+      referenceMessageIds: ["<msg-9@example.com>"],
+    },
+  });
+
+  const result = await service.scrubSyntheticThreadMetadata({
+    dryRun: true,
+    limit: 10,
+    includeMailLike: true,
+  });
+
+  assert.equal(result.eligible, 0);
+  assert.equal(result.updated, 0);
+});
+
 test("memory nanny reroutes non-allowlisted tenant and derives stable namespace", async () => {
   const service = createMemoryService({
     store: createInMemoryMemoryStoreAdapter(),

--- a/studio-brain/src/memory/service.ts
+++ b/studio-brain/src/memory/service.ts
@@ -14,6 +14,8 @@ import type {
   MemoryEmailThreadBackfillResult,
   MemorySignalIndexBackfillRequest,
   MemorySignalIndexBackfillResult,
+  MemoryThreadMetadataScrubRequest,
+  MemoryThreadMetadataScrubResult,
   MemoryContextRequest,
   MemoryContextResult,
   MemoryImportResult,
@@ -50,6 +52,7 @@ import {
   memoryContextRequestSchema,
   memoryEmailThreadBackfillRequestSchema,
   memorySignalIndexBackfillRequestSchema,
+  memoryThreadMetadataScrubRequestSchema,
   memoryLoopFeedbackStatsRequestSchema,
   memoryLoopAutomationTickRequestSchema,
   memoryLoopActionPlanRequestSchema,
@@ -594,17 +597,27 @@ function enrichCaptureMetadata(payload: {
     normalizeText(enriched.thread) ||
     normalizeText(enriched.thread_id) ||
     normalizeText(enriched.conversationId);
+  const supportsDerivedThreading = Boolean(
+    isEmailLike || normalizedMessageId || inReplyToNormalized || referenceMessageIds.length > 0
+  );
   const inferredThreadKey =
     existingThreadKey ||
-    normalizePatternKey(
-      [
-        "mail-thread",
-        subjectKey.slice(0, 80) || participantDomains[0] || "unknown",
-        referenceMessageIds[0] || inReplyToNormalized || normalizedMessageId || "",
-      ]
-        .filter(Boolean)
-        .join(":")
-    );
+    (supportsDerivedThreading
+      ? normalizePatternKey(
+          [
+            "mail-thread",
+            subjectKey.slice(0, 80) || participantDomains[0] || "unknown",
+            referenceMessageIds[0] || inReplyToNormalized || normalizedMessageId || "",
+          ]
+            .filter(Boolean)
+            .join(":")
+        )
+      : "");
+  const threadEvidence: "explicit" | "derived" | "none" = existingThreadKey
+    ? "explicit"
+    : inferredThreadKey
+      ? "derived"
+      : "none";
 
   const tickets = mergeUniqueStrings(
     enriched.mentionedTickets,
@@ -625,14 +638,18 @@ function enrichCaptureMetadata(payload: {
   ).map((value) => String(value).toLowerCase());
 
   const inferredLoopState = inferLoopStateFromContent(subject, payload.content.slice(0, 14_000));
-  const loopClusterKey = inferLoopClusterKeyFromEmail({
-    existing: normalizeText(enriched.loopClusterKey),
-    threadKey: inferredThreadKey,
-    subjectKey,
-    tickets,
-    participantDomains,
-  });
+  const loopClusterKey =
+    threadEvidence !== "none"
+      ? inferLoopClusterKeyFromEmail({
+          existing: normalizeText(enriched.loopClusterKey),
+          threadKey: inferredThreadKey,
+          subjectKey,
+          tickets,
+          participantDomains,
+        })
+      : "";
   const deterministicThreadSignature = (() => {
+    if (threadEvidence === "none") return "";
     const signatureBasis = [
       inferredThreadKey,
       normalizedMessageId,
@@ -666,16 +683,16 @@ function enrichCaptureMetadata(payload: {
     patternHints.add(`state:${inferredLoopState}`);
   }
   if (inReplyToNormalized || referenceMessageIds.length > 0) patternHints.add("structure:has-references");
-  if (inferredThreadKey) patternHints.add("structure:has-thread");
-  if (deterministicThreadSignature) patternHints.add(`thread-signature:${deterministicThreadSignature}`);
+  if (threadEvidence !== "none" && inferredThreadKey) patternHints.add("structure:has-thread");
+  if (threadEvidence !== "none" && deterministicThreadSignature) patternHints.add(`thread-signature:${deterministicThreadSignature}`);
   if (normalizedMessageId && (inReplyToNormalized || referenceMessageIds.length > 0)) {
     patternHints.add("structure:deterministic-thread-link");
   }
   if (normalizedMessageId) entityHints.add(`message-id:${normalizedMessageId}`);
   if (inReplyToNormalized) entityHints.add(`message-ref:${inReplyToNormalized}`);
   for (const ref of referenceMessageIds.slice(0, 16)) entityHints.add(`message-ref:${ref}`);
-  if (inferredThreadKey) entityHints.add(`thread:${inferredThreadKey}`);
-  if (deterministicThreadSignature) entityHints.add(`thread-signature:${deterministicThreadSignature}`);
+  if (threadEvidence !== "none" && inferredThreadKey) entityHints.add(`thread:${inferredThreadKey}`);
+  if (threadEvidence !== "none" && deterministicThreadSignature) entityHints.add(`thread-signature:${deterministicThreadSignature}`);
   if (participantKey) entityHints.add(`participants:${participantKey}`);
   for (const domain of participantDomains.slice(0, 12)) entityHints.add(`domain:${domain}`);
   for (const ticket of tickets.slice(0, 12)) entityHints.add(`ticket:${ticket}`);
@@ -696,6 +713,8 @@ function enrichCaptureMetadata(payload: {
   messageStructure.hasReplyTo = Boolean(inReplyToNormalized);
   messageStructure.hasReferences = referenceMessageIds.length > 0;
   messageStructure.hasThreadKey = Boolean(inferredThreadKey);
+  messageStructure.sourceFamily = isEmailLike ? "mail" : "generic";
+  messageStructure.threadEvidence = threadEvidence;
   const structureSignalCount =
     Number(messageStructure.hasMessageId === true) +
     Number(messageStructure.hasReplyTo === true) +
@@ -719,9 +738,10 @@ function enrichCaptureMetadata(payload: {
   if (normalizedMessageId) enriched.normalizedMessageId = normalizedMessageId;
   if (inReplyToNormalized) enriched.inReplyToNormalized = inReplyToNormalized;
   if (referenceMessageIds.length > 0) enriched.referenceMessageIds = referenceMessageIds;
-  if (inferredThreadKey) enriched.threadKey = inferredThreadKey;
-  if (loopClusterKey) enriched.loopClusterKey = loopClusterKey;
-  if (deterministicThreadSignature) enriched.threadDeterministicSignature = deterministicThreadSignature;
+  if (threadEvidence !== "none" && inferredThreadKey) enriched.threadKey = inferredThreadKey;
+  if (threadEvidence !== "none" && loopClusterKey) enriched.loopClusterKey = loopClusterKey;
+  if (threadEvidence !== "none" && deterministicThreadSignature) enriched.threadDeterministicSignature = deterministicThreadSignature;
+  enriched.threadEvidence = threadEvidence;
   if (!normalizeText(enriched.loopState) && inferredLoopState) enriched.loopState = inferredLoopState;
   if (tickets.length > 0) enriched.mentionedTickets = tickets;
   if (urls.length > 0) enriched.mentionedUrls = urls;
@@ -748,6 +768,7 @@ function enrichCaptureMetadata(payload: {
     hasMessageId: Boolean(normalizedMessageId),
     inferredLoopState: inferredLoopState ?? null,
     sourceFamily: isEmailLike ? "mail" : "generic",
+    threadEvidence,
   };
   return enriched;
 }
@@ -1097,7 +1118,7 @@ function deriveSignalIndex(payload: {
     appendEntity(entities, entitySeen, "tag", tag, tag, 0.55);
   }
 
-  const threadKey = normalizeText(metadata.threadKey || metadata.thread || metadata.conversationId || metadata.thread_id);
+  const threadKey = threadKeyFromMetadata(metadata);
   if (threadKey) appendEntity(entities, entitySeen, "thread", threadKey, threadKey, 0.9);
   if (threadKey) appendPattern(patterns, patternSeen, "thread", threadKey, threadKey, 0.88);
   const subjectKey = normalizeText(metadata.subjectKey || metadata.subject);
@@ -1106,7 +1127,7 @@ function deriveSignalIndex(payload: {
   const participantKey = normalizeText(metadata.participantKey);
   if (participantKey) appendEntity(entities, entitySeen, "participants", participantKey, participantKey, 0.82);
   if (participantKey) appendPattern(patterns, patternSeen, "participants", participantKey, participantKey, 0.78);
-  const loopClusterKey = normalizeText(metadata.loopClusterKey);
+  const loopClusterKey = loopClusterKeyFromMetadata(metadata);
   if (loopClusterKey) appendPattern(patterns, patternSeen, "loop-cluster", loopClusterKey, loopClusterKey, 0.92);
   const normalizedMessageId =
     normalizeMessageReferenceList([metadata.normalizedMessageId, metadata.messageId, metadata.rawMessageId], 1)[0] ?? "";
@@ -1363,8 +1384,202 @@ function extractRelationIds(metadata: Record<string, unknown>): string[] {
   return Array.from(ids).filter((value) => value.length > 0 && value.length <= 128);
 }
 
+function metadataHasThreadSignals(metadata: Record<string, unknown>): boolean {
+  const messageStructure = normalizeMetadata(metadata.messageStructure);
+  if (
+    messageStructure.hasMessageId === true ||
+    messageStructure.hasReplyTo === true ||
+    messageStructure.hasReferences === true
+  ) {
+    return true;
+  }
+  const normalizedMessageId =
+    normalizeMessageReferenceList([metadata.normalizedMessageId, metadata.messageId, metadata.rawMessageId], 1)[0] ?? "";
+  if (normalizedMessageId) return true;
+  return normalizeMessageReferenceList(
+    [metadata.referenceMessageIds, metadata.inReplyToNormalized, metadata.inReplyTo, metadata.replyTo, metadata.references],
+    2
+  ).length > 0;
+}
+
+function normalizeThreadEvidence(metadata: Record<string, unknown>): "explicit" | "derived" | "none" {
+  const explicit = normalizeText(metadata.threadEvidence);
+  if (explicit === "explicit" || explicit === "derived" || explicit === "none") {
+    return explicit as "explicit" | "derived" | "none";
+  }
+  const emailSignalSummary = normalizeMetadata(metadata.emailSignalSummary);
+  const sourceFamily =
+    normalizeText(emailSignalSummary.sourceFamily) ||
+    normalizeText(normalizeMetadata(metadata.messageStructure).sourceFamily) ||
+    normalizeText(metadata.sourceFamily);
+  if (sourceFamily === "mail" || metadataHasThreadSignals(metadata)) {
+    return "derived";
+  }
+  return "none";
+}
+
+function threadRelationshipsAllowed(metadata: Record<string, unknown>): boolean {
+  const evidence = normalizeThreadEvidence(metadata);
+  if (evidence === "explicit") return true;
+  if (evidence !== "derived") return false;
+  const emailSignalSummary = normalizeMetadata(metadata.emailSignalSummary);
+  const sourceFamily =
+    normalizeText(emailSignalSummary.sourceFamily) ||
+    normalizeText(normalizeMetadata(metadata.messageStructure).sourceFamily) ||
+    normalizeText(metadata.sourceFamily);
+  return sourceFamily === "mail" || metadataHasThreadSignals(metadata);
+}
+
 function threadKeyFromMetadata(metadata: Record<string, unknown>): string {
-  return normalizeText(metadata.threadKey) || normalizeText(metadata.thread) || normalizeText(metadata.thread_id);
+  if (!threadRelationshipsAllowed(metadata)) return "";
+  return (
+    normalizeText(metadata.threadKey) ||
+    normalizeText(metadata.thread) ||
+    normalizeText(metadata.thread_id) ||
+    normalizeText(metadata.conversationId)
+  );
+}
+
+function loopClusterKeyFromMetadata(metadata: Record<string, unknown>): string {
+  if (!threadRelationshipsAllowed(metadata)) return "";
+  return normalizeText(metadata.loopClusterKey);
+}
+
+function isMailLikeThreadSource(source: string, metadata: Record<string, unknown>): boolean {
+  const normalized = normalizeSource(source);
+  if (normalized.startsWith("mail:") || normalized.includes("email") || normalized.startsWith("message-signal:")) {
+    return true;
+  }
+  const emailSignalSummary = normalizeMetadata(metadata.emailSignalSummary);
+  const sourceFamily =
+    normalizeText(emailSignalSummary.sourceFamily) ||
+    normalizeText(normalizeMetadata(metadata.messageStructure).sourceFamily) ||
+    normalizeText(metadata.sourceFamily);
+  return sourceFamily === "mail";
+}
+
+function isThreadEntityHint(value: string): boolean {
+  const normalized = normalizeText(value);
+  return normalized.startsWith("thread:") || normalized.startsWith("thread-signature:");
+}
+
+function isThreadPatternHint(value: string): boolean {
+  const normalized = normalizeText(value);
+  return (
+    normalized === "structure:has-thread" ||
+    normalized === "thread:shallow" ||
+    normalized.startsWith("thread:") ||
+    normalized.startsWith("thread-signature:") ||
+    normalized.startsWith("loop-cluster:") ||
+    normalized.startsWith("loop-state:") ||
+    normalized.startsWith("loop:thread:")
+  );
+}
+
+function scrubThreadMetadata(metadata: Record<string, unknown>): {
+  changed: boolean;
+  reason: string;
+  metadata: Record<string, unknown>;
+  beforeThreadKey: string | null;
+  afterThreadKey: string | null;
+  beforeLoopClusterKey: string | null;
+  afterLoopClusterKey: string | null;
+  beforeThreadEvidence: "explicit" | "derived" | "none";
+  afterThreadEvidence: "explicit" | "derived" | "none";
+} {
+  const before = normalizeMetadata(metadata);
+  const beforeThreadKey = normalizeText(before.threadKey) || null;
+  const beforeLoopClusterKey = normalizeText(before.loopClusterKey) || null;
+  const beforeThreadSignature = normalizeText(before.threadDeterministicSignature);
+  const beforeThreadEvidence = normalizeThreadEvidence(before);
+  const entityHints = readStringValues(before.entityHints, 128);
+  const patternHints = readStringValues(before.patternHints, 192);
+  const hadThreadHints = entityHints.some(isThreadEntityHint) || patternHints.some(isThreadPatternHint);
+  const hadThreadArtifacts = Boolean(beforeThreadKey || beforeLoopClusterKey || beforeThreadSignature || hadThreadHints);
+  const hasUnknownThreadKey =
+    (beforeThreadKey?.includes("mail-thread:unknown") ?? false) ||
+    (beforeThreadKey?.endsWith(":unknown") ?? false) ||
+    (beforeLoopClusterKey?.includes("mail-thread:unknown") ?? false) ||
+    (beforeLoopClusterKey?.endsWith(":unknown") ?? false);
+  const relationshipsAllowed = threadRelationshipsAllowed(before);
+
+  if (!hadThreadArtifacts || (beforeThreadEvidence === "explicit" && !hasUnknownThreadKey) || (relationshipsAllowed && !hasUnknownThreadKey)) {
+    return {
+      changed: false,
+      reason: "",
+      metadata: before,
+      beforeThreadKey,
+      afterThreadKey: beforeThreadKey,
+      beforeLoopClusterKey,
+      afterLoopClusterKey: beforeLoopClusterKey,
+      beforeThreadEvidence,
+      afterThreadEvidence: beforeThreadEvidence,
+    };
+  }
+
+  const next: Record<string, unknown> = { ...before };
+  delete next.threadKey;
+  delete next.thread;
+  delete next.thread_id;
+  delete next.loopClusterKey;
+  delete next.threadDeterministicSignature;
+  next.threadEvidence = "none";
+
+  const filteredEntityHints = entityHints.filter((value) => !isThreadEntityHint(value));
+  if (filteredEntityHints.length > 0) next.entityHints = filteredEntityHints;
+  else delete next.entityHints;
+
+  const filteredPatternHints = patternHints.filter((value) => !isThreadPatternHint(value));
+  if (filteredPatternHints.length > 0) next.patternHints = filteredPatternHints;
+  else delete next.patternHints;
+
+  const workstreamKey = normalizeText(next.workstreamKey);
+  if (workstreamKey.startsWith("thread:")) {
+    delete next.workstreamKey;
+  }
+
+  const messageStructure = normalizeMetadata(next.messageStructure);
+  if (Object.keys(messageStructure).length > 0) {
+    messageStructure.hasThreadKey = false;
+    messageStructure.threadEvidence = "none";
+    if (messageStructure.sourceFamily === "mail" && !metadataHasThreadSignals(before)) {
+      messageStructure.sourceFamily = "generic";
+    }
+    next.messageStructure = messageStructure;
+  }
+
+  const threadSignals = normalizeMetadata(next.threadReconstructionSignals);
+  if (Object.keys(threadSignals).length > 0) {
+    threadSignals.deterministicSignature = "";
+    threadSignals.hasLinkableMessagePath = false;
+    if (!metadataHasThreadSignals(before)) {
+      threadSignals.messageIdCount = 0;
+      threadSignals.replyReferenceCount = 0;
+      threadSignals.participantCount = 0;
+    }
+    next.threadReconstructionSignals = threadSignals;
+  }
+
+  const after = normalizeMetadata(next);
+  const afterThreadEvidence = normalizeThreadEvidence(after);
+  const reasons: string[] = [];
+  if (hasUnknownThreadKey) reasons.push("unknown-thread-key");
+  if (!relationshipsAllowed) reasons.push("unsupported-thread-source");
+  if (beforeThreadSignature) reasons.push("thread-signature");
+  if (hadThreadHints) reasons.push("thread-hints");
+  if (workstreamKey.startsWith("thread:")) reasons.push("thread-workstream");
+
+  return {
+    changed: stableStringify(before) !== stableStringify(after),
+    reason: reasons.join(",") || "synthetic-thread-metadata",
+    metadata: after,
+    beforeThreadKey,
+    afterThreadKey: normalizeText(after.threadKey) || null,
+    beforeLoopClusterKey,
+    afterLoopClusterKey: normalizeText(after.loopClusterKey) || null,
+    beforeThreadEvidence,
+    afterThreadEvidence,
+  };
 }
 
 function halfLifeDays(memoryType: MemoryType): number {
@@ -1437,15 +1652,11 @@ function buildContextualizedContent(payload: {
   metadata?: Record<string, unknown>;
 }): string {
   const metadata = normalizeMetadata(payload.metadata);
-  const threadKey =
-    normalizeText(metadata.threadKey) ||
-    normalizeText(metadata.conversationId) ||
-    normalizeText(metadata.thread) ||
-    normalizeText(metadata.thread_id);
+  const threadKey = threadKeyFromMetadata(metadata);
   const subject = normalizeText(metadata.subject);
   const from = normalizeText(metadata.from);
   const participantKey = normalizeText(metadata.participantKey);
-  const loopClusterKey = normalizeText(metadata.loopClusterKey);
+  const loopClusterKey = loopClusterKeyFromMetadata(metadata);
   const loopState = normalizeText(metadata.loopState);
   const contextSignals = normalizeMetadata(metadata.contextSignals);
   const signalKeys = Object.entries(contextSignals)
@@ -1665,7 +1876,7 @@ function computeSignalBoost(row: MemorySearchResult, query: string): number {
       participantKey.includes(",") ||
       participantKey.includes("|");
     if (hasManyParticipants) boost += 0.07;
-    if (normalizeText(metadata.threadKey)) boost += 0.04;
+    if (threadKeyFromMetadata(metadata)) boost += 0.04;
     if (participantDomains.length >= 2) boost += Math.min(0.06, participantDomains.length * 0.018);
     if (participantCount >= 5) boost += Math.min(0.06, participantCount * 0.01);
   }
@@ -1694,7 +1905,7 @@ function computeSignalBoost(row: MemorySearchResult, query: string): number {
   }
   if (querySignals.relationship) {
     const hasThread =
-      normalizeText(metadata.threadKey) ||
+      threadKeyFromMetadata(metadata) ||
       normalizeText(metadata.conversationId) ||
       normalizeText(metadata.inReplyTo) ||
       normalizeText(metadata.references);
@@ -1754,7 +1965,7 @@ function applyRelatedBoost(row: MemorySearchResult, hit: MemoryRelatedResult | u
 
 function loopKeyFromRow(row: MemorySearchResult): string {
   const metadata = normalizeMetadata(row.metadata);
-  return normalizeText(metadata.loopClusterKey);
+  return loopClusterKeyFromMetadata(metadata);
 }
 
 function applyLoopStateBoost(
@@ -2405,7 +2616,7 @@ function computeLoopFeedbackAdjustment(
 
 function diversityGroupForRow(row: MemorySearchResult): string {
   const metadata = normalizeMetadata(row.metadata);
-  const threadKey = normalizeText(metadata.threadKey);
+  const threadKey = threadKeyFromMetadata(metadata);
   if (threadKey) return `thread:${threadKey}`;
   const subjectKey = normalizeText(metadata.subjectKey);
   if (subjectKey) return `subject:${subjectKey}`;
@@ -3671,7 +3882,7 @@ export function createMemoryService(options: MemoryServiceOptions) {
       const pointer = pointerRowsById.get(pointerId);
       if (!pointer) continue;
       const metadata = normalizeMetadata(pointer.metadata);
-      const threadKey = normalizeText(metadata.threadKey);
+      const threadKey = threadKeyFromMetadata(metadata);
       const participantKey = normalizeText(metadata.participantKey);
       const actorTokens = Array.from(
         new Set(
@@ -3732,7 +3943,7 @@ export function createMemoryService(options: MemoryServiceOptions) {
       const pointerMemoryId = pointerMemoryIdForLoopState(row);
       const pointerRow = pointerMemoryId ? pointerRowsById.get(pointerMemoryId) : undefined;
       const metadata = normalizeMetadata(pointerRow?.metadata);
-      const threadKey = normalizeText(metadata.threadKey);
+      const threadKey = threadKeyFromMetadata(metadata);
       const participantKey = normalizeText(metadata.participantKey);
       const actorTokens = Array.from(
         new Set(
@@ -4181,7 +4392,7 @@ export function createMemoryService(options: MemoryServiceOptions) {
         const pointerId = String(entry.pointerMemoryId ?? "").trim();
         const pointer = pointerId ? pointerRowsById.get(pointerId) : undefined;
         const metadata = normalizeMetadata(pointer?.metadata);
-        const threadKey = normalizeText(metadata.threadKey);
+        const threadKey = threadKeyFromMetadata(metadata);
         const actorTokens = Array.from(
           new Set(
             [
@@ -6897,6 +7108,176 @@ export function createMemoryService(options: MemoryServiceOptions) {
     };
   };
 
+  const scrubSyntheticThreadMetadata = async (raw: unknown): Promise<MemoryThreadMetadataScrubResult> => {
+    let parsed: MemoryThreadMetadataScrubRequest;
+    try {
+      parsed = memoryThreadMetadataScrubRequestSchema.parse(raw ?? {});
+    } catch (error) {
+      throw normalizeError(error);
+    }
+    const startedAt = new Date().toISOString();
+    const tenantId = normalizeTenant(parsed.tenantId);
+    const sourcePrefixes = sanitizeStringList(parsed.sourcePrefixes).slice(0, 24);
+    const rows = await (options.store.recentCreated
+      ? options.store.recentCreated({
+          tenantId,
+          limit: parsed.limit,
+        })
+      : options.store.recent({
+          tenantId,
+          limit: parsed.limit,
+        }));
+    let scanned = 0;
+    let eligible = 0;
+    let updated = 0;
+    let skipped = 0;
+    let failed = 0;
+    let writesAttempted = 0;
+    let timeoutErrors = 0;
+    let consecutiveTimeoutErrors = 0;
+    let stopReason: string | null = null;
+    const maxWrites = Math.max(1, Math.min(parsed.maxWrites, parsed.limit));
+    const writeDelayMs = Math.max(0, parsed.writeDelayMs);
+    const stopAfterTimeoutErrors = Math.max(1, parsed.stopAfterTimeoutErrors);
+    const sample: MemoryThreadMetadataScrubResult["sample"] = [];
+    const errors: MemoryThreadMetadataScrubResult["errors"] = [];
+    const pushSample = (entry: MemoryThreadMetadataScrubResult["sample"][number]) => {
+      if (sample.length >= 40) return;
+      sample.push(entry);
+    };
+    const sleep = async (ms: number) =>
+      new Promise<void>((resolve) => {
+        setTimeout(resolve, Math.max(0, ms));
+      });
+
+    for (const row of rows) {
+      if (!parsed.dryRun && writesAttempted >= maxWrites) {
+        stopReason = "max-writes-reached";
+        break;
+      }
+      scanned += 1;
+      const metadataBefore = normalizeMetadata(row.metadata);
+      const normalizedSource = normalizeSource(row.source);
+      if (sourcePrefixes.length > 0 && !sourcePrefixes.some((prefix) => normalizedSource.startsWith(prefix))) {
+        skipped += 1;
+        continue;
+      }
+      if (!parsed.includeMailLike && isMailLikeThreadSource(normalizedSource, metadataBefore)) {
+        skipped += 1;
+        continue;
+      }
+
+      const scrubbed = scrubThreadMetadata(metadataBefore);
+      if (!scrubbed.changed) {
+        skipped += 1;
+        continue;
+      }
+
+      eligible += 1;
+      if (parsed.dryRun) {
+        pushSample({
+          id: row.id,
+          source: row.source,
+          reason: scrubbed.reason,
+          beforeThreadKey: scrubbed.beforeThreadKey,
+          afterThreadKey: scrubbed.afterThreadKey,
+          beforeLoopClusterKey: scrubbed.beforeLoopClusterKey,
+          afterLoopClusterKey: scrubbed.afterLoopClusterKey,
+          beforeThreadEvidence: scrubbed.beforeThreadEvidence,
+          afterThreadEvidence: scrubbed.afterThreadEvidence,
+        });
+        continue;
+      }
+
+      try {
+        writesAttempted += 1;
+        await capture(
+          {
+            id: row.id,
+            tenantId: row.tenantId ?? undefined,
+            agentId: row.agentId,
+            runId: row.runId,
+            content: row.content,
+            source: row.source,
+            tags: row.tags,
+            metadata: scrubbed.metadata,
+            clientRequestId: `thread-scrub:${row.id}`.slice(0, 120),
+            occurredAt: row.occurredAt ?? undefined,
+            status: row.status,
+            memoryType: row.memoryType,
+            sourceConfidence: row.sourceConfidence,
+            importance: row.importance,
+          },
+          {
+            bypassRunWriteBurstLimit: true,
+          }
+        );
+        updated += 1;
+        consecutiveTimeoutErrors = 0;
+        pushSample({
+          id: row.id,
+          source: row.source,
+          reason: scrubbed.reason,
+          beforeThreadKey: scrubbed.beforeThreadKey,
+          afterThreadKey: scrubbed.afterThreadKey,
+          beforeLoopClusterKey: scrubbed.beforeLoopClusterKey,
+          afterLoopClusterKey: scrubbed.afterLoopClusterKey,
+          beforeThreadEvidence: scrubbed.beforeThreadEvidence,
+          afterThreadEvidence: scrubbed.afterThreadEvidence,
+        });
+      } catch (error) {
+        failed += 1;
+        if (isTransientStoreTimeoutError(error)) {
+          timeoutErrors += 1;
+          consecutiveTimeoutErrors += 1;
+        } else {
+          consecutiveTimeoutErrors = 0;
+        }
+        errors.push({
+          id: row.id,
+          message: error instanceof Error ? error.message : String(error),
+        });
+        if (consecutiveTimeoutErrors >= stopAfterTimeoutErrors) {
+          stopReason = "timeout-error-threshold";
+          break;
+        }
+      }
+
+      if (!parsed.dryRun && writeDelayMs > 0) {
+        await sleep(writeDelayMs);
+      }
+    }
+
+    return {
+      tenantId,
+      dryRun: parsed.dryRun,
+      startedAt,
+      finishedAt: new Date().toISOString(),
+      scanned,
+      eligible,
+      updated,
+      skipped,
+      failed,
+      writesAttempted,
+      maxWrites,
+      stoppedEarly: stopReason !== null,
+      stopReason,
+      timeoutErrors,
+      convergence: {
+        windowScanned: scanned,
+        windowEligible: eligible,
+        windowUpdated: updated,
+        windowRemainingEligible: Math.max(0, eligible - updated),
+        windowRemainingRatio: scanned > 0 ? Math.max(0, eligible - updated) / scanned : 0,
+        writeUtilization: maxWrites > 0 ? Math.min(1, writesAttempted / maxWrites) : 0,
+        timeoutRate: writesAttempted > 0 ? timeoutErrors / writesAttempted : 0,
+        exhaustedWithinWindow: Math.max(0, eligible - updated) === 0,
+      },
+      sample,
+      errors,
+    };
+  };
+
   const importBatch = async (raw: unknown): Promise<MemoryImportResult> => {
     let parsed: {
       sourceOverride?: string;
@@ -7080,6 +7461,7 @@ export function createMemoryService(options: MemoryServiceOptions) {
     context,
     backfillEmailThreading,
     backfillSignalIndexing,
+    scrubSyntheticThreadMetadata,
     importBatch,
   };
 }


### PR DESCRIPTION
## Summary
- add a live scrub-thread-metadata repair path to Studio Brain and the open-memory CLI
- scrub synthetic thread metadata safely by replaying affected memories through capture()
- add tests for non-threaded repo rows, real mail threading, and the new scrubber behavior

## Verification
- 
ode --check D:/tmp/mf-portal-thread-scrubber/scripts/open-memory.mjs
- 
ode --test D:/tmp/mf-portal-thread-scrubber/studio-brain/lib/memory/service.test.js
- git -C D:/tmp/mf-portal-thread-scrubber diff --check -- scripts/open-memory.mjs studio-brain/src/http/server.ts studio-brain/src/memory/adapters.ts studio-brain/src/memory/contracts.ts studio-brain/src/memory/inMemoryAdapter.ts studio-brain/src/memory/postgresAdapter.ts studio-brain/src/memory/service.ts studio-brain/src/memory/service.test.ts

## Notes
- the live Studio Brain host still needs a direct service deploy/restart; SSH from this machine to wuff@192.168.1.226 is currently denying publickey auth, so I could not roll the remote runtime in this step