### PR TITLE
[codex] preserve stored startup history signals

### DIFF
--- a/scripts/codex-startup-scorecard.mjs
+++ b/scripts/codex-startup-scorecard.mjs
@@ -412,37 +412,43 @@ function normalizeHistoryEntries(entries) {
       return null;
     })
     .filter(Boolean)
-    .map((entry) => ({
-      tsIso: clean(entry.tsIso || entry.generatedAt),
-      status: clean(entry.status || "fail"),
-      reasonCode: clean(entry.reasonCode || STARTUP_REASON_CODES.STARTUP_UNAVAILABLE),
-      continuityState: clean(entry.continuityState || "missing").toLowerCase(),
-      itemCount: Math.max(0, Math.round(Number(entry.itemCount || 0))),
-      contextSummary: clean(entry.contextSummary).slice(0, 300),
-      groundingReady:
-        entry.groundingReady === true ||
-        (Number(entry.itemCount || 0) > 0 && clean(entry.contextSummary).length > 0),
-      richContext: entry.richContext === true || Number(entry.itemCount || 0) >= 2,
-      fallbackOnly:
-        entry.fallbackOnly === true ||
-        (clean(entry.reasonCode || STARTUP_REASON_CODES.STARTUP_UNAVAILABLE) === STARTUP_REASON_CODES.OK &&
-          clean(entry.continuityState || "missing").toLowerCase() !== "ready"),
-      studioBrainReachable:
-        typeof entry.studioBrainReachable === "boolean" ? entry.studioBrainReachable : null,
-      studioBrainLatencyMs: toFiniteNumber(entry.studioBrainLatencyMs),
-      tokenState: clean(entry.tokenState || "unknown").toLowerCase(),
-      latencyMs: toFiniteNumber(entry.latencyMs),
-      latencyState: clean(entry.latencyState || "unknown"),
-      mcpBridgeOk: typeof entry.mcpBridgeOk === "boolean" ? entry.mcpBridgeOk : null,
-      mcpBridgeLatencyMs: toFiniteNumber(entry.mcpBridgeLatencyMs),
-      startupToolStatus: clean(entry.startupToolStatus || "unknown").toLowerCase(),
-      groundingLineEmitted: toNullableBoolean(entry.groundingLineEmitted),
-      groundingLineObserved: entry.groundingLineObserved === true,
-      repoReadsBeforeStartupContext: toFiniteNumber(entry.repoReadsBeforeStartupContext),
-      repoReadTelemetryObserved: entry.repoReadTelemetryObserved === true,
-      recoveryStep: clean(entry.recoveryStep),
-      error: clean(entry.error),
-    }))
+    .map((entry) => {
+      const itemCount = Math.max(0, Math.round(Number(entry.itemCount || 0)));
+      const contextSummary = clean(entry.contextSummary).slice(0, 300);
+      const storedGroundingReady = toNullableBoolean(entry.groundingReady);
+      const storedRichContext = toNullableBoolean(entry.richContext);
+
+      return {
+        tsIso: clean(entry.tsIso || entry.generatedAt),
+        status: clean(entry.status || "fail"),
+        reasonCode: clean(entry.reasonCode || STARTUP_REASON_CODES.STARTUP_UNAVAILABLE),
+        continuityState: clean(entry.continuityState || "missing").toLowerCase(),
+        itemCount,
+        contextSummary,
+        groundingReady:
+          storedGroundingReady ?? (itemCount > 0 && contextSummary.length > 0),
+        richContext: storedRichContext ?? itemCount >= 2,
+        fallbackOnly:
+          entry.fallbackOnly === true ||
+          (clean(entry.reasonCode || STARTUP_REASON_CODES.STARTUP_UNAVAILABLE) === STARTUP_REASON_CODES.OK &&
+            clean(entry.continuityState || "missing").toLowerCase() !== "ready"),
+        studioBrainReachable:
+          typeof entry.studioBrainReachable === "boolean" ? entry.studioBrainReachable : null,
+        studioBrainLatencyMs: toFiniteNumber(entry.studioBrainLatencyMs),
+        tokenState: clean(entry.tokenState || "unknown").toLowerCase(),
+        latencyMs: toFiniteNumber(entry.latencyMs),
+        latencyState: clean(entry.latencyState || "unknown"),
+        mcpBridgeOk: typeof entry.mcpBridgeOk === "boolean" ? entry.mcpBridgeOk : null,
+        mcpBridgeLatencyMs: toFiniteNumber(entry.mcpBridgeLatencyMs),
+        startupToolStatus: clean(entry.startupToolStatus || "unknown").toLowerCase(),
+        groundingLineEmitted: toNullableBoolean(entry.groundingLineEmitted),
+        groundingLineObserved: entry.groundingLineObserved === true,
+        repoReadsBeforeStartupContext: toFiniteNumber(entry.repoReadsBeforeStartupContext),
+        repoReadTelemetryObserved: entry.repoReadTelemetryObserved === true,
+        recoveryStep: clean(entry.recoveryStep),
+        error: clean(entry.error),
+      };
+    })
     .filter((entry) => toMs(entry.tsIso) != null);
 }
 

--- a/scripts/codex-startup-scorecard.test.mjs
+++ b/scripts/codex-startup-scorecard.test.mjs
@@ -154,6 +154,53 @@ test("computeStartupScorecardReport measures startup quality and highlights cove
   assert.equal(report.rubric.grade === "D" || report.rubric.grade === "F", true);
 });
 
+test("computeStartupScorecardReport preserves stored historical grounding and rich-context signals", () => {
+  const report = computeStartupScorecardReport({
+    generatedAtIso: "2026-04-12T18:00:00.000Z",
+    windowHours: 24,
+    latestSample: {
+      tsIso: "2026-04-12T18:00:00.000Z",
+      status: "pass",
+      reasonCode: "ok",
+      continuityState: "ready",
+      itemCount: 3,
+      contextSummary: "Current startup sample with trusted grounding.",
+      groundingReady: true,
+      richContext: true,
+      fallbackOnly: false,
+      tokenState: "fresh",
+      latencyMs: 700,
+      latencyState: "healthy",
+      mcpBridgeOk: true,
+    },
+    historySamples: [
+      {
+        sample: {
+          tsIso: "2026-04-12T10:00:00.000Z",
+          status: "pass",
+          reasonCode: "ok",
+          continuityState: "ready",
+          itemCount: 2,
+          contextSummary: "Older live startup row captured before lane metadata existed.",
+          groundingReady: false,
+          richContext: true,
+          fallbackOnly: false,
+          tokenState: "fresh",
+          latencyMs: 650,
+          latencyState: "healthy",
+          mcpBridgeOk: true,
+        },
+      },
+    ],
+    toolcallEntries: [],
+    interactionEntries: [],
+  });
+
+  assert.equal(report.window.current.sampleCount, 2);
+  assert.equal(report.metrics.groundingReadyRate, 0.5);
+  assert.equal(report.metrics.richContextRate, 1);
+});
+
 test("computeStartupScorecardReport scores Grounding compliance and pre-start repo-read telemetry from startup toolcalls", () => {
   const report = computeStartupScorecardReport({
     generatedAtIso: "2026-04-03T18:00:00.000Z",


### PR DESCRIPTION
## What changed
- preserve explicit historical `groundingReady` and `richContext` booleans during `normalizeHistoryEntries()`
- only fall back to heuristic recomputation when those stored values are absent
- add a regression test covering older history rows that predate newer lane metadata

## Why it changed
Older live startup rows can carry valid stored quality signals without newer lane fields like `presentationProjectLane` or `threadScopedItemCount`.

## Root cause
`normalizeHistoryEntries()` was recomputing `groundingReady` and `richContext` from current heuristics even when historical rows already stored explicit boolean values. That silently downgraded older samples and distorted scorecard trendlines.

## Impact
Current-vs-history comparisons stay stable, and historical scorecard metrics no longer regress just because the schema evolved.

## Validation
- `node --test scripts/codex-startup-scorecard.test.mjs`
