### PR TITLE
Fix Studio Brain MCP startup auth header resolution

### DIFF
--- a/studio-brain-mcp/README.md
+++ b/studio-brain-mcp/README.md
@@ -20,6 +20,8 @@ This package is intentionally isolated from the main `studio-brain/` app so it c
   - default: `http://192.168.1.226:8787`
 - `STUDIO_BRAIN_MCP_ID_TOKEN`
   - Firebase ID token for Studio Brain staff auth
+- `STUDIO_BRAIN_MCP_AUTH_HEADER`
+  - optional full `Authorization` header value (for example `Bearer <token>`); falls back to the ID token variables when unset
 - `STUDIO_BRAIN_MCP_ADMIN_TOKEN`
   - optional extra admin token for local/dev setups
 - `STUDIO_BRAIN_MCP_TIMEOUT_MS`

--- a/studio-brain-mcp/launch.mjs
+++ b/studio-brain-mcp/launch.mjs
@@ -57,6 +57,16 @@ function normalizeBearer(value) {
   return /^bearer\s+/i.test(token) ? token : `Bearer ${token}`;
 }
 
+function resolveStudioBrainAuthHeader(env) {
+  return normalizeBearer(
+    env.STUDIO_BRAIN_MCP_AUTH_HEADER ||
+      env.STUDIO_BRAIN_MCP_ID_TOKEN ||
+      env.STUDIO_BRAIN_ID_TOKEN ||
+      env.STUDIO_BRAIN_AUTH_TOKEN ||
+      ""
+  );
+}
+
 function resolveFromRepoRoot(candidate, fallbackRelativePath = "") {
   const raw = clean(candidate || fallbackRelativePath);
   return raw ? resolve(repoRoot, raw) : "";
@@ -440,7 +450,7 @@ async function requestRemoteBootstrapContext({ env, query, threadInfo, timeoutMs
     "content-type": "application/json",
     accept: "application/json",
   };
-  const authHeader = normalizeBearer(env.STUDIO_BRAIN_MCP_ID_TOKEN || env.STUDIO_BRAIN_ID_TOKEN || "");
+  const authHeader = resolveStudioBrainAuthHeader(env);
   if (authHeader) headers.authorization = authHeader;
   const adminToken = clean(env.STUDIO_BRAIN_MCP_ADMIN_TOKEN || env.STUDIO_BRAIN_ADMIN_TOKEN || "");
   if (adminToken) headers["x-studio-brain-admin-token"] = adminToken;
@@ -741,6 +751,9 @@ if (!clean(mergedEnv.STUDIO_BRAIN_MCP_ADMIN_TOKEN) && clean(mergedEnv.STUDIO_BRA
 if (!clean(mergedEnv.STUDIO_BRAIN_MCP_ID_TOKEN) && clean(mergedEnv.STUDIO_BRAIN_ID_TOKEN)) {
   mergedEnv.STUDIO_BRAIN_MCP_ID_TOKEN = clean(mergedEnv.STUDIO_BRAIN_ID_TOKEN);
 }
+if (!clean(mergedEnv.STUDIO_BRAIN_MCP_AUTH_HEADER)) {
+  mergedEnv.STUDIO_BRAIN_MCP_AUTH_HEADER = resolveStudioBrainAuthHeader(mergedEnv);
+}
 if (!clean(mergedEnv.STUDIO_BRAIN_MCP_BASE_URL)) {
   mergedEnv.STUDIO_BRAIN_MCP_BASE_URL = "http://192.168.1.226:8787";
 }
@@ -779,11 +792,18 @@ if (!clean(mergedEnv.PORTAL_AGENT_STAFF_CREDENTIALS)) {
 }
 
 await hydrateStartupAuth(mergedEnv);
+const normalizedAuthHeader = resolveStudioBrainAuthHeader(mergedEnv);
+if (normalizedAuthHeader) {
+  mergedEnv.STUDIO_BRAIN_MCP_AUTH_HEADER = normalizedAuthHeader;
+}
 if (!clean(mergedEnv.STUDIO_BRAIN_ID_TOKEN) && clean(mergedEnv.STUDIO_BRAIN_MCP_ID_TOKEN)) {
   mergedEnv.STUDIO_BRAIN_ID_TOKEN = clean(mergedEnv.STUDIO_BRAIN_MCP_ID_TOKEN);
 }
 if (!clean(mergedEnv.STUDIO_BRAIN_AUTH_TOKEN) && clean(mergedEnv.STUDIO_BRAIN_ID_TOKEN)) {
   mergedEnv.STUDIO_BRAIN_AUTH_TOKEN = clean(mergedEnv.STUDIO_BRAIN_ID_TOKEN);
+}
+if (!clean(mergedEnv.STUDIO_BRAIN_AUTH_TOKEN) && clean(mergedEnv.STUDIO_BRAIN_MCP_AUTH_HEADER)) {
+  mergedEnv.STUDIO_BRAIN_AUTH_TOKEN = clean(mergedEnv.STUDIO_BRAIN_MCP_AUTH_HEADER);
 }
 if (!clean(mergedEnv.STUDIO_BRAIN_ADMIN_TOKEN) && clean(mergedEnv.STUDIO_BRAIN_MCP_ADMIN_TOKEN)) {
   mergedEnv.STUDIO_BRAIN_ADMIN_TOKEN = clean(mergedEnv.STUDIO_BRAIN_MCP_ADMIN_TOKEN);
@@ -876,4 +896,3 @@ child.on("exit", (code, signal) => {
   }
   process.exit(code ?? 0);
 });
-

--- a/studio-brain-mcp/server.mjs
+++ b/studio-brain-mcp/server.mjs
@@ -22,7 +22,13 @@ const AUTH_REFRESH_MIN_INTERVAL_MS = 10_000;
 const DEFAULT_REPO_CREDENTIALS_PATH = resolve(repoRoot, "secrets", "portal", "portal-agent-staff.json");
 const DEFAULT_HOME_CREDENTIALS_PATH = resolve(homedir(), ".ssh", "portal-agent-staff.json");
 
-let authorizationHeader = normalizeBearer(process.env.STUDIO_BRAIN_MCP_ID_TOKEN || process.env.STUDIO_BRAIN_ID_TOKEN || "");
+let authorizationHeader = normalizeBearer(
+  process.env.STUDIO_BRAIN_MCP_AUTH_HEADER ||
+    process.env.STUDIO_BRAIN_MCP_ID_TOKEN ||
+    process.env.STUDIO_BRAIN_ID_TOKEN ||
+    process.env.STUDIO_BRAIN_AUTH_TOKEN ||
+    ""
+);
 let lastAuthRefreshAtMs = 0;
 
 function parsePositiveInt(value, fallback) {


### PR DESCRIPTION
## Summary
- add a shared Studio Brain auth header fallback chain for MCP startup bootstrap requests
- propagate the resolved auth header through launch env hydration so startup and runtime auth stay aligned
- document `STUDIO_BRAIN_MCP_AUTH_HEADER` as an explicit header-based auth option

## Testing
- npm --prefix studio-brain-mcp test
- npm --prefix studio-brain-mcp run smoke