### PR TITLE
[codex] fix portal review findings

### DIFF
--- a/functions/src/events.ts
+++ b/functions/src/events.ts
@@ -564,6 +564,47 @@ export async function collectWorkshopCommunitySignalCountsByEventIds(
   const queryLimit = WORKSHOP_SIGNAL_QUERY_LIMIT_DEFAULT;
   const queryPageLimit = WORKSHOP_SIGNAL_QUERY_PAGE_LIMIT;
 
+  const collectFallbackPages = async (params: {
+    buildQuery: (pageIndex: number) => any;
+    label: string;
+    sourceFilter?: WorkshopDemandSignalSource[];
+    sourceValue?: null | "";
+    eventIdChunkSize?: number;
+  }): Promise<void> => {
+    for (let pageIndex = 0; pageIndex < queryPageLimit; pageIndex += 1) {
+      let pageQuery = params.buildQuery(pageIndex);
+      if (pageIndex > 0) {
+        if (typeof pageQuery.offset !== "function") {
+          logger.warn(`${params.label} pagination unsupported`, {
+            sourceFilter: params.sourceFilter,
+            sourceValue: params.sourceValue,
+            eventIdChunkSize: params.eventIdChunkSize ?? 0,
+          });
+          return;
+        }
+        pageQuery = pageQuery.offset(pageIndex * queryLimit);
+      }
+      if (typeof pageQuery.limit === "function") {
+        pageQuery = pageQuery.limit(queryLimit);
+      }
+      const pageSnaps = await pageQuery.get();
+      const docs = pageSnaps.docs ?? [];
+      for (const docSnap of docs) {
+        addSignalDoc(docSnap);
+      }
+      if (!Array.isArray(docs) || docs.length < queryLimit) {
+        return;
+      }
+    }
+
+    logger.warn(`${params.label} pagination reached cap`, {
+      sourceFilter: params.sourceFilter,
+      sourceValue: params.sourceValue,
+      eventIdChunkSize: params.eventIdChunkSize ?? 0,
+      pageLimit: queryPageLimit,
+    });
+  };
+
   const addSignalDoc = (docSnap: any) => {
     if (!docSnap?.id) return;
     if (signalDocsById.has(docSnap.id)) return;
@@ -689,8 +730,12 @@ export async function collectWorkshopCommunitySignalCountsByEventIds(
           eventIdChunkSize: chunk?.length ?? 0,
         });
         try {
-          const fallbackSnaps = await buildQuery(sourceChunk, chunk, false).get();
-          fallbackSnaps.forEach((docSnap: any) => addSignalDoc(docSnap));
+          await collectFallbackPages({
+            buildQuery: () => buildQuery(sourceChunk, chunk, false),
+            label: "collectWorkshopCommunitySignalCountsByEventIds source query fallback",
+            sourceFilter: sourceChunk,
+            eventIdChunkSize: chunk?.length ?? 0,
+          });
         } catch (fallbackError: any) {
           logger.warn("collectWorkshopCommunitySignalCountsByEventIds source query fallback failed", {
             message: toErrorMessage(fallbackError),
@@ -764,16 +809,22 @@ export async function collectWorkshopCommunitySignalCountsByEventIds(
           eventIdChunkSize: chunk?.length ?? 0,
           sourceValue,
         });
-        let fallbackQuery = db
-          .collection(SUPPORT_REQUESTS_COL)
-          .where("category", "==", "Workshops")
-          .where("source", "==", sourceValue) as any;
-        if (chunk?.length) {
-          fallbackQuery = fallbackQuery.where("eventId", "in", chunk);
-        }
         try {
-          const snaps = await fallbackQuery.limit(queryLimit).get();
-          snaps.forEach((docSnap: any) => addSignalDoc(docSnap));
+          await collectFallbackPages({
+            buildQuery: () => {
+              let query = db
+                .collection(SUPPORT_REQUESTS_COL)
+                .where("category", "==", "Workshops")
+                .where("source", "==", sourceValue) as any;
+              if (chunk?.length) {
+                query = query.where("eventId", "in", chunk);
+              }
+              return query;
+            },
+            label: "collectWorkshopCommunitySignalCountsByEventIds null-source fallback",
+            sourceValue,
+            eventIdChunkSize: chunk?.length ?? 0,
+          });
         } catch (fallbackError: any) {
           logger.warn("collectWorkshopCommunitySignalCountsByEventIds null-source fallback failed", {
             message: toErrorMessage(fallbackError),
@@ -839,15 +890,20 @@ export async function collectWorkshopCommunitySignalCountsByEventIds(
           message: toErrorMessage(error),
           eventIdChunkSize: chunk?.length ?? 0,
         });
-        let fallbackQuery = db
-          .collection(SUPPORT_REQUESTS_COL)
-          .where("category", "==", "Workshops") as any;
-        if (chunk?.length) {
-          fallbackQuery = fallbackQuery.where("eventId", "in", chunk);
-        }
         try {
-          const snaps = await fallbackQuery.limit(queryLimit).get();
-          snaps.forEach((docSnap: any) => addSignalDoc(docSnap));
+          await collectFallbackPages({
+            buildQuery: () => {
+              let query = db
+                .collection(SUPPORT_REQUESTS_COL)
+                .where("category", "==", "Workshops") as any;
+              if (chunk?.length) {
+                query = query.where("eventId", "in", chunk);
+              }
+              return query;
+            },
+            label: "collectWorkshopCommunitySignalCountsByEventIds source-free fallback",
+            eventIdChunkSize: chunk?.length ?? 0,
+          });
         } catch (fallbackError: any) {
           logger.warn("collectWorkshopCommunitySignalCountsByEventIds source-free fallback failed", {
             message: toErrorMessage(fallbackError),
@@ -1919,6 +1975,48 @@ export const listWorkshopDemandSignals = onRequest({ region: REGION }, async (re
   try {
     const signalDocsById = new Map<string, { id: string; raw: Record<string, any> }>();
     const eventIdsWithRecognizedSourceSignals = new Set<string>();
+    const collectFallbackPages = async (params: {
+      buildQuery: (pageIndex: number) => any;
+      label: string;
+      sourceFilter?: WorkshopDemandSignalSource[];
+      sourceValue?: null | "";
+      eventIdChunkSize?: number;
+    }): Promise<void> => {
+      for (let pageIndex = 0; pageIndex < WORKSHOP_SIGNAL_QUERY_PAGE_LIMIT; pageIndex += 1) {
+        let pageQuery = params.buildQuery(pageIndex);
+        if (pageIndex > 0) {
+          if (typeof pageQuery.offset !== "function") {
+            logger.warn(`${params.label} pagination unsupported`, {
+              requestId,
+              sourceFilter: params.sourceFilter,
+              sourceValue: params.sourceValue,
+              eventIdChunkSize: params.eventIdChunkSize ?? 0,
+            });
+            return;
+          }
+          pageQuery = pageQuery.offset(pageIndex * limit);
+        }
+        if (typeof pageQuery.limit === "function") {
+          pageQuery = pageQuery.limit(limit);
+        }
+        const pageSnaps = await pageQuery.get();
+        const docs = pageSnaps.docs ?? [];
+        for (const docSnap of docs) {
+          addSignalDoc(docSnap);
+        }
+        if (!Array.isArray(docs) || docs.length < limit) {
+          return;
+        }
+      }
+
+      logger.warn(`${params.label} pagination reached cap`, {
+        requestId,
+        sourceFilter: params.sourceFilter,
+        sourceValue: params.sourceValue,
+        eventIdChunkSize: params.eventIdChunkSize ?? 0,
+        pageLimit: WORKSHOP_SIGNAL_QUERY_PAGE_LIMIT,
+      });
+    };
 
     const addSignalDoc = (docSnap: any) => {
       if (!docSnap?.id) return;
@@ -1974,8 +2072,12 @@ export const listWorkshopDemandSignals = onRequest({ region: REGION }, async (re
             sourceCount: sourceChunk.length,
             eventIdChunkSize: eventIdChunk?.length ?? 0,
           });
-          const fallbackSnaps = await buildQuery(sourceChunk, eventIdChunk, false).get();
-          fallbackSnaps.forEach((docSnap: any) => addSignalDoc(docSnap));
+          await collectFallbackPages({
+            buildQuery: () => buildQuery(sourceChunk, eventIdChunk, false),
+            label: "listWorkshopDemandSignals source query fallback",
+            sourceFilter: sourceChunk,
+            eventIdChunkSize: eventIdChunk?.length ?? 0,
+          });
         }
       };
 
@@ -2016,15 +2118,21 @@ export const listWorkshopDemandSignals = onRequest({ region: REGION }, async (re
             eventIdChunkSize: eventIdChunk.length,
             sourceValue,
           });
-          let fallbackQuery = db
-            .collection(SUPPORT_REQUESTS_COL)
-            .where("category", "==", "Workshops")
-            .where("source", "==", sourceValue) as any;
-          if (eventIdChunk.length > 0) {
-            fallbackQuery = fallbackQuery.where("eventId", "in", eventIdChunk);
-          }
-          const fallbackSnaps = await fallbackQuery.limit(limit).get();
-          fallbackSnaps.forEach((docSnap: any) => addSignalDoc(docSnap));
+          await collectFallbackPages({
+            buildQuery: () => {
+              let query = db
+                .collection(SUPPORT_REQUESTS_COL)
+                .where("category", "==", "Workshops")
+                .where("source", "==", sourceValue) as any;
+              if (eventIdChunk.length > 0) {
+                query = query.where("eventId", "in", eventIdChunk);
+              }
+              return query;
+            },
+            label: "listWorkshopDemandSignals null-source fallback",
+            sourceValue,
+            eventIdChunkSize: eventIdChunk.length,
+          });
         }
       };
 
@@ -2059,12 +2167,17 @@ export const listWorkshopDemandSignals = onRequest({ region: REGION }, async (re
             message: toErrorMessage(error),
             eventIdChunkSize: eventIdChunk.length,
           });
-          let fallbackQuery = db.collection(SUPPORT_REQUESTS_COL).where("category", "==", "Workshops") as any;
-          if (eventIdChunk.length > 0) {
-            fallbackQuery = fallbackQuery.where("eventId", "in", eventIdChunk);
-          }
-          const fallbackSnaps = await fallbackQuery.limit(limit).get();
-          fallbackSnaps.forEach((docSnap: any) => addSignalDoc(docSnap));
+          await collectFallbackPages({
+            buildQuery: () => {
+              let query = db.collection(SUPPORT_REQUESTS_COL).where("category", "==", "Workshops") as any;
+              if (eventIdChunk.length > 0) {
+                query = query.where("eventId", "in", eventIdChunk);
+              }
+              return query;
+            },
+            label: "listWorkshopDemandSignals source-free fallback",
+            eventIdChunkSize: eventIdChunk.length,
+          });
         }
       };
 

--- a/functions/src/events.workshopSignals.test.ts
+++ b/functions/src/events.workshopSignals.test.ts
@@ -1,0 +1,164 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import * as shared from "./shared";
+import { collectWorkshopCommunitySignalCountsByEventIds } from "./events";
+
+type SupportRequestRow = Record<string, unknown>;
+type SupportRequestDoc = {
+  id: string;
+  row: SupportRequestRow;
+};
+
+type QueryFilter =
+  | { field: string; op: "=="; value: unknown }
+  | { field: string; op: "in"; value: unknown[] };
+
+type MockQueryState = {
+  filters: QueryFilter[];
+  ordered: boolean;
+  limitCount: number | null;
+  offsetCount: number;
+};
+
+type MockSnapshot = {
+  id: string;
+  data: () => SupportRequestRow;
+};
+
+function matchesFilter(row: SupportRequestRow, filter: QueryFilter): boolean {
+  const value = row[filter.field];
+  if (filter.op === "==") {
+    return value === filter.value;
+  }
+  return Array.isArray(filter.value) && filter.value.includes(value);
+}
+
+function createSupportRequestQuery(
+  rows: SupportRequestDoc[],
+  state: MockQueryState,
+): {
+  where: (field: string, op: "==" | "in", value: unknown) => ReturnType<typeof createSupportRequestQuery>;
+  orderBy: (_field: string, _direction?: string) => ReturnType<typeof createSupportRequestQuery>;
+  limit: (limit: number) => ReturnType<typeof createSupportRequestQuery>;
+  offset: (offset: number) => ReturnType<typeof createSupportRequestQuery>;
+  get: () => Promise<{ docs: MockSnapshot[]; empty: boolean }>;
+} {
+  return {
+    where: (field, op, value) =>
+      createSupportRequestQuery(rows, {
+        ...state,
+        filters: [
+          ...state.filters,
+          op === "in"
+            ? { field, op, value: Array.isArray(value) ? value : [] }
+            : { field, op, value },
+        ],
+      }),
+    orderBy: () =>
+      createSupportRequestQuery(rows, {
+        ...state,
+        ordered: true,
+      }),
+    limit: (limit) =>
+      createSupportRequestQuery(rows, {
+        ...state,
+        limitCount: limit,
+      }),
+    offset: (offset) =>
+      createSupportRequestQuery(rows, {
+        ...state,
+        offsetCount: offset,
+      }),
+    get: async () => {
+      const sourceEquality = state.filters.find(
+        (filter) => filter.field === "source" && filter.op === "==",
+      );
+      const hasSourceInFilter = state.filters.some(
+        (filter) => filter.field === "source" && filter.op === "in",
+      );
+      const shouldFailOrdered =
+        state.ordered &&
+        (!hasSourceInFilter ||
+          sourceEquality?.value === null ||
+          sourceEquality?.value === "");
+      if (shouldFailOrdered) {
+        throw new Error("requires an index");
+      }
+
+      const filtered = rows.filter(({ row }) =>
+        state.filters.every((filter) => matchesFilter(row, filter)),
+      );
+      const start = Math.max(0, state.offsetCount);
+      const end =
+        state.limitCount === null ? undefined : start + Math.max(0, state.limitCount);
+      const docs = filtered.slice(start, end).map<MockSnapshot>(({ id, row }) => ({
+        id,
+        data: () => row,
+      }));
+      return {
+        docs,
+        empty: docs.length === 0,
+      };
+    },
+  };
+}
+
+async function withMockSupportRequests<T>(
+  supportRequests: Record<string, SupportRequestRow>,
+  callback: () => Promise<T>,
+): Promise<T> {
+  const db = shared.db as unknown as {
+    collection: (path: string) => unknown;
+  };
+  const originalCollection = db.collection;
+  const rows = Object.entries(supportRequests).map(([id, row]) => ({ id, row }));
+
+  db.collection = (path: string) => {
+    if (path !== "supportRequests") {
+      throw new Error(`Unexpected collection path in test: ${path}`);
+    }
+    return createSupportRequestQuery(rows, {
+      filters: [],
+      ordered: false,
+      limitCount: null,
+      offsetCount: 0,
+    });
+  };
+
+  try {
+    return await callback();
+  } finally {
+    db.collection = originalCollection;
+  }
+}
+
+test("collectWorkshopCommunitySignalCountsByEventIds paginates fallback queries beyond 250 docs", async () => {
+  const supportRequests: Record<string, SupportRequestRow> = {};
+  for (let index = 0; index < 260; index += 1) {
+    const minute = String(index % 60).padStart(2, "0");
+    const second = String(Math.floor(index / 60)).padStart(2, "0");
+    supportRequests[`support-${index}`] = {
+      category: "Workshops",
+      source: null,
+      eventId: "event-null-fallback-123",
+      uid: `member-${index}`,
+      createdAt: `2031-01-01T10:${minute}:${second}.000Z`,
+      subject: "Workshop request: Large format clay",
+      body: "Workshop request:\nWorkshop id: event-null-fallback-123",
+    };
+  }
+
+  const counts = await withMockSupportRequests(supportRequests, async () =>
+    await collectWorkshopCommunitySignalCountsByEventIds("owner-1", ["event-null-fallback-123"]),
+  );
+
+  const eventCounts = counts.get("event-null-fallback-123");
+  assert.ok(eventCounts);
+  assert.equal(eventCounts?.requestSignals, 260);
+  assert.equal(eventCounts?.interestSignals, 0);
+  assert.equal(eventCounts?.showcaseSignals, 0);
+  assert.equal(eventCounts?.withdrawnSignals, 0);
+  assert.ok(typeof eventCounts?.latestSignalAtMs === "number");
+  assert.ok((eventCounts?.latestSignalAtMs ?? 0) > 0);
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2845,7 +2845,7 @@ export default function App() {
                 prefersReducedMotion,
               }}
             >
-              <div key={`${nav}:${themeName}:${enhancedMotion ? "m1" : "m0"}`} className="view-root">
+              <div className="view-root">
                 {renderView(nav)}
               </div>
             </UiSettingsProvider>

--- a/web/src/api/ensureUserDoc.test.ts
+++ b/web/src/api/ensureUserDoc.test.ts
@@ -18,10 +18,14 @@ async function loadEnsureUserDocModule(): Promise<EnsureModule> {
 
 beforeEach(() => {
   vi.restoreAllMocks();
+  window.localStorage.clear();
+  window.sessionStorage.clear();
 });
 
 afterEach(() => {
   vi.restoreAllMocks();
+  window.localStorage.clear();
+  window.sessionStorage.clear();
 });
 
 describe("ensureUserDocForSession", () => {
@@ -110,5 +114,54 @@ describe("ensureUserDocForSession", () => {
     expect(third.code).not.toBe("RETRY_SUPPRESSED");
     expect(fetchMock.mock.calls.length).toBeGreaterThanOrEqual(1);
     expect(fetchMock.mock.calls.length).toBeLessThanOrEqual(3);
+  });
+
+  it("does not trust legacy localStorage success markers from previous browser sessions", async () => {
+    const key = "bootstrapped:user_legacy:project_1";
+    window.localStorage.setItem(key, "1");
+
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({ ok: true, userCreated: false, profileCreated: false })
+    );
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    const { ensureUserDocForSession } = await loadEnsureUserDocModule();
+    const result = await ensureUserDocForSession({
+      uid: "user_legacy",
+      projectId: "project_1",
+      baseUrl: "https://example.test/functions",
+      getIdToken: async () => "id-token-123",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(window.localStorage.getItem(key)).toBeNull();
+    expect(window.sessionStorage.getItem(key)).toBe("1");
+  });
+
+  it("re-checks ensureUserDoc after a new browser session starts", async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({ ok: true, userCreated: false, profileCreated: false })
+    );
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    const firstModule = await loadEnsureUserDocModule();
+    const args = {
+      uid: "user_browser_session",
+      projectId: "project_1",
+      baseUrl: "https://example.test/functions",
+      getIdToken: async () => "id-token-123",
+    };
+
+    const first = await firstModule.ensureUserDocForSession(args);
+    expect(first.ok).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    window.sessionStorage.clear();
+
+    const secondModule = await loadEnsureUserDocModule();
+    const second = await secondModule.ensureUserDocForSession(args);
+    expect(second.ok).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/web/src/api/ensureUserDoc.ts
+++ b/web/src/api/ensureUserDoc.ts
@@ -42,6 +42,42 @@ function retryCooldownKey(uid: string, projectId: string): string {
   return `bootstrappedRetryAfter:${uid}:${projectId}`;
 }
 
+function readBootstrapSuccess(uid: string, projectId: string): boolean {
+  const key = bootstrapSuccessKey(uid, projectId);
+  try {
+    if (safeStorageGetItem("sessionStorage", key) === "1") {
+      return true;
+    }
+  } catch {
+    // Ignore storage availability issues.
+  }
+
+  try {
+    if (safeStorageGetItem("localStorage", key) === "1") {
+      safeStorageRemoveItem("localStorage", key);
+    }
+  } catch {
+    // Ignore storage availability issues.
+  }
+
+  return false;
+}
+
+function writeBootstrapSuccess(uid: string, projectId: string) {
+  const key = bootstrapSuccessKey(uid, projectId);
+  try {
+    safeStorageSetItem("sessionStorage", key, "1");
+  } catch {
+    // Ignore storage availability issues.
+  }
+
+  try {
+    safeStorageRemoveItem("localStorage", key);
+  } catch {
+    // Ignore storage availability issues.
+  }
+}
+
 function readRetryCooldown(uid: string, projectId: string): number {
   try {
     const raw = safeStorageGetItem("localStorage", retryCooldownKey(uid, projectId));
@@ -81,14 +117,9 @@ export async function ensureUserDocForSession(args: EnsureUserDocArgs): Promise<
     return { ok: true, userCreated: false, profileCreated: false, skipped: true };
   }
 
-  try {
-    const key = bootstrapSuccessKey(args.uid, projectId);
-    if (safeStorageGetItem("localStorage", key) === "1") {
-      sessionGuards.add(sessionKey);
-      return { ok: true, userCreated: false, profileCreated: false, skipped: true };
-    }
-  } catch {
-    // Ignore storage availability issues.
+  if (readBootstrapSuccess(args.uid, projectId)) {
+    sessionGuards.add(sessionKey);
+    return { ok: true, userCreated: false, profileCreated: false, skipped: true };
   }
 
   const retryAfterMs = readRetryCooldown(args.uid, projectId);
@@ -157,12 +188,7 @@ export async function ensureUserDocForSession(args: EnsureUserDocArgs): Promise<
 
       sessionGuards.add(sessionKey);
       clearRetryCooldown(args.uid, projectId);
-
-      try {
-        safeStorageSetItem("localStorage", bootstrapSuccessKey(args.uid, projectId), "1");
-      } catch {
-        // Ignore storage availability issues.
-      }
+      writeBootstrapSuccess(args.uid, projectId);
 
       return {
         ok: true,

--- a/web/src/api/portalApi.test.ts
+++ b/web/src/api/portalApi.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+type PortalModule = typeof import("./portalApi");
+
+vi.mock("./requestId", () => ({
+  makeRequestId: () => "req_test",
+}));
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+async function loadPortalApiModule(): Promise<PortalModule> {
+  vi.resetModules();
+  return await import("./portalApi");
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("portalApi transport isolation", () => {
+  it("deduplicates identical in-flight requests for the same caller context", async () => {
+    let resolveFetch: ((value: Response) => void) | null = null;
+    const fetchMock = vi.fn(
+      () =>
+        new Promise<Response>((resolve) => {
+          resolveFetch = resolve;
+        })
+    );
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    const { createPortalApi } = await loadPortalApiModule();
+    const api = createPortalApi({ baseUrl: "https://example.test/functions" });
+    const args = {
+      idToken: "id-token-1",
+      payload: { uid: "user_1", fromBatchId: "batch_1" },
+    };
+
+    const first = api.continueJourney(args);
+    const second = api.continueJourney(args);
+
+    await vi.waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    if (!resolveFetch) {
+      throw new Error("fetch resolver missing");
+    }
+    resolveFetch(jsonResponse({ ok: true, batchId: "batch_new" }));
+
+    await expect(first).resolves.toMatchObject({
+      data: { ok: true, batchId: "batch_new" },
+    });
+    await expect(second).resolves.toMatchObject({
+      data: { ok: true, batchId: "batch_new" },
+    });
+  });
+
+  it("does not share in-flight requests across different base URLs", async () => {
+    const resolvers: Array<(value: Response) => void> = [];
+    const fetchMock = vi.fn(
+      () =>
+        new Promise<Response>((resolve) => {
+          resolvers.push(resolve);
+        })
+    );
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    const { createPortalApi } = await loadPortalApiModule();
+    const apiA = createPortalApi({ baseUrl: "https://api-a.test/functions" });
+    const apiB = createPortalApi({ baseUrl: "https://api-b.test/functions" });
+    const args = {
+      idToken: "id-token-1",
+      payload: { uid: "user_1", fromBatchId: "batch_1" },
+    };
+
+    const first = apiA.continueJourney(args);
+    const second = apiB.continueJourney(args);
+
+    await vi.waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("https://api-a.test/functions/continueJourney");
+    expect(fetchMock.mock.calls[1]?.[0]).toBe("https://api-b.test/functions/continueJourney");
+
+    resolvers[0]?.(jsonResponse({ ok: true, scope: "a" }));
+    resolvers[1]?.(jsonResponse({ ok: true, scope: "b" }));
+
+    await expect(first).resolves.toMatchObject({ data: { ok: true, scope: "a" } });
+    await expect(second).resolves.toMatchObject({ data: { ok: true, scope: "b" } });
+  });
+
+  it("does not suppress auth retries across different base URLs", async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({ ok: false, message: "Token expired" }, 401));
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    const { createPortalApi } = await loadPortalApiModule();
+    const apiA = createPortalApi({ baseUrl: "https://api-a.test/functions" });
+    const apiB = createPortalApi({ baseUrl: "https://api-b.test/functions" });
+    const args = {
+      idToken: "id-token-expired",
+      payload: { uid: "user_1", fromBatchId: "batch_1" },
+    };
+
+    await expect(apiA.continueJourney(args)).rejects.toThrow(/sign in/i);
+    await expect(apiB.continueJourney(args)).rejects.toThrow(/sign in/i);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/web/src/api/portalApi.ts
+++ b/web/src/api/portalApi.ts
@@ -425,6 +425,10 @@ const portalAuthRetryGuardByRoute = new Map<
   { tokenSignature: string; blockedUntilMs: number; reason: string }
 >();
 
+function normalizePortalBaseUrl(baseUrl: string): string {
+  return baseUrl.trim().replace(/\/+$/, "");
+}
+
 function safeStringifyJson(value: unknown): string {
   try {
     return JSON.stringify(value, null, 2);
@@ -442,12 +446,30 @@ function makeTokenSignature(token: string): string {
   return `sig_${(hash >>> 0).toString(16)}`;
 }
 
-function makePortalActionKey(route: string, payload: unknown): string {
-  return `${route}::${safeStringifyJson(payload)}`;
+function makeCredentialSignature(token?: string): string {
+  const trimmed = token?.trim() ?? "";
+  return trimmed ? makeTokenSignature(trimmed) : "none";
 }
 
-function makePortalRetryKey(route: string): string {
-  return `POST:${route.toLowerCase()}`;
+function makePortalScopeKey(baseUrl: string, idToken: string, adminToken?: string): string {
+  return [
+    normalizePortalBaseUrl(baseUrl).toLowerCase(),
+    `id=${makeCredentialSignature(idToken)}`,
+    `admin=${makeCredentialSignature(adminToken)}`,
+  ].join("::");
+}
+
+function makePortalActionKey(scopeKey: string, route: string, payload: unknown): string {
+  return `${scopeKey}::${route}::${safeStringifyJson(payload)}`;
+}
+
+function makePortalRetryKey(baseUrl: string, route: string, adminToken?: string): string {
+  return [
+    "POST",
+    normalizePortalBaseUrl(baseUrl).toLowerCase(),
+    route.toLowerCase(),
+    `admin=${makeCredentialSignature(adminToken)}`,
+  ].join(":");
 }
 
 function buildCurlExample(url: string, payload: unknown, includeAdminToken: boolean): string {
@@ -486,7 +508,15 @@ async function callFn<TReq, TResp>(
   args: PortalApiCallArgs<TReq>
 ): Promise<PortalApiCallResult<TResp>> {
   const route = LEGACY_RESERVATION_FN_PATHS[fn] ?? fn;
-  const actionKey = args.signal ? null : makePortalActionKey(route, args.payload ?? {});
+  const normalizedBaseUrl = normalizePortalBaseUrl(baseUrl);
+  const trimmedAdminToken = args.adminToken?.trim() || undefined;
+  const actionKey = args.signal
+    ? null
+    : makePortalActionKey(
+        makePortalScopeKey(normalizedBaseUrl, args.idToken, trimmedAdminToken),
+        route,
+        args.payload ?? {}
+      );
   if (actionKey) {
     const existingInFlight = portalInFlightByAction.get(actionKey) as
       | Promise<PortalApiCallResult<TResp>>
@@ -497,10 +527,10 @@ async function callFn<TReq, TResp>(
   }
 
   const run = async (): Promise<PortalApiCallResult<TResp>> => {
-    const url = `${baseUrl.replace(/\/$/, "")}/${route}`;
+    const url = `${normalizedBaseUrl}/${route}`;
     const requestId = makeRequestId();
     const startedAtMs = Date.now();
-    const retryGuardKey = makePortalRetryKey(route);
+    const retryGuardKey = makePortalRetryKey(normalizedBaseUrl, route, trimmedAdminToken);
     const tokenSignature = makeTokenSignature(args.idToken);
 
     const metaStart: PortalApiMeta = {
@@ -509,7 +539,7 @@ async function callFn<TReq, TResp>(
       fn,
       url,
       payload: args.payload,
-      curlExample: buildCurlExample(url, args.payload, !!args.adminToken),
+      curlExample: buildCurlExample(url, args.payload, Boolean(trimmedAdminToken)),
     };
     publishRequestTelemetry({
       atIso: metaStart.atIso,
@@ -587,7 +617,7 @@ async function callFn<TReq, TResp>(
         headers: {
           "Content-Type": "application/json",
           Authorization: `Bearer ${args.idToken}`,
-          ...(args.adminToken ? { "x-admin-token": args.adminToken } : {}),
+          ...(trimmedAdminToken ? { "x-admin-token": trimmedAdminToken } : {}),
         },
         body: JSON.stringify(args.payload ?? {}),
         signal: abortController.signal,

--- a/web/src/views/staff/StudioBrainControlTowerModule.test.tsx
+++ b/web/src/views/staff/StudioBrainControlTowerModule.test.tsx
@@ -1,6 +1,6 @@
 /** @vitest-environment jsdom */
 
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { User } from "firebase/auth";
 import * as controlTowerUtils from "../../utils/studioBrainControlTower";
@@ -396,6 +396,7 @@ function createRoomPayload() {
 afterEach(() => {
   window.localStorage.clear();
   cleanup();
+  vi.useRealTimers();
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
 });
@@ -669,5 +670,87 @@ describe("StudioBrainControlTowerModule", () => {
     fireEvent.click(await screen.findByRole("button", { name: /Open portal/i }));
 
     expect(await screen.findByRole("dialog", { name: "portal details" })).toBeTruthy();
+  });
+
+  it("stops fallback polling once the stream is live", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(controlTowerUtils, "getStudioBrainControlTowerResolution").mockReturnValue({
+      baseUrl: "https://studio-brain.runtime.example",
+      configured: true,
+      enabled: true,
+      reason: "",
+    });
+    const fetchStateSpy = vi
+      .spyOn(controlTowerUtils, "fetchControlTowerState")
+      .mockResolvedValue(createStatePayload().state);
+    vi.spyOn(controlTowerUtils, "subscribeControlTowerEvents").mockImplementation((options) => {
+      options.onOpen?.();
+      return () => undefined;
+    });
+
+    render(
+      <StudioBrainControlTowerModule
+        user={createUser()}
+        active={true}
+        disabled={false}
+        adminToken=""
+        onNavigateTarget={() => undefined}
+      />,
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(screen.getByText("30-second operator plane")).toBeTruthy();
+    expect(fetchStateSpy).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      vi.advanceTimersByTime(6_000);
+      await Promise.resolve();
+    });
+
+    expect(fetchStateSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps polling when the stream falls back", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(controlTowerUtils, "getStudioBrainControlTowerResolution").mockReturnValue({
+      baseUrl: "https://studio-brain.runtime.example",
+      configured: true,
+      enabled: true,
+      reason: "",
+    });
+    const fetchStateSpy = vi
+      .spyOn(controlTowerUtils, "fetchControlTowerState")
+      .mockResolvedValue(createStatePayload().state);
+    vi.spyOn(controlTowerUtils, "subscribeControlTowerEvents").mockImplementation((options) => {
+      options.onError?.(new Error("stream offline"));
+      return () => undefined;
+    });
+
+    render(
+      <StudioBrainControlTowerModule
+        user={createUser()}
+        active={true}
+        disabled={false}
+        adminToken=""
+        onNavigateTarget={() => undefined}
+      />,
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(screen.getByText("30-second operator plane")).toBeTruthy();
+    expect(fetchStateSpy).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      vi.advanceTimersByTime(6_000);
+      await Promise.resolve();
+    });
+
+    expect(fetchStateSpy).toHaveBeenCalledTimes(3);
   });
 });

--- a/web/src/views/staff/StudioBrainControlTowerModule.tsx
+++ b/web/src/views/staff/StudioBrainControlTowerModule.tsx
@@ -270,6 +270,12 @@ export default function StudioBrainControlTowerModule({
 
   useEffect(() => {
     if (!active || isDisabled || !resolution.baseUrl) return;
+    void loadState();
+  }, [active, isDisabled, loadState, resolution.baseUrl]);
+
+  useEffect(() => {
+    if (!active || isDisabled || !resolution.baseUrl) return;
+    if (streamStatus === "live") return;
     let cancelled = false;
     let timer: number | null = null;
 
@@ -282,7 +288,9 @@ export default function StudioBrainControlTowerModule({
       }, delay);
     };
 
-    void loadState();
+    if (streamStatus === "fallback") {
+      void loadState({ silent: true });
+    }
     queueNext();
 
     const onVisibilityChange = () => {
@@ -295,7 +303,7 @@ export default function StudioBrainControlTowerModule({
       if (timer !== null) window.clearTimeout(timer);
       document.removeEventListener("visibilitychange", onVisibilityChange);
     };
-  }, [active, isDisabled, loadState, resolution.baseUrl]);
+  }, [active, isDisabled, loadState, resolution.baseUrl, streamStatus]);
 
   useEffect(() => {
     if (!active || isDisabled || !resolution.baseUrl) return;


### PR DESCRIPTION
## What changed
- scope portal API request de-duping and auth retry guards to caller context so base URL and auth boundaries cannot share in-flight work
- paginate workshop signal fallback queries so signal counts do not silently truncate beyond the first 250 documents
- rework ensureUserDoc bootstrap caching to re-check on later browser sessions
- stop Studio Brain control tower fallback polling when SSE is live
- remove the App view key that forced full remounts on theme and motion changes
- add regression coverage for each of the above

## Why
These fixes address the review findings from the repo audit and remove a mix of correctness, performance, and UX reset bugs that could stay latent while tests still passed.

## Validation
- npm --prefix web run lint
- npm --prefix web run build
- npm --prefix web run test:run
- npm --prefix functions run test
- deployed to https://portal.monsoonfire.com via the guarded Namecheap portal flow
- cutover verification passed
- post-deploy promotion gate passed, including authenticated canary, theme sweep, and index guard
