### PR TITLE
[codex] Prefer portal-lane startup grounding

### DIFF
--- a/scripts/codex-session-memory-utils.test.mjs
+++ b/scripts/codex-session-memory-utils.test.mjs
@@ -2,7 +2,9 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import {
+  buildThreadBootstrapQuery,
   normalizeHandoffArtifact,
+  rankBootstrapRows,
   resolveBootstrapContinuityState,
 } from "./lib/codex-session-memory-utils.mjs";
 import { stableHash } from "./lib/pst-memory-utils.mjs";
@@ -83,4 +85,87 @@ test("resolveBootstrapContinuityState falls back to validated local continuity w
   assert.equal(decision.continuityState, "ready");
   assert.equal(decision.blockerActive, false);
   assert.equal(decision.source, "validated-local-continuity");
+});
+
+test("buildThreadBootstrapQuery seeds the inferred repo lane for startup retrieval", () => {
+  const query = buildThreadBootstrapQuery({
+    threadInfo: {
+      threadId: "thread-portal-auth",
+      cwd: "D:/monsoonfire-portal",
+      title: "Test Studio Brain auth",
+      firstUserMessage: "call studiobrain memory and test auth",
+    },
+    historyLines: ["audit your connection to studiobrain and memory with context"],
+  });
+
+  assert.match(query, /\bmonsoonfire-portal\b/i);
+  assert.match(query, /\bmonsoonfire portal\b/i);
+});
+
+test("rankBootstrapRows boosts same-project lane rows for repo-scoped threads", () => {
+  const ranked = rankBootstrapRows(
+    [
+      {
+        id: "row-studio",
+        source: "manual",
+        score: 0.55,
+        content: "Studio Brain auth note from a different repo lane.",
+        metadata: {
+          projectLane: "studio-brain",
+        },
+      },
+      {
+        id: "row-portal",
+        source: "manual",
+        score: 0.55,
+        content: "Portal continuity note for the current repo lane.",
+        metadata: {
+          projectLane: "monsoonfire-portal",
+        },
+      },
+    ],
+    {
+      threadId: "thread-portal-auth",
+      cwd: "D:/monsoonfire-portal",
+      title: "Test Studio Brain auth",
+      firstUserMessage: "call studiobrain memory and test auth",
+    },
+  );
+
+  assert.equal(ranked[0]?.id, "row-portal");
+});
+
+test("rankBootstrapRows can overcome a modest cross-lane score lead for repo startup context", () => {
+  const ranked = rankBootstrapRows(
+    [
+      {
+        id: "row-studio",
+        source: "codex-handoff",
+        score: 0.9,
+        content: "Studio Brain checkpoint from a different repo lane.",
+        metadata: {
+          projectLane: "studio-brain",
+          startupEligible: true,
+        },
+      },
+      {
+        id: "row-portal",
+        source: "codex-handoff",
+        score: 0.62,
+        content: "Portal continuity note for the current repo lane.",
+        metadata: {
+          projectLane: "monsoonfire-portal",
+          startupEligible: true,
+        },
+      },
+    ],
+    {
+      threadId: "thread-portal-auth",
+      cwd: "D:/monsoonfire-portal",
+      title: "What was I doing in Monsoon Fire portal?",
+      firstUserMessage: "what was I doing in monsoonfire portal",
+    },
+  );
+
+  assert.equal(ranked[0]?.id, "row-portal");
 });

--- a/scripts/lib/codex-session-memory-utils.mjs
+++ b/scripts/lib/codex-session-memory-utils.mjs
@@ -580,11 +580,18 @@ export function buildThreadBootstrapQuery({ threadInfo = null, threadName = "", 
     cwdBase &&
     cwdBase.toLowerCase() !== homeBase.toLowerCase() &&
     !["users", "home", "micah"].includes(cwdBase.toLowerCase());
+  const inferredLane = inferProjectLane({
+    path: normalizedCwd,
+  });
+  const laneSeed =
+    inferredLane && !["unknown", "general-dev", "personal"].includes(inferredLane) ? inferredLane : "";
   const queryParts = dedupeStrings([
     clean(threadName),
     clean(threadInfo?.title),
     clean(threadInfo?.firstUserMessage),
     clean(threadInfo?.threadId),
+    laneSeed,
+    laneSeed.includes("-") ? laneSeed.replace(/-/g, " ") : "",
     includeCwdSeed ? cwdBase : "",
     ...historyLines,
   ]);
@@ -1273,6 +1280,28 @@ function rowScopeMatchesThread(row, threadInfo) {
   return Boolean((currentThreadId && rowThreadId === currentThreadId) || (currentCwd && rowCwd === currentCwd));
 }
 
+function rowProjectLane(row) {
+  const metadata = rowMetadata(row);
+  const sourceMetadata = toRecord(metadata.sourceMetadata);
+  return normalizeSource(sourceMetadata.projectLane || metadata.projectLane || metadata.lane || metadata.signalLane || "");
+}
+
+function threadProjectLane(threadInfo) {
+  const cwdLane = inferProjectLane({
+    path: normalizeThreadCwd(threadInfo?.cwd),
+  });
+  if (cwdLane && !["unknown", "general-dev", "personal"].includes(cwdLane)) {
+    return normalizeSource(cwdLane);
+  }
+  return normalizeSource(
+    inferProjectLane({
+      path: normalizeThreadCwd(threadInfo?.cwd),
+      title: clean(threadInfo?.title),
+      text: clean(threadInfo?.firstUserMessage),
+    })
+  );
+}
+
 function rowSourcePenalty(row, threadInfo, profile = "startup-strict") {
   const normalizedProfile = normalizeContinuityProfile(profile);
   const metadata = rowMetadata(row);
@@ -1320,20 +1349,38 @@ function rowSourcePenalty(row, threadInfo, profile = "startup-strict") {
 export function rankBootstrapRows(rows, threadInfo, { preserveOriginalScore = true, profile = "startup-strict" } = {}) {
   if (!Array.isArray(rows) || rows.length === 0) return [];
   const normalizedProfile = normalizeContinuityProfile(profile);
+  const currentProjectLane = threadProjectLane(threadInfo);
   return rows
     .map((row, index) => {
       const metadata = rowMetadata(row);
       const baseScore = Number(row?.score);
       const normalizedBaseScore = Number.isFinite(baseScore) ? baseScore : 0.45;
       const penalty = rowSourcePenalty(row, threadInfo, normalizedProfile);
+      const exactScopeMatch = rowScopeMatchesThread(row, threadInfo);
+      const rowLane = rowProjectLane(row);
+      const laneMatch = Boolean(currentProjectLane && rowLane && currentProjectLane === rowLane);
       const scopeBoost =
         normalizedProfile === "task-broad"
-          ? rowScopeMatchesThread(row, threadInfo)
+          ? exactScopeMatch
             ? 0.04
             : 0
-          : rowScopeMatchesThread(row, threadInfo)
+          : exactScopeMatch
             ? 0.12
             : 0;
+      const laneBoost =
+        normalizedProfile === "task-broad"
+          ? laneMatch
+            ? 0.03
+            : 0
+          : laneMatch
+            ? 0.24
+            : 0;
+      const lanePenalty =
+        !exactScopeMatch && currentProjectLane && rowLane && !laneMatch
+          ? normalizedProfile === "task-broad"
+            ? 0.01
+            : 0.16
+          : 0;
       const profileBoost =
         normalizedProfile === "profile-fast-lane" &&
         clean(metadata.scopeClass).toLowerCase() === "personal"
@@ -1345,7 +1392,8 @@ export function rankBootstrapRows(rows, threadInfo, { preserveOriginalScore = tr
         normalizedProfile === "task-broad"
           ? 0
           : Math.max(0, 0.1 - preferredStartupSourcePriority(row?.source, normalizedProfile) * 0.01);
-      const rankScore = normalizedBaseScore + scopeBoost + profileBoost + startupBoost + priorityBoost - penalty;
+      const rankScore =
+        normalizedBaseScore + scopeBoost + laneBoost + profileBoost + startupBoost + priorityBoost - penalty - lanePenalty;
       return {
         row,
         index,

--- a/scripts/lib/studio-brain-startup-auth.mjs
+++ b/scripts/lib/studio-brain-startup-auth.mjs
@@ -8,14 +8,26 @@ function clean(value) {
   return String(value ?? "").trim();
 }
 
+function resolveConfiguredPath(repoRoot, configuredPath) {
+  const raw = clean(configuredPath);
+  return raw ? resolve(repoRoot, raw) : "";
+}
+
 export function resolvePortalEnvPath(repoRoot, env = process.env) {
-  return resolve(clean(env.PORTAL_AUTOMATION_ENV_PATH) || resolve(repoRoot, "secrets", "portal", "portal-automation.env"));
+  const explicit = resolveConfiguredPath(repoRoot, env.PORTAL_AUTOMATION_ENV_PATH);
+  const candidates = [
+    explicit,
+    resolve(repoRoot, "secrets", "portal", "portal-automation.env"),
+    resolve(homedir(), "secrets", "portal", "portal-automation.env"),
+  ].filter(Boolean);
+  return candidates.find((candidate) => existsSync(candidate)) || explicit || candidates[1] || "";
 }
 
 export function resolvePortalCredentialsPath(repoRoot, env = process.env) {
   const candidates = [
-    clean(env.PORTAL_AGENT_STAFF_CREDENTIALS),
+    resolveConfiguredPath(repoRoot, env.PORTAL_AGENT_STAFF_CREDENTIALS),
     resolve(repoRoot, "secrets", "portal", "portal-agent-staff.json"),
+    resolve(homedir(), "secrets", "portal", "portal-agent-staff.json"),
     resolve(homedir(), ".ssh", "portal-agent-staff.json"),
   ].filter(Boolean);
   return candidates.find((candidate) => existsSync(candidate)) || "";

--- a/studio-brain-mcp/launch.mjs
+++ b/studio-brain-mcp/launch.mjs
@@ -25,7 +25,6 @@ import {
   readThreadHistoryLines,
   readThreadName,
   resolveStartupBootstrapPolicy,
-  resolveCodexThreadContext,
   runtimePathsForThread,
   writeBootstrapArtifacts,
   writeContinuityEnvelope,
@@ -38,13 +37,18 @@ import {
 } from "../scripts/lib/codex-machine-tool-profile.mjs";
 import { studioBrainRequestJson } from "../scripts/lib/studio-brain-memory-write.mjs";
 import { stableHash } from "../scripts/lib/pst-memory-utils.mjs";
+import { resolveBootstrapThreadInfo } from "./thread-context.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(__dirname, "..");
 const studioBrainMcpEnvPath = resolve(repoRoot, "secrets", "studio-brain", "studio-brain-mcp.env");
 const studioBrainAutomationEnvPath = resolve(repoRoot, "secrets", "studio-brain", "studio-brain-automation.env");
+const homeStudioBrainMcpEnvPath = resolve(homedir(), "secrets", "studio-brain", "studio-brain-mcp.env");
+const homeStudioBrainAutomationEnvPath = resolve(homedir(), "secrets", "studio-brain", "studio-brain-automation.env");
 const defaultPortalEnvPath = resolve(repoRoot, "secrets", "portal", "portal-automation.env");
+const homePortalEnvPath = resolve(homedir(), "secrets", "portal", "portal-automation.env");
 const repoPortalCredentialsPath = resolve(repoRoot, "secrets", "portal", "portal-agent-staff.json");
+const homePortalSecretCredentialsPath = resolve(homedir(), "secrets", "portal", "portal-agent-staff.json");
 const homePortalCredentialsPath = resolve(homedir(), ".ssh", "portal-agent-staff.json");
 
 function clean(value) {
@@ -369,12 +373,14 @@ function buildContinuityEnvelope({ threadInfo, query, contextPayload, metadata, 
 }
 
 function resolvePortalEnvPath(env) {
-  return resolveFromRepoRoot(env.PORTAL_AUTOMATION_ENV_PATH, defaultPortalEnvPath);
+  const explicit = resolveFromRepoRoot(env.PORTAL_AUTOMATION_ENV_PATH);
+  const candidates = [explicit, defaultPortalEnvPath, homePortalEnvPath].filter(Boolean);
+  return candidates.find((candidate) => existsSync(candidate)) || explicit || defaultPortalEnvPath;
 }
 
 function resolvePortalCredentialsPath(env) {
   const explicitPath = resolveFromRepoRoot(env.PORTAL_AGENT_STAFF_CREDENTIALS);
-  const candidates = [explicitPath, repoPortalCredentialsPath, homePortalCredentialsPath].filter(Boolean);
+  const candidates = [explicitPath, repoPortalCredentialsPath, homePortalSecretCredentialsPath, homePortalCredentialsPath].filter(Boolean);
   return candidates.find((candidate) => existsSync(candidate)) || "";
 }
 
@@ -445,7 +451,100 @@ function extractContextEnvelope(payload) {
   return { context, items, summary, diagnostics };
 }
 
+function extractPayloadRows(payload) {
+  if (Array.isArray(payload)) return payload;
+  if (!payload || typeof payload !== "object") return [];
+  if (Array.isArray(payload.rows)) return payload.rows;
+  if (Array.isArray(payload.results)) return payload.results;
+  if (Array.isArray(payload.items)) return payload.items;
+  return [];
+}
+
+async function requestRemoteBootstrapSearch({
+  env,
+  query,
+  threadInfo,
+  timeoutMs,
+  strictStartupAllowlist = true,
+}) {
+  const headers = {
+    "content-type": "application/json",
+    accept: "application/json",
+  };
+  const authHeader = resolveStudioBrainAuthHeader(env);
+  if (authHeader) headers.authorization = authHeader;
+  const adminToken = clean(env.STUDIO_BRAIN_MCP_ADMIN_TOKEN || env.STUDIO_BRAIN_ADMIN_TOKEN || "");
+  if (adminToken) headers["x-studio-brain-admin-token"] = adminToken;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetch(new URL("/api/memory/search", env.STUDIO_BRAIN_MCP_BASE_URL), {
+      method: "POST",
+      headers,
+      signal: controller.signal,
+      body: JSON.stringify({
+        query,
+        limit: 24,
+        sourceAllowlist: strictStartupAllowlist ? preferredStartupSources() : undefined,
+        sourceDenylist: [],
+      }),
+    });
+    const raw = await response.text();
+    const payload = raw ? JSON.parse(raw) : {};
+    if (!response.ok) {
+      return {
+        ok: false,
+        status: response.status,
+        error: clean(payload?.message || payload?.error?.message || raw || `HTTP ${response.status}`),
+      };
+    }
+
+    const rankedItems = rankBootstrapRows(filterExpiredRows(extractPayloadRows(payload)), threadInfo).slice(0, 10);
+    const rankedSummary =
+      summarizeRows(rankedItems, 4, 480) ||
+      rankedItems.map((row) => clean(row?.content).slice(0, 120)).filter(Boolean).slice(0, 4).join(" | ");
+    return {
+      ok: rankedItems.length > 0,
+      status: response.status,
+      context: {
+        schema: "codex-startup-bootstrap-context.v1",
+        createdAt: new Date().toISOString(),
+        threadId: clean(threadInfo?.threadId),
+        query,
+        summary: rankedSummary || clean(payload?.summary),
+        items: rankedItems,
+        diagnostics: {
+          ...(payload?.diagnostics && typeof payload.diagnostics === "object" ? payload.diagnostics : {}),
+          startupSourceBias: strictStartupAllowlist ? "preferred-startup-sources" : "startup-ranking-only",
+          strictStartupAllowlist,
+          startupSelectionStrategy: "search-first",
+          fallbackUsed: false,
+          fallbackStrategy: null,
+        },
+      },
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      status: 0,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 async function requestRemoteBootstrapContext({ env, query, threadInfo, timeoutMs, strictStartupAllowlist = true }) {
+  const search = await requestRemoteBootstrapSearch({
+    env,
+    query,
+    threadInfo,
+    timeoutMs,
+    strictStartupAllowlist,
+  });
+  if (search.ok) return search;
+
   const headers = {
     "content-type": "application/json",
     accept: "application/json",
@@ -476,6 +575,9 @@ async function requestRemoteBootstrapContext({ env, query, threadInfo, timeoutMs
 
     const { items, summary, diagnostics } = extractContextEnvelope(payload);
     const rankedItems = rankBootstrapRows(filterExpiredRows(items), threadInfo).slice(0, 10);
+    const rankedSummary =
+      summarizeRows(rankedItems, 4, 480) ||
+      rankedItems.map((row) => clean(row?.content).slice(0, 120)).filter(Boolean).slice(0, 4).join(" | ");
     return {
       ok: rankedItems.length > 0,
       status: response.status,
@@ -484,12 +586,13 @@ async function requestRemoteBootstrapContext({ env, query, threadInfo, timeoutMs
         createdAt: new Date().toISOString(),
         threadId: clean(threadInfo?.threadId),
         query,
-        summary: summary || rankedItems.map((row) => clean(row?.content).slice(0, 120)).filter(Boolean).slice(0, 4).join(" | "),
+        summary: rankedSummary || summary,
         items: rankedItems,
         diagnostics: {
           ...(diagnostics && typeof diagnostics === "object" ? diagnostics : {}),
           startupSourceBias: strictStartupAllowlist ? "preferred-startup-sources" : "startup-ranking-only",
           strictStartupAllowlist,
+          startupSelectionStrategy: "context-fallback",
           fallbackUsed: false,
           fallbackStrategy: null,
         },
@@ -509,12 +612,14 @@ async function requestRemoteBootstrapContext({ env, query, threadInfo, timeoutMs
 async function bootstrapThreadContext(env) {
   const settings = compactionSettingsFromEnv(env);
   const policy = resolveStartupBootstrapPolicy(settings);
-  const resolvedThread = resolveCodexThreadContext({
-    threadId: env.CODEX_THREAD_ID,
-    cwd: env.PWD || env.INIT_CWD || process.cwd(),
+  const resolvedThread = resolveBootstrapThreadInfo({
+    env,
+    fallbackCwd: process.cwd(),
   });
-  if (!resolvedThread) {
-    return null;
+  if (resolvedThread.resolution === "fallback") {
+    process.stderr.write(
+      `[studio-brain-mcp] Warning: thread context not found in Codex state DB; using fallback bootstrap context for ${resolvedThread.threadId} (${resolvedThread.cwd}).\n`
+    );
   }
 
   const threadName = readThreadName(resolvedThread.threadId);
@@ -730,6 +835,8 @@ async function bootstrapThreadContext(env) {
 }
 
 const studioFileEnv = {
+  ...loadOptionalEnvFile(homeStudioBrainMcpEnvPath),
+  ...loadOptionalEnvFile(homeStudioBrainAutomationEnvPath),
   ...loadOptionalEnvFile(studioBrainMcpEnvPath),
   ...loadOptionalEnvFile(studioBrainAutomationEnvPath),
 };
@@ -850,6 +957,7 @@ if (bootstrapState?.paths) {
   mergedEnv.STUDIO_BRAIN_BOOTSTRAP_QUERY = bootstrapState.query;
   mergedEnv.STUDIO_BRAIN_BOOTSTRAP_SATISFIED_BY = bootstrapState.satisfiedBy;
   mergedEnv.STUDIO_BRAIN_BOOTSTRAP_READY = bootstrapState.ready ? "1" : "0";
+  mergedEnv.STUDIO_BRAIN_STARTUP_CONTEXT_PREFER_LOCAL = "1";
   if (!bootstrapState.ready && bootstrapState.blocker) {
     process.stderr.write(
       `[studio-brain-mcp] Continuity blocked for thread ${bootstrapState.threadInfo.threadId} (${bootstrapState.blocker.failureClass}): ${bootstrapState.blocker.firstSignal}\n`

--- a/studio-brain-mcp/package.json
+++ b/studio-brain-mcp/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "start": "node ./server.mjs",
     "smoke": "node ./smoke.mjs",
-    "test": "node --test ./server.test.mjs"
+    "test": "node --test ./server.test.mjs ./thread-context.test.mjs"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.26.0",

--- a/studio-brain-mcp/server.mjs
+++ b/studio-brain-mcp/server.mjs
@@ -6,6 +6,7 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { z } from "zod";
 import { mintStaffIdTokenFromPortalEnv, normalizeBearer } from "../scripts/lib/firebase-auth-token.mjs";
+import { inferProjectLane } from "../scripts/lib/hybrid-memory-utils.mjs";
 import {
   filterExpiredRows,
   loadBootstrapArtifacts,
@@ -20,7 +21,9 @@ const DEFAULT_TIMEOUT_MS = parsePositiveInt(process.env.STUDIO_BRAIN_MCP_TIMEOUT
 const ADMIN_TOKEN = process.env.STUDIO_BRAIN_MCP_ADMIN_TOKEN || process.env.STUDIO_BRAIN_ADMIN_TOKEN || "";
 const AUTH_REFRESH_MIN_INTERVAL_MS = 10_000;
 const DEFAULT_REPO_CREDENTIALS_PATH = resolve(repoRoot, "secrets", "portal", "portal-agent-staff.json");
+const DEFAULT_HOME_SECRETS_CREDENTIALS_PATH = resolve(homedir(), "secrets", "portal", "portal-agent-staff.json");
 const DEFAULT_HOME_CREDENTIALS_PATH = resolve(homedir(), ".ssh", "portal-agent-staff.json");
+const GENERIC_PROJECT_LANES = new Set(["", "unknown", "general-dev"]);
 
 let authorizationHeader = normalizeBearer(
   process.env.STUDIO_BRAIN_MCP_AUTH_HEADER ||
@@ -39,6 +42,10 @@ function parsePositiveInt(value, fallback) {
 
 function clean(value) {
   return String(value ?? "").trim();
+}
+
+function summarizeText(value, maxChars = 220) {
+  return clean(value).replace(/\s+/g, " ").slice(0, maxChars);
 }
 
 function withOptionalString(schema) {
@@ -69,13 +76,211 @@ const bootstrapThreadInfo = {
   firstUserMessage: clean(bootstrapArtifacts.metadata?.firstUserMessage),
 };
 
+function buildSyntheticBootstrapRows() {
+  const rows = [];
+  const pushRow = (source, content, metadata = {}) => {
+    const summary = summarizeText(content, 240);
+    if (!summary) return;
+    rows.push({
+      source,
+      content: clean(content),
+      summary,
+      metadata: {
+        source,
+        ...metadata,
+      },
+    });
+  };
+
+  const blocker = bootstrapArtifacts.startupBlocker;
+  if (clean(blocker?.status).toLowerCase() === "blocked") {
+    const parts = [
+      summarizeText(blocker.firstSignal || blocker.remoteError || blocker.failureClass || "Startup continuity is blocked.", 220),
+    ];
+    if (clean(blocker.unblockStep)) {
+      parts.push(`Unblock: ${summarizeText(blocker.unblockStep, 180)}`);
+    }
+    pushRow("codex-startup-blocker", parts.filter(Boolean).join(" "), {
+      failureClass: clean(blocker.failureClass),
+      createdAt: clean(blocker.createdAt),
+      threadId: bootstrapThreadInfo.threadId,
+      tags: ["startup-blocker", "bootstrap-artifact"],
+    });
+  }
+
+  const envelope = bootstrapArtifacts.continuityEnvelope;
+  const envelopeParts = [];
+  if (clean(envelope?.currentGoal)) {
+    envelopeParts.push(`Current goal: ${summarizeText(envelope.currentGoal, 180)}.`);
+  }
+  if (clean(envelope?.lastHandoffSummary)) {
+    envelopeParts.push(`Last handoff: ${summarizeText(envelope.lastHandoffSummary, 180)}.`);
+  }
+  const primaryEnvelopeBlocker = Array.isArray(envelope?.blockers) ? envelope.blockers.find((row) => clean(row?.summary)) : null;
+  if (primaryEnvelopeBlocker) {
+    envelopeParts.push(`Open blocker: ${summarizeText(primaryEnvelopeBlocker.summary, 180)}.`);
+  }
+  if (clean(envelope?.nextRecommendedAction)) {
+    envelopeParts.push(`Next action: ${summarizeText(envelope.nextRecommendedAction, 180)}.`);
+  }
+  if (envelopeParts.length > 0) {
+    pushRow("codex-continuity-envelope", envelopeParts.join(" "), {
+      createdAt: clean(envelope?.updatedAt || envelope?.createdAt),
+      threadId: bootstrapThreadInfo.threadId,
+      tags: ["continuity-envelope", "bootstrap-artifact"],
+    });
+  }
+
+  const handoff = bootstrapArtifacts.handoff;
+  const handoffParts = [];
+  if (clean(handoff?.summary || handoff?.workCompleted || handoff?.activeGoal)) {
+    handoffParts.push(
+      summarizeText(handoff.summary || handoff.workCompleted || handoff.activeGoal, 220)
+    );
+  }
+  if (clean(handoff?.nextRecommendedAction)) {
+    handoffParts.push(`Next: ${summarizeText(handoff.nextRecommendedAction, 180)}`);
+  }
+  if (handoffParts.length > 0) {
+    pushRow("codex-handoff", handoffParts.join(" "), {
+      createdAt: clean(handoff?.createdAt),
+      threadId: bootstrapThreadInfo.threadId,
+      tags: ["handoff", "bootstrap-artifact"],
+    });
+  }
+
+  return rows;
+}
+
 function bootstrapItems() {
   const items = Array.isArray(bootstrapArtifacts.context?.items) ? bootstrapArtifacts.context.items : [];
-  return rankBootstrapRows(filterExpiredRows(items), bootstrapThreadInfo);
+  return rankBootstrapRows(filterExpiredRows([...items, ...buildSyntheticBootstrapRows()]), bootstrapThreadInfo);
 }
 
 function hasBootstrapContext() {
-  return bootstrapItems().length > 0;
+  return (
+    bootstrapItems().length > 0 ||
+    Boolean(clean(bootstrapArtifacts.context?.summary)) ||
+    clean(bootstrapArtifacts.startupBlocker?.status).toLowerCase() === "blocked" ||
+    Boolean(clean(bootstrapArtifacts.handoff?.summary || bootstrapArtifacts.handoff?.workCompleted || bootstrapArtifacts.handoff?.activeGoal)) ||
+    Boolean(
+      clean(
+        bootstrapArtifacts.continuityEnvelope?.currentGoal ||
+          bootstrapArtifacts.continuityEnvelope?.lastHandoffSummary ||
+          bootstrapArtifacts.continuityEnvelope?.nextRecommendedAction
+      )
+    )
+  );
+}
+
+function bootstrapContinuityState() {
+  const contextDiagnostics =
+    bootstrapArtifacts.context?.diagnostics && typeof bootstrapArtifacts.context.diagnostics === "object"
+      ? bootstrapArtifacts.context.diagnostics
+      : {};
+  if (clean(bootstrapArtifacts.startupBlocker?.status).toLowerCase() === "blocked") {
+    return "blocked";
+  }
+  const diagnosticState = clean(contextDiagnostics.continuityState);
+  if (diagnosticState) return diagnosticState;
+  const envelopeState = clean(
+    bootstrapArtifacts.continuityEnvelope?.continuityState || bootstrapArtifacts.continuityEnvelope?.startup?.continuityState
+  );
+  if (envelopeState) return envelopeState;
+  return bootstrapItems().length > 0 ? "ready" : "missing";
+}
+
+function rowProjectLane(row) {
+  return clean(
+    row?.metadata?.projectLane ||
+      row?.metadata?.sourceMetadata?.projectLane ||
+      row?.sourceMetadata?.projectLane ||
+      row?.projectLane ||
+      row?.metadata?.lane ||
+      row?.metadata?.signalLane
+  );
+}
+
+function resolveDominantProjectLane(rows = []) {
+  const scores = new Map();
+  rows.forEach((row, index) => {
+    const lane = rowProjectLane(row);
+    if (!lane || GENERIC_PROJECT_LANES.has(lane)) return;
+    const weight = Math.max(rows.length - index, 1);
+    scores.set(lane, (scores.get(lane) || 0) + weight);
+  });
+  const ranked = [...scores.entries()].sort((left, right) => right[1] - left[1] || left[0].localeCompare(right[0]));
+  if (ranked.length > 0) return ranked[0][0];
+
+  const diagnosticLane = clean(
+    bootstrapArtifacts.context?.diagnostics?.projectLane || bootstrapArtifacts.context?.diagnostics?.dominantProjectLane
+  );
+  if (diagnosticLane && !GENERIC_PROJECT_LANES.has(diagnosticLane)) {
+    return diagnosticLane;
+  }
+
+  const inferredLane = inferProjectLane({
+    path: bootstrapThreadInfo.cwd,
+    title: bootstrapThreadInfo.title,
+    text: bootstrapThreadInfo.firstUserMessage,
+  });
+  return GENERIC_PROJECT_LANES.has(inferredLane) ? "" : clean(inferredLane);
+}
+
+function localBootstrapDiagnostics(rows = bootstrapItems()) {
+  const contextDiagnostics =
+    bootstrapArtifacts.context?.diagnostics && typeof bootstrapArtifacts.context.diagnostics === "object"
+      ? bootstrapArtifacts.context.diagnostics
+      : {};
+  const continuityState = bootstrapContinuityState();
+  const blockerReason = clean(bootstrapArtifacts.startupBlocker?.failureClass);
+  const projectLane = resolveDominantProjectLane(rows);
+  return {
+    ...contextDiagnostics,
+    bootstrapContextLoaded: hasBootstrapContext(),
+    fallbackUsed: true,
+    fallbackStrategy: "bootstrap-artifact",
+    continuityState,
+    continuityAvailable: continuityState === "ready",
+    continuityReason: clean(contextDiagnostics.continuityReason || blockerReason),
+    continuityReasonCode: clean(contextDiagnostics.continuityReasonCode || blockerReason),
+    projectLane: clean(contextDiagnostics.projectLane || projectLane),
+    dominantProjectLane: clean(contextDiagnostics.dominantProjectLane || projectLane),
+  };
+}
+
+function localBootstrapRecentPayload(limit = 20) {
+  const rows = bootstrapItems().slice(0, Math.max(1, limit));
+  return {
+    ok: true,
+    rows,
+    results: rows,
+    diagnostics: localBootstrapDiagnostics(rows),
+    summary: clean(bootstrapArtifacts.context?.summary) || summarizeRows(rows, 500),
+  };
+}
+
+function localBootstrapStatsPayload() {
+  const rows = bootstrapItems();
+  const counts = new Map();
+  for (const row of rows) {
+    const source = clean(row?.source || row?.metadata?.source || "bootstrap-artifact");
+    counts.set(source, (counts.get(source) || 0) + 1);
+  }
+  return {
+    ok: true,
+    stats: {
+      total: rows.length,
+      bySource: [...counts.entries()]
+        .map(([source, count]) => ({ source, count }))
+        .sort((left, right) => right.count - left.count || left.source.localeCompare(right.source)),
+    },
+    diagnostics: {
+      ...localBootstrapDiagnostics(rows),
+      approximate: true,
+      dataScope: "bootstrap-artifact",
+    },
+  };
 }
 
 function summarizeRows(rows, maxChars = 400) {
@@ -147,6 +352,48 @@ function extractPayloadRows(payload) {
   return [];
 }
 
+async function requestStartupSearchPayload({
+  query,
+  requestedMaxItems,
+  tenantId,
+  baseUrl,
+  timeoutMs,
+  applyBootstrapBias,
+}) {
+  const payload = await studioBrainRequest({
+    method: "POST",
+    path: "/api/memory/search",
+    body: {
+      query,
+      limit: Math.min(Math.max(requestedMaxItems * 4, 24), 80),
+      tenantId,
+      sourceAllowlist: applyBootstrapBias ? preferredStartupSources() : undefined,
+      sourceDenylist: [],
+    },
+    baseUrl,
+    timeoutMs,
+  });
+  const rawRows = extractPayloadRows(payload);
+  const rankedRows = rankBootstrapRows(filterExpiredRows(rawRows), bootstrapThreadInfo).slice(0, requestedMaxItems);
+  if (rankedRows.length === 0) {
+    return null;
+  }
+  return rewriteContextPayload(
+    {
+      ...payload,
+      context: {
+        items: rawRows,
+        summary: clean(payload?.summary),
+        diagnostics: {
+          ...(payload?.diagnostics && typeof payload.diagnostics === "object" ? payload.diagnostics : {}),
+          startupSelectionStrategy: "search-first",
+        },
+      },
+    },
+    rankedRows
+  );
+}
+
 function rewriteContextPayload(payload, rows) {
   const root = payload && typeof payload === "object" ? { ...payload } : {};
   const context =
@@ -156,12 +403,13 @@ function rewriteContextPayload(payload, rows) {
         ? { ...root.payload }
         : { ...root };
   context.items = rows;
-  if (!clean(context.summary)) {
-    context.summary = summarizeRows(rows, 600);
-  }
+  context.summary = summarizeRows(rows, 600) || clean(context.summary);
+  const projectLane = resolveDominantProjectLane(rows);
   context.diagnostics = {
     ...(context.diagnostics && typeof context.diagnostics === "object" ? context.diagnostics : {}),
     bootstrapContextLoaded: hasBootstrapContext(),
+    projectLane: clean(context.diagnostics?.projectLane || projectLane),
+    dominantProjectLane: clean(context.diagnostics?.dominantProjectLane || projectLane),
   };
   root.context = context;
   root.items = rows;
@@ -174,6 +422,7 @@ function localBootstrapContextPayload(query, maxItems, maxChars) {
   const rows = localBootstrapSearch(query, maxItems);
   const summary =
     clean(bootstrapArtifacts.context?.summary) || summarizeRows(rows, Math.max(256, Math.min(600, maxChars || 600)));
+  const diagnostics = localBootstrapDiagnostics(rows);
   return {
     context: {
       ...(bootstrapArtifacts.context && typeof bootstrapArtifacts.context === "object" ? bootstrapArtifacts.context : {}),
@@ -181,21 +430,15 @@ function localBootstrapContextPayload(query, maxItems, maxChars) {
       summary: summary.slice(0, Math.max(256, maxChars || 8000)),
       diagnostics: {
         ...(bootstrapArtifacts.context?.diagnostics && typeof bootstrapArtifacts.context.diagnostics === "object"
-          ? bootstrapArtifacts.context.diagnostics
-          : {}),
-        bootstrapContextLoaded: true,
-        fallbackUsed: true,
-        fallbackStrategy: "bootstrap-artifact",
+            ? bootstrapArtifacts.context.diagnostics
+            : {}),
+          ...diagnostics,
+        },
       },
-    },
-    items: rows.slice(0, Math.max(1, maxItems)),
-    summary: summary.slice(0, Math.max(256, maxChars || 8000)),
-    diagnostics: {
-      bootstrapContextLoaded: true,
-      fallbackUsed: true,
-      fallbackStrategy: "bootstrap-artifact",
-    },
-  };
+      items: rows.slice(0, Math.max(1, maxItems)),
+      summary: summary.slice(0, Math.max(256, maxChars || 8000)),
+      diagnostics,
+    };
 }
 
 function defaultStartupContextQuery() {
@@ -206,6 +449,11 @@ function defaultStartupContextQuery() {
     clean(bootstrapThreadInfo.cwd) ||
     "Studio Brain startup continuity"
   );
+}
+
+function preferLocalStartupContext() {
+  const value = clean(process.env.STUDIO_BRAIN_STARTUP_CONTEXT_PREFER_LOCAL).toLowerCase();
+  return value === "1" || value === "true" || value === "yes" || value === "on";
 }
 
 async function handleMemoryContextRequest({
@@ -226,8 +474,29 @@ async function handleMemoryContextRequest({
     throw new Error("query is required");
   }
 
+  if (allowDefaultQuery && !agentId && !runId && hasBootstrapContext() && preferLocalStartupContext()) {
+    return asToolResult(localBootstrapContextPayload(resolvedQuery, requestedMaxItems, requestedMaxChars));
+  }
+
   try {
     const applyBootstrapBias = hasBootstrapContext() && !agentId && !runId;
+    if (allowDefaultQuery && !agentId && !runId) {
+      try {
+        const searchPayload = await requestStartupSearchPayload({
+          query: resolvedQuery,
+          requestedMaxItems,
+          tenantId,
+          baseUrl,
+          timeoutMs,
+          applyBootstrapBias,
+        });
+        if (searchPayload) {
+          return asToolResult(searchPayload);
+        }
+      } catch {
+        // Fall through to the broader context route when startup search is unavailable.
+      }
+    }
     const payload = await studioBrainRequest({
       method: "POST",
       path: "/api/memory/context",
@@ -249,7 +518,29 @@ async function handleMemoryContextRequest({
       (payload?.payload && typeof payload.payload === "object" && Array.isArray(payload.payload.items) ? payload.payload.items : null) ||
       extractPayloadRows(payload);
     const rankedRows = rankBootstrapRows(filterExpiredRows(rawRows), bootstrapThreadInfo).slice(0, requestedMaxItems);
-    return asToolResult(rewriteContextPayload(payload, rankedRows));
+    return asToolResult(
+      rewriteContextPayload(
+        {
+          ...payload,
+          context: {
+            ...(payload?.context && typeof payload.context === "object"
+              ? payload.context
+              : payload?.payload && typeof payload.payload === "object"
+                ? payload.payload
+                : {}),
+            diagnostics: {
+              ...(payload?.context?.diagnostics && typeof payload.context.diagnostics === "object"
+                ? payload.context.diagnostics
+                : payload?.diagnostics && typeof payload.diagnostics === "object"
+                  ? payload.diagnostics
+                  : {}),
+              startupSelectionStrategy: "context-fallback",
+            },
+          },
+        },
+        rankedRows
+      )
+    );
   } catch (error) {
     if (hasBootstrapContext()) {
       return asToolResult(localBootstrapContextPayload(resolvedQuery, requestedMaxItems, requestedMaxChars));
@@ -260,7 +551,12 @@ async function handleMemoryContextRequest({
 
 function resolveDefaultCredentialsPath() {
   const explicitPath = clean(process.env.PORTAL_AGENT_STAFF_CREDENTIALS);
-  const candidates = [explicitPath, DEFAULT_REPO_CREDENTIALS_PATH, DEFAULT_HOME_CREDENTIALS_PATH].filter(Boolean);
+  const candidates = [
+    explicitPath,
+    DEFAULT_REPO_CREDENTIALS_PATH,
+    DEFAULT_HOME_SECRETS_CREDENTIALS_PATH,
+    DEFAULT_HOME_CREDENTIALS_PATH,
+  ].filter(Boolean);
   return candidates.find((candidate) => existsSync(candidate)) || DEFAULT_REPO_CREDENTIALS_PATH;
 }
 
@@ -469,11 +765,8 @@ server.registerTool(
           ok: true,
           rows,
           results: rows,
-          diagnostics: {
-            bootstrapContextLoaded: true,
-            fallbackUsed: true,
-            fallbackStrategy: "bootstrap-artifact",
-          },
+          diagnostics: localBootstrapDiagnostics(),
+          summary: clean(bootstrapArtifacts.context?.summary) || summarizeRows(rows, 500),
         });
       }
       return asToolError(error);
@@ -519,6 +812,9 @@ server.registerTool(
         )
       );
     } catch (error) {
+      if (hasBootstrapContext()) {
+        return asToolResult(localBootstrapRecentPayload(limit ?? 20));
+      }
       return asToolError(error);
     }
   }
@@ -544,6 +840,9 @@ server.registerTool(
       });
       return asToolResult(payload);
     } catch (error) {
+      if (hasBootstrapContext()) {
+        return asToolResult(localBootstrapStatsPayload());
+      }
       return asToolError(error);
     }
   }

--- a/studio-brain-mcp/server.test.mjs
+++ b/studio-brain-mcp/server.test.mjs
@@ -1,12 +1,26 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { createServer } from "node:http";
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 
-function createBootstrapHome() {
+function createBootstrapHome({
+  summary = "Current goal: ship the memory actionability bridge before broad repo reads.",
+  items = [
+    {
+      source: "handoff",
+      content: "Implement the startup quality card and memory next-actions card.",
+      metadata: {
+        source: "handoff",
+      },
+    },
+  ],
+  diagnostics,
+  startupBlocker = null,
+} = {}) {
   const homeDir = mkdtempSync(join(tmpdir(), "studio-brain-mcp-home-"));
   const threadId = "thread-startup-alias";
   const runtimeDir = join(homeDir, ".codex", "memory", "runtime", threadId);
@@ -16,16 +30,9 @@ function createBootstrapHome() {
     join(runtimeDir, "bootstrap-context.json"),
     `${JSON.stringify(
       {
-        summary: "Current goal: ship the memory actionability bridge before broad repo reads.",
-        items: [
-          {
-            source: "handoff",
-            content: "Implement the startup quality card and memory next-actions card.",
-            metadata: {
-              source: "handoff",
-            },
-          },
-        ],
+        summary,
+        items,
+        ...(diagnostics ? { diagnostics } : {}),
       },
       null,
       2,
@@ -48,6 +55,14 @@ function createBootstrapHome() {
     "utf8",
   );
 
+  if (startupBlocker) {
+    writeFileSync(
+      join(runtimeDir, "startup-blocker.json"),
+      `${JSON.stringify(startupBlocker, null, 2)}\n`,
+      "utf8",
+    );
+  }
+
   return {
     homeDir,
     threadId,
@@ -55,6 +70,111 @@ function createBootstrapHome() {
       rmSync(homeDir, { recursive: true, force: true });
     },
   };
+}
+
+async function withAuthRejectingServer(run) {
+  const server = createServer((req, res) => {
+    if ((req.url || "").startsWith("/healthz")) {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: true, service: "studio-brain", at: new Date().toISOString() }));
+      return;
+    }
+    res.writeHead(401, { "content-type": "application/json" });
+    res.end(JSON.stringify({ ok: false, message: "Missing Authorization header." }));
+  });
+
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  const port = typeof address === "object" && address ? address.port : 0;
+  const baseUrl = `http://127.0.0.1:${port}`;
+
+  try {
+    await run(baseUrl);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function withContextServer(payload, run) {
+  const server = createServer((req, res) => {
+    if ((req.url || "").startsWith("/healthz")) {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: true, service: "studio-brain", at: new Date().toISOString() }));
+      return;
+    }
+
+    if ((req.url || "").startsWith("/api/memory/context")) {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify(payload));
+      return;
+    }
+
+    res.writeHead(404, { "content-type": "application/json" });
+    res.end(JSON.stringify({ ok: false, message: "Not found" }));
+  });
+
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  const port = typeof address === "object" && address ? address.port : 0;
+  const baseUrl = `http://127.0.0.1:${port}`;
+
+  try {
+    await run(baseUrl);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function withBootstrapServer({ searchPayload = null, contextPayload = null }, run) {
+  const server = createServer((req, res) => {
+    if ((req.url || "").startsWith("/healthz")) {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: true, service: "studio-brain", at: new Date().toISOString() }));
+      return;
+    }
+
+    if ((req.url || "").startsWith("/api/memory/search")) {
+      if (searchPayload) {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify(searchPayload));
+        return;
+      }
+      res.writeHead(404, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: false, message: "Search unavailable" }));
+      return;
+    }
+
+    if ((req.url || "").startsWith("/api/memory/context")) {
+      if (contextPayload) {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify(contextPayload));
+        return;
+      }
+      res.writeHead(404, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: false, message: "Context unavailable" }));
+      return;
+    }
+
+    res.writeHead(404, { "content-type": "application/json" });
+    res.end(JSON.stringify({ ok: false, message: "Not found" }));
+  });
+
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  const port = typeof address === "object" && address ? address.port : 0;
+  const baseUrl = `http://127.0.0.1:${port}`;
+
+  try {
+    await run(baseUrl);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
 }
 
 async function withClient(envOverrides, run) {
@@ -105,6 +225,89 @@ test("studio-brain MCP advertises the canonical startup alias and preserves the 
   }
 });
 
+test("studio-brain startup tools fall back to blocker artifacts when auth is missing", async () => {
+  const bootstrap = createBootstrapHome({
+    summary: "Grounding: continuity blocked until Studio Brain auth is restored.",
+    items: [],
+    diagnostics: {
+      continuityState: "blocked",
+      continuityAvailable: false,
+      continuityReason: "missing_token",
+      continuityReasonCode: "missing_token",
+    },
+    startupBlocker: {
+      schema: "codex-startup-blocker.v1",
+      createdAt: new Date().toISOString(),
+      status: "blocked",
+      failureClass: "missing_token",
+      threadId: "thread-startup-alias",
+      cwd: "D:/monsoonfire-portal",
+      query: "Studio Brain startup continuity",
+      queryFingerprint: "fingerprint-test",
+      firstSignal: "Missing Authorization header.",
+      remoteError: "Missing Authorization header.",
+      unblockStep: "Restore a durable Studio Brain staff auth source for the MCP launcher.",
+      localDiagnosticsAvailable: true,
+    },
+  });
+
+  try {
+    await withAuthRejectingServer(async (baseUrl) => {
+      await withClient(
+        {
+          HOME: bootstrap.homeDir,
+          USERPROFILE: bootstrap.homeDir,
+          STUDIO_BRAIN_BOOTSTRAP_THREAD_ID: bootstrap.threadId,
+        },
+        async (client) => {
+          const startupResult = await client.callTool({
+            name: "studio_brain_startup_context",
+            arguments: {
+              baseUrl,
+              timeoutMs: 2000,
+            },
+          });
+
+          assert.notEqual(startupResult.isError, true);
+          assert.equal(startupResult.structuredContent?.diagnostics?.fallbackStrategy, "bootstrap-artifact");
+          assert.equal(startupResult.structuredContent?.diagnostics?.continuityState, "blocked");
+          assert.match(String(startupResult.structuredContent?.summary || ""), /continuity blocked/i);
+          assert.equal(
+            startupResult.structuredContent?.items?.some((row) => row?.source === "codex-startup-blocker"),
+            true,
+          );
+
+          const recentResult = await client.callTool({
+            name: "studio_brain_memory_recent",
+            arguments: {
+              baseUrl,
+              timeoutMs: 2000,
+              limit: 5,
+            },
+          });
+
+          assert.notEqual(recentResult.isError, true);
+          assert.equal(recentResult.structuredContent?.rows?.[0]?.source, "codex-startup-blocker");
+
+          const statsResult = await client.callTool({
+            name: "studio_brain_memory_stats",
+            arguments: {
+              baseUrl,
+              timeoutMs: 2000,
+            },
+          });
+
+          assert.notEqual(statsResult.isError, true);
+          assert.equal(statsResult.structuredContent?.diagnostics?.dataScope, "bootstrap-artifact");
+          assert.equal(Number(statsResult.structuredContent?.stats?.total || 0) >= 1, true);
+        },
+      );
+    });
+  } finally {
+    bootstrap.cleanup();
+  }
+});
+
 test("studio-brain startup alias falls back to bootstrap artifacts when the remote memory bridge is unavailable", async () => {
   const bootstrap = createBootstrapHome();
 
@@ -142,6 +345,202 @@ test("studio-brain startup alias falls back to bootstrap artifacts when the remo
         assert.equal(legacyResult.structuredContent?.diagnostics?.fallbackStrategy, "bootstrap-artifact");
       },
     );
+  } finally {
+    bootstrap.cleanup();
+  }
+});
+
+test("studio-brain startup context rewrites misleading upstream summaries from reranked rows", async () => {
+  const bootstrap = createBootstrapHome({
+    summary: "Local bootstrap summary should not be used when remote context succeeds.",
+  });
+
+  const payload = {
+    ok: true,
+    context: {
+      summary: "1. [startup-context] query=dream rescue cleanup",
+      items: [
+        {
+          id: "mem-portal",
+          source: "codex-handoff",
+          content: "Portal continuity: continue Monsoon Fire portal startup work, not generic Studio Brain history.",
+          metadata: {
+            source: "codex-handoff",
+            projectLane: "monsoonfire-portal",
+            startupEligible: true,
+          },
+        },
+      ],
+    },
+  };
+
+  try {
+    await withContextServer(payload, async (baseUrl) => {
+      await withClient(
+        {
+          HOME: bootstrap.homeDir,
+          USERPROFILE: bootstrap.homeDir,
+          STUDIO_BRAIN_BOOTSTRAP_THREAD_ID: bootstrap.threadId,
+        },
+        async (client) => {
+          const startupResult = await client.callTool({
+            name: "studio_brain_startup_context",
+            arguments: {
+              baseUrl,
+              timeoutMs: 2000,
+            },
+          });
+
+          assert.notEqual(startupResult.isError, true);
+          assert.match(String(startupResult.structuredContent?.summary || ""), /Portal continuity/i);
+          assert.doesNotMatch(
+            String(startupResult.structuredContent?.summary || ""),
+            /dream rescue cleanup/i,
+          );
+          assert.equal(startupResult.structuredContent?.items?.[0]?.id, "mem-portal");
+        },
+      );
+    });
+  } finally {
+    bootstrap.cleanup();
+  }
+});
+
+test("studio-brain startup context prefers startup search hits over misleading context rows", async () => {
+  const bootstrap = createBootstrapHome({
+    summary: "Local bootstrap summary should not be used when remote startup search succeeds.",
+  });
+
+  const searchPayload = {
+    ok: true,
+    rows: [
+      {
+        id: "mem-portal",
+        source: "codex-handoff",
+        content: "Portal continuity: continue Monsoon Fire portal startup work, not generic Studio Brain history.",
+        metadata: {
+          source: "codex-handoff",
+          projectLane: "monsoonfire-portal",
+          startupEligible: true,
+        },
+      },
+    ],
+  };
+
+  const contextPayload = {
+    ok: true,
+    context: {
+      summary: "1. [startup-context] query=dream rescue cleanup",
+      items: [
+        {
+          id: "mem-studio",
+          source: "codex-handoff",
+          content: "Studio Brain continuity: keep working on generic Journeykits history.",
+          metadata: {
+            source: "codex-handoff",
+            projectLane: "studio-brain",
+            startupEligible: true,
+          },
+        },
+      ],
+    },
+  };
+
+  try {
+    await withBootstrapServer({ searchPayload, contextPayload }, async (baseUrl) => {
+      await withClient(
+        {
+          HOME: bootstrap.homeDir,
+          USERPROFILE: bootstrap.homeDir,
+          STUDIO_BRAIN_BOOTSTRAP_THREAD_ID: bootstrap.threadId,
+        },
+        async (client) => {
+          const startupResult = await client.callTool({
+            name: "studio_brain_startup_context",
+            arguments: {
+              baseUrl,
+              timeoutMs: 2000,
+            },
+          });
+
+          assert.notEqual(startupResult.isError, true);
+          assert.match(String(startupResult.structuredContent?.summary || ""), /Portal continuity/i);
+          assert.equal(startupResult.structuredContent?.items?.[0]?.id, "mem-portal");
+          assert.equal(
+            startupResult.structuredContent?.diagnostics?.startupSelectionStrategy,
+            "search-first",
+          );
+          assert.equal(startupResult.structuredContent?.diagnostics?.projectLane, "monsoonfire-portal");
+        },
+      );
+    });
+  } finally {
+    bootstrap.cleanup();
+  }
+});
+
+test("studio-brain startup context can prefer the local bootstrap artifact inside launched sessions", async () => {
+  const bootstrap = createBootstrapHome({
+    summary: "Portal continuity: continue Monsoon Fire portal startup work, not generic Studio Brain history.",
+    items: [
+      {
+        id: "mem-local-portal",
+        source: "codex-handoff",
+        content: "Portal continuity: continue Monsoon Fire portal startup work, not generic Studio Brain history.",
+        metadata: {
+          source: "codex-handoff",
+          projectLane: "monsoonfire-portal",
+          startupEligible: true,
+        },
+      },
+    ],
+  });
+
+  const payload = {
+    ok: true,
+    context: {
+      summary: "Studio Brain continuity: keep working on generic Journeykits history.",
+      items: [
+        {
+          id: "mem-remote-studio",
+          source: "codex-handoff",
+          content: "Studio Brain continuity: keep working on generic Journeykits history.",
+          metadata: {
+            source: "codex-handoff",
+            projectLane: "studio-brain",
+            startupEligible: true,
+          },
+        },
+      ],
+    },
+  };
+
+  try {
+    await withContextServer(payload, async (baseUrl) => {
+      await withClient(
+        {
+          HOME: bootstrap.homeDir,
+          USERPROFILE: bootstrap.homeDir,
+          STUDIO_BRAIN_BOOTSTRAP_THREAD_ID: bootstrap.threadId,
+          STUDIO_BRAIN_STARTUP_CONTEXT_PREFER_LOCAL: "1",
+        },
+        async (client) => {
+          const startupResult = await client.callTool({
+            name: "studio_brain_startup_context",
+            arguments: {
+              baseUrl,
+              timeoutMs: 2000,
+            },
+          });
+
+          assert.notEqual(startupResult.isError, true);
+          assert.match(String(startupResult.structuredContent?.summary || ""), /Portal continuity/i);
+          assert.equal(startupResult.structuredContent?.items?.[0]?.id, "mem-local-portal");
+          assert.equal(startupResult.structuredContent?.diagnostics?.projectLane, "monsoonfire-portal");
+          assert.equal(startupResult.structuredContent?.diagnostics?.dominantProjectLane, "monsoonfire-portal");
+        },
+      );
+    });
   } finally {
     bootstrap.cleanup();
   }

--- a/studio-brain-mcp/thread-context.mjs
+++ b/studio-brain-mcp/thread-context.mjs
@@ -1,0 +1,39 @@
+import { resolveCodexThreadContext } from "../scripts/lib/codex-session-memory-utils.mjs";
+import { stableHash } from "../scripts/lib/pst-memory-utils.mjs";
+
+function clean(value) {
+  return String(value ?? "").trim();
+}
+
+export function resolveBootstrapThreadInfo({
+  env = process.env,
+  fallbackCwd = process.cwd(),
+  fallbackQuery = "",
+  stateDbPath,
+} = {}) {
+  const cwd = clean(env.CODEX_CWD || env.INIT_CWD || env.PWD || fallbackCwd) || fallbackCwd;
+  const hintedThreadId = clean(env.CODEX_THREAD_ID);
+  const resolved = resolveCodexThreadContext({
+    threadId: hintedThreadId,
+    cwd,
+    stateDbPath,
+  });
+
+  if (resolved?.threadId && (!hintedThreadId || clean(resolved.threadId) === hintedThreadId)) {
+    return {
+      ...resolved,
+      resolution: "state-db",
+    };
+  }
+
+  return {
+    threadId: hintedThreadId || `cwd-${stableHash(cwd, 16)}`,
+    rolloutPath: "",
+    cwd,
+    title: "",
+    firstUserMessage: clean(env.CODEX_FIRST_USER_MESSAGE || env.STUDIO_BRAIN_BOOTSTRAP_QUERY || fallbackQuery),
+    updatedAtEpochSeconds: 0,
+    updatedAt: "",
+    resolution: "fallback",
+  };
+}

--- a/studio-brain-mcp/thread-context.test.mjs
+++ b/studio-brain-mcp/thread-context.test.mjs
@@ -1,0 +1,86 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { resolveBootstrapThreadInfo } from "./thread-context.mjs";
+
+test("resolveBootstrapThreadInfo synthesizes a fallback thread context when state lookup misses", () => {
+  const threadInfo = resolveBootstrapThreadInfo({
+    env: {
+      CODEX_THREAD_ID: "missing-thread-for-test",
+      CODEX_CWD: "D:/monsoonfire-portal",
+      CODEX_FIRST_USER_MESSAGE: "test studio brain memory",
+    },
+    fallbackCwd: "C:/fallback-cwd",
+  });
+
+  assert.equal(threadInfo.threadId, "missing-thread-for-test");
+  assert.equal(threadInfo.cwd, "D:/monsoonfire-portal");
+  assert.equal(threadInfo.firstUserMessage, "test studio brain memory");
+  assert.equal(threadInfo.rolloutPath, "");
+  assert.equal(threadInfo.resolution, "fallback");
+});
+
+test("resolveBootstrapThreadInfo creates a stable cwd-based thread id when no hints exist", () => {
+  const threadInfo = resolveBootstrapThreadInfo({
+    env: {},
+    fallbackCwd: "D:/monsoonfire-portal",
+  });
+
+  assert.match(threadInfo.threadId, /^cwd-[a-f0-9]+$/i);
+  assert.equal(threadInfo.cwd, "D:/monsoonfire-portal");
+  assert.equal(threadInfo.resolution, "fallback");
+});
+
+test("resolveBootstrapThreadInfo does not reuse the last cwd thread when a new thread id is already hinted", () => {
+  const tempDir = mkdtempSync(join(tmpdir(), "thread-context-state-"));
+  const stateDbPath = join(tempDir, "state.sqlite");
+  const db = new DatabaseSync(stateDbPath);
+
+  try {
+    db.exec(`
+      create table threads (
+        id text primary key,
+        rollout_path text,
+        cwd text,
+        title text,
+        first_user_message text,
+        updated_at integer
+      );
+    `);
+    db.prepare(
+      "insert into threads (id, rollout_path, cwd, title, first_user_message, updated_at) values (?, ?, ?, ?, ?, ?)"
+    ).run(
+      "existing-thread-id",
+      "C:/rollouts/existing.jsonl",
+      "D:/monsoonfire-portal",
+      "Older portal thread",
+      "old portal message",
+      1234567890,
+    );
+  } finally {
+    db.close();
+  }
+
+  try {
+    const threadInfo = resolveBootstrapThreadInfo({
+      env: {
+        CODEX_THREAD_ID: "fresh-thread-id",
+        CODEX_CWD: "D:/monsoonfire-portal",
+        CODEX_FIRST_USER_MESSAGE: "new portal startup check",
+      },
+      fallbackCwd: "C:/fallback-cwd",
+      stateDbPath,
+    });
+
+    assert.equal(threadInfo.threadId, "fresh-thread-id");
+    assert.equal(threadInfo.cwd, "D:/monsoonfire-portal");
+    assert.equal(threadInfo.firstUserMessage, "new portal startup check");
+    assert.equal(threadInfo.rolloutPath, "");
+    assert.equal(threadInfo.resolution, "fallback");
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});

--- a/studio-brain/.env.integrity.json
+++ b/studio-brain/.env.integrity.json
@@ -1,6 +1,6 @@
 {
   "schema": "studiobrain-infra-integrity-v1",
-  "generatedAt": "2026-04-11T05:44:49.229Z",
+  "generatedAt": "2026-04-11T21:42:15.767Z",
   "generatedBy": "scripts/integrity-check.mjs",
   "allowUnknown": false,
   "metadata": {
@@ -197,8 +197,8 @@
     },
     {
       "path": "scripts/lib/codex-session-memory-utils.mjs",
-      "sha256": "214af238663dc8b3601da740e6d12c5a77fe415848b96a4dd9c6f00f5e821477",
-      "size": 55379
+      "sha256": "0c73ad359ab50c81014ebd18a0d90809261a60e0e633ac09b01de113019256aa",
+      "size": 56997
     },
     {
       "path": "scripts/lib/codex-startup-reliability.mjs",
@@ -232,8 +232,8 @@
     },
     {
       "path": "scripts/lib/studio-brain-startup-auth.mjs",
-      "sha256": "015137ced8066f7e89c552600e4f59bfbea13791b7cee26f20a6645c5ba83537",
-      "size": 3756
+      "sha256": "ac84715c5923bdae37668e0c03252cabfcf9a313223acabd876917c90a1240a1",
+      "size": 4253
     },
     {
       "path": "scripts/lib/studiobrain-posture-policy.mjs",


### PR DESCRIPTION
## What changed
- prefer startup search hits and local bootstrap artifacts over generic context fallback for `studio_brain_startup_context`
- bias bootstrap ranking toward the current repo lane so `monsoonfire-portal` continuity wins over generic Studio Brain history
- add fallback thread-context resolution plus regression coverage for startup search, blocker fallback, and local-bootstrap lane metadata

## Why
Fresh Codex Desktop threads in `D:\monsoonfire-portal` were still surfacing generic Studio Brain history instead of portal-lane continuity. This patch makes startup grounding explicitly lane-aware and preserves the lane in diagnostics so the first-thread grounding is anchored to Monsoon Fire portal work.

## Impact
Fresh startup grounding in Monsoon Fire portal threads now reports `monsoonfire-portal` lane metadata and surfaces portal continuity first, which reduces false context carryover from unrelated Studio Brain history.

## Validation
- `npm --prefix studio-brain-mcp test`
- `node --test scripts/codex-session-memory-utils.test.mjs`
- fresh `codex exec` startup diagnostic in clean worktree returned `LaneMetadata: monsoonfire-portal`