### PR TITLE
[codex] preserve ware crate dwell reservation metadata

### DIFF
--- a/functions/src/apiV1.test.ts
+++ b/functions/src/apiV1.test.ts
@@ -7079,6 +7079,97 @@ test("reservations.pickupWindow records misses without bypassing the storage gra
   assert.equal(data.pickupWindowStatus, "missed");
 });
 
+test("reservations.pickupWindow staff_mark_completed computes crate dwell time from arrival", async () => {
+  const arrivedAtIso = "2026-02-20T18:00:00.000Z";
+  const state: MockDbState = {
+    reservations: {
+      "reservation-pickup-completed": {
+        ownerUid: "owner-1",
+        status: "CONFIRMED",
+        loadStatus: "loaded",
+        arrivedAt: arrivedAtIso,
+        pickupWindow: {
+          status: "confirmed",
+          confirmedStart: "2026-02-21T17:00:00.000Z",
+          confirmedEnd: "2026-02-21T19:00:00.000Z",
+        },
+        stageHistory: [],
+      },
+    },
+  };
+
+  const response = await invokeApiV1Route(
+    state,
+    makeApiV1Request({
+      path: "/v1/reservations.pickupWindow",
+      body: {
+        reservationId: "reservation-pickup-completed",
+        action: "staff_mark_completed",
+      },
+      ctx: staffContext({ uid: "staff-1" }),
+      routeFamily: "v1",
+      staffAuthUid: "staff-1",
+    }),
+  );
+
+  assert.equal(response.status, 200);
+  const body = response.body as Record<string, unknown>;
+  const data = (body.data ?? {}) as Record<string, unknown>;
+  assert.equal(data.pickupWindowStatus, "completed");
+  assert.ok(typeof data.crateDwellMs === "number");
+  assert.ok(Number(data.crateDwellMs) >= 0);
+  assert.ok(data.crateCheckedOutAt instanceof Date);
+});
+
+test("reservations.pickupWindow staff_mark_completed replays stored crate dwell metadata once completed", async () => {
+  const checkedOutAtIso = "2026-02-21T19:05:00.000Z";
+  const state: MockDbState = {
+    reservations: {
+      "reservation-pickup-completed-replay": {
+        ownerUid: "owner-1",
+        status: "CONFIRMED",
+        loadStatus: "loaded",
+        arrivedAt: "2026-02-20T18:00:00.000Z",
+        crateDwellMs: 90 * 60 * 1000,
+        crateCheckedOutAt: checkedOutAtIso,
+        pickupWindow: {
+          status: "completed",
+          confirmedStart: "2026-02-21T17:00:00.000Z",
+          confirmedEnd: "2026-02-21T19:00:00.000Z",
+          confirmedAt: "2026-02-21T17:05:00.000Z",
+          completedAt: checkedOutAtIso,
+        },
+        stageHistory: [],
+      },
+    },
+  };
+
+  const response = await invokeApiV1Route(
+    state,
+    makeApiV1Request({
+      path: "/v1/reservations.pickupWindow",
+      body: {
+        reservationId: "reservation-pickup-completed-replay",
+        action: "staff_mark_completed",
+      },
+      ctx: staffContext({ uid: "staff-1" }),
+      routeFamily: "v1",
+      staffAuthUid: "staff-1",
+    }),
+  );
+
+  assert.equal(response.status, 200);
+  const body = response.body as Record<string, unknown>;
+  const data = (body.data ?? {}) as Record<string, unknown>;
+  assert.equal(data.idempotentReplay, true);
+  assert.equal(data.pickupWindowStatus, "completed");
+  assert.equal(data.crateDwellMs, 90 * 60 * 1000);
+  assert.equal((data.crateCheckedOutAt as Date).toISOString(), checkedOutAtIso);
+  const reservationRow = state.reservations?.["reservation-pickup-completed-replay"] as Record<string, unknown> | undefined;
+  assert.equal(reservationRow?.crateDwellMs, 90 * 60 * 1000);
+  assert.equal(reservationRow?.crateCheckedOutAt, checkedOutAtIso);
+});
+
 test("reservations.queueFairness records no-show evidence and updates policy penalty", async () => {
   const state: MockDbState = {
     reservations: {
@@ -7210,6 +7301,8 @@ test("reservations.list excludes cancelled by default and includes it when reque
       "reservation-open": {
         ownerUid: "owner-1",
         status: "REQUESTED",
+        crateDwellMs: 5400000,
+        crateCheckedOutAt: "2026-02-21T19:05:00.000Z",
         createdAt: { toMillis: () => 2 },
       },
       "reservation-cancelled": {
@@ -7234,6 +7327,8 @@ test("reservations.list excludes cancelled by default and includes it when reque
   const defaultRows = (((defaultBody.data ?? {}) as Record<string, unknown>).reservations ?? []) as Array<Record<string, unknown>>;
   assert.equal(defaultRows.length, 1);
   assert.equal(defaultRows[0]?.status, "REQUESTED");
+  assert.equal(defaultRows[0]?.crateDwellMs, 5400000);
+  assert.equal((defaultRows[0]?.crateCheckedOutAt as Date).toISOString(), "2026-02-21T19:05:00.000Z");
 
   const includeCancelledList = await invokeApiV1Route(
     state,
@@ -7596,6 +7691,11 @@ test("reservations.checkIn allows owner check-in by reservation id", async () =>
   const body = response.body as Record<string, unknown>;
   const data = (body.data ?? {}) as Record<string, unknown>;
   assert.equal(data.arrivalStatus, "arrived");
+  assert.equal(data.crateDwellMs, 0);
+  assert.equal(data.crateCheckedOutAt, null);
+  const reservationRow = state.reservations?.["reservation-checkin-owner"] as Record<string, unknown> | undefined;
+  assert.equal(reservationRow?.crateDwellMs, 0);
+  assert.equal(reservationRow?.crateCheckedOutAt, null);
 });
 
 test("reservations.checkIn rejects non-owner non-staff caller", async () => {

--- a/functions/src/apiV1.ts
+++ b/functions/src/apiV1.ts
@@ -2299,6 +2299,8 @@ function toReservationRow(id: string, row: Record<string, unknown>) {
     archivedAt: parseReservationIsoDate(row.archivedAt),
     arrivalStatus: safeString(row.arrivalStatus) || null,
     arrivedAt: parseReservationIsoDate(row.arrivedAt),
+    crateDwellMs: readFiniteNumberOrNull(row.crateDwellMs),
+    crateCheckedOutAt: parseReservationIsoDate(row.crateCheckedOutAt),
     arrivalToken: safeString(row.arrivalToken) || null,
     arrivalTokenIssuedAt: parseReservationIsoDate(row.arrivalTokenIssuedAt),
     arrivalTokenExpiresAt: parseReservationIsoDate(row.arrivalTokenExpiresAt),
@@ -5554,6 +5556,8 @@ export async function handleApiV1(req: RequestLike, res: ResponseLike) {
         lastReminderFailureAt: null,
         storageNoticeHistory: [],
         storageBilling: toReservationStorageBillingWrite(storageBillingSeed),
+        crateDwellMs: null,
+        crateCheckedOutAt: null,
         isArchived: false,
         archivedAt: null,
         createdByUid: ctx.uid,
@@ -6496,6 +6500,8 @@ export async function handleApiV1(req: RequestLike, res: ResponseLike) {
         {
           arrivalStatus: "arrived",
           arrivedAt: row.arrivedAt ?? now,
+          crateDwellMs: 0,
+          crateCheckedOutAt: null,
           arrivalCheckIns: [...existingArrivalChecks, arrivalCheckRecord].slice(-40),
           stageHistory: stageHistory.slice(-120),
           stageStatus: {
@@ -6518,6 +6524,8 @@ export async function handleApiV1(req: RequestLike, res: ResponseLike) {
         reservationId,
         arrivalStatus: "arrived",
         arrivedAt: row.arrivedAt ?? now,
+        crateDwellMs: 0,
+        crateCheckedOutAt: null,
         idempotentReplay: alreadyArrived && !note && !photoUrl && !photoPath,
       });
       return;
@@ -6791,6 +6799,8 @@ export async function handleApiV1(req: RequestLike, res: ResponseLike) {
 
           const pickupWindow = normalizeReservationPickupWindow(row.pickupWindow);
           const storageHistory = normalizeReservationStorageNoticeHistory(row.storageNoticeHistory);
+          const storedCrateDwellMs = readFiniteNumberOrNull(row.crateDwellMs);
+          const storedCrateCheckedOutAt = parseReservationIsoDate(row.crateCheckedOutAt);
           const updates: Record<string, unknown> = { updatedAt: now };
           let storageHistoryNext = [...storageHistory];
           let storageStatus = normalizeReservationStorageStatus(row.storageStatus) ?? "active";
@@ -6908,10 +6918,24 @@ export async function handleApiV1(req: RequestLike, res: ResponseLike) {
               storageStatus
             );
           } else if (action === "staff_mark_completed") {
+            if (pickupWindow.status === "completed" && !force) {
+              return {
+                reservationId,
+                pickupWindow,
+                storageStatus,
+                crateDwellMs: storedCrateDwellMs,
+                crateCheckedOutAt: storedCrateCheckedOutAt,
+                idempotentReplay: true,
+              };
+            }
+
             pickupWindow.status = "completed";
             pickupWindow.completedAt = nowDate;
             pickupWindow.confirmedAt = pickupWindow.confirmedAt ?? nowDate;
             transitionReason = "pickup_window_completed";
+            const arrivedAtMs = readTimestampLikeMs(row.arrivedAt);
+            updates.crateDwellMs = arrivedAtMs > 0 ? Math.max(0, nowDate.getTime() - arrivedAtMs) : null;
+            updates.crateCheckedOutAt = now;
             storageStatus = "active";
             updates.storageStatus = storageStatus;
             updates.readyForPickupAt = null;
@@ -6965,6 +6989,8 @@ export async function handleApiV1(req: RequestLike, res: ResponseLike) {
             reservationId,
             pickupWindow,
             storageStatus,
+            crateDwellMs: readFiniteNumberOrNull(updates.crateDwellMs) ?? storedCrateDwellMs,
+            crateCheckedOutAt: parseReservationIsoDate(updates.crateCheckedOutAt) ?? storedCrateCheckedOutAt,
             idempotentReplay,
           };
         });
@@ -6986,6 +7012,8 @@ export async function handleApiV1(req: RequestLike, res: ResponseLike) {
             lastRescheduleRequestedAt: out.pickupWindow.lastRescheduleRequestedAt,
           },
           storageStatus: out.storageStatus,
+          crateDwellMs: out.crateDwellMs ?? null,
+          crateCheckedOutAt: out.crateCheckedOutAt ?? null,
           idempotentReplay: out.idempotentReplay,
         });
       } catch (error: unknown) {

--- a/web/src/api/portalContracts.ts
+++ b/web/src/api/portalContracts.ts
@@ -460,6 +460,8 @@ export type ReservationRecord = {
   storageNoticeHistory?: unknown[] | null;
   arrivalStatus?: string | null;
   arrivedAt?: string | null;
+  crateDwellMs?: number | null;
+  crateCheckedOutAt?: string | null;
   arrivalToken?: string | null;
   arrivalTokenIssuedAt?: string | null;
   arrivalTokenExpiresAt?: string | null;
@@ -527,6 +529,8 @@ export type ReservationPickupWindowResponse = PortalApiOkEnvelope & {
     lastRescheduleRequestedAt?: string | null;
   } | null;
   storageStatus?: string | null;
+  crateDwellMs?: number | null;
+  crateCheckedOutAt?: string | null;
   idempotentReplay?: boolean;
 };
 
@@ -1562,6 +1566,8 @@ export type ReservationCheckInResponse = PortalApiOkEnvelope & {
   reservationId?: string;
   arrivalStatus?: string | null;
   arrivedAt?: string | null;
+  crateDwellMs?: number | null;
+  crateCheckedOutAt?: string | null;
   idempotentReplay?: boolean;
 };
 

--- a/web/src/lib/normalizers/reservations.ts
+++ b/web/src/lib/normalizers/reservations.ts
@@ -111,6 +111,8 @@ export type ReservationRecord = {
   archivedAt?: { toDate?: () => Date } | null;
   arrivalStatus?: string | null;
   arrivedAt?: { toDate?: () => Date } | null;
+  crateDwellMs?: number | null;
+  crateCheckedOutAt?: { toDate?: () => Date } | string | null;
   arrivalToken?: string | null;
   arrivalTokenIssuedAt?: { toDate?: () => Date } | null;
   arrivalTokenExpiresAt?: { toDate?: () => Date } | null;
@@ -555,6 +557,11 @@ export function normalizeReservationRecord(
     archivedAt: raw.archivedAt ?? null,
     arrivalStatus: typeof raw.arrivalStatus === "string" ? raw.arrivalStatus : null,
     arrivedAt: raw.arrivedAt ?? null,
+    crateDwellMs:
+      typeof raw.crateDwellMs === "number" && Number.isFinite(raw.crateDwellMs)
+        ? Math.max(0, Math.round(raw.crateDwellMs))
+        : null,
+    crateCheckedOutAt: raw.crateCheckedOutAt ?? null,
     arrivalToken: typeof raw.arrivalToken === "string" ? raw.arrivalToken : null,
     arrivalTokenIssuedAt: raw.arrivalTokenIssuedAt ?? null,
     arrivalTokenExpiresAt: raw.arrivalTokenExpiresAt ?? null,


### PR DESCRIPTION
## Summary
- add crate dwell fields to reservation create, check-in, pickup completion, and read-model projection
- preserve stored crate dwell metadata when `staff_mark_completed` is replayed on an already-completed reservation
- expose the new fields through portal reservation contracts and the reservation normalizer
- cover the new read-model and idempotency behavior with focused reservation tests

## Why
The ware reservation dwell tracking work was only partially surfaced. The mutation routes could write the new metadata, but the normal reservation read path dropped it after refresh, and repeat `staff_mark_completed` calls would overwrite the original dwell snapshot.

## Impact
Staff and downstream analytics can now rely on crate dwell metadata from normal reservation payloads, not just the immediate mutation response. Retry or duplicate-complete flows preserve the original checkout timestamp and dwell duration instead of inflating them.

## Validation
- `npm --prefix functions run build`
- `node --test --test-name-pattern "reservations\\.checkIn allows owner check-in by reservation id|reservations\\.pickupWindow staff_mark_completed computes crate dwell time from arrival|reservations\\.pickupWindow staff_mark_completed replays stored crate dwell metadata once completed|reservations\\.list excludes cancelled by default and includes it when requested" .\\lib\\apiV1.test.js` (from `functions/`)
- `npm --prefix web run build`
