### PR TITLE
docs: add 2026-04-12 live surface audit access notes

### DIFF
--- a/docs/audits/live-surface-audit-2026-04-12.md
+++ b/docs/audits/live-surface-audit-2026-04-12.md
@@ -1,0 +1,17 @@
+# Live Surface Audit Notes — 2026-04-12
+
+## Access check from this environment
+- `curl -I https://monsoonfire.com` returned `HTTP/1.1 403 Forbidden`.
+- `curl -I https://portal.monsoonfire.com` returned `HTTP/1.1 403 Forbidden`.
+- Headless Playwright browser installation was attempted (`npx playwright install chromium`) and failed due CDN `403 Forbidden`, so direct rendered visual verification could not be completed from this runner.
+
+## Website evidence sampled from repository source
+- Homepage login points to `https://portal.monsoonfire.com`.
+- Several other pages still point login to `https://monsoonfire.kilnfire.com`.
+- Homepage includes loading placeholders for kiln status and updates.
+- Kiln status data file reports `lastUpdated: 2026-01-31 5:30 PM`.
+
+## Portal evidence sampled from repository source
+- Main nav currently groups areas into Kiln Rentals, Studio & Resources, Community.
+- Unknown routes fall back to generic `PlaceholderView` that says "Coming soon. We are designing this area next."
+- `WareCheckInView` currently re-exports `ReservationsView`.


### PR DESCRIPTION
### Motivation
- Record results and constraints from a live-surface audit run on 2026-04-12 so the team has a reproducible evidence snapshot describing why full rendered verification could not be completed from this environment.

### Description
- Add `docs/audits/live-surface-audit-2026-04-12.md` containing the access checks (`403` results), website-sourced evidence (login destination inconsistencies, loading/placeholders, stale `kiln-status` timestamp), and portal-sourced evidence (nav grouping, `PlaceholderView`, `WareCheckInView` aliasing).

### Testing
- Ran `curl -I https://monsoonfire.com` and `curl -I https://portal.monsoonfire.com` which returned `HTTP/1.1 403 Forbidden` from this environment; attempted `npx playwright install chromium` which failed due to remote CDN `403`; used repo scans (`rg` / file reads) to capture source-backed evidence referenced in the note.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db14247ca8832bb34d771c3e15950c)