### PR TITLE
[codex] Harden startup continuity and host deploy integrity

### DIFF
--- a/scripts/codex-capture-startup-handoff.mjs
+++ b/scripts/codex-capture-startup-handoff.mjs
@@ -1,0 +1,183 @@
+import {
+  refreshLocalBootstrapArtifacts,
+  loadBootstrapArtifacts,
+  normalizeContinuityEnvelope,
+  normalizeHandoffArtifact,
+  resolveCodexThreadContext,
+  writeContinuityEnvelope,
+  writeHandoffArtifact,
+} from "./lib/codex-session-memory-utils.mjs";
+import { rememberWithStudioBrain } from "./lib/studio-brain-memory-write.mjs";
+
+function clean(value) {
+  return String(value ?? "").trim();
+}
+
+function parseArgs(argv = process.argv.slice(2)) {
+  const args = new Map();
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (!token.startsWith("--")) continue;
+    const key = token.slice(2);
+    const next = argv[index + 1];
+    if (!next || next.startsWith("--")) {
+      args.set(key, "true");
+      continue;
+    }
+    args.set(key, next);
+    index += 1;
+  }
+  return args;
+}
+
+function boolFlag(value) {
+  return ["1", "true", "yes", "on"].includes(clean(value).toLowerCase());
+}
+
+function blockerRows(blocker) {
+  const summary = clean(blocker);
+  return summary ? [{ summary }] : [];
+}
+
+async function main() {
+  const args = parseArgs();
+  const cwd = clean(args.get("cwd")) || process.cwd();
+  const resolvedThread = resolveCodexThreadContext({
+    threadId: clean(args.get("thread-id")),
+    cwd,
+  });
+  const threadId = clean(args.get("thread-id")) || clean(resolvedThread?.threadId);
+  if (!threadId) {
+    throw new Error("Unable to resolve a Codex thread. Pass --thread-id explicitly.");
+  }
+
+  const threadTitle = clean(args.get("title")) || clean(resolvedThread?.title);
+  const firstUserMessage = clean(args.get("first-user-message")) || clean(resolvedThread?.firstUserMessage);
+  const summary = clean(args.get("summary"));
+  const activeGoal = clean(args.get("goal")) || firstUserMessage || threadTitle;
+  const nextRecommendedAction = clean(args.get("next-action"));
+  const blocker = clean(args.get("blocker"));
+  const completionStatus = clean(args.get("status")) || (blocker ? "degraded" : "pass");
+  const emitJson = boolFlag(args.get("json"));
+
+  if (!summary) {
+    throw new Error("Missing required --summary.");
+  }
+
+  const payload = {
+    kind: "handoff",
+    content: summary,
+    rememberForStartup: true,
+    metadata: {
+      activeGoal,
+      nextRecommendedAction,
+      blockers: blockerRows(blocker),
+      completionStatus,
+      capturedFrom: "codex-startup-handoff-cli",
+    },
+  };
+
+  let mode = "remote";
+  let result = null;
+  try {
+    result = await rememberWithStudioBrain(payload, {
+      threadId,
+      cwd,
+      threadTitle,
+      firstUserMessage,
+      capturedFrom: "codex-startup-handoff-cli",
+    });
+  } catch (error) {
+    mode = "local-repair";
+    const priorArtifacts = loadBootstrapArtifacts(threadId);
+    const handoff = normalizeHandoffArtifact(
+      {
+        threadId,
+        summary,
+        activeGoal,
+        workCompleted: summary,
+        nextRecommendedAction,
+        blockers: blockerRows(blocker),
+        completionStatus,
+      },
+      {
+        threadId,
+        existing: priorArtifacts?.handoff,
+      }
+    );
+    writeHandoffArtifact(threadId, handoff);
+    writeContinuityEnvelope(
+      threadId,
+      normalizeContinuityEnvelope(
+        {
+          continuityState: blocker ? "continuity_degraded" : "ready",
+          startupSatisfiedBy: "validated-local-continuity",
+          currentGoal: activeGoal,
+          lastHandoffSummary: summary,
+          nextRecommendedAction,
+          blockers: blockerRows(blocker),
+          fallbackOnly: false,
+          startupSourceQuality: "thread-scoped-dominant",
+          laneSourceQuality: "thread-scoped-dominant",
+          threadScopedItemCount: 1,
+          startup: {
+            satisfiedBy: "validated-local-continuity",
+            threadScopedItemCount: 1,
+            startupSourceQuality: "thread-scoped-dominant",
+          },
+        },
+        {
+          threadId,
+          cwd,
+          existing: priorArtifacts?.continuityEnvelope,
+        }
+      )
+    );
+    refreshLocalBootstrapArtifacts({
+      threadId,
+      cwd,
+      threadTitle,
+      firstUserMessage,
+      metadata: {
+        startupGateSatisfiedBy: "validated-local-continuity",
+        continuityState: blocker ? "continuity_degraded" : "ready",
+        threadScopedItemCount: 1,
+        startupSourceQuality: "thread-scoped-dominant",
+      },
+    });
+    result = {
+      ok: true,
+      verified: false,
+      saved: 1,
+      failed: 0,
+      memoryIds: [],
+      error: clean(error?.message),
+    };
+  }
+
+  const output = {
+    ok: true,
+    mode,
+    threadId,
+    cwd,
+    threadTitle,
+    firstUserMessage,
+    summary,
+    activeGoal,
+    nextRecommendedAction,
+    blocker,
+    completionStatus,
+    result,
+  };
+
+  if (emitJson) {
+    process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
+    return;
+  }
+  process.stdout.write(`Captured startup handoff via ${mode} for ${threadId}.\n`);
+}
+
+main().catch((error) => {
+  process.stderr.write(`${clean(error?.message || error)}\n`);
+  process.exitCode = 1;
+});

--- a/scripts/codex-doctor.mjs
+++ b/scripts/codex-doctor.mjs
@@ -802,25 +802,6 @@ export async function runCodexDoctor({
     });
   }
 
-  const rememberHelperPath = resolve(repoRoot, "scripts", "lib", "studio-brain-memory-write.mjs");
-  const studioBrainMcpServerPath = resolve(repoRoot, "studio-brain-mcp", "server.mjs");
-  const rememberToolRegistered =
-    existsSync(rememberHelperPath) &&
-    existsSync(studioBrainMcpServerPath) &&
-    readFileSync(studioBrainMcpServerPath, "utf8").includes('"studio_brain_remember"');
-  checkCollector.push(
-    "codex-studio-brain-remember-surface",
-    rememberToolRegistered ? "info" : "warning",
-    rememberToolRegistered,
-    rememberToolRegistered
-      ? "Studio Brain remember write surface is registered in the MCP server."
-      : "Studio Brain remember write surface is not registered in the MCP server.",
-    {
-      mcpServerPath: studioBrainMcpServerPath,
-      rememberHelperPath,
-    },
-  );
-
   const summary = checkCollector.summarize();
   let report = {
     schema: "codex-doctor-v1",

--- a/scripts/codex-doctor.mjs
+++ b/scripts/codex-doctor.mjs
@@ -8,6 +8,12 @@ import { fileURLToPath } from "node:url";
 
 import { compareSemver, resolveCodexCliCandidates } from "./lib/codex-cli-utils.mjs";
 import { loadCodexAutomationEnv } from "./lib/codex-automation-env.mjs";
+import {
+  buildOperatorDragMetrics,
+  summarizeRetryGovernorSignals,
+  summarizeToolcallDrag,
+} from "./lib/codex-toolcall-governance.mjs";
+import { isTrustedStartupGroundingAuthority } from "./lib/codex-startup-reliability.mjs";
 import { hydrateStudioBrainAuthFromPortal } from "./lib/studio-brain-startup-auth.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -15,6 +21,11 @@ const __dirname = dirname(__filename);
 const REPO_ROOT = resolve(__dirname, "..");
 
 const DEFAULT_ARTIFACT = "output/codex-doctor/latest.json";
+const DEFAULT_TOOLCALL_WINDOW_HOURS = 168;
+
+function clean(value) {
+  return String(value ?? "").trim();
+}
 
 function parseArgs(argv) {
   const parsed = {
@@ -130,6 +141,94 @@ function parseJsonOutput(raw) {
   }
 }
 
+function readJsonFile(path) {
+  if (!path || !existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function readNdjson(path) {
+  if (!path || !existsSync(path)) return [];
+  return String(readFileSync(path, "utf8") || "")
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      try {
+        return JSON.parse(line);
+      } catch {
+        return null;
+      }
+    })
+    .filter(Boolean);
+}
+
+function toMs(value) {
+  if (!value) return null;
+  const parsed = new Date(value);
+  const millis = parsed.getTime();
+  return Number.isFinite(millis) ? millis : null;
+}
+
+function readCurrentToolcallWindow(repoRoot, windowHours = DEFAULT_TOOLCALL_WINDOW_HOURS) {
+  const toolcallPath = resolve(repoRoot, ".codex", "toolcalls.ndjson");
+  const cutoffMs = Date.now() - windowHours * 60 * 60 * 1000;
+  const entries = readNdjson(toolcallPath).filter((entry) => {
+    const tsMs = toMs(entry?.tsIso);
+    return tsMs != null && tsMs >= cutoffMs;
+  });
+  return {
+    toolcallPath,
+    entries,
+    windowHours,
+  };
+}
+
+function summarizeDoctorChanges(previousReport, currentReport) {
+  if (!previousReport || typeof previousReport !== "object") {
+    return ["No previous doctor artifact was available for comparison."];
+  }
+  const changes = [];
+  if (String(previousReport.status || "") !== String(currentReport.status || "")) {
+    changes.push(`Overall status changed from \`${previousReport.status || "unknown"}\` to \`${currentReport.status || "unknown"}\`.`);
+  }
+  if (Number(previousReport.summary?.warnings || 0) !== Number(currentReport.summary?.warnings || 0)) {
+    changes.push(
+      `Warning count changed from ${Number(previousReport.summary?.warnings || 0)} to ${Number(currentReport.summary?.warnings || 0)}.`
+    );
+  }
+  if (Number(previousReport.summary?.errors || 0) !== Number(currentReport.summary?.errors || 0)) {
+    changes.push(
+      `Error count changed from ${Number(previousReport.summary?.errors || 0)} to ${Number(currentReport.summary?.errors || 0)}.`
+    );
+  }
+  if (
+    Number(previousReport.drag?.operatorMetrics?.liveStartupEntries || 0) !==
+    Number(currentReport.drag?.operatorMetrics?.liveStartupEntries || 0)
+  ) {
+    changes.push(
+      `Live startup coverage changed from ${Number(previousReport.drag?.operatorMetrics?.liveStartupEntries || 0)} to ${Number(currentReport.drag?.operatorMetrics?.liveStartupEntries || 0)}.`
+    );
+  }
+  if (
+    Number(previousReport.drag?.operatorMetrics?.startupArtifactRepairEntries || 0) !==
+    Number(currentReport.drag?.operatorMetrics?.startupArtifactRepairEntries || 0)
+  ) {
+    changes.push(
+      `Startup artifact repairs changed from ${Number(previousReport.drag?.operatorMetrics?.startupArtifactRepairEntries || 0)} to ${Number(currentReport.drag?.operatorMetrics?.startupArtifactRepairEntries || 0)}.`
+    );
+  }
+  const previousTop = String(previousReport.drag?.topSources?.[0]?.signature || "").trim();
+  const currentTop = String(currentReport.drag?.topSources?.[0]?.signature || "").trim();
+  if (previousTop !== currentTop) {
+    changes.push(`Top drag source changed from \`${previousTop || "none"}\` to \`${currentTop || "none"}\`.`);
+  }
+  return changes.length > 0 ? changes.slice(0, 5) : ["No material doctor drift was detected since the last artifact."];
+}
+
 function runNodeScript(relativePath, extraArgs = [], { repoRoot = REPO_ROOT, env = process.env } = {}) {
   const absolutePath = resolve(repoRoot, relativePath);
   if (!existsSync(absolutePath)) {
@@ -230,6 +329,7 @@ export async function runCodexDoctor({
   hydrateStudioBrainAuthFromPortalFn = hydrateStudioBrainAuthFromPortal,
 } = {}) {
   const artifactPath = resolve(repoRoot, artifact);
+  const previousArtifact = readJsonFile(artifactPath);
 
   const checkCollector = createCheckCollector();
 
@@ -435,6 +535,30 @@ export async function runCodexDoctor({
     const startupLatencyState = startupPreflightPayload.checks?.startupContext?.latency?.state || "unknown";
     const tokenState = startupPreflightPayload.checks?.tokenFreshness?.state || "missing";
     const mcpBridgeOk = startupPreflightPayload.checks?.mcpBridge?.ok !== false;
+    const startupContext =
+      startupPreflightPayload.checks?.startupContext && typeof startupPreflightPayload.checks.startupContext === "object"
+        ? startupPreflightPayload.checks.startupContext
+        : {};
+    const startupStage = clean(startupContext.startupContextStage || startupContext.startupPacket?.startupContextStage);
+    const startupCache =
+      startupContext.startupCache && typeof startupContext.startupCache === "object"
+        ? startupContext.startupCache
+        : startupContext.startupPacket?.startupCache && typeof startupContext.startupPacket.startupCache === "object"
+          ? startupContext.startupPacket.startupCache
+          : {};
+    const trustMismatchDetected =
+      startupContext.trustMismatchDetected === true || startupContext.startupPacket?.trustMismatchDetected === true;
+    const groundingAuthority = clean(startupContext.groundingAuthority);
+    const advisory =
+      startupContext.advisory && typeof startupContext.advisory === "object" ? startupContext.advisory : {};
+    const advisoryLeakDetected =
+      startupContext.publishTrustedGrounding !== true &&
+      Boolean(
+        clean(startupContext.dominantGoal || startupContext.topBlocker || startupContext.nextRecommendedAction)
+      );
+    const readyWithoutTrustedGrounding =
+      clean(startupContext.continuityState).toLowerCase() === "ready" &&
+      !isTrustedStartupGroundingAuthority(groundingAuthority);
     const preflightHealthy =
       startupPreflightPayload.status === "pass" &&
       !["missing_token", "expired_token", "transport_unreachable", "timeout"].includes(startupReasonCode) &&
@@ -452,7 +576,135 @@ export async function runCodexDoctor({
         checks: startupPreflightPayload.checks,
       },
     );
+    const fastPathHealthy =
+      startupCache.shortCircuitLocal === true ||
+      startupCache.cacheHit === true ||
+      !/fallback/i.test(startupStage);
+    const fastPathMessage =
+      startupCache.shortCircuitLocal === true
+        ? "Startup is using the validated-local fast path."
+        : startupCache.cacheHit === true
+          ? `Startup reused a fresh startup cache entry (${clean(startupCache.hitType) || "cache-hit"}).`
+          : startupStage
+            ? `Startup resolved via ${startupStage}.`
+            : "Startup fast-path stage was not reported.";
+    checkCollector.push(
+      "codex-startup-fast-path",
+      fastPathHealthy ? "info" : "warning",
+      fastPathHealthy,
+      fastPathMessage,
+      {
+        startupContextStage: startupStage,
+        startupCache,
+        groundingAuthority,
+        continuityState: clean(startupContext.continuityState),
+      },
+    );
+    const groundingTrustHealthy = !trustMismatchDetected && !advisoryLeakDetected && !readyWithoutTrustedGrounding;
+    checkCollector.push(
+      "codex-startup-grounding-trust",
+      groundingTrustHealthy ? "info" : "warning",
+      groundingTrustHealthy,
+      groundingTrustHealthy
+        ? "Startup grounding trust is aligned with the published goal/blocker fields."
+        : readyWithoutTrustedGrounding
+          ? `Startup reported ready continuity with untrusted grounding authority (${groundingAuthority || "unknown"}).`
+          : advisoryLeakDetected
+            ? "Startup is publishing goal/blocker fields from advisory-only context."
+            : "Startup grounding trust signals are inconsistent.",
+      {
+        continuityState: clean(startupContext.continuityState),
+        groundingAuthority,
+        publishTrustedGrounding: startupContext.publishTrustedGrounding === true,
+        trustMismatchDetected,
+        advisoryLeakDetected,
+        advisory,
+      },
+    );
   }
+
+  const rememberHelperPath = resolve(repoRoot, "scripts", "lib", "studio-brain-memory-write.mjs");
+  const studioBrainMcpServerPath = resolve(repoRoot, "studio-brain-mcp", "server.mjs");
+  const rememberToolRegistered =
+    existsSync(rememberHelperPath) &&
+    existsSync(studioBrainMcpServerPath) &&
+    readFileSync(studioBrainMcpServerPath, "utf8").includes('"studio_brain_remember"');
+  checkCollector.push(
+    "codex-studio-brain-remember-surface",
+    rememberToolRegistered ? "info" : "warning",
+    rememberToolRegistered,
+    rememberToolRegistered
+      ? "Studio Brain remember write surface is registered in the MCP server."
+      : "Studio Brain remember write surface is not registered in the MCP server.",
+    {
+      mcpServerPath: studioBrainMcpServerPath,
+      rememberHelperPath,
+    },
+  );
+
+  const toolcallWindow = readCurrentToolcallWindow(repoRoot);
+  const retryGovernorSignals = summarizeRetryGovernorSignals(toolcallWindow.entries);
+  const operatorDragMetrics = buildOperatorDragMetrics(toolcallWindow.entries);
+  const topDragSources = summarizeToolcallDrag(toolcallWindow.entries, { limit: 3 });
+
+  checkCollector.push(
+    "codex-startup-live-coverage",
+    operatorDragMetrics.liveStartupEntries >= 5 ? "info" : "warning",
+    operatorDragMetrics.liveStartupEntries >= 1,
+    operatorDragMetrics.liveStartupEntries >= 5
+      ? `Deduped live startup coverage meets the minimum trust threshold (${operatorDragMetrics.liveStartupEntries} unique observation(s) from ${operatorDragMetrics.liveRawRows} raw row(s)).`
+      : operatorDragMetrics.liveStartupEntries > 0
+        ? `Deduped live startup coverage exists but is still thin (${operatorDragMetrics.liveStartupEntries}/5 unique observation(s) from ${operatorDragMetrics.liveRawRows} raw row(s)).`
+        : "No live launcher startup coverage is present yet.",
+    {
+      liveStartupEntries: operatorDragMetrics.liveStartupEntries,
+      syntheticStartupEntries: operatorDragMetrics.syntheticStartupEntries,
+      liveRawRows: operatorDragMetrics.liveRawRows,
+      syntheticRawRows: operatorDragMetrics.syntheticRawRows,
+      liveUniqueObservations: operatorDragMetrics.liveUniqueObservations,
+      syntheticUniqueObservations: operatorDragMetrics.syntheticUniqueObservations,
+      duplicateObservationCount: operatorDragMetrics.duplicateObservationCount,
+      windowHours: toolcallWindow.windowHours,
+      toolcallsPath: toolcallWindow.toolcallPath,
+    },
+  );
+
+  checkCollector.push(
+    "codex-startup-duplicate-observations",
+    operatorDragMetrics.duplicateObservationCount > 0 ? "warning" : "info",
+    operatorDragMetrics.duplicateObservationCount === 0,
+    operatorDragMetrics.duplicateObservationCount > 0
+      ? `Startup telemetry contains ${operatorDragMetrics.duplicateObservationCount} duplicate observation row(s); coverage is being deduped by observation identity.`
+      : "Startup telemetry shows no duplicate observation rows in the current window.",
+    {
+      duplicateObservationCount: operatorDragMetrics.duplicateObservationCount,
+      liveRawRows: operatorDragMetrics.liveRawRows,
+      liveUniqueObservations: operatorDragMetrics.liveUniqueObservations,
+      syntheticRawRows: operatorDragMetrics.syntheticRawRows,
+      syntheticUniqueObservations: operatorDragMetrics.syntheticUniqueObservations,
+      toolcallsPath: toolcallWindow.toolcallPath,
+    },
+  );
+
+  checkCollector.push(
+    "codex-retry-governor",
+    retryGovernorSignals.triggeredEntries > 0 ? "warning" : "info",
+    retryGovernorSignals.triggeredEntries === 0,
+    retryGovernorSignals.triggeredEntries > 0
+      ? `Retry governor triggered on ${retryGovernorSignals.triggeredEntries} call(s) across ${retryGovernorSignals.triggeredUniqueSignatures} signature(s).`
+      : "Retry governor shows no active bursts in the current window.",
+    retryGovernorSignals,
+  );
+
+  checkCollector.push(
+    "codex-command-shape-guard",
+    operatorDragMetrics.repeatedCommandShapeFailures > 0 ? "warning" : "info",
+    operatorDragMetrics.repeatedCommandShapeFailures === 0,
+    operatorDragMetrics.repeatedCommandShapeFailures > 0
+      ? `Command-shape failures are recurring (${operatorDragMetrics.repeatedCommandShapeFailures} in the current window).`
+      : "No recurring Windows command-shape failures were detected in the current window.",
+    operatorDragMetrics,
+  );
 
   const memoryRun = runNodeScriptImpl("scripts/codex-memory-pipeline.mjs", ["status", "--json"], { repoRoot, env });
   const memoryPayload = memoryRun.json;
@@ -570,7 +822,7 @@ export async function runCodexDoctor({
   );
 
   const summary = checkCollector.summarize();
-  const report = {
+  let report = {
     schema: "codex-doctor-v1",
     generatedAt: new Date().toISOString(),
     strict,
@@ -580,6 +832,38 @@ export async function runCodexDoctor({
     package: packageMeta,
     summary,
     checks: checkCollector.checks,
+    startupContract:
+      startupPreflightPayload?.checks?.startupContext && typeof startupPreflightPayload.checks.startupContext === "object"
+        ? {
+            status: startupPreflightPayload.status,
+            reasonCode: startupPreflightPayload.checks.startupContext.reasonCode,
+            continuityState: startupPreflightPayload.checks.startupContext.continuityState,
+            recoveryStep: startupPreflightPayload.checks.startupContext.recoveryStep,
+            presentationProjectLane: startupPreflightPayload.checks.startupContext.presentationProjectLane,
+            threadScopedItemCount: startupPreflightPayload.checks.startupContext.threadScopedItemCount,
+            transcriptOrderingProven: startupPreflightPayload.checks.startupContext.transcriptOrderingProven === true,
+            degradationBuckets: startupPreflightPayload.checks.startupContext.degradationBuckets || [],
+            missingStartupIngredients: startupPreflightPayload.checks.startupContext.missingStartupIngredients || [],
+            dominantGoal: startupPreflightPayload.checks.startupContext.dominantGoal || "",
+            topBlocker: startupPreflightPayload.checks.startupContext.topBlocker || "",
+            nextRecommendedAction: startupPreflightPayload.checks.startupContext.nextRecommendedAction || "",
+            startupContextStage: startupPreflightPayload.checks.startupContext.startupContextStage || "",
+            startupCache:
+              startupPreflightPayload.checks.startupContext.startupCache && typeof startupPreflightPayload.checks.startupContext.startupCache === "object"
+                ? startupPreflightPayload.checks.startupContext.startupCache
+                : {},
+            groundingAuthority: startupPreflightPayload.checks.startupContext.groundingAuthority || "",
+            trustMismatchDetected: startupPreflightPayload.checks.startupContext.trustMismatchDetected === true,
+            localArtifactRepair: startupPreflightPayload.checks.startupContext.localArtifactRepair || null,
+          }
+        : null,
+    drag: {
+      windowHours: toolcallWindow.windowHours,
+      toolcallsPath: toolcallWindow.toolcallPath,
+      operatorMetrics: operatorDragMetrics,
+      retryGovernor: retryGovernorSignals,
+      topSources: topDragSources,
+    },
     remediation: {
       docsDrift: "npm run codex:docs:drift",
       mcpAudit: "npm run audit:codex-mcp",
@@ -587,8 +871,14 @@ export async function runCodexDoctor({
       startupPreflight: "node ./scripts/codex-startup-preflight.mjs --json",
       memoryFallbackInit: "npm run codex:memory:init",
       wrapperAudit: "node ./scripts/audit-cross-platform-wrappers.mjs",
+      commandShapeAudit: "node ./scripts/codex-command-shape-audit.mjs --command <command>",
       ephemeralGuard: "npm run guard:ephemeral:artifacts",
+      recoveryRunbook: "docs/runbooks/CODEX_RECOVERY.md",
     },
+  };
+  report = {
+    ...report,
+    changedSinceLastRun: summarizeDoctorChanges(previousArtifact, report),
   };
 
   mkdirSync(dirname(artifactPath), { recursive: true });

--- a/scripts/codex-doctor.test.mjs
+++ b/scripts/codex-doctor.test.mjs
@@ -6,7 +6,7 @@ import { tmpdir } from "node:os";
 
 import { runCodexDoctor } from "./codex-doctor.mjs";
 
-function makeScriptRunner({ openMemoryHealthy, layoutReady }) {
+function makeScriptRunner({ openMemoryHealthy, layoutReady, startupPreflightPayload = null }) {
   return (relativePath) => {
     if (relativePath === "scripts/codex-docs-drift-check.mjs") {
       return {
@@ -55,13 +55,21 @@ function makeScriptRunner({ openMemoryHealthy, layoutReady }) {
     if (relativePath === "scripts/codex-startup-preflight.mjs") {
       return {
         ok: true,
-        json: {
+        json: startupPreflightPayload || {
           status: "pass",
           checks: {
             tokenFreshness: { state: "fresh" },
             startupContext: {
               reasonCode: "ok",
               latency: { state: "healthy" },
+              continuityState: "ready",
+              groundingAuthority: "validated-local",
+              publishTrustedGrounding: true,
+              startupContextStage: "local-validated-short-circuit",
+              startupCache: {
+                cacheHit: false,
+                shortCircuitLocal: true,
+              },
             },
             mcpBridge: { ok: true },
           },
@@ -105,7 +113,7 @@ function makeScriptRunner({ openMemoryHealthy, layoutReady }) {
   };
 }
 
-async function runDoctorScenario({ openMemoryHealthy, layoutReady }) {
+async function runDoctorScenario({ openMemoryHealthy, layoutReady, startupPreflightPayload = null }) {
   const repoRoot = mkdtempSync(join(tmpdir(), "codex-doctor-"));
   const codexConfigPath = join(repoRoot, "config.toml");
 
@@ -142,7 +150,7 @@ async function runDoctorScenario({ openMemoryHealthy, layoutReady }) {
         packageJsonPath: join(repoRoot, "package.json"),
         packageLockPath: join(repoRoot, "package-lock.json"),
       },
-      runNodeScriptImpl: makeScriptRunner({ openMemoryHealthy, layoutReady }),
+      runNodeScriptImpl: makeScriptRunner({ openMemoryHealthy, layoutReady, startupPreflightPayload }),
       loadCodexAutomationEnvFn: () => [],
       hydrateStudioBrainAuthFromPortalFn: async ({ env: authEnv }) => {
         if (openMemoryHealthy) {
@@ -180,4 +188,61 @@ test("runCodexDoctor reports initialized local fallback cleanly when remote Open
   assert.equal(memoryCheck?.severity, "info");
   assert.equal(memoryCheck?.ok, true);
   assert.match(memoryCheck?.message || "", /initialized/i);
+});
+
+test("runCodexDoctor surfaces the validated-local fast path and trusted grounding alignment", async () => {
+  const report = await runDoctorScenario({ openMemoryHealthy: true, layoutReady: true });
+  const fastPathCheck = report.checks.find((check) => check.id === "codex-startup-fast-path");
+  const trustCheck = report.checks.find((check) => check.id === "codex-startup-grounding-trust");
+
+  assert.equal(fastPathCheck?.severity, "info");
+  assert.equal(fastPathCheck?.ok, true);
+  assert.match(fastPathCheck?.message || "", /validated-local fast path/i);
+  assert.equal(trustCheck?.severity, "info");
+  assert.equal(trustCheck?.ok, true);
+  assert.match(trustCheck?.message || "", /aligned/i);
+  assert.equal(report.startupContract?.startupContextStage, "local-validated-short-circuit");
+  assert.equal(report.startupContract?.groundingAuthority, "validated-local");
+});
+
+test("runCodexDoctor warns when startup publishes untrusted or advisory-only grounding", async () => {
+  const report = await runDoctorScenario({
+    openMemoryHealthy: true,
+    layoutReady: true,
+    startupPreflightPayload: {
+      status: "degraded",
+      checks: {
+        tokenFreshness: { state: "fresh" },
+        startupContext: {
+          reasonCode: "ok",
+          latency: { state: "healthy" },
+          continuityState: "ready",
+          groundingAuthority: "cross-thread-fallback",
+          publishTrustedGrounding: false,
+          dominantGoal: "Resume an unrelated startup thread.",
+          topBlocker: "Dream consolidation artifact is missing.",
+          startupContextStage: "search-fallback",
+          startupCache: {
+            cacheHit: false,
+            shortCircuitLocal: false,
+          },
+          trustMismatchDetected: true,
+          advisory: {
+            dominantGoal: "Resume an unrelated startup thread.",
+            topBlocker: "Dream consolidation artifact is missing.",
+          },
+        },
+        mcpBridge: { ok: true },
+      },
+    },
+  });
+  const fastPathCheck = report.checks.find((check) => check.id === "codex-startup-fast-path");
+  const trustCheck = report.checks.find((check) => check.id === "codex-startup-grounding-trust");
+
+  assert.equal(fastPathCheck?.severity, "warning");
+  assert.equal(fastPathCheck?.ok, false);
+  assert.match(fastPathCheck?.message || "", /search-fallback/i);
+  assert.equal(trustCheck?.severity, "warning");
+  assert.equal(trustCheck?.ok, false);
+  assert.match(trustCheck?.message || "", /untrusted grounding authority|advisory-only/i);
 });

--- a/scripts/codex-startup-preflight.mjs
+++ b/scripts/codex-startup-preflight.mjs
@@ -6,15 +6,24 @@ import { fileURLToPath } from "node:url";
 import { loadAutomationStartupMemoryContext } from "./codex/open-memory-automation.mjs";
 import { loadCodexAutomationEnv } from "./lib/codex-automation-env.mjs";
 import {
+  buildThreadBootstrapQuery,
+  readThreadHistoryLines,
+  readThreadName,
+  resolveCodexThreadContext,
+} from "./lib/codex-session-memory-utils.mjs";
+import {
   STARTUP_REASON_CODES,
+  buildStartupContract,
   clean,
   evaluateStartupLatency,
   inspectTokenFreshness,
+  isTrustedStartupGroundingAuthority,
   startupRecoveryStep,
 } from "./lib/codex-startup-reliability.mjs";
 import {
   inspectStartupTranscriptTelemetry,
   logStartupTelemetryToolcall,
+  maybeLogStartupTelemetryToolcall,
 } from "./lib/codex-startup-telemetry.mjs";
 import { hydrateStudioBrainAuthFromPortal } from "./lib/studio-brain-startup-auth.mjs";
 import { resolveStudioBrainBaseUrlFromEnv } from "./studio-brain-url-resolution.mjs";
@@ -23,11 +32,28 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const REPO_ROOT = resolve(__dirname, "..");
 
+function buildStartupObservationKey(transcriptTelemetry) {
+  const threadId = clean(transcriptTelemetry?.threadId);
+  const rolloutPath = clean(transcriptTelemetry?.rolloutPath);
+  if (threadId && rolloutPath) return `${threadId}|${rolloutPath}`;
+  return threadId || rolloutPath || "";
+}
+
+function normalizeLocalArtifactRepair(value) {
+  if (!value || typeof value !== "object") return null;
+  return {
+    repaired: value.repaired === true,
+    reason: clean(value.reason),
+    source: clean(value.source),
+    capturedFrom: clean(value.capturedFrom),
+  };
+}
+
 function parseArgs(argv) {
   const options = {
     json: false,
     includeMcpSmoke: true,
-    query: "codex shell startup preflight",
+    query: "",
     runId: "codex-startup-preflight",
   };
   for (let index = 0; index < argv.length; index += 1) {
@@ -60,6 +86,26 @@ function parseArgs(argv) {
     }
   }
   return options;
+}
+
+function resolvePreflightStartupQuery() {
+  const hintedThreadId = clean(
+    process.env.STUDIO_BRAIN_BOOTSTRAP_THREAD_ID || process.env.CODEX_THREAD_ID || process.env.CODEX_RUN_THREAD_ID || ""
+  );
+  const threadInfo = resolveCodexThreadContext({
+    threadId: hintedThreadId,
+    cwd: REPO_ROOT,
+  });
+  if (!threadInfo?.threadId) {
+    return "codex shell startup preflight";
+  }
+  const threadName = readThreadName(threadInfo.threadId);
+  const historyLines = readThreadHistoryLines(threadInfo.threadId, { limit: 5 });
+  return buildThreadBootstrapQuery({
+    threadInfo,
+    threadName,
+    historyLines,
+  }) || "codex shell startup preflight";
 }
 
 async function probeStudioBrainReachability(baseUrl) {
@@ -120,10 +166,11 @@ async function main() {
   const token = clean(process.env.STUDIO_BRAIN_AUTH_TOKEN || process.env.STUDIO_BRAIN_ID_TOKEN || process.env.STUDIO_BRAIN_MCP_ID_TOKEN || "");
   const tokenFreshness = inspectTokenFreshness(token);
   const reachability = await probeStudioBrainReachability(baseUrl);
+  const resolvedQuery = clean(options.query) || resolvePreflightStartupQuery();
   const startup = await loadAutomationStartupMemoryContext({
     tool: "codex-startup-preflight",
     runId: options.runId,
-    query: options.query,
+    query: resolvedQuery,
     maxItems: 8,
     maxChars: 2200,
     scanLimit: 120,
@@ -134,20 +181,94 @@ async function main() {
     cwd: REPO_ROOT,
   });
   const mcpBridge = options.includeMcpSmoke ? probeMcpBridge() : null;
-  const status =
-    reachability.ok &&
-    startup.reasonCode !== STARTUP_REASON_CODES.MISSING_TOKEN &&
-    startup.reasonCode !== STARTUP_REASON_CODES.EXPIRED_TOKEN &&
-    startup.reasonCode !== STARTUP_REASON_CODES.TRANSPORT_UNREACHABLE &&
-    startup.reasonCode !== STARTUP_REASON_CODES.TIMEOUT &&
-    (!mcpBridge || mcpBridge.ok)
-      ? "pass"
-      : "fail";
+  const startupDiagnostics =
+    startup.diagnostics && typeof startup.diagnostics === "object"
+      ? startup.diagnostics
+      : {};
+  const presentationProjectLane = clean(
+    startupDiagnostics.presentationProjectLane || startupDiagnostics.projectLane || startupDiagnostics.dominantProjectLane
+  );
+  const threadScopedItemCount = Math.max(0, Math.round(Number(startupDiagnostics.threadScopedItemCount || 0)));
+  const manualOnly = startupDiagnostics.manualOnly === true;
+  const groundingQuality = clean(startupDiagnostics.groundingQuality || "missing");
+  const localArtifactRepair = normalizeLocalArtifactRepair(startupDiagnostics.localArtifactRepair);
+  const transcriptOrderingProven =
+    transcriptTelemetry.startupToolObserved === true &&
+    transcriptTelemetry.startupToolCalledBeforeFirstAssistantMessage === true &&
+    transcriptTelemetry.repoReadTelemetryObserved === true;
+  const startupContract = buildStartupContract({
+    reasonCode: startup.reasonCode,
+    continuityState: startup.continuityState,
+    diagnostics: {
+      ...startupDiagnostics,
+      presentationProjectLane,
+      threadScopedItemCount,
+      manualOnly,
+      groundingQuality,
+      dominantGoal: startup.dominantGoal || startupDiagnostics.dominantGoal,
+      topBlocker: startup.topBlocker || startupDiagnostics.topBlocker,
+      nextRecommendedAction: startup.nextRecommendedAction || startupDiagnostics.nextRecommendedAction,
+      laneSourceQuality: startup.laneSourceQuality || startupDiagnostics.laneSourceQuality,
+      fallbackOnly: startup.fallbackOnly === true,
+      groundingAuthority: clean(startup.groundingAuthority || startupDiagnostics.groundingAuthority),
+    },
+    telemetry: {
+      transcriptOrderingProven,
+      groundingLineEmitted: transcriptTelemetry.groundingLineEmitted,
+      repoReadsBeforeStartupContext: transcriptTelemetry.repoReadsBeforeStartupContext,
+    },
+    tokenFreshness,
+    studioBrainReachable: reachability.ok,
+    mcpBridgeOk: mcpBridge?.ok ?? null,
+  });
+  const observationKey = buildStartupObservationKey(transcriptTelemetry);
+  const startupLatencyBreakdown =
+    startup.latencyBreakdown && typeof startup.latencyBreakdown === "object" ? startup.latencyBreakdown : {};
+  const startupContextStage = clean(startupDiagnostics.startupContextStage);
+  const startupCache =
+    startupDiagnostics.startupCache && typeof startupDiagnostics.startupCache === "object"
+      ? startupDiagnostics.startupCache
+      : {};
+  const trustMismatchDetected =
+    (
+      clean(startup.continuityState || "").toLowerCase() === "ready" &&
+      !isTrustedStartupGroundingAuthority(clean(startup.groundingAuthority || startupDiagnostics.groundingAuthority))
+    ) ||
+    (
+      startupDiagnostics.publishTrustedGrounding !== true &&
+      Boolean(clean(startup.dominantGoal || startup.topBlocker || startup.nextRecommendedAction))
+    );
+  const startupPacket = {
+    schema: "codex-startup-packet.v1",
+    observationKey,
+    observationClass: "synthetic",
+    status: reportStatusForContract(startupContract.status),
+    reasonCode: clean(startup.reasonCode || STARTUP_REASON_CODES.STARTUP_UNAVAILABLE),
+    continuityState: clean(startup.continuityState || "missing").toLowerCase(),
+    groundingAuthority: clean(startup.groundingAuthority || startupDiagnostics.groundingAuthority || startupContract.groundingAuthority),
+    presentationProjectLane,
+    threadScopedItemCount,
+    itemCount: Number(startup.itemCount || 0),
+    contextSummary: clean(startup.contextSummary).slice(0, 300),
+    grounding: startup.grounding && typeof startup.grounding === "object" ? startup.grounding : {},
+    advisory: startup.advisory && typeof startup.advisory === "object" ? startup.advisory : {},
+    startupContextStage,
+    startupCache,
+    trustMismatchDetected,
+    degradationBuckets: startupContract.degradationBuckets,
+    missingStartupIngredients: startupContract.missingStartupIngredients,
+    latencyBreakdown: {
+      ...startupLatencyBreakdown,
+      startup: startupLatency,
+      studioBrainReachabilityMs: reachability.latencyMs ?? null,
+      mcpBridgeMs: mcpBridge?.latencyMs ?? null,
+    },
+  };
 
   const report = {
     schema: "codex-startup-preflight.v1",
     generatedAt: new Date().toISOString(),
-    status,
+    status: startupContract.status,
     baseUrl,
     checks: {
       studioBrainReachability: reachability,
@@ -162,11 +283,36 @@ async function main() {
         error: clean(startup.error),
         itemCount: Number(startup.itemCount || 0),
         contextSummary: clean(startup.contextSummary).slice(0, 300),
+        query: resolvedQuery,
+        presentationProjectLane,
+        threadScopedItemCount,
+        manualOnly,
+        groundingQuality,
+        degradationBuckets: startupContract.degradationBuckets,
+        missingStartupIngredients: startupContract.missingStartupIngredients,
+        transcriptOrderingProven: startupContract.transcriptOrderingProven,
+        dominantGoal: clean(startup.dominantGoal),
+        topBlocker: clean(startup.topBlocker),
+        nextRecommendedAction: clean(startup.nextRecommendedAction),
+        groundingAuthority: startupPacket.groundingAuthority,
+        grounding: startupPacket.grounding,
+        advisory: startupPacket.advisory,
+        goalAuthority: clean(startup.goalAuthority || startupDiagnostics.goalAuthority),
+        blockerAuthority: clean(startup.blockerAuthority || startupDiagnostics.blockerAuthority),
+        publishTrustedGrounding: startupDiagnostics.publishTrustedGrounding === true,
+        laneSourceQuality: startupContract.laneSourceQuality,
+        startupSourceQuality: startupContract.startupSourceQuality,
+        fallbackOnly: startupContract.fallbackOnly,
+        startupContextStage,
+        startupCache,
+        trustMismatchDetected,
+        ...(localArtifactRepair ? { localArtifactRepair } : {}),
         fallbackSources: Array.isArray(startup.fallbackSources) ? startup.fallbackSources.slice(0, 8) : [],
         memoryBriefPath: clean(startup.memoryBriefPath),
         consolidationMode: clean(startup.memoryBrief?.consolidation?.mode || "unavailable"),
         latency: startupLatency,
-        recoveryStep: startupRecoveryStep(startup.reasonCode || STARTUP_REASON_CODES.STARTUP_UNAVAILABLE),
+        startupPacket,
+        recoveryStep: startupContract.recoveryStep || startupRecoveryStep(startup.reasonCode || STARTUP_REASON_CODES.STARTUP_UNAVAILABLE),
         telemetry: {
           toolName: "studio_brain_startup_context",
           toolStatus: "called",
@@ -176,6 +322,7 @@ async function main() {
           groundingLineObserved: transcriptTelemetry.groundingLineObserved,
           repoReadsBeforeStartupContext: transcriptTelemetry.repoReadsBeforeStartupContext,
           repoReadTelemetryObserved: transcriptTelemetry.repoReadTelemetryObserved,
+          transcriptOrderingProven,
           transcriptSource: transcriptTelemetry.source,
           threadId: transcriptTelemetry.threadId,
           rolloutPath: transcriptTelemetry.rolloutPath,
@@ -188,9 +335,9 @@ async function main() {
   logStartupTelemetryToolcall({
     tool: "codex-startup-preflight",
     action: "startup-bootstrap",
-    ok: report.status === "pass",
+    ok: report.status !== "fail",
     durationMs: startupLatency.latencyMs ?? null,
-    errorType: report.status === "pass" ? null : "startup-preflight",
+    errorType: report.status === "fail" ? "startup-preflight" : report.status === "degraded" ? "startup-preflight-degraded" : null,
     errorMessage:
       clean(report.checks.startupContext.error) ||
       clean(reachability.error) ||
@@ -198,11 +345,41 @@ async function main() {
       null,
     context: {
       startup: {
+        observationKey,
+        observationClass: "synthetic",
         toolName: "studio_brain_startup_context",
         startupToolStatus: "called",
+        itemCount: Number(startup.itemCount || 0),
+        contextSummary: clean(startup.contextSummary).slice(0, 300),
         reasonCode: report.checks.startupContext.reasonCode,
         continuityState: report.checks.startupContext.continuityState,
+        presentationProjectLane,
+        threadScopedItemCount,
+        manualOnly,
+        groundingQuality,
+        degradationBuckets: startupContract.degradationBuckets,
+        missingStartupIngredients: startupContract.missingStartupIngredients,
+        transcriptOrderingProven: startupContract.transcriptOrderingProven,
+        dominantGoal: clean(startup.dominantGoal),
+        topBlocker: clean(startup.topBlocker),
+        nextRecommendedAction: clean(startup.nextRecommendedAction),
+        groundingAuthority: startupPacket.groundingAuthority,
+        grounding: startupPacket.grounding,
+        advisory: startupPacket.advisory,
+        goalAuthority: clean(startup.goalAuthority || startupDiagnostics.goalAuthority),
+        blockerAuthority: clean(startup.blockerAuthority || startupDiagnostics.blockerAuthority),
+        publishTrustedGrounding: startupDiagnostics.publishTrustedGrounding === true,
+        laneSourceQuality: startupContract.laneSourceQuality,
+        startupSourceQuality: startupContract.startupSourceQuality,
+        fallbackOnly: startupContract.fallbackOnly,
+        startupContextStage,
+        startupCache,
+        trustMismatchDetected,
+        localArtifactRepairApplied: localArtifactRepair?.repaired === true,
+        ...(localArtifactRepair ? { localArtifactRepair } : {}),
         latencyMs: startupLatency.latencyMs ?? null,
+        latencyBreakdown: startupPacket.latencyBreakdown,
+        startupPacket,
         recoveryStep: report.checks.startupContext.recoveryStep,
         groundingLineEmitted: transcriptTelemetry.groundingLineEmitted,
         groundingLineObserved: transcriptTelemetry.groundingLineObserved,
@@ -210,6 +387,7 @@ async function main() {
         repoReadTelemetryObserved: transcriptTelemetry.repoReadTelemetryObserved,
         startupToolObservedInTranscript: transcriptTelemetry.startupToolObserved,
         startupToolCalledBeforeFirstAssistantMessage: transcriptTelemetry.startupToolCalledBeforeFirstAssistantMessage,
+        transcriptOrderingProven,
         telemetryCoverage: {
           groundingLine: transcriptTelemetry.groundingLineObserved,
           preStartupRepoReads: transcriptTelemetry.repoReadTelemetryObserved,
@@ -221,12 +399,105 @@ async function main() {
         threadId: transcriptTelemetry.threadId || null,
         rolloutPath: transcriptTelemetry.rolloutPath || null,
       },
+      telemetryCoverage: {
+        startupSource: transcriptTelemetry.source,
+        transcriptOrderingProven: startupContract.transcriptOrderingProven,
+        groundingLineObserved: transcriptTelemetry.groundingLineObserved,
+        preStartupRepoReadObserved: transcriptTelemetry.repoReadTelemetryObserved,
+      },
       studioBrainReachable: reachability.ok,
       mcpBridgeOk: mcpBridge?.ok ?? null,
     },
     env: process.env,
     cwd: REPO_ROOT,
   });
+
+  if (transcriptTelemetry.startupToolObserved === true) {
+    maybeLogStartupTelemetryToolcall({
+      tool: "codex-desktop",
+      action: "startup-bootstrap",
+      ok: report.status !== "fail",
+      durationMs: startupLatency.latencyMs ?? null,
+      errorType:
+        report.status === "fail" ? "startup-bootstrap" : report.status === "degraded" ? "startup-bootstrap-degraded" : null,
+      errorMessage:
+        clean(report.checks.startupContext.error) ||
+        clean(reachability.error) ||
+        clean(mcpBridge?.error) ||
+        null,
+      context: {
+        startup: {
+          observationKey,
+          observationClass: "live",
+          observedVia: "codex-startup-preflight",
+          toolName: "studio_brain_startup_context",
+          startupToolStatus: "called",
+          startupToolObservedInTranscript: transcriptTelemetry.startupToolObserved,
+          startupToolNameObserved: transcriptTelemetry.startupToolName || null,
+          startupToolCalledBeforeFirstAssistantMessage: transcriptTelemetry.startupToolCalledBeforeFirstAssistantMessage,
+          itemCount: Number(startup.itemCount || 0),
+          contextSummary: clean(startup.contextSummary).slice(0, 300),
+          reasonCode: report.checks.startupContext.reasonCode,
+          continuityState: report.checks.startupContext.continuityState,
+          presentationProjectLane,
+          threadScopedItemCount,
+          manualOnly,
+          groundingQuality,
+          degradationBuckets: startupContract.degradationBuckets,
+          missingStartupIngredients: startupContract.missingStartupIngredients,
+          dominantGoal: clean(startup.dominantGoal),
+          topBlocker: clean(startup.topBlocker),
+          nextRecommendedAction: clean(startup.nextRecommendedAction),
+          groundingAuthority: startupPacket.groundingAuthority,
+          grounding: startupPacket.grounding,
+          advisory: startupPacket.advisory,
+          goalAuthority: clean(startup.goalAuthority || startupDiagnostics.goalAuthority),
+          blockerAuthority: clean(startup.blockerAuthority || startupDiagnostics.blockerAuthority),
+          publishTrustedGrounding: startupDiagnostics.publishTrustedGrounding === true,
+          laneSourceQuality: startupContract.laneSourceQuality,
+          startupSourceQuality: startupContract.startupSourceQuality,
+          fallbackOnly: startupContract.fallbackOnly,
+          startupContextStage,
+          startupCache,
+          trustMismatchDetected,
+          localArtifactRepairApplied: localArtifactRepair?.repaired === true,
+          ...(localArtifactRepair ? { localArtifactRepair } : {}),
+          latencyMs: startupLatency.latencyMs ?? null,
+          latencyBreakdown: startupPacket.latencyBreakdown,
+          startupPacket: {
+            ...startupPacket,
+            observationClass: "live",
+          },
+          recoveryStep: report.checks.startupContext.recoveryStep,
+          groundingLineEmitted: transcriptTelemetry.groundingLineEmitted,
+          groundingLineObserved: transcriptTelemetry.groundingLineObserved,
+          repoReadsBeforeStartupContext: transcriptTelemetry.repoReadsBeforeStartupContext,
+          repoReadTelemetryObserved: transcriptTelemetry.repoReadTelemetryObserved,
+          transcriptOrderingProven,
+          telemetryCoverage: {
+            groundingLine: transcriptTelemetry.groundingLineObserved,
+            preStartupRepoReads: transcriptTelemetry.repoReadTelemetryObserved,
+            fullyObserved:
+              transcriptTelemetry.groundingLineObserved === true &&
+              transcriptTelemetry.repoReadTelemetryObserved === true,
+          },
+          transcriptSource: transcriptTelemetry.source,
+          threadId: transcriptTelemetry.threadId || null,
+          rolloutPath: transcriptTelemetry.rolloutPath || null,
+        },
+        telemetryCoverage: {
+          startupSource: transcriptTelemetry.source,
+          transcriptOrderingProven: startupContract.transcriptOrderingProven,
+          groundingLineObserved: transcriptTelemetry.groundingLineObserved,
+          preStartupRepoReadObserved: transcriptTelemetry.repoReadTelemetryObserved,
+        },
+        studioBrainReachable: reachability.ok,
+        mcpBridgeOk: mcpBridge?.ok ?? null,
+      },
+      env: process.env,
+      cwd: REPO_ROOT,
+    });
+  }
 
   if (options.json) {
     process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
@@ -238,11 +509,29 @@ async function main() {
   process.stdout.write(`token: ${tokenFreshness.state}\n`);
   process.stdout.write(`startup reason: ${report.checks.startupContext.reasonCode}\n`);
   process.stdout.write(`continuity state: ${report.checks.startupContext.continuityState}\n`);
+  process.stdout.write(`presentation lane: ${report.checks.startupContext.presentationProjectLane || "unresolved"}\n`);
+  process.stdout.write(`grounding quality: ${report.checks.startupContext.groundingQuality}\n`);
+  process.stdout.write(`startup stage: ${report.checks.startupContext.startupContextStage || "unspecified"}\n`);
+  process.stdout.write(
+    `startup cache: ${
+      report.checks.startupContext.startupCache?.shortCircuitLocal === true
+        ? "validated-local-short-circuit"
+        : report.checks.startupContext.startupCache?.cacheHit === true
+          ? `cache-hit (${report.checks.startupContext.startupCache?.hitType || "hit"})`
+          : "cache-miss"
+    }\n`
+  );
   process.stdout.write(`dream cycle: ${report.checks.startupContext.consolidationMode}\n`);
   process.stdout.write(`startup latency: ${startupLatency.latencyMs ?? "n/a"}ms (${startupLatency.state})\n`);
   if (mcpBridge) {
     process.stdout.write(`mcp bridge: ${mcpBridge.ok ? "reachable" : `unreachable (${mcpBridge.error || "unknown"})`}\n`);
   }
+}
+
+function reportStatusForContract(status) {
+  const normalized = clean(status).toLowerCase();
+  if (normalized === "pass" || normalized === "degraded" || normalized === "fail") return normalized;
+  return "fail";
 }
 
 main().catch((error) => {

--- a/scripts/codex/open-memory-automation.mjs
+++ b/scripts/codex/open-memory-automation.mjs
@@ -1,22 +1,32 @@
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { closeSync, existsSync, mkdirSync, openSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   STARTUP_REASON_CODES,
   classifyStartupReason,
+  deriveStartupGroundingAuthority,
   evaluateStartupLatency,
   inspectTokenFreshness,
+  isTrustedStartupGroundingAuthority,
 } from "../lib/codex-startup-reliability.mjs";
 import {
   buildLocalBootstrapContext,
   loadBootstrapArtifacts,
+  normalizeThreadCwd,
   parseRolloutEntries,
+  preferredStartupSourcePriority,
+  rankBootstrapRows,
   readThreadHistoryLines,
   readThreadName,
   resolveBootstrapContinuityState,
   resolveCodexThreadContext,
+  runtimePathsForThread,
+  writeContinuityEnvelope,
+  writeHandoffArtifact,
 } from "../lib/codex-session-memory-utils.mjs";
+import { inferProjectLane } from "../lib/hybrid-memory-utils.mjs";
+import { stableHash } from "../lib/pst-memory-utils.mjs";
 import { hydrateStudioBrainAuthFromPortal } from "../lib/studio-brain-startup-auth.mjs";
 import { resolveStudioBrainBaseUrlFromEnv } from "../studio-brain-url-resolution.mjs";
 import { notifyAutomationOutcome } from "./phone-notify.mjs";
@@ -30,6 +40,10 @@ const OPEN_MEMORY_CLI_SCRIPT = resolve(REPO_ROOT, "scripts/open-memory.mjs");
 const MEMORY_BRIEF_ARTIFACT_PATH = resolve(REPO_ROOT, "output", "studio-brain", "memory-brief", "latest.json");
 const MEMORY_CONSOLIDATION_ARTIFACT_PATH = resolve(REPO_ROOT, "output", "studio-brain", "memory-consolidation", "latest.json");
 const MEMORY_CONSOLIDATION_STALE_MS = 36 * 60 * 60 * 1000;
+const DEFAULT_STARTUP_CONTEXT_CACHE_TTL_MS = 20_000;
+const DEFAULT_STARTUP_CONTEXT_SINGLE_FLIGHT_TIMEOUT_MS = 8_000;
+const DEFAULT_STARTUP_CONTEXT_SINGLE_FLIGHT_POLL_MS = 40;
+const STARTUP_CONTEXT_INFLIGHT = new Map();
 
 function clean(value) {
   return String(value || "").trim();
@@ -98,6 +112,18 @@ function normalizeSource(raw) {
 function parseIsoMs(value) {
   const parsed = Date.parse(clean(value));
   return Number.isFinite(parsed) ? parsed : null;
+}
+
+function normalizeCwdValue(value) {
+  return clean(value)
+    .replace(/^\\\\\?\\/, "")
+    .replace(/\\/g, "/")
+    .toLowerCase();
+}
+
+function usableProjectLane(value) {
+  const lane = normalizeSource(value);
+  return lane && !["unknown", "general-dev", "personal"].includes(lane) ? lane : "";
 }
 
 function looksLikeStartupPlaceholder(value) {
@@ -418,23 +444,6 @@ function isPreferredStartupSource(source) {
   return false;
 }
 
-function preferredStartupSourcePriority(source) {
-  const normalized = normalizeSource(source || "");
-  if (normalized === "codex-compaction-promoted") return 0;
-  if (normalized === "codex-handoff") return 0;
-  if (normalized === "codex-resumable-session") return 1;
-  if (normalized === "codex-friction-feedback-loop") return 2;
-  if (normalized === "codex") return 3;
-  if (normalized === "manual") return 4;
-  if (normalized === "context-slice:automation") return 5;
-  if (normalized.startsWith("context-slice:")) return 6;
-  if (normalized === "codex-compaction-window") return 7;
-  if (normalized === "codex-compaction-raw") return 8;
-  if (normalized.startsWith("codex-")) return 9;
-  if (normalized === "mcp") return 10;
-  return 99;
-}
-
 function readRowSource(row) {
   return row?.source || row?.metadata?.source || "";
 }
@@ -523,9 +532,9 @@ function rowHasStartupSignal(row) {
   return true;
 }
 
-function filterStartupRows(rows, { preferredOnly = false } = {}) {
+export function selectStartupRows(rows, { preferredOnly = false, threadInfo = null } = {}) {
   if (!Array.isArray(rows)) return [];
-  return rows
+  const filtered = rows
     .map((row, index) => ({
       row,
       index,
@@ -533,24 +542,53 @@ function filterStartupRows(rows, { preferredOnly = false } = {}) {
       score: readRowScore(row),
     }))
     .filter((entry) => rowHasStartupSignal(entry.row))
-    .filter((entry) => !preferredOnly || isPreferredStartupSource(entry.source))
-    .sort((left, right) => {
-      const leftPriority = isPreferredStartupSource(left.source) ? preferredStartupSourcePriority(left.source) : 50;
-      const rightPriority = isPreferredStartupSource(right.source) ? preferredStartupSourcePriority(right.source) : 50;
-      const priorityDelta = leftPriority - rightPriority;
-      if (priorityDelta !== 0) return priorityDelta;
-      if (right.score !== left.score) return right.score - left.score;
-      return left.index - right.index;
-    })
-    .map((entry) => entry.row);
+    .filter((entry) => !preferredOnly || isPreferredStartupSource(entry.source));
+  const ranked = rankBootstrapRows(
+    filtered.map((entry) => ({
+      ...entry.row,
+      metadata: {
+        ...(entry.row?.metadata && typeof entry.row.metadata === "object" ? entry.row.metadata : {}),
+        startupQueryOriginalIndex: entry.index,
+      },
+    })),
+    threadInfo,
+    {
+      preserveOriginalScore: true,
+      profile: "startup-strict",
+    }
+  );
+  return ranked.sort((left, right) => {
+    const leftRank = Number(left?.metadata?.bootstrapRankScore);
+    const rightRank = Number(right?.metadata?.bootstrapRankScore);
+    if (Number.isFinite(leftRank) && Number.isFinite(rightRank) && rightRank !== leftRank) {
+      return rightRank - leftRank;
+    }
+    const leftPriority = isPreferredStartupSource(readRowSource(left))
+      ? preferredStartupSourcePriority(readRowSource(left), "startup-strict")
+      : 50;
+    const rightPriority = isPreferredStartupSource(readRowSource(right))
+      ? preferredStartupSourcePriority(readRowSource(right), "startup-strict")
+      : 50;
+    if (leftPriority !== rightPriority) return leftPriority - rightPriority;
+    const leftScore = Number(readRowScore(left));
+    const rightScore = Number(readRowScore(right));
+    if (Number.isFinite(leftScore) && Number.isFinite(rightScore) && rightScore !== leftScore) {
+      return rightScore - leftScore;
+    }
+    return Number(left?.metadata?.startupQueryOriginalIndex || 0) - Number(right?.metadata?.startupQueryOriginalIndex || 0);
+  });
 }
 
-function filterPreferredRows(rows) {
-  return filterStartupRows(rows, { preferredOnly: true });
+function filterStartupRows(rows, options = {}) {
+  return selectStartupRows(rows, options);
 }
 
-function summarizeStartupRows(rows, maxChars = 400) {
-  const startupRows = filterStartupRows(rows);
+function filterPreferredRows(rows, options = {}) {
+  return selectStartupRows(rows, { ...options, preferredOnly: true });
+}
+
+function summarizeStartupRows(rows, maxChars = 400, threadInfo = null) {
+  const startupRows = filterStartupRows(rows, { threadInfo });
   if (startupRows.length === 0) return "";
   const lines = [];
   const seen = new Set();
@@ -570,16 +608,349 @@ function summarizeStartupRows(rows, maxChars = 400) {
   return summarizeBriefLines(lines, "", maxChars);
 }
 
-function resolveSelectedStartupSummary(summary, items, maxChars = 400) {
+function resolveSelectedStartupSummary(summary, items, maxChars = 400, threadInfo = null) {
   const summaryLines = sanitizeBriefLines(summary, 8);
   if (summaryLines.length > 0) {
     return summarizeBriefLines(summaryLines, "", maxChars);
   }
-  return summarizeStartupRows(items, maxChars);
+  return summarizeStartupRows(items, maxChars, threadInfo);
 }
 
 function readRowMemoryLayer(row) {
   return clean(row?.memoryLayer || row?.metadata?.memoryLayer || "").toLowerCase();
+}
+
+function readRowProjectLane(row) {
+  const metadata = row?.metadata && typeof row.metadata === "object" ? row.metadata : {};
+  const sourceMetadata = metadata.sourceMetadata && typeof metadata.sourceMetadata === "object"
+    ? metadata.sourceMetadata
+    : {};
+  return usableProjectLane(
+    sourceMetadata.projectLane || metadata.projectLane || row?.projectLane || metadata.lane || metadata.signalLane
+  );
+}
+
+function rowMatchesThread(row, threadInfo) {
+  const metadata = row?.metadata && typeof row.metadata === "object" ? row.metadata : {};
+  const rowThreadId = clean(metadata.threadId || row?.threadId);
+  const rowCwd = normalizeCwdValue(metadata.cwd || row?.cwd);
+  const threadId = clean(threadInfo?.threadId);
+  const cwd = normalizeCwdValue(threadInfo?.cwd);
+  return Boolean((threadId && rowThreadId === threadId) || (cwd && rowCwd === cwd));
+}
+
+function hasUsableLocalStartupArtifacts(artifacts = {}) {
+  const handoff = artifacts?.handoff && typeof artifacts.handoff === "object" ? artifacts.handoff : {};
+  const envelope = artifacts?.continuityEnvelope && typeof artifacts.continuityEnvelope === "object"
+    ? artifacts.continuityEnvelope
+    : {};
+  const handoffSummary = clean(handoff.summary || handoff.workCompleted || handoff.activeGoal);
+  if (handoffSummary) return true;
+  const envelopeSummary = clean(envelope.lastHandoffSummary || envelope.currentGoal || envelope.nextRecommendedAction);
+  const sourceQuality = clean(
+    envelope.startupSourceQuality || envelope.laneSourceQuality || envelope.startup?.startupSourceQuality
+  ).toLowerCase();
+  return Boolean(envelopeSummary) && sourceQuality === "thread-scoped-dominant";
+}
+
+function rowCanRepairStartupArtifacts(row, threadInfo = null) {
+  if (!rowMatchesThread(row, threadInfo)) return false;
+  const metadata = row?.metadata && typeof row.metadata === "object" ? row.metadata : {};
+  const source = normalizeSource(readRowSource(row));
+  if (source === "codex-startup-blocker") return false;
+  const checkpointKind = clean(metadata.checkpointKind).toLowerCase();
+  const startupEligible =
+    source === "codex-handoff" ||
+    metadata.startupEligible === true ||
+    checkpointKind === "handoff" ||
+    checkpointKind === "checkpoint";
+  if (!startupEligible) return false;
+  const summary = clean(metadata.summary || metadata.workCompleted || readRowText(row));
+  const activeGoal = clean(metadata.activeGoal || metadata.currentGoal || metadata.goal);
+  const nextRecommendedAction = clean(metadata.nextRecommendedAction || metadata.unblockStep);
+  const blockers = Array.isArray(metadata.blockers) ? metadata.blockers : [];
+  return Boolean(summary || activeGoal || nextRecommendedAction || blockers.length > 0);
+}
+
+export function selectStartupArtifactRepairCandidate(rows, { threadInfo = null } = {}) {
+  const startupRows = selectStartupRows(rows, { threadInfo });
+  return startupRows.find((row) => rowCanRepairStartupArtifacts(row, threadInfo)) || null;
+}
+
+export function buildStartupArtifactRepair(candidate, {
+  threadInfo = null,
+  threadScopedItemCount = 0,
+} = {}) {
+  if (!candidate) return null;
+  const metadata = candidate?.metadata && typeof candidate.metadata === "object" ? candidate.metadata : {};
+  const threadId = clean(metadata.threadId || threadInfo?.threadId);
+  if (!threadId) return null;
+  const summary = clean(metadata.summary || metadata.workCompleted || readRowText(candidate));
+  const activeGoal = clean(metadata.activeGoal || metadata.currentGoal || threadInfo?.firstUserMessage || threadInfo?.title || summary);
+  const nextRecommendedAction = clean(metadata.nextRecommendedAction || metadata.unblockStep);
+  const blockers = Array.isArray(metadata.blockers) ? metadata.blockers : [];
+  const completionStatus = clean(
+    metadata.completionStatus || metadata.status || metadata.checkpointStatus || (blockers.length > 0 ? "degraded" : "pass")
+  ) || "pass";
+  const workCompleted = clean(metadata.workCompleted || summary);
+  const presentationProjectLane = readRowProjectLane(candidate) || resolveThreadProjectLane(threadInfo);
+  return {
+    handoff: {
+      threadId,
+      createdAt: clean(candidate?.createdAt || candidate?.occurredAt),
+      runId: clean(candidate?.runId || metadata.runId),
+      agentId: clean(candidate?.agentId || metadata.agentId),
+      summary,
+      activeGoal,
+      workCompleted: workCompleted || summary,
+      nextRecommendedAction,
+      blockers,
+      completionStatus,
+      startupProvenance: {
+        repairedFromSource: clean(readRowSource(candidate)),
+        repairedFromCapturedFrom: clean(metadata.capturedFrom),
+        repairedFromMemoryId: clean(candidate?.id),
+      },
+    },
+    continuityEnvelope: {
+      threadId,
+      cwd: clean(metadata.cwd || threadInfo?.cwd),
+      continuityState: "ready",
+      currentGoal: activeGoal,
+      lastHandoffSummary: summary || workCompleted,
+      nextRecommendedAction,
+      blockers,
+      fallbackOnly: false,
+      startupSourceQuality: "thread-scoped-dominant",
+      laneSourceQuality: "thread-scoped-dominant",
+      presentationProjectLane,
+      threadScopedItemCount: Math.max(1, Math.round(Number(threadScopedItemCount || 0))),
+    },
+  };
+}
+
+function repairLocalStartupArtifactsFromRows(rows, {
+  threadInfo = null,
+  existingArtifacts = null,
+} = {}) {
+  const threadId = clean(threadInfo?.threadId);
+  if (!threadId || !Array.isArray(rows) || rows.length === 0) {
+    return {
+      repaired: false,
+      reason: "missing-thread-or-rows",
+    };
+  }
+  const artifacts = existingArtifacts || loadBootstrapArtifacts(threadId);
+  if (hasUsableLocalStartupArtifacts(artifacts)) {
+    return {
+      repaired: false,
+      reason: "existing-local-artifacts",
+    };
+  }
+  const candidate = selectStartupArtifactRepairCandidate(rows, { threadInfo });
+  if (!candidate) {
+    return {
+      repaired: false,
+      reason: "no-repair-candidate",
+    };
+  }
+  const threadScopedItemCount = rows.filter((row) => rowMatchesThread(row, threadInfo)).length;
+  const repair = buildStartupArtifactRepair(candidate, { threadInfo, threadScopedItemCount });
+  if (!repair) {
+    return {
+      repaired: false,
+      reason: "candidate-not-repairable",
+    };
+  }
+  writeHandoffArtifact(threadId, repair.handoff);
+  writeContinuityEnvelope(threadId, repair.continuityEnvelope);
+  return {
+    repaired: true,
+    reason: "repaired-from-remote-startup-row",
+    source: clean(readRowSource(candidate)),
+    capturedFrom: clean(candidate?.metadata?.capturedFrom),
+  };
+}
+
+function resolveThreadCwdLane(threadInfo) {
+  return usableProjectLane(
+    inferProjectLane({
+      path: normalizeThreadCwd(threadInfo?.cwd),
+    })
+  );
+}
+
+function resolveThreadProjectLane(threadInfo, cwdLane = resolveThreadCwdLane(threadInfo)) {
+  if (cwdLane) return cwdLane;
+  return usableProjectLane(
+    inferProjectLane({
+      path: normalizeThreadCwd(threadInfo?.cwd),
+      title: clean(threadInfo?.title),
+      text: clean(threadInfo?.firstUserMessage),
+    })
+  );
+}
+
+function computeGroundingQuality({
+  rows = [],
+  continuityState = "missing",
+  presentationProjectLane = "",
+  threadScopedItemCount = 0,
+  manualOnly = false,
+} = {}) {
+  if (!Array.isArray(rows) || rows.length === 0) {
+    return clean(continuityState).toLowerCase() === "blocked" ? "blocked" : "missing";
+  }
+  if (manualOnly) return "manual-only";
+  if (threadScopedItemCount > 0 && presentationProjectLane) {
+    return rows.length >= 2 ? "thread-scoped-rich" : "thread-scoped";
+  }
+  if (threadScopedItemCount > 0) return "thread-scoped";
+  if (presentationProjectLane) return rows.length >= 2 ? "lane-resolved-rich" : "lane-resolved";
+  return "thin";
+}
+
+function continuityArtifactSignalCount(row) {
+  const metadata = row?.metadata && typeof row.metadata === "object" ? row.metadata : {};
+  let signals = 0;
+  if (clean(metadata.activeGoal || metadata.currentGoal)) signals += 1;
+  if (clean(metadata.nextRecommendedAction || metadata.unblockStep)) signals += 1;
+  if (clean(metadata.summary || metadata.lastHandoffSummary || metadata.workCompleted || metadata.bootstrapSummary)) {
+    signals += 1;
+  }
+  if (Array.isArray(metadata.blockers) && metadata.blockers.length > 0) signals += 1;
+  if (clean(metadata.firstSignal)) signals += 1;
+  if (Array.isArray(metadata.resumeHints) && metadata.resumeHints.length > 0) signals += 1;
+  return signals;
+}
+
+function isTrustedStartupArtifactRow(row) {
+  const source = normalizeSource(readRowSource(row));
+  if (!["codex-handoff", "codex-continuity-envelope", "codex-startup-blocker"].includes(source)) {
+    return false;
+  }
+  const signals = continuityArtifactSignalCount(row);
+  return source === "codex-startup-blocker" ? signals >= 1 : signals >= 2;
+}
+
+function computeStartupSourceQuality(rows = [], threadScopedItemCount = 0, threadInfo = null) {
+  const startupRows = Array.isArray(rows) ? rows : [];
+  if (startupRows.length === 0) {
+    return {
+      startupSourceQuality: "missing",
+      compactionDominated: false,
+      sourceCounts: {},
+    };
+  }
+  const sourceCounts = {};
+  let compactionRows = 0;
+  let trustedThreadScopedArtifactRows = 0;
+  for (const row of startupRows) {
+    const source = normalizeSource(readRowSource(row)) || "unknown";
+    sourceCounts[source] = Number(sourceCounts[source] || 0) + 1;
+    if (source.startsWith("codex-compaction-")) {
+      compactionRows += 1;
+    }
+    if (isTrustedStartupArtifactRow(row) && rowMatchesThread(row, threadInfo)) {
+      trustedThreadScopedArtifactRows += 1;
+    }
+  }
+  const compactionDominated =
+    trustedThreadScopedArtifactRows === 0 &&
+    compactionRows / startupRows.length >= 0.5;
+  const startupSourceQuality = trustedThreadScopedArtifactRows > 0
+    ? "thread-scoped-dominant"
+    : compactionDominated
+    ? "compaction-promoted-dominant"
+    : threadScopedItemCount > 0
+      ? "thread-scoped-dominant"
+      : "cross-thread-fallback";
+  return {
+    startupSourceQuality,
+    compactionDominated,
+    sourceCounts,
+  };
+}
+
+export function deriveStartupGroundingDiagnostics({
+  rows = [],
+  diagnostics = {},
+  threadInfo = null,
+  continuityState = "",
+} = {}) {
+  const startupRows = Array.isArray(rows) ? rows : [];
+  const baseDiagnostics = diagnostics && typeof diagnostics === "object" ? diagnostics : {};
+  const threadScopedItemCount = startupRows.length > 0
+    ? startupRows.filter((row) => rowMatchesThread(row, threadInfo)).length
+    : Math.max(0, Math.round(Number(baseDiagnostics.threadScopedItemCount || 0)));
+  const manualOnly = startupRows.length > 0
+    ? startupRows.every((row) => normalizeSource(readRowSource(row)) === "manual")
+    : baseDiagnostics.manualOnly === true;
+  const rankedLaneRow = startupRows.find((row) => readRowProjectLane(row));
+  const rankedRowMatchesThread = Boolean(rankedLaneRow) && rowMatchesThread(rankedLaneRow, threadInfo);
+  const diagnosticsLane = usableProjectLane(
+    baseDiagnostics.presentationProjectLane || baseDiagnostics.projectLane || baseDiagnostics.dominantProjectLane
+  );
+  const cwdLane = resolveThreadCwdLane(threadInfo);
+  const inferredLane = resolveThreadProjectLane(threadInfo, cwdLane);
+  const rankedLane = rankedLaneRow ? readRowProjectLane(rankedLaneRow) : "";
+  const shouldOverrideThreadScopedLane =
+    Boolean(rankedLaneRow) &&
+    Boolean(inferredLane) &&
+    rankedRowMatchesThread &&
+    Boolean(rankedLane) &&
+    rankedLane !== inferredLane;
+  const shouldPreferRepoLaneOverCrossLane =
+    Boolean(rankedLaneRow) &&
+    Boolean(cwdLane) &&
+    !rankedRowMatchesThread &&
+    Boolean(rankedLane) &&
+    rankedLane !== inferredLane;
+  const presentationProjectLane = rankedLaneRow
+    ? shouldOverrideThreadScopedLane || shouldPreferRepoLaneOverCrossLane
+      ? inferredLane
+      : rankedLane
+    : inferredLane || diagnosticsLane;
+  const laneResolutionSource = rankedLaneRow
+    ? shouldOverrideThreadScopedLane
+      ? "thread-inference-override"
+      : shouldPreferRepoLaneOverCrossLane
+        ? "thread-inference"
+      : rankedRowMatchesThread
+      ? "thread-scoped-ranked-row"
+      : "ranked-row"
+    : inferredLane
+      ? "thread-inference"
+      : diagnosticsLane
+        ? "diagnostics"
+        : "unresolved";
+  const normalizedContinuityState = clean(continuityState || baseDiagnostics.continuityState || "missing").toLowerCase();
+  const sourceQuality = computeStartupSourceQuality(startupRows, threadScopedItemCount, threadInfo);
+  const laneSourceQuality =
+    sourceQuality.compactionDominated === true
+      ? "compaction-promoted-dominant"
+      : clean(baseDiagnostics.laneSourceQuality || baseDiagnostics.groundingQuality || "");
+  return {
+    ...baseDiagnostics,
+    projectLane: presentationProjectLane || usableProjectLane(baseDiagnostics.projectLane),
+    dominantProjectLane:
+      presentationProjectLane || usableProjectLane(baseDiagnostics.dominantProjectLane || baseDiagnostics.projectLane),
+    presentationProjectLane,
+    laneResolutionSource,
+    threadScopedItemCount,
+    manualOnly,
+    groundingQuality: computeGroundingQuality({
+      rows: startupRows,
+      continuityState: normalizedContinuityState,
+      presentationProjectLane,
+      threadScopedItemCount,
+      manualOnly,
+    }),
+    laneSourceQuality: laneSourceQuality || sourceQuality.startupSourceQuality,
+    startupSourceQuality: sourceQuality.startupSourceQuality,
+    compactionDominated: sourceQuality.compactionDominated,
+    rowSourceCounts: sourceQuality.sourceCounts,
+  };
 }
 
 function hasNonCoreRows(rows) {
@@ -624,6 +995,7 @@ async function fallbackSearchContext({
   sourceDenylist,
   retrievalMode,
   strictStartupAllowlist,
+  threadInfo = null,
 }) {
   const attempts = [];
   const queryText = clean(query);
@@ -667,8 +1039,8 @@ async function fallbackSearchContext({
       : Array.isArray(response.payload?.results)
         ? response.payload.results
         : [];
-    const preferredRows = filterPreferredRows(rows);
-    const startupRows = filterStartupRows(rows);
+    const preferredRows = filterPreferredRows(rows, { threadInfo });
+    const startupRows = filterStartupRows(rows, { threadInfo });
     const selectedRows =
       strictStartupAllowlist
         ? preferredRows
@@ -696,6 +1068,7 @@ async function requestStartupContextStage({
   payload,
   strictStartupAllowlist = true,
   startupStage = "scoped",
+  threadInfo = null,
 } = {}) {
   const response = await requestJson(client, "/api/memory/context", payload);
   if (!response.ok) {
@@ -714,15 +1087,21 @@ async function requestStartupContextStage({
   }
 
   const { items, summary, diagnostics } = extractContextEnvelope(response.payload);
-  const preferredItems = filterPreferredRows(items);
-  const startupItems = filterStartupRows(items);
+  const preferredItems = filterPreferredRows(items, { threadInfo });
+  const startupItems = filterStartupRows(items, { threadInfo });
   const selectedItems =
     strictStartupAllowlist
       ? preferredItems
       : preferredItems.length > 0
         ? preferredItems
         : startupItems;
-  const selectedSummary = resolveSelectedStartupSummary(summary, selectedItems, 400);
+  const selectedSummary = resolveSelectedStartupSummary(summary, selectedItems, 400, threadInfo);
+  const selectedDiagnostics = deriveStartupGroundingDiagnostics({
+    rows: selectedItems,
+    diagnostics,
+    threadInfo,
+    continuityState: clean(diagnostics?.continuityState),
+  });
   return {
     ok: true,
     response,
@@ -732,6 +1111,8 @@ async function requestStartupContextStage({
     summary,
     selectedSummary,
     diagnostics,
+    selectedDiagnostics,
+    compactionDominated: selectedDiagnostics.compactionDominated === true,
     hasSelectedItems: selectedItems.length > 0,
     hasNonCoreSelected: hasNonCoreRows(selectedItems),
   };
@@ -773,6 +1154,275 @@ function readJsonFile(path) {
   }
 }
 
+function delayMs(durationMs) {
+  const millis = Math.max(0, Math.round(Number(durationMs) || 0));
+  if (millis <= 0) return Promise.resolve();
+  return new Promise((resolveDelay) => setTimeout(resolveDelay, millis));
+}
+
+function resolveStartupContextCacheTtlMs(env = process.env) {
+  const raw = Number(env.CODEX_STARTUP_CONTEXT_CACHE_TTL_MS || env.CODEX_OPEN_MEMORY_STARTUP_CACHE_TTL_MS);
+  if (!Number.isFinite(raw) || raw <= 0) return DEFAULT_STARTUP_CONTEXT_CACHE_TTL_MS;
+  return Math.max(1000, Math.trunc(raw));
+}
+
+function resolveStartupContextSingleFlightTimeoutMs(env = process.env) {
+  const raw = Number(env.CODEX_STARTUP_CONTEXT_SINGLE_FLIGHT_TIMEOUT_MS);
+  if (!Number.isFinite(raw) || raw <= 0) return DEFAULT_STARTUP_CONTEXT_SINGLE_FLIGHT_TIMEOUT_MS;
+  return Math.max(1000, Math.trunc(raw));
+}
+
+function resolveStartupContextSingleFlightPollMs(env = process.env) {
+  const raw = Number(env.CODEX_STARTUP_CONTEXT_SINGLE_FLIGHT_POLL_MS);
+  if (!Number.isFinite(raw) || raw <= 0) return DEFAULT_STARTUP_CONTEXT_SINGLE_FLIGHT_POLL_MS;
+  return Math.max(10, Math.trunc(raw));
+}
+
+function startupContextCacheEnabled(env = process.env) {
+  return isEnabled(env.CODEX_STARTUP_CONTEXT_CACHE_ENABLED, true);
+}
+
+function buildStartupContextCacheKey({ threadInfo = null, payload = {}, strictStartupAllowlist = true } = {}) {
+  return stableHash(
+    JSON.stringify({
+      threadId: clean(threadInfo?.threadId),
+      rolloutPath: clean(threadInfo?.rolloutPath),
+      cwd: clean(threadInfo?.cwd),
+      query: clean(payload?.query),
+      tenantId: clean(payload?.tenantId),
+      sourceAllowlist: Array.isArray(payload?.sourceAllowlist) ? payload.sourceAllowlist.map((value) => clean(value)) : [],
+      sourceDenylist: Array.isArray(payload?.sourceDenylist) ? payload.sourceDenylist.map((value) => clean(value)) : [],
+      retrievalMode: clean(payload?.retrievalMode),
+      expandRelationships: payload?.expandRelationships !== false,
+      maxHops: Number(payload?.maxHops || 0),
+      strictStartupAllowlist: strictStartupAllowlist === true,
+    }),
+    24
+  );
+}
+
+function buildStartupContextCacheState({ threadId = "", cacheKey = "" } = {}) {
+  const paths = runtimePathsForThread(threadId);
+  return {
+    threadId: clean(threadId),
+    cacheKey: clean(cacheKey),
+    cachePath: paths.startupContextCachePath,
+    lockPath: `${paths.startupContextCachePath}.${clean(cacheKey) || "startup"}.lock`,
+  };
+}
+
+function cloneStartupContextResult(result = {}) {
+  try {
+    return JSON.parse(JSON.stringify(result));
+  } catch {
+    return { ...(result && typeof result === "object" ? result : {}) };
+  }
+}
+
+function readFreshStartupContextCache(cacheState, { env = process.env, nowMs = Date.now() } = {}) {
+  if (!startupContextCacheEnabled(env) || !cacheState?.cachePath) return null;
+  const entry = readJsonFile(cacheState.cachePath);
+  if (!entry || entry.schema !== "codex-startup-context-cache.v1") return null;
+  if (clean(entry.threadId) !== clean(cacheState.threadId)) return null;
+  if (clean(entry.cacheKey) !== clean(cacheState.cacheKey)) return null;
+  const expiresAtMs = Date.parse(clean(entry.expiresAt));
+  if (!Number.isFinite(expiresAtMs) || expiresAtMs <= nowMs) return null;
+  const savedAtMs = Date.parse(clean(entry.savedAt));
+  return {
+    entry,
+    ageMs: Number.isFinite(savedAtMs) ? Math.max(0, nowMs - savedAtMs) : 0,
+  };
+}
+
+function applyStartupContextCacheMetadata(
+  result,
+  {
+    cacheState = null,
+    cacheHit = false,
+    hitType = "",
+    ageMs = 0,
+    waitMs = 0,
+    shortCircuit = false,
+  } = {},
+  {
+    startedAt = Date.now(),
+    recomputeLatency = false,
+    env = process.env,
+  } = {},
+) {
+  const next = cloneStartupContextResult(result);
+  const baseLatencyBreakdown =
+    next.latencyBreakdown && typeof next.latencyBreakdown === "object"
+      ? next.latencyBreakdown
+      : next.diagnostics?.startupLatencyBreakdown && typeof next.diagnostics.startupLatencyBreakdown === "object"
+        ? next.diagnostics.startupLatencyBreakdown
+        : {};
+  const resolvedLatencyMs = recomputeLatency ? Math.max(0, Date.now() - Number(startedAt || Date.now())) : next.latencyMs;
+  if (recomputeLatency) {
+    next.latencyMs = resolvedLatencyMs;
+    next.startupLatency = evaluateStartupLatency(resolvedLatencyMs);
+  }
+  const startupCache = {
+    enabled: startupContextCacheEnabled(env),
+    cacheHit,
+    hitType: clean(hitType),
+    cacheKey: clean(cacheState?.cacheKey),
+    cachePath: clean(cacheState?.cachePath),
+    cacheAgeMs: Math.max(0, Math.round(Number(ageMs) || 0)),
+    cacheWaitMs: Math.max(0, Math.round(Number(waitMs) || 0)),
+    shortCircuitLocal: shortCircuit === true,
+  };
+  const latencyBreakdown = sanitizeMetrics({
+    ...baseLatencyBreakdown,
+    totalMs: resolvedLatencyMs,
+    cacheAgeMs: startupCache.cacheAgeMs,
+    cacheWaitMs: startupCache.cacheWaitMs,
+    cacheHit: startupCache.cacheHit,
+    shortCircuitLocal: startupCache.shortCircuitLocal,
+  });
+  next.latencyBreakdown = latencyBreakdown;
+  next.diagnostics = {
+    ...(next.diagnostics && typeof next.diagnostics === "object" ? next.diagnostics : {}),
+    startupCache,
+    startupLatencyBreakdown: latencyBreakdown,
+  };
+  return next;
+}
+
+function writeStartupContextCache(cacheState, result, { env = process.env } = {}) {
+  if (!startupContextCacheEnabled(env) || !cacheState?.cachePath) return false;
+  mkdirSync(dirname(cacheState.cachePath), { recursive: true });
+  const now = Date.now();
+  const ttlMs = resolveStartupContextCacheTtlMs(env);
+  const payload = {
+    schema: "codex-startup-context-cache.v1",
+    savedAt: new Date(now).toISOString(),
+    expiresAt: new Date(now + ttlMs).toISOString(),
+    threadId: clean(cacheState.threadId),
+    cacheKey: clean(cacheState.cacheKey),
+    result: cloneStartupContextResult(result),
+  };
+  writeFileSync(cacheState.cachePath, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+  return true;
+}
+
+async function waitForStartupContextCache(cacheState, {
+  env = process.env,
+  timeoutMs = resolveStartupContextSingleFlightTimeoutMs(env),
+  pollMs = resolveStartupContextSingleFlightPollMs(env),
+} = {}) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt <= timeoutMs) {
+    const cached = readFreshStartupContextCache(cacheState, { env });
+    if (cached) {
+      return {
+        ...cached,
+        waitMs: Math.max(0, Date.now() - startedAt),
+      };
+    }
+    if (!existsSync(cacheState.lockPath)) break;
+    await delayMs(pollMs);
+  }
+  return null;
+}
+
+async function withStartupContextSingleFlight(
+  cacheState,
+  factory,
+  {
+    env = process.env,
+    startedAt = Date.now(),
+  } = {},
+) {
+  if (!cacheState?.threadId || !cacheState?.cacheKey || !startupContextCacheEnabled(env)) {
+    return factory();
+  }
+  const inFlightKey = `${cacheState.threadId}:${cacheState.cacheKey}`;
+  if (STARTUP_CONTEXT_INFLIGHT.has(inFlightKey)) {
+    return STARTUP_CONTEXT_INFLIGHT.get(inFlightKey);
+  }
+  const promise = (async () => {
+    const cached = readFreshStartupContextCache(cacheState, { env });
+    if (cached?.entry?.result) {
+      return applyStartupContextCacheMetadata(cached.entry.result, {
+        cacheState,
+        cacheHit: true,
+        hitType: "warm-cache",
+        ageMs: cached.ageMs,
+      }, {
+        startedAt,
+        recomputeLatency: true,
+        env,
+      });
+    }
+
+    mkdirSync(dirname(cacheState.lockPath), { recursive: true });
+    let lockFd = null;
+    try {
+      lockFd = openSync(cacheState.lockPath, "wx");
+    } catch (error) {
+      if (error?.code !== "EEXIST") throw error;
+    }
+
+    if (lockFd == null) {
+      const waited = await waitForStartupContextCache(cacheState, { env });
+      if (waited?.entry?.result) {
+        return applyStartupContextCacheMetadata(waited.entry.result, {
+          cacheState,
+          cacheHit: true,
+          hitType: "lock-wait-cache",
+          ageMs: waited.ageMs,
+          waitMs: waited.waitMs,
+        }, {
+          startedAt,
+          recomputeLatency: true,
+          env,
+        });
+      }
+    }
+
+    try {
+      const recheck = readFreshStartupContextCache(cacheState, { env });
+      if (recheck?.entry?.result) {
+        return applyStartupContextCacheMetadata(recheck.entry.result, {
+          cacheState,
+          cacheHit: true,
+          hitType: "post-lock-cache",
+          ageMs: recheck.ageMs,
+        }, {
+          startedAt,
+          recomputeLatency: true,
+          env,
+        });
+      }
+      const resolved = await factory();
+      const annotated = applyStartupContextCacheMetadata(resolved, {
+        cacheState,
+        cacheHit: false,
+      }, {
+        startedAt,
+        env,
+      });
+      writeStartupContextCache(cacheState, annotated, { env });
+      return annotated;
+    } finally {
+      if (lockFd != null) {
+        closeSync(lockFd);
+        try {
+          unlinkSync(cacheState.lockPath);
+        } catch {}
+      }
+    }
+  })();
+  STARTUP_CONTEXT_INFLIGHT.set(inFlightKey, promise);
+  promise.finally(() => {
+    if (STARTUP_CONTEXT_INFLIGHT.get(inFlightKey) === promise) {
+      STARTUP_CONTEXT_INFLIGHT.delete(inFlightKey);
+    }
+  }).catch(() => {});
+  return promise;
+}
+
 async function safeNotifyAutomationOutcome(payload) {
   try {
     return await notifyAutomationOutcome(payload);
@@ -807,6 +1457,25 @@ function resolveStartupThreadHint(env = process.env) {
 
 function resolveStartupCwd(env = process.env) {
   return clean(env.CODEX_CWD || env.INIT_CWD || env.PWD || process.cwd()) || process.cwd();
+}
+
+function resolveStartupThreadInfo(env = process.env) {
+  const cwd = resolveStartupCwd(env);
+  const hintedThreadId = resolveStartupThreadHint(env);
+  const resolvedThreadInfo = resolveCodexThreadContext({
+    threadId: hintedThreadId,
+    cwd,
+  });
+  if (resolvedThreadInfo) return resolvedThreadInfo;
+  if (!hintedThreadId && !cwd) return null;
+  return {
+    threadId: clean(hintedThreadId),
+    rolloutPath: "",
+    cwd,
+    title: "",
+    firstUserMessage: "",
+    updatedAt: "",
+  };
 }
 
 function timeoutController(timeoutMs) {
@@ -905,17 +1574,12 @@ function loadLocalStartupContext({
   strictStartupAllowlist = true,
   env = process.env,
 } = {}) {
-  const cwd = resolveStartupCwd(env);
-  const hintedThreadId = resolveStartupThreadHint(env);
-  const resolvedThreadInfo = resolveCodexThreadContext({
-    threadId: hintedThreadId,
-    cwd,
-  });
-  const resolvedThreadId = clean(resolvedThreadInfo?.threadId || hintedThreadId);
+  const resolvedThreadInfo = resolveStartupThreadInfo(env);
+  const resolvedThreadId = clean(resolvedThreadInfo?.threadId);
   if (!resolvedThreadId && !resolvedThreadInfo) {
     return {
       ok: false,
-      attempted: Boolean(hintedThreadId || cwd),
+      attempted: Boolean(resolveStartupThreadHint(env) || resolveStartupCwd(env)),
       reason: "missing-local-thread",
     };
   }
@@ -953,6 +1617,7 @@ function loadLocalStartupContext({
     startupBlocker: artifacts?.startupBlocker,
     continuityEnvelope: artifacts?.continuityEnvelope,
     handoff: artifacts?.handoff,
+    bootstrapContext: artifacts?.context,
     query,
   });
   const localContext = buildLocalBootstrapContext({
@@ -975,18 +1640,33 @@ function loadLocalStartupContext({
       artifacts?.startupBlocker?.remoteError ||
       artifacts?.startupBlocker?.blockers?.[0]?.summary
   );
+  const derivedLocalDiagnostics = deriveStartupGroundingDiagnostics({
+    rows: localContext?.items || [],
+    diagnostics: localContext?.diagnostics,
+    threadInfo,
+    continuityState: continuityDecision.continuityState,
+  });
+  const hasValidatedLocalHandoff = Boolean(
+    clean(artifacts?.handoff?.summary || artifacts?.handoff?.workCompleted || artifacts?.handoff?.activeGoal)
+  );
+  const adjustedLocalContinuityState =
+    continuityDecision.continuityState === "ready" &&
+    !hasValidatedLocalHandoff &&
+    derivedLocalDiagnostics.compactionDominated === true
+      ? "continuity_degraded"
+      : continuityDecision.continuityState;
   const reasonCode =
-    continuityDecision.continuityState === "ready"
+    adjustedLocalContinuityState === "ready" || adjustedLocalContinuityState === "continuity_degraded"
       ? STARTUP_REASON_CODES.OK
-      : continuityDecision.continuityState === "blocked"
+      : adjustedLocalContinuityState === "blocked"
         ? STARTUP_REASON_CODES.STARTUP_UNAVAILABLE
         : STARTUP_REASON_CODES.EMPTY_CONTEXT;
 
   return {
     ok: itemCount > 0,
     attempted: true,
-    reason: continuityDecision.continuityState === "blocked" ? "local-startup-blocker" : "",
-    error: continuityDecision.continuityState === "blocked" ? blockerSummary : "",
+    reason: adjustedLocalContinuityState === "blocked" ? "local-startup-blocker" : "",
+    error: adjustedLocalContinuityState === "blocked" ? blockerSummary : "",
     status: 200,
     itemCount,
     contextSummary: clean(localContext?.summary).slice(0, 400),
@@ -994,16 +1674,19 @@ function loadLocalStartupContext({
     contextRows: localContext?.items || [],
     fallbackSources: listSourcesFromRows(localContext?.items || []),
     diagnostics: {
-      ...(localContext?.diagnostics && typeof localContext.diagnostics === "object" ? localContext.diagnostics : {}),
+      ...derivedLocalDiagnostics,
       startupSourceBias: "local-fallback",
       strictStartupAllowlist,
       fallbackUsed: true,
       fallbackStrategy: localFallbackStrategy,
       selectedRows: localContext?.items || [],
       localThreadId: clean(threadInfo.threadId),
-      localContinuityState: continuityDecision.continuityState,
-      localContinuitySource: continuityDecision.source,
-      localContinuityValidated: continuityDecision.continuityState === "ready",
+      localContinuityState: adjustedLocalContinuityState,
+      localContinuitySource:
+        adjustedLocalContinuityState !== continuityDecision.continuityState
+          ? "local-artifact-quality"
+          : continuityDecision.source,
+      localContinuityValidated: adjustedLocalContinuityState === "ready",
       localContinuityBlocked: continuityDecision.blockerActive,
       localContinuitySummary: clean(continuityDecision.supplementalHandoffSummary),
       bootstrapArtifactPaths: {
@@ -1013,6 +1696,27 @@ function loadLocalStartupContext({
       },
     },
   };
+}
+
+function hasTrustedLocalStartupContext(localFallback, localFallbackDiagnostics) {
+  if (!localFallback?.ok) return false;
+  const mergedDiagnostics = {
+    ...(localFallback.diagnostics && typeof localFallback.diagnostics === "object" ? localFallback.diagnostics : {}),
+    ...(localFallbackDiagnostics && typeof localFallbackDiagnostics === "object" ? localFallbackDiagnostics : {}),
+  };
+  const continuityState = clean(
+    mergedDiagnostics.localContinuityState || mergedDiagnostics.continuityState || ""
+  ).toLowerCase();
+  const groundingAuthority = deriveStartupGroundingAuthority({
+    diagnostics: mergedDiagnostics,
+    continuityState: continuityState || "ready",
+  });
+  return (
+    continuityState === "ready" &&
+    isTrustedStartupGroundingAuthority(groundingAuthority) &&
+    Math.max(0, Number(mergedDiagnostics.threadScopedItemCount || 0)) > 0 &&
+    mergedDiagnostics.compactionDominated !== true
+  );
 }
 
 function captureViaCli({ payload, env = process.env } = {}) {
@@ -1125,6 +1829,65 @@ function listSourcesFromRows(rows, maxItems = 8) {
     if (output.length >= maxItems) break;
   }
   return output;
+}
+
+function isGenericAdvisoryOnlyBlocker(value) {
+  const normalized = clean(value).toLowerCase();
+  if (!normalized) return false;
+  return (
+    normalized.startsWith("using fallback strategy:") ||
+    normalized.startsWith("startup continuity loaded via fallback retrieval") ||
+    normalized === "dream consolidation artifact is missing." ||
+    normalized.startsWith("dreamactionability=")
+  );
+}
+
+function pickTrustedTopBlocker(blockers = []) {
+  const normalizedBlockers = Array.isArray(blockers) ? blockers.map((value) => clean(value)).filter(Boolean) : [];
+  return normalizedBlockers.find((value) => !isGenericAdvisoryOnlyBlocker(value)) || "";
+}
+
+export function buildStartupContextPack({
+  brief = {},
+  diagnostics = {},
+  continuityState = "missing",
+  reasonCode = STARTUP_REASON_CODES.STARTUP_UNAVAILABLE,
+  groundingAuthority = "",
+} = {}) {
+  const authority = groundingAuthority || deriveStartupGroundingAuthority({ diagnostics, continuityState });
+  const publishTrustedGrounding =
+    clean(continuityState).toLowerCase() === "ready" &&
+    isTrustedStartupGroundingAuthority(authority);
+  const advisoryGoal = clean(brief?.goal);
+  const advisoryBlocker = clean(brief?.blockers?.[0]);
+  const advisoryNextRecommendedAction = clean(brief?.recommendedNextActions?.[0]);
+  const trustedTopBlocker = pickTrustedTopBlocker(brief?.blockers);
+
+  return {
+    dominantGoal: publishTrustedGrounding ? advisoryGoal : "",
+    topBlocker: publishTrustedGrounding ? trustedTopBlocker : "",
+    nextRecommendedAction: publishTrustedGrounding ? advisoryNextRecommendedAction : "",
+    groundingAuthority: authority,
+    grounding: publishTrustedGrounding
+      ? {
+          dominantGoal: advisoryGoal,
+          topBlocker: trustedTopBlocker,
+          nextRecommendedAction: advisoryNextRecommendedAction,
+        }
+      : {},
+    advisory:
+      publishTrustedGrounding
+        ? {}
+        : {
+            dominantGoal: advisoryGoal,
+            topBlocker: advisoryBlocker,
+            nextRecommendedAction: advisoryNextRecommendedAction,
+          },
+    goalAuthority: publishTrustedGrounding && advisoryGoal ? authority : "",
+    blockerAuthority: publishTrustedGrounding && trustedTopBlocker ? authority : "",
+    publishTrustedGrounding,
+    fallbackOnly: clean(continuityState).toLowerCase() !== "ready" && reasonCode === STARTUP_REASON_CODES.OK,
+  };
 }
 
 export function buildMemoryBrief({
@@ -1299,14 +2062,21 @@ function finalizeStartupContextResult(
     contextRows = [],
     diagnostics = {},
     fallbackSources = [],
+    threadInfo = null,
+    latencyBreakdown = {},
   } = {},
 ) {
   const latencyMs = Math.max(0, Date.now() - Number(startedAt || Date.now()));
   const startupLatency = evaluateStartupLatency(latencyMs);
-  const mergedDiagnostics = {
-    ...(diagnostics && typeof diagnostics === "object" ? diagnostics : {}),
-    ...(result?.diagnostics && typeof result.diagnostics === "object" ? result.diagnostics : {}),
-  };
+  const mergedDiagnostics = deriveStartupGroundingDiagnostics({
+    rows: contextRows,
+    diagnostics: {
+      ...(diagnostics && typeof diagnostics === "object" ? diagnostics : {}),
+      ...(result?.diagnostics && typeof result.diagnostics === "object" ? result.diagnostics : {}),
+    },
+    threadInfo,
+    continuityState: result?.continuityState,
+  });
   const sourceFallbacks = Array.from(
     new Set(
       [...fallbackSources, ...listSourcesFromRows(contextRows), ...listSourcesFromRows(mergedDiagnostics?.selectedRows || [])].filter(Boolean),
@@ -1333,7 +2103,7 @@ function finalizeStartupContextResult(
   const localContinuityValidated = mergedDiagnostics?.localContinuityValidated === true;
   const localContinuityBlocked =
     mergedDiagnostics?.localContinuityBlocked === true || explicitContinuityState === "blocked";
-  const continuityState =
+  let continuityState =
     explicitContinuityState === "ready" && localContinuityValidated
       ? "ready"
       : reasonCode === STARTUP_REASON_CODES.OK
@@ -1345,6 +2115,17 @@ function finalizeStartupContextResult(
           : explicitContinuityState === "missing" || reasonCode === STARTUP_REASON_CODES.EMPTY_CONTEXT
             ? "missing"
             : "continuity_degraded";
+  let groundingAuthority = deriveStartupGroundingAuthority({
+    diagnostics: mergedDiagnostics,
+    continuityState,
+  });
+  if (continuityState === "ready" && !isTrustedStartupGroundingAuthority(groundingAuthority)) {
+    continuityState = "continuity_degraded";
+    groundingAuthority = deriveStartupGroundingAuthority({
+      diagnostics: mergedDiagnostics,
+      continuityState,
+    });
+  }
   const brief = buildMemoryBrief({
     generatedAt: new Date().toISOString(),
     continuityState,
@@ -1357,6 +2138,23 @@ function finalizeStartupContextResult(
     error: result?.error || result?.reason || "",
   });
   const memoryBriefPath = writeMemoryBriefArtifact(brief);
+  const startupContextPack = {
+    ...buildStartupContextPack({
+      brief,
+      diagnostics: mergedDiagnostics,
+      continuityState,
+      reasonCode,
+      groundingAuthority,
+    }),
+    laneSourceQuality: clean(
+      mergedDiagnostics?.laneSourceQuality || mergedDiagnostics?.startupSourceQuality || mergedDiagnostics?.groundingQuality
+    ),
+    threadScoped: Math.max(0, Math.round(Number(mergedDiagnostics?.threadScopedItemCount || 0))) > 0,
+  };
+  const detailedLatencyBreakdown = sanitizeMetrics({
+    ...(latencyBreakdown && typeof latencyBreakdown === "object" ? latencyBreakdown : {}),
+    totalMs: latencyMs,
+  });
 
   return {
     ...result,
@@ -1364,8 +2162,19 @@ function finalizeStartupContextResult(
     continuityState,
     latencyMs,
     startupLatency,
+    latencyBreakdown: detailedLatencyBreakdown,
     tokenFreshness,
     fallbackSources: sourceFallbacks,
+    dominantGoal: startupContextPack.dominantGoal,
+    topBlocker: startupContextPack.topBlocker,
+    nextRecommendedAction: startupContextPack.nextRecommendedAction,
+    groundingAuthority: startupContextPack.groundingAuthority,
+    grounding: startupContextPack.grounding,
+    advisory: startupContextPack.advisory,
+    goalAuthority: startupContextPack.goalAuthority,
+    blockerAuthority: startupContextPack.blockerAuthority,
+    laneSourceQuality: startupContextPack.laneSourceQuality,
+    fallbackOnly: startupContextPack.fallbackOnly,
     diagnostics: {
       ...mergedDiagnostics,
       continuityState,
@@ -1373,6 +2182,9 @@ function finalizeStartupContextResult(
       continuityReason: clean(result?.error || result?.reason || ""),
       memoryLayerModel: "core-blocks|working-memory|episodic-memory|canonical-memory",
       fallbackSources: sourceFallbacks,
+      startupLatencyBreakdown: detailedLatencyBreakdown,
+      ...startupContextPack,
+      contextPack: startupContextPack,
     },
     memoryBrief: brief,
     memoryBriefPath,
@@ -1391,7 +2203,14 @@ export async function loadAutomationStartupMemoryContext({
   env = process.env,
 } = {}) {
   const startedAt = Date.now();
+  const latencyBreakdown = {};
+  const recordStage = (key, stageStartedAt) => {
+    latencyBreakdown[key] = Math.max(0, Date.now() - Number(stageStartedAt || Date.now()));
+  };
+  const startupThreadInfo = resolveStartupThreadInfo(env);
+  const authStartedAt = Date.now();
   const authState = await ensureAutomationAuth(env);
+  recordStage("authMs", authStartedAt);
   const tokenFreshness = authState?.tokenFreshness || inspectTokenFreshness(resolveStudioBrainAuthToken(env));
   const strictStartupAllowlist = isEnabled(env.CODEX_OPEN_MEMORY_STRICT_STARTUP_ALLOWLIST, true);
   const payload = {
@@ -1425,102 +2244,56 @@ export async function loadAutomationStartupMemoryContext({
     layerAllowlist: [],
     layerDenylist: [],
   };
-  const localFallback = loadLocalStartupContext({
+  const cacheState = buildStartupContextCacheState({
+    threadId: clean(startupThreadInfo?.threadId),
+    cacheKey: buildStartupContextCacheKey({
+      threadInfo: startupThreadInfo,
+      payload,
+      strictStartupAllowlist,
+    }),
+  });
+  const finalizeResolvedStartup = (
+    result,
+    {
+      contextRows = [],
+      diagnostics = {},
+      fallbackSources = [],
+    } = {},
+  ) =>
+    finalizeStartupContextResult(result, {
+      startedAt,
+      tokenFreshness,
+      query: payload.query,
+      contextRows,
+      diagnostics: {
+        ...(diagnostics && typeof diagnostics === "object" ? diagnostics : {}),
+        startupLatencyBreakdown: sanitizeMetrics(latencyBreakdown),
+      },
+      fallbackSources,
+      threadInfo: startupThreadInfo,
+      latencyBreakdown,
+    });
+
+  const localFallbackStartedAt = Date.now();
+  let localFallback = loadLocalStartupContext({
     query: payload.query,
     maxItems: payload.maxItems,
     maxChars: payload.maxChars,
     strictStartupAllowlist,
     env,
   });
-
-  const client = buildClient({ env, capability: "context" });
-  if (!client.ready) {
-    if (localFallback.ok) {
-      return finalizeStartupContextResult({
-        attempted: true,
-        ok: true,
-        reason: localFallback.reason,
-        error: localFallback.error,
-        status: localFallback.status,
-        itemCount: localFallback.itemCount,
-        contextSummary: localFallback.contextSummary,
-        reasonCode: localFallback.reasonCode,
+  recordStage("localFallbackMs", localFallbackStartedAt);
+  let localFallbackDiagnostics = localFallback.ok
+    ? deriveStartupGroundingDiagnostics({
+        rows: localFallback.contextRows,
         diagnostics: localFallback.diagnostics,
-      }, {
-        startedAt,
-        tokenFreshness,
-        query: payload.query,
-        contextRows: localFallback.contextRows,
-        diagnostics: localFallback.diagnostics,
-        fallbackSources: localFallback.fallbackSources,
-      });
-    }
-    const allowCliFallback = isEnabled(env.CODEX_OPEN_MEMORY_CLI_FALLBACK, true);
-    if (client.reason === "missing-auth-token" && allowCliFallback) {
-      const cliResponse = loadContextViaCli({ payload, strictStartupAllowlist, env });
-      if (cliResponse.ok) {
-        const { items, summary, diagnostics } = extractContextEnvelope(cliResponse.payload);
-        return finalizeStartupContextResult({
-          attempted: true,
-          ok: true,
-          reason: "",
-          error: "",
-          status: 200,
-          itemCount: Array.isArray(items) ? items.length : 0,
-          contextSummary: clean(summary).slice(0, 400),
-          diagnostics: {
-            ...(diagnostics && typeof diagnostics === "object" ? diagnostics : {}),
-            startupSourceBias: "preferred-startup-sources",
-            strictStartupAllowlist,
-            fallbackUsed: true,
-            fallbackStrategy: "open-memory-cli",
-          },
-        }, {
-          startedAt,
-          tokenFreshness,
-          query: payload.query,
-          contextRows: items,
-          diagnostics,
-          fallbackSources: ["open-memory-cli"],
-        });
-      }
-      return finalizeStartupContextResult({
-        attempted: true,
-        ok: false,
-        reason: "context-cli-fallback-failed",
-        error: cliResponse.error || "open-memory CLI fallback failed",
-        status: 0,
-        itemCount: 0,
-        contextSummary: "",
-      }, {
-        startedAt,
-        tokenFreshness,
-        query: payload.query,
-        fallbackSources: ["open-memory-cli"],
-      });
-    }
-    return finalizeStartupContextResult({
-      attempted: false,
-      ok: false,
-      reason: client.reason,
-      itemCount: 0,
-      contextSummary: "",
-    }, {
-      startedAt,
-      tokenFreshness,
-      query: payload.query,
-    });
-  }
-
-  const initialStage = await requestStartupContextStage({
-    client,
-    payload,
-    strictStartupAllowlist,
-    startupStage: "scoped",
-  });
-  if (!initialStage.ok) {
-    if (localFallback.ok) {
-      return finalizeStartupContextResult({
+        threadInfo: startupThreadInfo,
+        continuityState: clean(localFallback.diagnostics?.continuityState),
+      })
+    : null;
+  if (hasTrustedLocalStartupContext(localFallback, localFallbackDiagnostics)) {
+    return applyStartupContextCacheMetadata(
+      finalizeResolvedStartup({
         attempted: true,
         ok: true,
         reason: localFallback.reason,
@@ -1531,124 +2304,365 @@ export async function loadAutomationStartupMemoryContext({
         reasonCode: localFallback.reasonCode,
         diagnostics: {
           ...localFallback.diagnostics,
-          remoteFailure: clean(initialStage.response.error),
-          remoteStatus: Number(initialStage.response.status || 0),
+          startupContextStage: "local-validated-short-circuit",
+          fallbackUsed: true,
+          fallbackStrategy: clean(localFallback.diagnostics?.fallbackStrategy || "local-bootstrap-artifacts"),
         },
       }, {
-        startedAt,
-        tokenFreshness,
-        query: payload.query,
         contextRows: localFallback.contextRows,
         diagnostics: localFallback.diagnostics,
         fallbackSources: localFallback.fallbackSources,
+      }),
+      {
+        cacheState,
+        cacheHit: false,
+        shortCircuit: true,
+      },
+      {
+        startedAt,
+        env,
+      }
+    );
+  }
+
+  return withStartupContextSingleFlight(cacheState, async () => {
+    const client = buildClient({ env, capability: "context" });
+    if (!client.ready) {
+      if (localFallback.ok) {
+        return finalizeResolvedStartup({
+          attempted: true,
+          ok: true,
+          reason: localFallback.reason,
+          error: localFallback.error,
+          status: localFallback.status,
+          itemCount: localFallback.itemCount,
+          contextSummary: localFallback.contextSummary,
+          reasonCode: localFallback.reasonCode,
+          diagnostics: {
+            ...localFallback.diagnostics,
+            startupContextStage: "local-continuity-fallback",
+            fallbackUsed: true,
+            fallbackStrategy: clean(localFallback.diagnostics?.fallbackStrategy || "local-bootstrap-artifacts"),
+          },
+        }, {
+          contextRows: localFallback.contextRows,
+          diagnostics: localFallback.diagnostics,
+          fallbackSources: localFallback.fallbackSources,
+        });
+      }
+      const allowCliFallback = isEnabled(env.CODEX_OPEN_MEMORY_CLI_FALLBACK, true);
+      if (client.reason === "missing-auth-token" && allowCliFallback) {
+        const cliFallbackStartedAt = Date.now();
+        const cliResponse = loadContextViaCli({ payload, strictStartupAllowlist, env });
+        recordStage("cliFallbackMs", cliFallbackStartedAt);
+        if (cliResponse.ok) {
+          const { items, summary, diagnostics } = extractContextEnvelope(cliResponse.payload);
+          return finalizeResolvedStartup({
+            attempted: true,
+            ok: true,
+            reason: "",
+            error: "",
+            status: 200,
+            itemCount: Array.isArray(items) ? items.length : 0,
+            contextSummary: clean(summary).slice(0, 400),
+            diagnostics: {
+              ...(diagnostics && typeof diagnostics === "object" ? diagnostics : {}),
+              startupSourceBias: "preferred-startup-sources",
+              strictStartupAllowlist,
+              fallbackUsed: true,
+              fallbackStrategy: "open-memory-cli",
+              startupContextStage: "cli-fallback",
+            },
+          }, {
+            contextRows: items,
+            diagnostics,
+            fallbackSources: ["open-memory-cli"],
+          });
+        }
+        return finalizeResolvedStartup({
+          attempted: true,
+          ok: false,
+          reason: "context-cli-fallback-failed",
+          error: cliResponse.error || "open-memory CLI fallback failed",
+          status: 0,
+          itemCount: 0,
+          contextSummary: "",
+        }, {
+          fallbackSources: ["open-memory-cli"],
+        });
+      }
+      return finalizeResolvedStartup({
+        attempted: false,
+        ok: false,
+        reason: client.reason,
+        itemCount: 0,
+        contextSummary: "",
       });
     }
-    return finalizeStartupContextResult({
-      attempted: true,
-      ok: false,
-      reason: "context-request-failed",
-      error: initialStage.response.error,
-      status: initialStage.response.status,
-      itemCount: 0,
-      contextSummary: "",
-    }, {
-      startedAt,
-      tokenFreshness,
-      query: payload.query,
-    });
-  }
 
-  let activeStage = initialStage;
-  const needsTenantContinuityStage =
-    !initialStage.hasSelectedItems || !initialStage.selectedSummary || !initialStage.hasNonCoreSelected;
-  if (needsTenantContinuityStage) {
-    const tenantContinuityStage = await requestStartupContextStage({
+    const scopedStageStartedAt = Date.now();
+    const initialStage = await requestStartupContextStage({
       client,
-      payload: {
-        ...payload,
-        agentId: undefined,
-        runId: undefined,
-        includeTenantFallback: true,
-        layerAllowlist: [],
-        layerDenylist: ["working"],
-      },
+      payload,
       strictStartupAllowlist,
-      startupStage: "tenant-continuity",
+      startupStage: "scoped",
+      threadInfo: startupThreadInfo,
     });
-    if (
-      tenantContinuityStage.ok &&
-      (
-        tenantContinuityStage.hasNonCoreSelected
-        || tenantContinuityStage.hasSelectedItems
-        || Boolean(tenantContinuityStage.selectedSummary)
-      )
-    ) {
-      activeStage = tenantContinuityStage;
+    recordStage("remoteScopedMs", scopedStageStartedAt);
+    if (!initialStage.ok) {
+      if (localFallback.ok) {
+        return finalizeResolvedStartup({
+          attempted: true,
+          ok: true,
+          reason: localFallback.reason,
+          error: localFallback.error,
+          status: localFallback.status,
+          itemCount: localFallback.itemCount,
+          contextSummary: localFallback.contextSummary,
+          reasonCode: localFallback.reasonCode,
+          diagnostics: {
+            ...localFallback.diagnostics,
+            remoteFailure: clean(initialStage.response.error),
+            remoteStatus: Number(initialStage.response.status || 0),
+            startupContextStage: "local-continuity-fallback",
+            fallbackUsed: true,
+            fallbackStrategy: clean(localFallback.diagnostics?.fallbackStrategy || "local-bootstrap-artifacts"),
+          },
+        }, {
+          contextRows: localFallback.contextRows,
+          diagnostics: localFallback.diagnostics,
+          fallbackSources: localFallback.fallbackSources,
+        });
+      }
+      return finalizeResolvedStartup({
+        attempted: true,
+        ok: false,
+        reason: "context-request-failed",
+        error: initialStage.response.error,
+        status: initialStage.response.status,
+        itemCount: 0,
+        contextSummary: "",
+      });
     }
-  }
 
-  const selectedItems = activeStage.selectedItems;
-  const selectedSummary = activeStage.selectedSummary;
-  let fallback = null;
-  if (selectedItems.length === 0 || !selectedSummary) {
-    fallback = await fallbackSearchContext({
-      client,
-      tenantId: payload.tenantId,
-      agentId: payload.agentId,
-      runId: payload.runId,
-      query: payload.query,
-      sourceAllowlist: payload.sourceAllowlist,
-      sourceDenylist: payload.sourceDenylist,
-      retrievalMode: payload.retrievalMode,
-      strictStartupAllowlist,
+    let activeStage = initialStage;
+    const needsTenantContinuityStage =
+      !initialStage.hasSelectedItems ||
+      !initialStage.selectedSummary ||
+      !initialStage.hasNonCoreSelected ||
+      initialStage.compactionDominated === true;
+    if (needsTenantContinuityStage) {
+      const tenantStageStartedAt = Date.now();
+      const tenantContinuityStage = await requestStartupContextStage({
+        client,
+        payload: {
+          ...payload,
+          agentId: undefined,
+          runId: undefined,
+          includeTenantFallback: true,
+          layerAllowlist: [],
+          layerDenylist: ["working"],
+        },
+        strictStartupAllowlist,
+        startupStage: "tenant-continuity",
+        threadInfo: startupThreadInfo,
+      });
+      recordStage("tenantContinuityMs", tenantStageStartedAt);
+      const tenantImprovesContinuity =
+        tenantContinuityStage.compactionDominated === false &&
+        (activeStage.compactionDominated === true || !activeStage.hasSelectedItems || !activeStage.selectedSummary);
+      if (
+        tenantContinuityStage.ok &&
+        (
+          tenantContinuityStage.hasNonCoreSelected ||
+          tenantContinuityStage.hasSelectedItems ||
+          Boolean(tenantContinuityStage.selectedSummary)
+        )
+      ) {
+        activeStage = tenantImprovesContinuity ? tenantContinuityStage : activeStage;
+        if (!tenantImprovesContinuity && (!activeStage.hasSelectedItems || !activeStage.selectedSummary)) {
+          activeStage = tenantContinuityStage;
+        }
+      }
+    }
+
+    const selectedItems = activeStage.selectedItems;
+    const selectedSummary = activeStage.selectedSummary;
+    const selectedDiagnostics = deriveStartupGroundingDiagnostics({
+      rows: selectedItems.length > 0 ? selectedItems : activeStage.items || [],
+      diagnostics: activeStage.diagnostics,
+      threadInfo: startupThreadInfo,
+      continuityState: clean(activeStage.diagnostics?.continuityState),
     });
-  }
-  const useLocalFallback =
-    !fallback?.ok &&
-    localFallback.ok &&
-    (selectedItems.length === 0 || !selectedSummary);
-  const finalRows = useLocalFallback
-    ? localFallback.contextRows
-    : selectedItems.length > 0
-      ? selectedItems
-      : fallback?.rows || [];
-  const finalSummary = useLocalFallback
-    ? localFallback.contextSummary
-    : selectedSummary || summarizeSearchRows(fallback?.rows || [], 400);
-  const finalItemCount = Array.isArray(finalRows) ? finalRows.length : 0;
-  return finalizeStartupContextResult({
-    attempted: true,
-    ok: true,
-    reason: "",
-    error: useLocalFallback ? localFallback.error : "",
-    status: activeStage.response.status,
-    itemCount: finalItemCount,
-    contextSummary: finalSummary.slice(0, 400),
-    reasonCode: useLocalFallback ? localFallback.reasonCode : "",
-    diagnostics: {
-      ...activeStage.diagnostics,
-      ...(useLocalFallback ? localFallback.diagnostics : {}),
-      startupSourceBias: "preferred-startup-sources",
-      strictStartupAllowlist,
-      startupContextStage: useLocalFallback
-        ? "local-continuity-fallback"
-        : fallback?.ok
-          ? "search-fallback"
-          : activeStage.startupStage,
-      fallbackUsed: Boolean(fallback?.ok || useLocalFallback),
-      fallbackStrategy: useLocalFallback ? localFallback.diagnostics?.fallbackStrategy : fallback?.strategy || null,
-    },
+    let fallback = null;
+    if (selectedItems.length === 0 || !selectedSummary || activeStage.compactionDominated === true) {
+      const fallbackStartedAt = Date.now();
+      fallback = await fallbackSearchContext({
+        client,
+        tenantId: payload.tenantId,
+        agentId: payload.agentId,
+        runId: payload.runId,
+        query: payload.query,
+        sourceAllowlist: payload.sourceAllowlist,
+        sourceDenylist: payload.sourceDenylist,
+        retrievalMode: payload.retrievalMode,
+        strictStartupAllowlist,
+        threadInfo: startupThreadInfo,
+      });
+      recordStage("fallbackSearchMs", fallbackStartedAt);
+    }
+    const repairStartedAt = Date.now();
+    const localArtifactRepair = !localFallback.ok || !localFallbackDiagnostics?.threadScopedItemCount
+      ? repairLocalStartupArtifactsFromRows(
+          selectedItems.length > 0 ? selectedItems : fallback?.rows || activeStage.items || [],
+          {
+            threadInfo: startupThreadInfo,
+          }
+        )
+      : { repaired: false, reason: "existing-local-fallback-ready" };
+    recordStage("localArtifactRepairMs", repairStartedAt);
+    if (localArtifactRepair.repaired) {
+      const localReloadStartedAt = Date.now();
+      localFallback = loadLocalStartupContext({
+        query: payload.query,
+        maxItems: payload.maxItems,
+        maxChars: payload.maxChars,
+        strictStartupAllowlist,
+        env,
+      });
+      recordStage("localReloadMs", localReloadStartedAt);
+      localFallbackDiagnostics = localFallback.ok
+        ? deriveStartupGroundingDiagnostics({
+            rows: localFallback.contextRows,
+            diagnostics: localFallback.diagnostics,
+            threadInfo: startupThreadInfo,
+            continuityState: clean(localFallback.diagnostics?.continuityState),
+          })
+        : null;
+      if (hasTrustedLocalStartupContext(localFallback, localFallbackDiagnostics)) {
+        return finalizeResolvedStartup({
+          attempted: true,
+          ok: true,
+          reason: localFallback.reason,
+          error: localFallback.error,
+          status: localFallback.status,
+          itemCount: localFallback.itemCount,
+          contextSummary: localFallback.contextSummary,
+          reasonCode: localFallback.reasonCode,
+          diagnostics: {
+            ...localFallback.diagnostics,
+            localArtifactRepair,
+            startupContextStage: "local-repair-short-circuit",
+            fallbackUsed: true,
+            fallbackStrategy: clean(localFallback.diagnostics?.fallbackStrategy || "local-bootstrap-artifacts"),
+          },
+        }, {
+          contextRows: localFallback.contextRows,
+          diagnostics: localFallback.diagnostics,
+          fallbackSources: localFallback.fallbackSources,
+        });
+      }
+    }
+    const fallbackDiagnostics = fallback?.ok
+      ? deriveStartupGroundingDiagnostics({
+          rows: fallback.rows,
+          threadInfo: startupThreadInfo,
+          continuityState: clean(activeStage.diagnostics?.continuityState),
+        })
+      : null;
+    const shouldUseSearchFallback =
+      fallback?.ok &&
+      (
+        selectedItems.length === 0 ||
+        !selectedSummary ||
+        (activeStage.compactionDominated === true && fallbackDiagnostics?.compactionDominated === false)
+      );
+    const localFallbackImprovesContinuity =
+      localFallback.ok &&
+      (
+        selectedItems.length === 0 ||
+        !selectedSummary ||
+        (
+          Math.max(0, Number(localFallbackDiagnostics?.threadScopedItemCount || 0)) >
+            Math.max(0, Number(selectedDiagnostics?.threadScopedItemCount || 0)) &&
+          localFallbackDiagnostics?.compactionDominated !== true
+        ) ||
+        (
+          clean(localFallbackDiagnostics?.startupSourceQuality) === "thread-scoped-dominant" &&
+          clean(selectedDiagnostics?.startupSourceQuality) !== "thread-scoped-dominant"
+        ) ||
+        (shouldUseSearchFallback && fallbackDiagnostics?.compactionDominated === true && localFallbackDiagnostics?.compactionDominated === false) ||
+        (
+          activeStage.compactionDominated === true &&
+          localFallbackDiagnostics?.compactionDominated === false &&
+          Math.max(0, Number(localFallbackDiagnostics?.threadScopedItemCount || 0)) > 0
+        )
+      );
+    const useLocalFallback =
+      localFallbackImprovesContinuity ||
+      (
+        !shouldUseSearchFallback &&
+        localFallback.ok &&
+        (selectedItems.length === 0 || !selectedSummary)
+      );
+    const finalRows = useLocalFallback
+      ? localFallback.contextRows
+      : shouldUseSearchFallback
+        ? fallback.rows
+        : selectedItems.length > 0
+          ? selectedItems
+          : fallback?.rows || [];
+    const finalSummary = useLocalFallback
+      ? localFallback.contextSummary
+      : shouldUseSearchFallback
+        ? summarizeSearchRows(fallback?.rows || [], 400)
+        : selectedSummary || summarizeSearchRows(fallback?.rows || [], 400);
+    const finalItemCount = Array.isArray(finalRows) ? finalRows.length : 0;
+    return finalizeResolvedStartup({
+      attempted: true,
+      ok: true,
+      reason: "",
+      error: useLocalFallback ? localFallback.error : "",
+      status: activeStage.response.status,
+      itemCount: finalItemCount,
+      contextSummary: finalSummary.slice(0, 400),
+      reasonCode: useLocalFallback ? localFallback.reasonCode : "",
+      diagnostics: {
+        ...activeStage.diagnostics,
+        ...(useLocalFallback ? localFallback.diagnostics : {}),
+        startupSourceBias: "preferred-startup-sources",
+        strictStartupAllowlist,
+        ...(localArtifactRepair.repaired
+          ? {
+              localArtifactRepair,
+            }
+          : {}),
+        startupContextStage: useLocalFallback
+          ? "local-continuity-fallback"
+          : shouldUseSearchFallback
+            ? selectedItems.length > 0
+              ? "search-continuity-upgrade"
+              : "search-fallback"
+            : activeStage.startupStage,
+        fallbackUsed: Boolean(shouldUseSearchFallback || useLocalFallback),
+        fallbackStrategy: useLocalFallback
+          ? localFallback.diagnostics?.fallbackStrategy
+          : shouldUseSearchFallback
+            ? fallback?.strategy || null
+            : null,
+      },
+    }, {
+      contextRows: finalRows,
+      diagnostics: activeStage.diagnostics,
+      fallbackSources: useLocalFallback
+        ? localFallback.fallbackSources
+        : shouldUseSearchFallback
+          ? listSourcesFromRows(fallback.rows)
+          : [],
+    });
   }, {
+    env,
     startedAt,
-    tokenFreshness,
-    query: payload.query,
-    contextRows: finalRows,
-    diagnostics: activeStage.diagnostics,
-    fallbackSources: useLocalFallback
-      ? localFallback.fallbackSources
-      : fallback?.ok
-        ? listSourcesFromRows(fallback.rows)
-        : [],
   });
 }
 

--- a/scripts/codex/open-memory-automation.test.mjs
+++ b/scripts/codex/open-memory-automation.test.mjs
@@ -23,7 +23,7 @@ function cleanupThreadRuntime(threadId) {
   return paths;
 }
 
-const TEST_FRESH_TOKEN = "eyJhbGciOiJub25lIn0.eyJleHAiOjQxMDI0NDQ4MDB9.";
+const TEST_FRESH_TOKEN = "test~header.eyJleHAiOjQxMDI0NDQ4MDB9.test~signature";
 
 test("buildStartupContextPack keeps cross-thread fallback guidance in advisory fields only", () => {
   const pack = buildStartupContextPack({

--- a/scripts/codex/open-memory-automation.test.mjs
+++ b/scripts/codex/open-memory-automation.test.mjs
@@ -1,6 +1,79 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { buildMemoryBrief } from "./open-memory-automation.mjs";
+import { rmSync } from "node:fs";
+import {
+  buildMemoryBrief,
+  buildStartupContextPack,
+  buildStartupArtifactRepair,
+  deriveStartupGroundingDiagnostics,
+  loadAutomationStartupMemoryContext,
+  selectStartupArtifactRepairCandidate,
+  selectStartupRows,
+} from "./open-memory-automation.mjs";
+import {
+  refreshLocalBootstrapArtifacts,
+  runtimePathsForThread,
+  writeContinuityEnvelope,
+  writeHandoffArtifact,
+} from "../lib/codex-session-memory-utils.mjs";
+
+function cleanupThreadRuntime(threadId) {
+  const paths = runtimePathsForThread(threadId);
+  rmSync(paths.runtimeDir, { recursive: true, force: true });
+  return paths;
+}
+
+const TEST_FRESH_TOKEN = "eyJhbGciOiJub25lIn0.eyJleHAiOjQxMDI0NDQ4MDB9.";
+
+test("buildStartupContextPack keeps cross-thread fallback guidance in advisory fields only", () => {
+  const pack = buildStartupContextPack({
+    brief: {
+      goal: "Resume an unrelated startup thread.",
+      blockers: ["Dream consolidation artifact is missing."],
+      recommendedNextActions: ["Open the foreign startup thread."],
+    },
+    continuityState: "continuity_degraded",
+    reasonCode: "ok",
+    groundingAuthority: "cross-thread-fallback",
+  });
+
+  assert.equal(pack.publishTrustedGrounding, false);
+  assert.equal(pack.dominantGoal, "");
+  assert.equal(pack.topBlocker, "");
+  assert.equal(pack.nextRecommendedAction, "");
+  assert.equal(pack.goalAuthority, "");
+  assert.equal(pack.blockerAuthority, "");
+  assert.deepEqual(pack.grounding, {});
+  assert.deepEqual(pack.advisory, {
+    dominantGoal: "Resume an unrelated startup thread.",
+    topBlocker: "Dream consolidation artifact is missing.",
+    nextRecommendedAction: "Open the foreign startup thread.",
+  });
+  assert.equal(pack.fallbackOnly, true);
+});
+
+test("buildStartupContextPack filters generic consolidation blockers out of trusted grounding", () => {
+  const pack = buildStartupContextPack({
+    brief: {
+      goal: "Resume the current startup audit.",
+      blockers: [
+        "Dream consolidation artifact is missing.",
+        "Checkpoint emitter still skips local runtime artifact sync.",
+      ],
+      recommendedNextActions: ["Patch the checkpoint emitter."],
+    },
+    continuityState: "ready",
+    reasonCode: "ok",
+    groundingAuthority: "thread-scoped",
+  });
+
+  assert.equal(pack.publishTrustedGrounding, true);
+  assert.equal(pack.dominantGoal, "Resume the current startup audit.");
+  assert.equal(pack.topBlocker, "Checkpoint emitter still skips local runtime artifact sync.");
+  assert.equal(pack.nextRecommendedAction, "Patch the checkpoint emitter.");
+  assert.equal(pack.blockerAuthority, "thread-scoped");
+  assert.deepEqual(pack.advisory, {});
+});
 
 test("buildMemoryBrief filters placeholder startup lines and reports unavailable consolidation truthfully", () => {
   const brief = buildMemoryBrief({
@@ -154,4 +227,482 @@ test("buildMemoryBrief suppresses lifecycle audit rows unless they are explicitl
   assert.deepEqual(brief.recentDecisions, [
     "[codex-handoff] Resume the current goal from the last trusted handoff.",
   ]);
+});
+
+test("deriveStartupGroundingDiagnostics infers the presentation lane from thread context when rows omit it", () => {
+  const diagnostics = deriveStartupGroundingDiagnostics({
+    rows: [
+      {
+        source: "codex-handoff",
+        content: "Continue the current portal startup continuity work.",
+        metadata: {
+          startupEligible: true,
+        },
+      },
+    ],
+    threadInfo: {
+      threadId: "thread-portal-startup",
+      cwd: "D:/monsoonfire-portal",
+      title: "Audit startup hardening",
+      firstUserMessage: "what was I doing in monsoonfire portal",
+    },
+    continuityState: "ready",
+  });
+
+  assert.equal(diagnostics.presentationProjectLane, "monsoonfire-portal");
+  assert.equal(diagnostics.projectLane, "monsoonfire-portal");
+  assert.equal(diagnostics.laneResolutionSource, "thread-inference");
+  assert.equal(diagnostics.threadScopedItemCount, 0);
+  assert.equal(diagnostics.groundingQuality, "lane-resolved");
+});
+
+test("deriveStartupGroundingDiagnostics prefers the repo cwd lane over broader thread text", () => {
+  const diagnostics = deriveStartupGroundingDiagnostics({
+    rows: [
+      {
+        source: "codex-compaction-promoted",
+        content: "Audit startup hardening claims for the current repo thread.",
+        metadata: {
+          threadId: "thread-portal-startup",
+          cwd: "D:/monsoonfire-portal",
+        },
+      },
+    ],
+    threadInfo: {
+      threadId: "thread-portal-startup",
+      cwd: "D:/monsoonfire-portal",
+      title: "Studio Brain startup hardening audit",
+      firstUserMessage: "audit studio brain startup hardening in the monsoonfire portal repo",
+    },
+    continuityState: "ready",
+  });
+
+  assert.equal(diagnostics.presentationProjectLane, "monsoonfire-portal");
+  assert.equal(diagnostics.laneResolutionSource, "thread-inference");
+  assert.equal(diagnostics.threadScopedItemCount, 1);
+  assert.equal(diagnostics.groundingQuality, "thread-scoped");
+});
+
+test("deriveStartupGroundingDiagnostics prefers the repo cwd lane over conflicting diagnostics", () => {
+  const diagnostics = deriveStartupGroundingDiagnostics({
+    rows: [
+      {
+        source: "codex-compaction-promoted",
+        content: "Audit startup hardening claims for the current repo thread.",
+        metadata: {
+          threadId: "thread-portal-startup",
+          cwd: "D:/monsoonfire-portal",
+        },
+      },
+    ],
+    diagnostics: {
+      presentationProjectLane: "studio-brain",
+      projectLane: "studio-brain",
+      dominantProjectLane: "studio-brain",
+    },
+    threadInfo: {
+      threadId: "thread-portal-startup",
+      cwd: "D:/monsoonfire-portal",
+      title: "Studio Brain startup hardening audit",
+      firstUserMessage: "audit studio brain startup hardening in the monsoonfire portal repo",
+    },
+    continuityState: "ready",
+  });
+
+  assert.equal(diagnostics.presentationProjectLane, "monsoonfire-portal");
+  assert.equal(diagnostics.projectLane, "monsoonfire-portal");
+  assert.equal(diagnostics.dominantProjectLane, "monsoonfire-portal");
+  assert.equal(diagnostics.laneResolutionSource, "thread-inference");
+  assert.equal(diagnostics.threadScopedItemCount, 1);
+  assert.equal(diagnostics.groundingQuality, "thread-scoped");
+});
+
+test("deriveStartupGroundingDiagnostics overrides a conflicting thread-scoped row lane with the repo cwd lane", () => {
+  const diagnostics = deriveStartupGroundingDiagnostics({
+    rows: [
+      {
+        source: "codex-compaction-promoted",
+        content: "Audit startup hardening claims for the current repo thread.",
+        metadata: {
+          threadId: "thread-portal-startup",
+          cwd: "D:/monsoonfire-portal",
+          projectLane: "studio-brain",
+        },
+      },
+    ],
+    threadInfo: {
+      threadId: "thread-portal-startup",
+      cwd: "D:/monsoonfire-portal",
+      title: "Studio Brain startup hardening audit",
+      firstUserMessage: "audit studio brain startup hardening in the monsoonfire portal repo",
+    },
+    continuityState: "ready",
+  });
+
+  assert.equal(diagnostics.presentationProjectLane, "monsoonfire-portal");
+  assert.equal(diagnostics.projectLane, "monsoonfire-portal");
+  assert.equal(diagnostics.dominantProjectLane, "monsoonfire-portal");
+  assert.equal(diagnostics.laneResolutionSource, "thread-inference-override");
+  assert.equal(diagnostics.threadScopedItemCount, 1);
+  assert.equal(diagnostics.groundingQuality, "thread-scoped");
+});
+
+test("deriveStartupGroundingDiagnostics prefers the repo cwd lane over cross-lane ranked rows", () => {
+  const diagnostics = deriveStartupGroundingDiagnostics({
+    rows: [
+      {
+        source: "codex-handoff",
+        content: "Keep working on generic Studio Brain startup history.",
+        metadata: {
+          projectLane: "studio-brain",
+        },
+      },
+    ],
+    threadInfo: {
+      threadId: "thread-portal-startup",
+      cwd: "D:/monsoonfire-portal",
+      title: "Portal startup audit",
+      firstUserMessage: "audit startup lane handling in the monsoonfire portal repo",
+    },
+    continuityState: "ready",
+  });
+
+  assert.equal(diagnostics.presentationProjectLane, "monsoonfire-portal");
+  assert.equal(diagnostics.projectLane, "monsoonfire-portal");
+  assert.equal(diagnostics.dominantProjectLane, "monsoonfire-portal");
+  assert.equal(diagnostics.laneResolutionSource, "thread-inference");
+  assert.equal(diagnostics.threadScopedItemCount, 0);
+  assert.equal(diagnostics.groundingQuality, "lane-resolved");
+});
+
+test("deriveStartupGroundingDiagnostics does not mark startup as compaction-dominant when rich thread-scoped artifacts exist", () => {
+  const diagnostics = deriveStartupGroundingDiagnostics({
+    rows: [
+      {
+        source: "codex-handoff",
+        content: "Current goal: finish startup continuity. Next action: capture a trusted handoff before broad repo reads.",
+        metadata: {
+          threadId: "thread-portal-startup",
+          cwd: "D:/monsoonfire-portal",
+          activeGoal: "Finish startup continuity.",
+          summary: "Trusted handoff for the current thread.",
+          nextRecommendedAction: "Capture a trusted handoff before broad repo reads.",
+          blockers: [{ summary: "External checkpoint emitter still skips local handoff sync." }],
+        },
+      },
+      {
+        source: "codex-continuity-envelope",
+        content: "Current goal: finish startup continuity. Trusted handoff: trusted thread summary. Next action: patch the emitter.",
+        metadata: {
+          threadId: "thread-portal-startup",
+          cwd: "D:/monsoonfire-portal",
+          currentGoal: "Finish startup continuity.",
+          lastHandoffSummary: "Trusted thread summary.",
+          nextRecommendedAction: "Patch the emitter.",
+        },
+      },
+      {
+        source: "codex-compaction-promoted",
+        content: "Earlier transcript summary for the same thread.",
+        metadata: {
+          threadId: "thread-portal-startup",
+          cwd: "D:/monsoonfire-portal",
+        },
+      },
+      {
+        source: "codex-compaction-promoted",
+        content: "Another promoted transcript summary for the same thread.",
+        metadata: {
+          threadId: "thread-portal-startup",
+          cwd: "D:/monsoonfire-portal",
+        },
+      },
+      {
+        source: "codex-compaction-raw",
+        content: "Tool output from the same thread.",
+        metadata: {
+          threadId: "thread-portal-startup",
+          cwd: "D:/monsoonfire-portal",
+        },
+      },
+    ],
+    threadInfo: {
+      threadId: "thread-portal-startup",
+      cwd: "D:/monsoonfire-portal",
+      title: "Portal startup audit",
+      firstUserMessage: "take another slice on startup continuity",
+    },
+    continuityState: "ready",
+  });
+
+  assert.equal(diagnostics.threadScopedItemCount, 5);
+  assert.equal(diagnostics.compactionDominated, false);
+  assert.equal(diagnostics.startupSourceQuality, "thread-scoped-dominant");
+  assert.equal(diagnostics.laneSourceQuality, "thread-scoped-dominant");
+});
+
+test("selectStartupRows prefers rich thread-scoped handoff rows over compaction-promoted search fallback", () => {
+  const selected = selectStartupRows(
+    [
+      {
+        id: "row-compaction",
+        source: "codex-compaction-promoted",
+        score: 0.96,
+        content: "Generic promoted summary of earlier startup work.",
+        metadata: {
+          threadId: "thread-portal-startup",
+          cwd: "D:/monsoonfire-portal",
+          projectLane: "monsoonfire-portal",
+        },
+      },
+      {
+        id: "row-handoff",
+        source: "codex-handoff",
+        score: 0.71,
+        content: "Resume the Monsoon Fire portal startup continuity pass.",
+        metadata: {
+          threadId: "thread-portal-startup",
+          cwd: "D:/monsoonfire-portal",
+          projectLane: "monsoonfire-portal",
+          startupEligible: true,
+          activeGoal: "Fix startup continuity quality.",
+          nextRecommendedAction: "Prefer handoff rows over compaction fallback.",
+          blockers: [{ summary: "Compaction-only context is dominating startup." }],
+          resumeHints: [{ summary: "Re-run preflight after the ranking patch." }],
+        },
+      },
+    ],
+    {
+      threadInfo: {
+        threadId: "thread-portal-startup",
+        cwd: "D:/monsoonfire-portal",
+        title: "Portal startup continuity",
+        firstUserMessage: "improve startup continuity quality",
+      },
+    }
+  );
+
+  assert.equal(selected[0]?.id, "row-handoff");
+  assert.equal(Number(selected[0]?.metadata?.bootstrapRankScore) > Number(selected[1]?.metadata?.bootstrapRankScore), true);
+});
+
+test("selectStartupArtifactRepairCandidate prefers a thread-scoped startup-eligible checkpoint row", () => {
+  const candidate = selectStartupArtifactRepairCandidate(
+    [
+      {
+        id: "row-cross-thread",
+        source: "codex",
+        content: "A startup-eligible checkpoint from a different thread.",
+        metadata: {
+          threadId: "thread-other",
+          cwd: "D:/monsoonfire-portal",
+          startupEligible: true,
+          summary: "Other thread checkpoint.",
+        },
+      },
+      {
+        id: "row-checkpoint",
+        source: "codex",
+        content: "Progress: finish startup continuity quality loop.",
+        metadata: {
+          threadId: "thread-portal-startup",
+          cwd: "D:/monsoonfire-portal",
+          startupEligible: true,
+          checkpointKind: "checkpoint",
+          activeGoal: "Finish startup continuity quality loop.",
+          nextRecommendedAction: "Sync a local handoff from this checkpoint row.",
+          blockers: [{ summary: "External checkpoint emitter skipped local handoff sync." }],
+        },
+      },
+    ],
+    {
+      threadInfo: {
+        threadId: "thread-portal-startup",
+        cwd: "D:/monsoonfire-portal",
+        title: "Portal startup continuity",
+        firstUserMessage: "take another slice on startup continuity",
+      },
+    }
+  );
+
+  assert.equal(candidate?.id, "row-checkpoint");
+});
+
+test("buildStartupArtifactRepair produces a ready thread-scoped handoff scaffold from a checkpoint row", () => {
+  const repair = buildStartupArtifactRepair(
+    {
+      id: "row-checkpoint",
+      source: "codex",
+      content: "Progress: finish startup continuity quality loop.",
+      createdAt: "2026-04-12T01:10:00.000Z",
+      metadata: {
+        threadId: "thread-portal-startup",
+        cwd: "D:/monsoonfire-portal",
+        startupEligible: true,
+        checkpointKind: "checkpoint",
+        activeGoal: "Finish startup continuity quality loop.",
+        summary: "Checkpoint: startup continuity hardening progressed.",
+        workCompleted: "Checkpoint: startup continuity hardening progressed.",
+        nextRecommendedAction: "Write the repaired handoff scaffold locally.",
+        blockers: [{ summary: "External checkpoint emitter skipped local handoff sync." }],
+        capturedFrom: "codex-checkpoint-cli",
+        runId: "run-startup-1",
+        agentId: "agent:codex",
+        projectLane: "monsoonfire-portal",
+      },
+    },
+    {
+      threadInfo: {
+        threadId: "thread-portal-startup",
+        cwd: "D:/monsoonfire-portal",
+        title: "Portal startup continuity",
+        firstUserMessage: "take another slice on startup continuity",
+      },
+      threadScopedItemCount: 3,
+    }
+  );
+
+  assert.equal(repair?.handoff?.threadId, "thread-portal-startup");
+  assert.equal(repair?.handoff?.summary, "Checkpoint: startup continuity hardening progressed.");
+  assert.equal(repair?.handoff?.startupProvenance?.repairedFromCapturedFrom, "codex-checkpoint-cli");
+  assert.equal(repair?.continuityEnvelope?.continuityState, "ready");
+  assert.equal(repair?.continuityEnvelope?.presentationProjectLane, "monsoonfire-portal");
+  assert.equal(repair?.continuityEnvelope?.startupSourceQuality, "thread-scoped-dominant");
+  assert.equal(repair?.continuityEnvelope?.threadScopedItemCount, 3);
+});
+
+test("loadAutomationStartupMemoryContext short-circuits on trusted local startup artifacts", async () => {
+  const threadId = "startup-local-short-circuit-test";
+  cleanupThreadRuntime(threadId);
+  const originalFetch = global.fetch;
+  let fetchCalls = 0;
+
+  try {
+    writeHandoffArtifact(threadId, {
+      summary: "Handoff: resume the current startup audit.",
+      activeGoal: "Resume the current startup audit.",
+      nextRecommendedAction: "Run startup preflight.",
+    });
+    writeContinuityEnvelope(threadId, {
+      threadId,
+      cwd: "D:/monsoonfire-portal",
+      continuityState: "ready",
+      startupSatisfiedBy: "validated-local-continuity",
+      currentGoal: "Resume the current startup audit.",
+      lastHandoffSummary: "Handoff: resume the current startup audit.",
+      nextRecommendedAction: "Run startup preflight.",
+      presentationProjectLane: "monsoonfire-portal",
+      threadScopedItemCount: 2,
+      fallbackOnly: false,
+      startupSourceQuality: "thread-scoped-dominant",
+      laneSourceQuality: "thread-scoped-dominant",
+      startup: {
+        satisfiedBy: "validated-local-continuity",
+        threadScopedItemCount: 2,
+        startupSourceQuality: "thread-scoped-dominant",
+      },
+    });
+    refreshLocalBootstrapArtifacts({
+      threadId,
+      cwd: "D:/monsoonfire-portal",
+      threadTitle: "Startup audit",
+      firstUserMessage: "resume the current startup audit",
+    });
+
+    global.fetch = async () => {
+      fetchCalls += 1;
+      throw new Error("fetch should not be called when trusted local startup artifacts are present");
+    };
+
+    const result = await loadAutomationStartupMemoryContext({
+      tool: "codex-shell",
+      query: "resume the current startup audit",
+      env: {
+        CODEX_THREAD_ID: threadId,
+        CODEX_CWD: "D:/monsoonfire-portal",
+        STUDIO_BRAIN_MCP_ID_TOKEN: TEST_FRESH_TOKEN,
+        STUDIO_BRAIN_BASE_URL: "http://127.0.0.1:8787",
+      },
+    });
+
+    assert.equal(fetchCalls, 0);
+    assert.equal(result.continuityState, "ready");
+    assert.equal(result.groundingAuthority, "validated-local");
+    assert.equal(result.diagnostics.startupContextStage, "local-validated-short-circuit");
+    assert.equal(result.diagnostics.startupCache.shortCircuitLocal, true);
+  } finally {
+    global.fetch = originalFetch;
+    cleanupThreadRuntime(threadId);
+  }
+});
+
+test("loadAutomationStartupMemoryContext reuses a fresh startup cache entry without a second remote lookup", async () => {
+  const threadId = "startup-cache-hit-test";
+  cleanupThreadRuntime(threadId);
+  const originalFetch = global.fetch;
+  let fetchCalls = 0;
+
+  try {
+    global.fetch = async () => {
+      fetchCalls += 1;
+      return {
+        ok: true,
+        status: 200,
+        text: async () =>
+          JSON.stringify({
+            context: {
+              summary: "1. [manual] Resume the startup cache test.",
+              items: [
+                {
+                  source: "manual",
+                  content: "Resume the startup cache test.",
+                  metadata: {
+                    threadId,
+                    cwd: "D:/monsoonfire-portal",
+                    projectLane: "monsoonfire-portal",
+                  },
+                },
+              ],
+              diagnostics: {
+                continuityState: "ready",
+                presentationProjectLane: "monsoonfire-portal",
+                threadScopedItemCount: 1,
+                startupSourceQuality: "thread-scoped-dominant",
+                laneSourceQuality: "thread-scoped-dominant",
+              },
+            },
+          }),
+      };
+    };
+
+    const env = {
+      CODEX_THREAD_ID: threadId,
+      CODEX_CWD: "D:/monsoonfire-portal",
+      STUDIO_BRAIN_MCP_ID_TOKEN: TEST_FRESH_TOKEN,
+      STUDIO_BRAIN_BASE_URL: "http://127.0.0.1:8787",
+      CODEX_STARTUP_CONTEXT_CACHE_TTL_MS: "60000",
+    };
+
+    const first = await loadAutomationStartupMemoryContext({
+      tool: "codex-shell",
+      query: "startup cache test",
+      env,
+    });
+    const fetchCallsAfterFirst = fetchCalls;
+    const second = await loadAutomationStartupMemoryContext({
+      tool: "codex-shell",
+      query: "startup cache test",
+      env,
+    });
+
+    assert.equal(fetchCallsAfterFirst > 0, true);
+    assert.equal(fetchCalls, fetchCallsAfterFirst);
+    assert.equal(first.diagnostics.startupCache.cacheHit, false);
+    assert.equal(second.diagnostics.startupCache.cacheHit, true);
+    assert.equal(second.diagnostics.startupCache.hitType, "warm-cache");
+    assert.equal(second.continuityState, "ready");
+  } finally {
+    global.fetch = originalFetch;
+    cleanupThreadRuntime(threadId);
+  }
 });

--- a/scripts/lib/codex-command-shape-guardrails.mjs
+++ b/scripts/lib/codex-command-shape-guardrails.mjs
@@ -1,0 +1,127 @@
+function clean(value) {
+  return String(value ?? "").trim();
+}
+
+function readFlagValues(command, flags) {
+  const escapedFlags = flags.map((flag) => flag.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("|");
+  const pattern = new RegExp(`(?:^|\\s)(?:${escapedFlags})\\s+(?:\"([^\"]*)\"|'([^']*)'|(\\S+))`, "gi");
+  const values = [];
+  let match = pattern.exec(command);
+  while (match) {
+    values.push(clean(match[1] || match[2] || match[3]));
+    match = pattern.exec(command);
+  }
+  return values.filter(Boolean);
+}
+
+function hasFlag(command, flags) {
+  return readFlagValues(command, flags).length > 0;
+}
+
+function buildFinding(id, message, suggestion) {
+  return {
+    id,
+    severity: "warn",
+    message,
+    suggestion,
+  };
+}
+
+export function recommendedWindowsCommandPatterns() {
+  return [
+    {
+      area: "ripgrep search roots",
+      safePattern: 'rg -n "startup" scripts',
+    },
+    {
+      area: "ripgrep globs",
+      safePattern: 'rg -n --glob "scripts/*.mjs" "startup" .',
+    },
+    {
+      area: "PowerShell JSON reads",
+      safePattern: "Get-Content -Raw .codex/toolcalls.ndjson | ConvertFrom-Json",
+    },
+    {
+      area: "file read",
+      safePattern: "Get-Content -Path scripts/codex-startup-preflight.mjs -TotalCount 40",
+    },
+    {
+      area: "inline ESM evaluation",
+      safePattern: 'node --input-type=module -e "import fs from \\"node:fs\\"; console.log(fs.existsSync(\\"package.json\\"))"',
+    },
+    {
+      area: "long-running process checks",
+      safePattern: "Get-Process node,pwsh -ErrorAction SilentlyContinue | Select-Object Id, ProcessName, Path",
+    },
+    {
+      area: "npm/npx execution",
+      safePattern: "npm.cmd run codex:doctor",
+    },
+  ];
+}
+
+export function auditWindowsCommandShape(command) {
+  const source = clean(command);
+  if (!source) return [];
+
+  const findings = [];
+  const addFinding = (finding) => {
+    if (!findings.some((entry) => entry.id === finding.id)) {
+      findings.push(finding);
+    }
+  };
+
+  if (/\brg(?:\.exe)?\b/i.test(source) && hasFlag(source, ["-g", "--glob"])) {
+    for (const globValue of readFlagValues(source, ["-g", "--glob"])) {
+      if (globValue.includes("\\")) {
+        addFinding(
+          buildFinding(
+            "rg-glob-backslashes",
+            "ripgrep glob filters are slash-based even on Windows, so backslashes in `-g/--glob` usually misfire.",
+            'Rewrite the glob with `/`, for example `rg -n --glob "scripts/*.mjs" "startup" .`.'
+          )
+        );
+      }
+      if ((/^[A-Za-z]:[\\/]/.test(globValue) || /^\.{0,2}[\\/]/.test(globValue)) && !/[*?[{\]]/.test(globValue)) {
+        addFinding(
+          buildFinding(
+            "rg-glob-path-like",
+            "This `-g/--glob` value looks like a filesystem path, not a glob filter.",
+            'Pass the search root as a trailing path argument, for example `rg -n "startup" scripts`, and reserve `--glob` for include/exclude patterns.'
+          )
+        );
+      }
+    }
+  }
+
+  if (
+    /\bnode(?:\.exe)?\b/i.test(source) &&
+    /\s-e(?:val)?\s+/i.test(source) &&
+    /\bimport\s+[\w*{]/.test(source) &&
+    !/(?:^|\s)--input-type(?:=|\s+)module\b/i.test(source)
+  ) {
+    addFinding(
+      buildFinding(
+        "node-e-import-without-module",
+        "`node -e` with ESM `import` will fail unless module mode is enabled.",
+        'Use `node --input-type=module -e "import ..."` or move the snippet into a `.mjs` file.'
+      )
+    );
+  }
+
+  if (
+    /\b(?:Get-Content|gc)\b/i.test(source) &&
+    /\|\s*ConvertFrom-Json\b/i.test(source) &&
+    !/\b(?:Get-Content|gc)\b[^\r\n|]*\s-Raw\b/i.test(source)
+  ) {
+    addFinding(
+      buildFinding(
+        "get-content-json-without-raw",
+        "`Get-Content` without `-Raw` streams an array of lines, which commonly breaks JSON parsing and produces empty-output retries.",
+        "Use `Get-Content -Raw <path> | ConvertFrom-Json` when the target is JSON."
+      )
+    );
+  }
+
+  return findings;
+}

--- a/scripts/lib/codex-session-memory-utils.mjs
+++ b/scripts/lib/codex-session-memory-utils.mjs
@@ -191,6 +191,7 @@ export function runtimePathsForThread(threadId) {
     continuityEnvelopePath: resolve(runtimeDir, "continuity-envelope.json"),
     startupBlockerPath: resolve(runtimeDir, "startup-blocker.json"),
     handoffPath: resolve(runtimeDir, "handoff.json"),
+    startupContextCachePath: resolve(runtimeDir, "startup-context-cache.json"),
     writesJsonlPath: resolve(runtimeDir, "writes.jsonl"),
     compactionWatermarkPath: resolve(runtimeDir, "compaction-watermark.json"),
     pendingDir: resolve(runtimeDir, "pending"),
@@ -271,6 +272,7 @@ export function normalizeContinuityState(value, fallback = "missing") {
   const normalized = clean(value).toLowerCase();
   if (normalized === "ready") return "ready";
   if (normalized === "blocked") return "blocked";
+  if (normalized === "continuity_degraded") return "continuity_degraded";
   if (normalized === "missing") return "missing";
   return fallback;
 }
@@ -417,15 +419,45 @@ export function resolveBootstrapContinuityState({
   startupBlocker = null,
   continuityEnvelope = null,
   handoff = null,
+  bootstrapContext = null,
   query = "",
   nowMs = Date.now(),
 } = {}) {
   const blocker = normalizeStartupBlocker(startupBlocker);
   const envelope = normalizeContinuityEnvelope(continuityEnvelope);
   const handoffArtifact = normalizeHandoffArtifact(handoff);
+  const bootstrap = toRecord(bootstrapContext);
+  const bootstrapDiagnostics = toRecord(bootstrap.diagnostics);
   const supplementalHandoffSummary = clean(
     envelope.lastHandoffSummary || handoffArtifact.summary || handoffArtifact.workCompleted || handoffArtifact.activeGoal
   );
+  const validatedLocalHandoff = Boolean(
+    clean(handoffArtifact.summary || handoffArtifact.workCompleted || handoffArtifact.activeGoal)
+  );
+  const envelopeContinuityState = normalizeContinuityState(envelope.continuityState || envelope.startup?.continuityState);
+  const bootstrapContinuityState = normalizeContinuityState(
+    bootstrap.continuityState || bootstrapDiagnostics.continuityState,
+    "missing"
+  );
+  const envelopeFallbackOnly =
+    envelope.fallbackOnly === true ||
+    envelope.startup?.fallbackOnly === true;
+  const bootstrapFallbackOnly =
+    bootstrap.fallbackOnly === true ||
+    bootstrapDiagnostics.fallbackOnly === true;
+  const envelopeSourceQuality = clean(
+    envelope.startupSourceQuality || envelope.laneSourceQuality || envelope.startup?.startupSourceQuality
+  ).toLowerCase();
+  const bootstrapSourceQuality = clean(
+    bootstrap.startupSourceQuality || bootstrapDiagnostics.startupSourceQuality || bootstrapDiagnostics.laneSourceQuality
+  ).toLowerCase();
+  const degradedLocalContext =
+    envelopeContinuityState === "continuity_degraded" ||
+    bootstrapContinuityState === "continuity_degraded" ||
+    envelopeFallbackOnly ||
+    bootstrapFallbackOnly ||
+    envelopeSourceQuality === "compaction-promoted-dominant" ||
+    bootstrapSourceQuality === "compaction-promoted-dominant";
   const matchingBlocker =
     blocker.status === "blocked"
     && blocker.queryFingerprint
@@ -448,13 +480,24 @@ export function resolveBootstrapContinuityState({
     };
   }
   const priorReady =
-    normalizeContinuityState(envelope.continuityState || envelope.startup?.continuityState) === "ready"
-    || Boolean(supplementalHandoffSummary);
+    validatedLocalHandoff ||
+    (
+      envelopeContinuityState === "ready" &&
+      degradedLocalContext !== true
+    );
   if (priorReady) {
     return {
       continuityState: "ready",
       blockerActive: false,
       source: "validated-local-continuity",
+      supplementalHandoffSummary,
+    };
+  }
+  if (degradedLocalContext) {
+    return {
+      continuityState: "continuity_degraded",
+      blockerActive: false,
+      source: "local-fallback-continuity",
       supplementalHandoffSummary,
     };
   }
@@ -571,6 +614,15 @@ export function readThreadHistoryLines(threadId, { limit = 5, historyPath = code
     .filter(Boolean);
 }
 
+function clipBootstrapQuerySeed(value, maxChars = 140) {
+  const normalized = clean(value)
+    .replace(/\s+/g, " ")
+    .replace(/^you are in a new app window and new codex session\.?\s*/i, "");
+  if (!normalized) return "";
+  const firstSentence = normalized.match(/^(.{1,180}?[.!?])(?:\s|$)/)?.[1] || normalized;
+  return firstSentence.slice(0, maxChars).trim();
+}
+
 export function buildThreadBootstrapQuery({ threadInfo = null, threadName = "", historyLines = [] } = {}) {
   const normalizedCwd = normalizeThreadCwd(threadInfo?.cwd || process.cwd());
   const cwdBase = basename(normalizedCwd) || "workspace";
@@ -586,16 +638,16 @@ export function buildThreadBootstrapQuery({ threadInfo = null, threadName = "", 
   const laneSeed =
     inferredLane && !["unknown", "general-dev", "personal"].includes(inferredLane) ? inferredLane : "";
   const queryParts = dedupeStrings([
-    clean(threadName),
-    clean(threadInfo?.title),
-    clean(threadInfo?.firstUserMessage),
+    clipBootstrapQuerySeed(threadName),
+    clipBootstrapQuerySeed(threadInfo?.title),
+    clipBootstrapQuerySeed(threadInfo?.firstUserMessage),
     clean(threadInfo?.threadId),
     laneSeed,
     laneSeed.includes("-") ? laneSeed.replace(/-/g, " ") : "",
     includeCwdSeed ? cwdBase : "",
-    ...historyLines,
+    ...historyLines.map((line) => clipBootstrapQuerySeed(line, 96)).filter(Boolean),
   ]);
-  return queryParts.join(" ").slice(0, 4096);
+  return queryParts.join(" ").slice(0, 512);
 }
 
 function isBoilerplateText(text) {
@@ -1080,10 +1132,14 @@ export function extractCompactionMemoryProducts({
 }
 
 function buildLocalBootstrapItem(threadInfo, row, index) {
+  const explicitScore = Number(row?.metadata?.bootstrapRankScore ?? row?.score);
   return {
     id: row.clientRequestId || `local-bootstrap-${stableHash(`${threadInfo?.threadId}|${index}|${row.content}`, 16)}`,
     source: row.source,
-    score: 0.65 + Math.max(0, (Number(row.importance ?? 0.7) - 0.5) * 0.2),
+    score:
+      Number.isFinite(explicitScore)
+        ? explicitScore
+        : 0.65 + Math.max(0, (Number(row.importance ?? 0.7) - 0.5) * 0.2),
     content: row.content,
     tags: row.tags,
     metadata: {
@@ -1097,6 +1153,170 @@ function buildLocalBootstrapItem(threadInfo, row, index) {
   };
 }
 
+function resolveLocalArtifactProjectLane(threadInfo, artifact = {}) {
+  return normalizeSource(
+    inferProjectLane({
+      path: normalizeThreadCwd(artifact?.cwd || threadInfo?.cwd),
+      title: clean(artifact?.threadTitle || threadInfo?.title),
+      text: clean(
+        artifact?.firstUserMessage ||
+          artifact?.currentGoal ||
+          artifact?.activeGoal ||
+          artifact?.summary ||
+          artifact?.lastHandoffSummary ||
+          threadInfo?.firstUserMessage
+      ),
+    })
+  );
+}
+
+function firstBlockerSummary(blockers = []) {
+  const normalized = normalizeBlockers(blockers);
+  return clean(normalized[0]?.summary || normalized[0]?.detail || normalized[0]?.label);
+}
+
+function firstResumeHintSummary(resumeHints = []) {
+  const normalized = normalizeResumeHints(resumeHints);
+  const firstHint = normalized[0];
+  return clean(firstHint?.summary || firstHint?.nextStep || firstHint?.path);
+}
+
+function buildLocalArtifactRows({
+  threadInfo,
+  continuityEnvelope = null,
+  handoff = null,
+  startupBlocker = null,
+} = {}) {
+  const rows = [];
+  const normalizedEnvelope = normalizeContinuityEnvelope(continuityEnvelope, {
+    threadId: threadInfo?.threadId,
+    cwd: threadInfo?.cwd,
+  });
+  const normalizedHandoff = normalizeHandoffArtifact(handoff, {
+    threadId: threadInfo?.threadId,
+  });
+  const normalizedBlocker = normalizeStartupBlocker(startupBlocker, {
+    threadId: threadInfo?.threadId,
+    cwd: threadInfo?.cwd,
+  });
+  const envelopeBlocker = firstBlockerSummary(normalizedEnvelope.blockers);
+  const handoffBlocker = firstBlockerSummary(normalizedHandoff.blockers);
+  const blockerSummary = firstBlockerSummary(normalizedBlocker.blockers) || clean(normalizedBlocker.firstSignal);
+  const lane =
+    resolveLocalArtifactProjectLane(threadInfo, normalizedEnvelope) ||
+    resolveLocalArtifactProjectLane(threadInfo, normalizedHandoff) ||
+    resolveLocalArtifactProjectLane(threadInfo, normalizedBlocker);
+  const commonMetadata = {
+    threadId: clean(threadInfo?.threadId || normalizedEnvelope.threadId || normalizedHandoff.threadId || normalizedBlocker.threadId),
+    cwd: normalizeThreadCwd(threadInfo?.cwd || normalizedEnvelope.cwd || normalizedBlocker.cwd),
+    projectLane: lane,
+    startupEligible: true,
+    rememberForStartup: true,
+    scopeClass: "thread",
+  };
+
+  const envelopeContent = dedupeStrings(
+    [
+      clean(normalizedEnvelope.currentGoal) ? `Current goal: ${clean(normalizedEnvelope.currentGoal)}` : "",
+      clean(normalizedEnvelope.lastHandoffSummary)
+        ? `Trusted handoff: ${clean(normalizedEnvelope.lastHandoffSummary)}`
+        : clean(normalizedEnvelope.bootstrapSummary)
+          ? `Bootstrap summary: ${clean(normalizedEnvelope.bootstrapSummary)}`
+          : "",
+      envelopeBlocker ? `Top blocker: ${envelopeBlocker}` : "",
+      clean(normalizedEnvelope.nextRecommendedAction)
+        ? `Next action: ${clean(normalizedEnvelope.nextRecommendedAction)}`
+        : "",
+    ],
+    8
+  ).join(" ");
+  if (envelopeContent) {
+    rows.push({
+      content: safeClipByBytes(envelopeContent, 18_000),
+      source: "codex-continuity-envelope",
+      tags: ["codex", "bootstrap", "continuity-envelope", lane].filter(Boolean),
+      metadata: {
+        ...commonMetadata,
+        continuityState: clean(normalizedEnvelope.continuityState),
+        currentGoal: clean(normalizedEnvelope.currentGoal),
+        lastHandoffSummary: clean(normalizedEnvelope.lastHandoffSummary),
+        nextRecommendedAction: clean(normalizedEnvelope.nextRecommendedAction),
+        blockers: normalizeBlockers(normalizedEnvelope.blockers),
+        bootstrapSummary: clean(normalizedEnvelope.bootstrapSummary),
+      },
+      clientRequestId: `local-envelope-${stableHash(`${commonMetadata.threadId}|${normalizedEnvelope.updatedAt}|${envelopeContent}`, 20)}`,
+      occurredAt: normalizeIsoTimestamp(normalizedEnvelope.updatedAt || normalizedEnvelope.createdAt),
+      importance: clean(normalizedEnvelope.continuityState) === "ready" ? 0.92 : 0.84,
+    });
+  }
+
+  const firstResumeHint = firstResumeHintSummary(normalizedHandoff.resumeHints);
+  const handoffContent = dedupeStrings(
+    [
+      clean(normalizedHandoff.activeGoal) ? `Current goal: ${clean(normalizedHandoff.activeGoal)}` : "",
+      clean(normalizedHandoff.summary) ? `Handoff: ${clean(normalizedHandoff.summary)}` : "",
+      clean(normalizedHandoff.workCompleted) &&
+      clean(normalizedHandoff.workCompleted) !== clean(normalizedHandoff.summary)
+        ? `Work completed: ${clean(normalizedHandoff.workCompleted)}`
+        : "",
+      handoffBlocker ? `Top blocker: ${handoffBlocker}` : "",
+      clean(normalizedHandoff.nextRecommendedAction)
+        ? `Next action: ${clean(normalizedHandoff.nextRecommendedAction)}`
+        : "",
+      firstResumeHint ? `Resume hint: ${firstResumeHint}` : "",
+    ],
+    10
+  ).join(" ");
+  if (handoffContent) {
+    rows.push({
+      content: safeClipByBytes(handoffContent, 18_000),
+      source: "codex-handoff",
+      tags: ["codex", "bootstrap", "handoff", lane].filter(Boolean),
+      metadata: {
+        ...commonMetadata,
+        activeGoal: clean(normalizedHandoff.activeGoal),
+        summary: clean(normalizedHandoff.summary),
+        workCompleted: clean(normalizedHandoff.workCompleted),
+        nextRecommendedAction: clean(normalizedHandoff.nextRecommendedAction),
+        blockers: normalizeBlockers(normalizedHandoff.blockers),
+        resumeHints: normalizeResumeHints(normalizedHandoff.resumeHints),
+      },
+      clientRequestId: `local-handoff-${stableHash(`${commonMetadata.threadId}|${normalizedHandoff.createdAt}|${handoffContent}`, 20)}`,
+      occurredAt: normalizeIsoTimestamp(normalizedHandoff.createdAt),
+      importance: 0.96,
+    });
+  }
+
+  if (clean(normalizedBlocker.status) === "blocked" && (blockerSummary || clean(normalizedBlocker.unblockStep))) {
+    const blockerContent = dedupeStrings(
+      [
+        blockerSummary ? `Startup blocked: ${blockerSummary}` : "",
+        clean(normalizedBlocker.failureClass) ? `Failure class: ${clean(normalizedBlocker.failureClass)}` : "",
+        clean(normalizedBlocker.unblockStep) ? `Unblock step: ${clean(normalizedBlocker.unblockStep)}` : "",
+      ],
+      6
+    ).join(" ");
+    rows.push({
+      content: safeClipByBytes(blockerContent, 18_000),
+      source: "codex-startup-blocker",
+      tags: ["codex", "bootstrap", "startup-blocker", lane].filter(Boolean),
+      metadata: {
+        ...commonMetadata,
+        status: clean(normalizedBlocker.status),
+        failureClass: clean(normalizedBlocker.failureClass),
+        firstSignal: clean(normalizedBlocker.firstSignal),
+        unblockStep: clean(normalizedBlocker.unblockStep),
+        blockers: normalizeBlockers(normalizedBlocker.blockers),
+      },
+      clientRequestId: `local-blocker-${stableHash(`${commonMetadata.threadId}|${normalizedBlocker.createdAt}|${blockerContent}`, 20)}`,
+      occurredAt: normalizeIsoTimestamp(normalizedBlocker.createdAt),
+      importance: 0.9,
+    });
+  }
+
+  return rows;
+}
+
 export function buildLocalBootstrapContext({
   threadInfo,
   threadName = "",
@@ -1105,6 +1325,9 @@ export function buildLocalBootstrapContext({
   maxItems = 10,
   maxChars = 8000,
   strictStartupAllowlist = true,
+  continuityEnvelope = null,
+  handoff = null,
+  startupBlocker = null,
 } = {}) {
   const normalizedEntries = (rolloutEntries || [])
     .map((entry) => normalizeRolloutRecord(entry, threadInfo))
@@ -1113,6 +1336,14 @@ export function buildLocalBootstrapContext({
   const cwdBase = basename(normalizeThreadCwd(threadInfo?.cwd)) || "workspace";
   const title = clean(threadName) || clean(threadInfo?.title) || clean(threadInfo?.firstUserMessage) || "Codex thread";
   const fallbackRows = [];
+  const artifactRows = buildLocalArtifactRows({
+    threadInfo,
+    continuityEnvelope,
+    handoff,
+    startupBlocker,
+  });
+
+  fallbackRows.push(...artifactRows);
 
   for (const historyLine of historyLines.slice(-5)) {
     const normalized = normalizeRolloutText(historyLine);
@@ -1163,9 +1394,20 @@ export function buildLocalBootstrapContext({
     });
   }
 
-  const items = fallbackRows.slice(-Math.max(1, maxItems)).map((row, index) => buildLocalBootstrapItem(threadInfo, row, index));
+  const rankedRows = rankBootstrapRows(fallbackRows, threadInfo, {
+    preserveOriginalScore: true,
+    profile: "startup-strict",
+  });
+  const items = rankedRows.slice(0, Math.max(1, maxItems)).map((row, index) => buildLocalBootstrapItem(threadInfo, row, index));
   const summaryLines = [
     `Local fallback context for "${title}" in ${cwdBase}.`,
+    artifactRows.length > 0
+      ? `Trusted startup artifacts: ${artifactRows
+          .slice(0, 3)
+          .map((row) => normalizeHybridText(row.content).slice(0, 140))
+          .filter(Boolean)
+          .join(" | ")}`
+      : "",
     clean(threadInfo?.firstUserMessage) ? `First user message: ${clean(threadInfo.firstUserMessage)}` : "",
     historyLines.length > 0 ? `Recent user lines: ${historyLines.slice(-3).join(" | ")}` : "",
     items.length > 0
@@ -1186,11 +1428,12 @@ export function buildLocalBootstrapContext({
     summary,
     items,
     diagnostics: {
-      startupSourceBias: "local-fallback",
+      startupSourceBias: artifactRows.length > 0 ? "local-continuity-first" : "local-fallback",
       strictStartupAllowlist,
       fallbackUsed: true,
-      fallbackStrategy: "rollout-history",
+      fallbackStrategy: artifactRows.length > 0 ? "local-bootstrap-artifacts" : "rollout-history",
       itemCount: items.length,
+      startupArtifactCount: artifactRows.length,
     },
   };
 }
@@ -1216,6 +1459,120 @@ export function writeBootstrapArtifacts({ threadId, contextPayload, metadata } =
   writeFileSync(paths.bootstrapContextMarkdownPath, `${markdown}\n`, "utf8");
   writeJson(paths.bootstrapMetadataPath, metadata || {});
   return paths;
+}
+
+export function refreshLocalBootstrapArtifacts({
+  threadId,
+  cwd = "",
+  threadTitle = "",
+  firstUserMessage = "",
+  updatedAt = new Date().toISOString(),
+  historyLines = [],
+  rolloutEntries = [],
+  strictStartupAllowlist = true,
+  metadata = {},
+} = {}) {
+  const stableThreadId = clean(threadId);
+  if (!stableThreadId) return null;
+  const artifacts = loadBootstrapArtifacts(stableThreadId);
+  const paths = runtimePathsForThread(stableThreadId);
+  const normalizedUpdatedAt = normalizeIsoTimestamp(
+    updatedAt || artifacts?.continuityEnvelope?.updatedAt || artifacts?.handoff?.createdAt,
+    new Date().toISOString()
+  );
+  const threadInfo = {
+    threadId: stableThreadId,
+    cwd: clean(cwd || metadata?.cwd || artifacts?.continuityEnvelope?.cwd || process.cwd()),
+    title: clean(threadTitle || metadata?.threadTitle || artifacts?.continuityEnvelope?.threadTitle),
+    firstUserMessage: clean(
+      firstUserMessage || metadata?.firstUserMessage || artifacts?.continuityEnvelope?.firstUserMessage
+    ),
+    updatedAt: normalizedUpdatedAt,
+  };
+  const contextPayload = buildLocalBootstrapContext({
+    threadInfo,
+    threadName: threadInfo.title,
+    historyLines: Array.isArray(historyLines) ? historyLines : [],
+    rolloutEntries: Array.isArray(rolloutEntries) ? rolloutEntries : [],
+    strictStartupAllowlist,
+    continuityEnvelope: artifacts?.continuityEnvelope,
+    handoff: artifacts?.handoff,
+    startupBlocker: artifacts?.startupBlocker,
+  });
+  const existingMetadata = artifacts?.metadata && typeof artifacts.metadata === "object" ? artifacts.metadata : {};
+  const presentationProjectLane = clean(
+    metadata?.presentationProjectLane ||
+      artifacts?.continuityEnvelope?.presentationProjectLane ||
+      inferProjectLane({
+        text: `${threadInfo.firstUserMessage}\n${threadInfo.title}`,
+        title: threadInfo.title,
+        path: threadInfo.cwd,
+      })
+  );
+  const refreshedMetadata = {
+    ...existingMetadata,
+    ...(metadata && typeof metadata === "object" ? metadata : {}),
+    threadId: stableThreadId,
+    cwd: threadInfo.cwd,
+    threadTitle: threadInfo.title,
+    firstUserMessage: threadInfo.firstUserMessage,
+    updatedAt: normalizedUpdatedAt,
+    startupGateSatisfiedBy: clean(
+      metadata?.startupGateSatisfiedBy ||
+        artifacts?.continuityEnvelope?.startupSatisfiedBy ||
+        artifacts?.continuityEnvelope?.startup?.satisfiedBy ||
+        existingMetadata.startupGateSatisfiedBy ||
+        "validated-local-continuity"
+    ),
+    continuityState: clean(
+      metadata?.continuityState ||
+        artifacts?.continuityEnvelope?.continuityState ||
+        contextPayload?.diagnostics?.continuityState ||
+        "ready"
+    ),
+    itemCount: Array.isArray(contextPayload?.items) ? contextPayload.items.length : 0,
+    threadScopedItemCount: Math.max(
+      0,
+      Math.round(
+        Number(
+          metadata?.threadScopedItemCount ||
+            artifacts?.continuityEnvelope?.threadScopedItemCount ||
+            artifacts?.continuityEnvelope?.startup?.threadScopedItemCount ||
+            contextPayload?.diagnostics?.threadScopedItemCount ||
+            0
+        )
+      )
+    ),
+    presentationProjectLane,
+    startupSourceQuality: clean(
+      metadata?.startupSourceQuality ||
+        artifacts?.continuityEnvelope?.startupSourceQuality ||
+        artifacts?.continuityEnvelope?.laneSourceQuality ||
+        contextPayload?.diagnostics?.startupSourceQuality ||
+        contextPayload?.diagnostics?.laneSourceQuality ||
+        "thread-scoped-dominant"
+    ),
+    artifactPointers: {
+      ...normalizeArtifactPointers(existingMetadata.artifactPointers),
+      ...normalizeArtifactPointers(metadata?.artifactPointers),
+      continuityEnvelopePath: paths.continuityEnvelopePath,
+      bootstrapContextPath: paths.bootstrapContextJsonPath,
+      bootstrapMetadataPath: paths.bootstrapMetadataPath,
+      handoffPath: paths.handoffPath,
+      startupContextCachePath: paths.startupContextCachePath,
+      writesJsonlPath: paths.writesJsonlPath,
+    },
+  };
+  writeBootstrapArtifacts({
+    threadId: stableThreadId,
+    contextPayload,
+    metadata: refreshedMetadata,
+  });
+  return {
+    paths,
+    contextPayload,
+    metadata: refreshedMetadata,
+  };
 }
 
 export function writeContinuityEnvelope(threadId, envelope = {}) {
@@ -1302,6 +1659,46 @@ function threadProjectLane(threadInfo) {
   );
 }
 
+function rowHasGenericCoreStartupShape(row) {
+  const metadata = rowMetadata(row);
+  const source = normalizeSource(row?.source || metadata.source || "");
+  const tags = [
+    ...(Array.isArray(row?.tags) ? row.tags : []),
+    ...(Array.isArray(row?.matchedBy) ? row.matchedBy : []),
+    ...(Array.isArray(metadata.tags) ? metadata.tags : []),
+  ]
+    .map((value) => normalizeSource(value))
+    .filter(Boolean);
+  const memoryLayer = normalizeSource(row?.memoryLayer || metadata.memoryLayer || "");
+  const memoryType = normalizeSource(row?.memoryType || metadata.memoryType || "");
+  return (
+    source === "startup-context" ||
+    tags.includes("core-block") ||
+    (memoryLayer === "core" && memoryType === "procedural")
+  );
+}
+
+function rowContinuityRichness(row) {
+  const metadata = rowMetadata(row);
+  let richness = 0;
+  if (clean(metadata.activeGoal || metadata.currentGoal)) richness += 1;
+  if (clean(metadata.nextRecommendedAction || metadata.unblockStep)) richness += 1;
+  if (clean(metadata.lastHandoffSummary || metadata.summary || metadata.workCompleted || metadata.bootstrapSummary)) {
+    richness += 1;
+  }
+  if (normalizeBlockers(metadata.blockers).length > 0) richness += 1;
+  if (normalizeResumeHints(metadata.resumeHints).length > 0) richness += 1;
+  return richness;
+}
+
+function rowHasStructuredContinuityPayload(row) {
+  const source = normalizeSource(row?.source || row?.metadata?.source || "");
+  if (["codex-continuity-envelope", "codex-handoff", "codex-startup-blocker"].includes(source)) {
+    return rowContinuityRichness(row) > 0;
+  }
+  const metadata = rowMetadata(row);
+  return metadata.startupEligible === true && rowContinuityRichness(row) >= 2;
+}
 function rowSourcePenalty(row, threadInfo, profile = "startup-strict") {
   const normalizedProfile = normalizeContinuityProfile(profile);
   const metadata = rowMetadata(row);
@@ -1326,10 +1723,10 @@ function rowSourcePenalty(row, threadInfo, profile = "startup-strict") {
     if (source === "repo-markdown") return 0.2;
     return 0.08 + Math.min(0.28, preferredStartupSourcePriority(source, normalizedProfile) / 100);
   }
-  if (source === "codex-continuity-envelope") return 0.01;
-  if (source === "codex-compaction-promoted") return 0;
-  if (source === "codex-handoff") return 0.015;
-  if (source === "codex-startup-blocker") return 0.02;
+  if (source === "codex-continuity-envelope") return 0;
+  if (source === "codex-handoff") return 0.005;
+  if (source === "codex-startup-blocker") return 0.012;
+  if (source === "codex-compaction-promoted") return rowScopeMatchesThread(row, threadInfo) ? 0.055 : 0.08;
   if (source === "codex-friction-feedback-loop") return 0.025;
   if (source === "manual") return startupEligible || personalProfile ? 0.03 : 0.06;
   if (source === "codex") return startupEligible ? 0.035 : 0.06;
@@ -1350,6 +1747,8 @@ export function rankBootstrapRows(rows, threadInfo, { preserveOriginalScore = tr
   if (!Array.isArray(rows) || rows.length === 0) return [];
   const normalizedProfile = normalizeContinuityProfile(profile);
   const currentProjectLane = threadProjectLane(threadInfo);
+  const hasCompetingThreadScopedRow = rows.some((row) => rowScopeMatchesThread(row, threadInfo));
+  const hasCompetingUsableLane = rows.some((row) => rowProjectLane(row));
   return rows
     .map((row, index) => {
       const metadata = rowMetadata(row);
@@ -1381,10 +1780,23 @@ export function rankBootstrapRows(rows, threadInfo, { preserveOriginalScore = tr
             ? 0.01
             : 0.16
           : 0;
+      const genericCorePenalty =
+        !rowLane &&
+        !exactScopeMatch &&
+        rowHasGenericCoreStartupShape(row) &&
+        (hasCompetingThreadScopedRow || hasCompetingUsableLane)
+          ? normalizedProfile === "task-broad"
+            ? 0.03
+            : 0.28
+          : 0;
       const profileBoost =
         normalizedProfile === "profile-fast-lane" &&
         clean(metadata.scopeClass).toLowerCase() === "personal"
           ? 0.12
+          : 0;
+      const continuityBoost =
+        normalizedProfile !== "task-broad" && rowHasStructuredContinuityPayload(row)
+          ? Math.min(0.12, rowContinuityRichness(row) * 0.025)
           : 0;
       const startupBoost =
         normalizedProfile !== "task-broad" && metadata.startupEligible === true ? 0.06 : 0;
@@ -1393,7 +1805,16 @@ export function rankBootstrapRows(rows, threadInfo, { preserveOriginalScore = tr
           ? 0
           : Math.max(0, 0.1 - preferredStartupSourcePriority(row?.source, normalizedProfile) * 0.01);
       const rankScore =
-        normalizedBaseScore + scopeBoost + laneBoost + profileBoost + startupBoost + priorityBoost - penalty - lanePenalty;
+        normalizedBaseScore +
+        scopeBoost +
+        laneBoost +
+        profileBoost +
+        continuityBoost +
+        startupBoost +
+        priorityBoost -
+        penalty -
+        lanePenalty -
+        genericCorePenalty;
       return {
         row,
         index,
@@ -1444,6 +1865,162 @@ export function loadBootstrapArtifacts(threadId) {
     continuityEnvelope,
     startupBlocker,
     handoff,
+  };
+}
+
+function startupRepairRowSource(row) {
+  const metadata = rowMetadata(row);
+  return clean(row?.source || metadata.source);
+}
+
+function startupRepairRowText(row) {
+  return clean(row?.content || row?.summary || row?.text);
+}
+
+export function hasUsableLocalStartupArtifacts(artifacts = {}) {
+  const handoff = artifacts?.handoff && typeof artifacts.handoff === "object" ? artifacts.handoff : {};
+  const envelope =
+    artifacts?.continuityEnvelope && typeof artifacts.continuityEnvelope === "object"
+      ? artifacts.continuityEnvelope
+      : {};
+  const handoffSummary = clean(handoff.summary || handoff.workCompleted || handoff.activeGoal);
+  if (handoffSummary) return true;
+  const envelopeSummary = clean(envelope.lastHandoffSummary || envelope.currentGoal || envelope.nextRecommendedAction);
+  const threadScopedItemCount = Math.max(
+    0,
+    Number(envelope.threadScopedItemCount || envelope.startup?.threadScopedItemCount || 0)
+  );
+  const sourceQuality = clean(
+    envelope.startupSourceQuality || envelope.laneSourceQuality || envelope.startup?.startupSourceQuality
+  ).toLowerCase();
+  return Boolean(envelopeSummary) && (threadScopedItemCount > 0 || sourceQuality === "thread-scoped-dominant");
+}
+
+function rowCanRepairStartupArtifacts(row, threadInfo = null) {
+  if (!rowScopeMatchesThread(row, threadInfo)) return false;
+  const metadata = rowMetadata(row);
+  const source = normalizeSource(startupRepairRowSource(row));
+  if (source === "codex-startup-blocker") return false;
+  const checkpointKind = clean(metadata.checkpointKind).toLowerCase();
+  const startupEligible =
+    source === "codex-handoff" ||
+    metadata.startupEligible === true ||
+    checkpointKind === "handoff" ||
+    checkpointKind === "checkpoint";
+  if (!startupEligible) return false;
+  const summary = clean(metadata.summary || metadata.workCompleted || startupRepairRowText(row));
+  const activeGoal = clean(metadata.activeGoal || metadata.currentGoal || metadata.goal);
+  const nextRecommendedAction = clean(metadata.nextRecommendedAction || metadata.unblockStep);
+  const blockers = normalizeBlockers(metadata.blockers);
+  return Boolean(summary || activeGoal || nextRecommendedAction || blockers.length > 0);
+}
+
+export function selectStartupArtifactRepairCandidate(rows, { threadInfo = null } = {}) {
+  const rankedRows = rankBootstrapRows(filterExpiredRows(rows), threadInfo, {
+    preserveOriginalScore: true,
+    profile: "startup-strict",
+  });
+  return rankedRows.find((row) => rowCanRepairStartupArtifacts(row, threadInfo)) || null;
+}
+
+export function buildStartupArtifactRepair(candidate, {
+  threadInfo = null,
+  threadScopedItemCount = 0,
+} = {}) {
+  if (!candidate) return null;
+  const metadata = rowMetadata(candidate);
+  const threadId = clean(metadata.threadId || threadInfo?.threadId);
+  if (!threadId) return null;
+  const summary = clean(metadata.summary || metadata.workCompleted || startupRepairRowText(candidate));
+  const activeGoal = clean(
+    metadata.activeGoal || metadata.currentGoal || threadInfo?.firstUserMessage || threadInfo?.title || summary
+  );
+  const nextRecommendedAction = clean(metadata.nextRecommendedAction || metadata.unblockStep);
+  const blockers = normalizeBlockers(metadata.blockers);
+  const completionStatus =
+    clean(
+      metadata.completionStatus ||
+        metadata.status ||
+        metadata.checkpointStatus ||
+        (blockers.length > 0 ? "degraded" : "pass")
+    ) || "pass";
+  const workCompleted = clean(metadata.workCompleted || summary);
+  const presentationProjectLane = rowProjectLane(candidate) || threadProjectLane(threadInfo);
+  return {
+    handoff: {
+      threadId,
+      createdAt: clean(candidate?.createdAt || candidate?.occurredAt || metadata.createdAt),
+      runId: clean(candidate?.runId || metadata.runId),
+      agentId: clean(candidate?.agentId || metadata.agentId),
+      summary,
+      activeGoal,
+      workCompleted: workCompleted || summary,
+      nextRecommendedAction,
+      blockers,
+      completionStatus,
+      startupProvenance: {
+        repairedFromSource: clean(startupRepairRowSource(candidate)),
+        repairedFromCapturedFrom: clean(metadata.capturedFrom),
+        repairedFromMemoryId: clean(candidate?.id),
+      },
+    },
+    continuityEnvelope: {
+      threadId,
+      cwd: clean(metadata.cwd || threadInfo?.cwd),
+      continuityState: "ready",
+      currentGoal: activeGoal,
+      lastHandoffSummary: summary || workCompleted,
+      nextRecommendedAction,
+      blockers,
+      fallbackOnly: false,
+      startupSourceQuality: "thread-scoped-dominant",
+      laneSourceQuality: "thread-scoped-dominant",
+      presentationProjectLane,
+      threadScopedItemCount: Math.max(1, Math.round(Number(threadScopedItemCount || 0))),
+    },
+  };
+}
+
+export function repairLocalStartupArtifactsFromRows(rows, {
+  threadInfo = null,
+  existingArtifacts = null,
+} = {}) {
+  const threadId = clean(threadInfo?.threadId);
+  if (!threadId || !Array.isArray(rows) || rows.length === 0) {
+    return {
+      repaired: false,
+      reason: "missing-thread-or-rows",
+    };
+  }
+  const artifacts = existingArtifacts || loadBootstrapArtifacts(threadId);
+  if (hasUsableLocalStartupArtifacts(artifacts)) {
+    return {
+      repaired: false,
+      reason: "existing-local-artifacts",
+    };
+  }
+  const candidate = selectStartupArtifactRepairCandidate(rows, { threadInfo });
+  if (!candidate) {
+    return {
+      repaired: false,
+      reason: "no-repair-candidate",
+    };
+  }
+  const threadScopedItemCount = rows.filter((row) => rowScopeMatchesThread(row, threadInfo)).length;
+  const repair = buildStartupArtifactRepair(candidate, { threadInfo, threadScopedItemCount });
+  if (!repair) {
+    return {
+      repaired: false,
+      reason: "candidate-not-repairable",
+    };
+  }
+  writeHandoffArtifact(threadId, repair.handoff);
+  writeContinuityEnvelope(threadId, repair.continuityEnvelope);
+  return {
+    repaired: true,
+    reason: "repaired-from-remote-startup-row",
+    source: clean(startupRepairRowSource(candidate)),
+    capturedFrom: clean(rowMetadata(candidate).capturedFrom),
   };
 }
 

--- a/scripts/lib/codex-startup-reliability.mjs
+++ b/scripts/lib/codex-startup-reliability.mjs
@@ -12,8 +12,99 @@ export const STARTUP_REASON_CODES = Object.freeze({
   STARTUP_UNAVAILABLE: "startup_unavailable",
 });
 
+export const STARTUP_DEGRADATION_BUCKETS = Object.freeze({
+  MEMORY_UNAVAILABLE: "memory_unavailable",
+  MEMORY_FALLBACK_ONLY: "memory_fallback_only",
+  THREAD_SCOPE_MISSING: "thread_scope_missing",
+  GROUNDING_UNTRUSTED: "grounding_untrusted",
+  ORDERING_UNPROVEN: "ordering_unproven",
+  PRE_START_REPO_READS_DETECTED: "pre_start_repo_reads_detected",
+  GROUNDING_MISSING: "grounding_missing",
+  STARTUP_AUTH_STALE: "startup_auth_stale",
+});
+
+export const STARTUP_GROUNDING_AUTHORITIES = Object.freeze({
+  THREAD_SCOPED: "thread-scoped",
+  VALIDATED_LOCAL: "validated-local",
+  THREAD_SCOPED_REPAIRED: "thread-scoped-repaired",
+  CROSS_THREAD_FALLBACK: "cross-thread-fallback",
+  MANUAL: "manual",
+});
+
+const TRUSTED_STARTUP_GROUNDING_AUTHORITIES = new Set([
+  STARTUP_GROUNDING_AUTHORITIES.THREAD_SCOPED,
+  STARTUP_GROUNDING_AUTHORITIES.VALIDATED_LOCAL,
+  STARTUP_GROUNDING_AUTHORITIES.THREAD_SCOPED_REPAIRED,
+]);
+
 export function clean(value) {
   return String(value ?? "").trim();
+}
+
+export function normalizeStartupGroundingAuthority(value) {
+  const normalized = clean(value).toLowerCase();
+  return Object.values(STARTUP_GROUNDING_AUTHORITIES).includes(normalized)
+    ? normalized
+    : STARTUP_GROUNDING_AUTHORITIES.CROSS_THREAD_FALLBACK;
+}
+
+export function isTrustedStartupGroundingAuthority(value) {
+  return TRUSTED_STARTUP_GROUNDING_AUTHORITIES.has(normalizeStartupGroundingAuthority(value));
+}
+
+export function deriveStartupGroundingAuthority({
+  diagnostics = {},
+  continuityState = "missing",
+} = {}) {
+  const normalizedContinuityState = clean(continuityState || diagnostics?.continuityState || "missing").toLowerCase();
+  const threadScopedItemCount = Math.max(0, Math.round(Number(diagnostics?.threadScopedItemCount || 0)));
+  const startupSourceQuality = clean(
+    diagnostics?.startupSourceQuality || diagnostics?.laneSourceQuality || diagnostics?.groundingQuality
+  ).toLowerCase();
+  const localContinuityValidated = diagnostics?.localContinuityValidated === true;
+  const localContinuitySource = clean(diagnostics?.localContinuitySource).toLowerCase();
+  const manualOnly = diagnostics?.manualOnly === true;
+  const localArtifactRepair =
+    diagnostics?.localArtifactRepair && typeof diagnostics.localArtifactRepair === "object"
+      ? diagnostics.localArtifactRepair
+      : null;
+
+  if (localArtifactRepair?.repaired === true && threadScopedItemCount > 0) {
+    return STARTUP_GROUNDING_AUTHORITIES.THREAD_SCOPED_REPAIRED;
+  }
+  if (
+    localContinuityValidated &&
+    (
+      threadScopedItemCount > 0 ||
+      localContinuitySource === "validated-local-continuity" ||
+      localContinuitySource === "local-artifact-quality"
+    )
+  ) {
+    return STARTUP_GROUNDING_AUTHORITIES.VALIDATED_LOCAL;
+  }
+  if (
+    threadScopedItemCount > 0 &&
+    !["cross-thread-fallback", "compaction-promoted-dominant", "missing"].includes(startupSourceQuality)
+  ) {
+    return STARTUP_GROUNDING_AUTHORITIES.THREAD_SCOPED;
+  }
+  if (manualOnly && normalizedContinuityState !== "ready") {
+    return STARTUP_GROUNDING_AUTHORITIES.MANUAL;
+  }
+  return STARTUP_GROUNDING_AUTHORITIES.CROSS_THREAD_FALLBACK;
+}
+
+function uniqueStrings(values = []) {
+  const seen = new Set();
+  const output = [];
+  for (const value of values) {
+    const normalized = clean(value);
+    const hash = normalized.toLowerCase();
+    if (!normalized || seen.has(hash)) continue;
+    seen.add(hash);
+    output.push(normalized);
+  }
+  return output;
 }
 
 function normalizeJwtSegment(segment) {
@@ -170,6 +261,118 @@ export function startupRecoveryStep(reasonCode) {
     default:
       return "Capture the exact startup failure, take one unblock step, then retry the same query/runId once.";
   }
+}
+
+export function buildStartupContract({
+  reasonCode = STARTUP_REASON_CODES.STARTUP_UNAVAILABLE,
+  continuityState = "missing",
+  diagnostics = {},
+  telemetry = {},
+  tokenFreshness = null,
+  studioBrainReachable = null,
+  mcpBridgeOk = null,
+} = {}) {
+  const normalizedReasonCode = clean(reasonCode || STARTUP_REASON_CODES.STARTUP_UNAVAILABLE);
+  const normalizedContinuityState = clean(continuityState || diagnostics?.continuityState || "missing").toLowerCase();
+  const tokenState = clean(tokenFreshness?.state).toLowerCase();
+  const presentationProjectLane = clean(
+    diagnostics?.presentationProjectLane || diagnostics?.projectLane || diagnostics?.dominantProjectLane
+  );
+  const threadScopedItemCount = Math.max(0, Math.round(Number(diagnostics?.threadScopedItemCount || 0)));
+  const transcriptOrderingProven = telemetry?.transcriptOrderingProven === true;
+  const repoReadsBeforeStartupContext = Number(telemetry?.repoReadsBeforeStartupContext);
+  const groundingAuthority = normalizeStartupGroundingAuthority(
+    diagnostics?.groundingAuthority ||
+      deriveStartupGroundingAuthority({
+        diagnostics,
+        continuityState: normalizedContinuityState,
+      })
+  );
+  const trustedGrounding = isTrustedStartupGroundingAuthority(groundingAuthority);
+  const fallbackOnly =
+    diagnostics?.fallbackOnly === true ||
+    (normalizedContinuityState !== "ready" && normalizedReasonCode === STARTUP_REASON_CODES.OK);
+  const compactionDominated = diagnostics?.compactionDominated === true;
+  const startupSourceQuality = clean(
+    diagnostics?.startupSourceQuality || diagnostics?.laneSourceQuality || diagnostics?.groundingQuality
+  );
+  const fallbackDegraded =
+    fallbackOnly ||
+    (
+      diagnostics?.fallbackUsed === true &&
+      (
+        normalizedContinuityState !== "ready" ||
+        compactionDominated ||
+        startupSourceQuality === "compaction-promoted-dominant" ||
+        threadScopedItemCount <= 0
+      )
+    );
+  const failReasonCodes = new Set([
+    STARTUP_REASON_CODES.MISSING_TOKEN,
+    STARTUP_REASON_CODES.EXPIRED_TOKEN,
+    STARTUP_REASON_CODES.TRANSPORT_UNREACHABLE,
+    STARTUP_REASON_CODES.TIMEOUT,
+    STARTUP_REASON_CODES.STARTUP_UNAVAILABLE,
+  ]);
+  const degradationBuckets = uniqueStrings([
+    !studioBrainReachable || failReasonCodes.has(normalizedReasonCode)
+      ? STARTUP_DEGRADATION_BUCKETS.MEMORY_UNAVAILABLE
+      : "",
+    fallbackDegraded ? STARTUP_DEGRADATION_BUCKETS.MEMORY_FALLBACK_ONLY : "",
+    threadScopedItemCount <= 0 ? STARTUP_DEGRADATION_BUCKETS.THREAD_SCOPE_MISSING : "",
+    normalizedContinuityState === "ready" && !trustedGrounding
+      ? STARTUP_DEGRADATION_BUCKETS.GROUNDING_UNTRUSTED
+      : "",
+    transcriptOrderingProven ? "" : STARTUP_DEGRADATION_BUCKETS.ORDERING_UNPROVEN,
+    Number.isFinite(repoReadsBeforeStartupContext) && repoReadsBeforeStartupContext > 0
+      ? STARTUP_DEGRADATION_BUCKETS.PRE_START_REPO_READS_DETECTED
+      : "",
+    telemetry?.groundingLineEmitted === true ? "" : STARTUP_DEGRADATION_BUCKETS.GROUNDING_MISSING,
+    ["missing", "expired"].includes(tokenState) ||
+    normalizedReasonCode === STARTUP_REASON_CODES.MISSING_TOKEN ||
+    normalizedReasonCode === STARTUP_REASON_CODES.EXPIRED_TOKEN
+      ? STARTUP_DEGRADATION_BUCKETS.STARTUP_AUTH_STALE
+      : "",
+  ]);
+  const missingStartupIngredients = uniqueStrings([
+    threadScopedItemCount <= 0 ? "insufficient-thread-scoped-handoff-or-checkpoint-rows" : "",
+    compactionDominated || startupSourceQuality === "compaction-promoted-dominant"
+      ? "stale-or-generic-compaction-only-context"
+      : "",
+    presentationProjectLane ? "" : "missing-lane-resolution",
+    clean(diagnostics?.topBlocker) || normalizedContinuityState === "ready" ? "" : "unresolved-blocker-rows",
+  ]);
+  const status =
+    !studioBrainReachable ||
+    failReasonCodes.has(normalizedReasonCode) ||
+    mcpBridgeOk === false
+      ? "fail"
+      : normalizedContinuityState === "ready" &&
+          degradationBuckets.length === 0 &&
+          telemetry?.groundingLineEmitted === true &&
+          presentationProjectLane &&
+          diagnostics?.manualOnly !== true
+        ? "pass"
+        : "degraded";
+
+  return {
+    status,
+    reasonCode: normalizedReasonCode,
+    continuityState: normalizedContinuityState,
+    recoveryStep: startupRecoveryStep(normalizedReasonCode),
+    presentationProjectLane,
+    threadScopedItemCount,
+    transcriptOrderingProven,
+    degradationBuckets,
+    missingStartupIngredients,
+    dominantGoal: clean(diagnostics?.dominantGoal || diagnostics?.goal),
+    topBlocker: clean(diagnostics?.topBlocker),
+    nextRecommendedAction: clean(diagnostics?.nextRecommendedAction),
+    groundingAuthority,
+    laneSourceQuality: clean(diagnostics?.laneSourceQuality || diagnostics?.groundingQuality || "missing"),
+    startupSourceQuality: startupSourceQuality || "missing",
+    fallbackOnly,
+  };
 }
 
 export function evaluateStartupLatency(latencyMs, { targetMs = DEFAULT_STARTUP_BUDGET_TARGET_MS, hardMs = DEFAULT_STARTUP_BUDGET_HARD_MS } = {}) {

--- a/scripts/lib/codex-startup-telemetry.mjs
+++ b/scripts/lib/codex-startup-telemetry.mjs
@@ -1,4 +1,5 @@
 import { spawnSync } from "node:child_process";
+import { closeSync, existsSync, mkdirSync, openSync, readFileSync, unlinkSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { normalizeRolloutRecord, parseRolloutEntries, resolveCodexThreadContext } from "./codex-session-memory-utils.mjs";
@@ -24,6 +25,26 @@ const EXEC_REPO_READ_PATTERN = /\b(rg|cat|type|dir|ls|get-content|gc|sed|findstr
 
 function clean(value) {
   return String(value ?? "").trim();
+}
+
+function startupToolNameVariants(value) {
+  const normalized = clean(value);
+  if (!normalized) return [];
+  const variants = new Set([normalized]);
+  const withoutFunctionsPrefix = normalized.replace(/^functions\./i, "");
+  if (withoutFunctionsPrefix) variants.add(withoutFunctionsPrefix);
+  if (withoutFunctionsPrefix.startsWith("mcp__")) {
+    const parts = withoutFunctionsPrefix.split("__");
+    if (parts.length >= 3) {
+      variants.add(parts.slice(2).join("__"));
+    }
+  }
+  return Array.from(variants).filter(Boolean);
+}
+
+export function matchesStartupToolName(value, startupToolNames = DEFAULT_STARTUP_TOOL_NAMES) {
+  const allowed = new Set(Array.from(startupToolNames || []).map((entry) => clean(entry)).filter(Boolean));
+  return startupToolNameVariants(value).some((variant) => allowed.has(variant));
 }
 
 function resolveStartupThreadHint(env = process.env) {
@@ -110,7 +131,7 @@ export function inspectStartupTranscriptTelemetry({
 
   const firstStartupToolIndex = records.findIndex((record) => {
     if (record?.captureKind !== "function_call") return false;
-    return startupToolNames.has(clean(record?.metadata?.toolName));
+    return matchesStartupToolName(record?.metadata?.toolName, startupToolNames);
   });
   const firstAssistantIndex = records.findIndex((record) => isAssistantMessage(record));
   const assistantTelemetryIndex =
@@ -118,6 +139,7 @@ export function inspectStartupTranscriptTelemetry({
       ? records.findIndex((record, index) => index > firstStartupToolIndex && isAssistantMessage(record))
       : firstAssistantIndex;
   const assistantRecord = assistantTelemetryIndex >= 0 ? records[assistantTelemetryIndex] : null;
+  const startupToolRecord = firstStartupToolIndex >= 0 ? records[firstStartupToolIndex] : null;
   const groundingLineEmitted = assistantRecord
     ? clean(assistantRecord.content).replace(/^\s+/, "").startsWith("Grounding:")
     : null;
@@ -126,6 +148,7 @@ export function inspectStartupTranscriptTelemetry({
     threadId: clean(threadInfo.threadId),
     rolloutPath,
     startupToolObserved: firstStartupToolIndex >= 0,
+    startupToolName: clean(startupToolRecord?.metadata?.toolName),
     startupToolCalledBeforeFirstAssistantMessage:
       firstStartupToolIndex >= 0 && firstAssistantIndex >= 0 ? firstStartupToolIndex < firstAssistantIndex : null,
     groundingLineEmitted: toNullableBoolean(groundingLineEmitted),
@@ -137,6 +160,67 @@ export function inspectStartupTranscriptTelemetry({
     repoReadTelemetryObserved: firstStartupToolIndex >= 0,
     source: "codex-rollout",
   };
+}
+
+function readToolcallEntries(toolcallPath) {
+  if (!toolcallPath || !existsSync(toolcallPath)) return [];
+  const raw = readFileSync(toolcallPath, "utf8");
+  return String(raw || "")
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      try {
+        return JSON.parse(line);
+      } catch {
+        return null;
+      }
+    })
+    .filter(Boolean);
+}
+
+function sleepMs(durationMs) {
+  const millis = Math.max(0, Math.round(Number(durationMs) || 0));
+  if (millis <= 0) return;
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, millis);
+}
+
+function withStartupObservationLock(toolcallPath, fn, { timeoutMs = 2000, pollMs = 25 } = {}) {
+  const lockPath = `${toolcallPath}.startup.lock`;
+  mkdirSync(dirname(lockPath), { recursive: true });
+  const startedAt = Date.now();
+
+  while (Date.now() - startedAt <= timeoutMs) {
+    let lockFd = null;
+    try {
+      lockFd = openSync(lockPath, "wx");
+      try {
+        return fn();
+      } finally {
+        if (lockFd != null) closeSync(lockFd);
+        try {
+          unlinkSync(lockPath);
+        } catch {}
+      }
+    } catch (error) {
+      if (error?.code !== "EEXIST") throw error;
+      sleepMs(pollMs);
+    }
+  }
+
+  return fn();
+}
+
+function hasStartupObservation(entries, { tool, action, observationKey, threadId, rolloutPath }) {
+  return (entries || []).some((entry) => {
+    if (clean(entry?.tool) !== clean(tool) || clean(entry?.action) !== clean(action)) return false;
+    const startup = entry?.context?.startup && typeof entry.context.startup === "object" ? entry.context.startup : {};
+    if (observationKey && clean(startup.observationKey) === observationKey) return true;
+    if (threadId && rolloutPath) {
+      return clean(startup.threadId) === threadId && clean(startup.rolloutPath) === rolloutPath;
+    }
+    return false;
+  });
 }
 
 export function logStartupTelemetryToolcall({
@@ -190,4 +274,44 @@ export function logStartupTelemetryToolcall({
     stderr: clean(result.stderr),
     error: result.error instanceof Error ? result.error.message : "",
   };
+}
+
+export function maybeLogStartupTelemetryToolcall({
+  tool,
+  action = "startup-bootstrap",
+  context = null,
+  cwd = REPO_ROOT,
+  ...rest
+} = {}) {
+  const startup = context?.startup && typeof context.startup === "object" ? context.startup : {};
+  const observationKey = clean(startup.observationKey);
+  const threadId = clean(startup.threadId);
+  const rolloutPath = clean(startup.rolloutPath);
+  if (!observationKey && !(threadId && rolloutPath)) {
+    return {
+      ok: false,
+      skipped: true,
+      reason: "missing-startup-observation-key",
+    };
+  }
+
+  const toolcallPath = resolve(cwd, ".codex", "toolcalls.ndjson");
+  return withStartupObservationLock(toolcallPath, () => {
+    const existingEntries = readToolcallEntries(toolcallPath);
+    if (hasStartupObservation(existingEntries, { tool, action, observationKey, threadId, rolloutPath })) {
+      return {
+        ok: true,
+        skipped: true,
+        reason: "startup-observation-already-logged",
+      };
+    }
+
+    return logStartupTelemetryToolcall({
+      tool,
+      action,
+      context,
+      cwd,
+      ...rest,
+    });
+  });
 }

--- a/scripts/lib/codex-toolcall-governance.mjs
+++ b/scripts/lib/codex-toolcall-governance.mjs
@@ -1,0 +1,598 @@
+import { auditWindowsCommandShape, recommendedWindowsCommandPatterns } from "./codex-command-shape-guardrails.mjs";
+
+const SYNTHETIC_STARTUP_TOOL_NAMES = new Set([
+  "codex-startup-preflight",
+  "codex-doctor",
+  "codex-startup-scorecard",
+]);
+
+const LIVE_STARTUP_TOOL_NAMES = new Set([
+  "codex-desktop",
+  "codex-shell",
+  "codex-worktree",
+]);
+
+const STARTUP_AUTH_REASON_CODES = new Set([
+  "missing_token",
+  "expired_token",
+  "transport_unreachable",
+  "timeout",
+]);
+
+const OUTPUT_BLOAT_PATTERNS = [
+  /\bcontext window\b/i,
+  /\bmax output\b/i,
+  /\btoo much output\b/i,
+  /\btoo large\b/i,
+  /\btruncated\b/i,
+  /\bmax buffer\b/i,
+  /\btoken limit\b/i,
+];
+
+const EMPTY_OUTPUT_PATTERNS = [
+  /\bempty output\b/i,
+  /\bnull output\b/i,
+  /\bno output\b/i,
+  /\bempty-result\b/i,
+];
+
+const PATH_FAILURE_PATTERNS = [
+  /\benoent\b/i,
+  /\bno such file\b/i,
+  /\bpath not found\b/i,
+  /\bfile not found\b/i,
+  /\bcannot find path\b/i,
+];
+
+const COMMAND_SHAPE_PATTERN_BY_FINDING = Object.freeze({
+  "rg-glob-backslashes": ['rg -n --glob "scripts/*.mjs" "startup" .'],
+  "rg-glob-path-like": ['rg -n "startup" scripts'],
+  "node-e-import-without-module": [
+    'node --input-type=module -e "import fs from \\"node:fs\\"; console.log(fs.existsSync(\\"package.json\\"))"',
+    "Move the snippet into a checked-in `.mjs` helper when the command will be retried.",
+  ],
+  "get-content-json-without-raw": ["Get-Content -Raw .codex/toolcalls.ndjson | ConvertFrom-Json"],
+});
+
+function clean(value) {
+  return String(value ?? "").trim();
+}
+
+function getStartupContext(entry) {
+  return entry?.context?.startup && typeof entry.context.startup === "object" ? entry.context.startup : {};
+}
+
+function getStartupPacket(entry) {
+  const startup = getStartupContext(entry);
+  return startup?.startupPacket && typeof startup.startupPacket === "object" ? startup.startupPacket : {};
+}
+
+function toFiniteNumber(value) {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : null;
+}
+
+function toMs(value) {
+  if (!value) return null;
+  const parsed = new Date(value);
+  const millis = parsed.getTime();
+  return Number.isFinite(millis) ? millis : null;
+}
+
+function uniqueStrings(values = []) {
+  const seen = new Set();
+  const output = [];
+  for (const value of values) {
+    const normalized = clean(value);
+    const hash = normalized.toLowerCase();
+    if (!normalized || seen.has(hash)) continue;
+    seen.add(hash);
+    output.push(normalized);
+  }
+  return output;
+}
+
+function readNestedString(source, path) {
+  let current = source;
+  for (const segment of path) {
+    if (!current || typeof current !== "object") return "";
+    current = current[segment];
+  }
+  return clean(current);
+}
+
+export function extractRetryGovernor(entry) {
+  const context = entry?.context && typeof entry.context === "object" ? entry.context : {};
+  const governor =
+    (entry?.retryGovernor && typeof entry.retryGovernor === "object" ? entry.retryGovernor : null) ||
+    (context?.retryGovernor && typeof context.retryGovernor === "object" ? context.retryGovernor : null);
+  if (!governor) return null;
+
+  const signature = clean(governor.signature);
+  const action = clean(governor.action);
+  const burstCount = toFiniteNumber(governor.burstCount);
+  const burstThreshold = toFiniteNumber(governor.burstThreshold);
+  const windowMinutes = toFiniteNumber(governor.windowMinutes);
+  const normalized = {
+    enabled: governor.enabled !== false,
+    signature:
+      signature ||
+      `${clean(entry?.tool) || "unknown"}::${clean(entry?.action) || "unknown"}::${clean(entry?.errorType) || "none"}`,
+    burstCount: burstCount != null && burstCount >= 0 ? burstCount : null,
+    burstThreshold: burstThreshold != null && burstThreshold >= 0 ? burstThreshold : null,
+    windowMinutes: windowMinutes != null && windowMinutes >= 0 ? windowMinutes : null,
+    triggered: governor.triggered === true,
+    action: action || null,
+  };
+
+  if (
+    normalized.enabled === true &&
+    normalized.triggered === false &&
+    normalized.burstCount == null &&
+    normalized.burstThreshold == null &&
+    normalized.windowMinutes == null &&
+    !normalized.action
+  ) {
+    return null;
+  }
+
+  return normalized;
+}
+
+export function summarizeRetryGovernorSignals(entries) {
+  const governedEntries = (entries || []).filter((entry) => extractRetryGovernor(entry));
+  const triggeredEntries = governedEntries.filter((entry) => extractRetryGovernor(entry)?.triggered);
+  const bySignature = new Map();
+
+  for (const entry of triggeredEntries) {
+    const governor = extractRetryGovernor(entry);
+    const signature =
+      clean(governor?.signature) ||
+      `${clean(entry?.tool) || "unknown"}::${clean(entry?.action) || "unknown"}::${clean(entry?.errorType) || "none"}`;
+    if (!bySignature.has(signature)) {
+      bySignature.set(signature, {
+        signature,
+        triggeredEntries: 0,
+        maxBurstCount: null,
+        burstThreshold: null,
+        windowMinutes: null,
+        lastTriggeredAtIso: null,
+        actions: new Set(),
+      });
+    }
+    const item = bySignature.get(signature);
+    item.triggeredEntries += 1;
+    if (Number.isFinite(governor?.burstCount)) {
+      item.maxBurstCount = Math.max(item.maxBurstCount ?? 0, Number(governor.burstCount));
+    }
+    if (Number.isFinite(governor?.burstThreshold)) {
+      item.burstThreshold = Number(governor.burstThreshold);
+    }
+    if (Number.isFinite(governor?.windowMinutes)) {
+      item.windowMinutes = Number(governor.windowMinutes);
+    }
+    if (!item.lastTriggeredAtIso || (toMs(entry?.tsIso) ?? 0) > (toMs(item.lastTriggeredAtIso) ?? 0)) {
+      item.lastTriggeredAtIso = clean(entry?.tsIso);
+    }
+    if (governor?.action) {
+      item.actions.add(governor.action);
+    }
+  }
+
+  const topTriggeredSignatures = Array.from(bySignature.values())
+    .map((entry) => ({
+      signature: entry.signature,
+      triggeredEntries: entry.triggeredEntries,
+      maxBurstCount: entry.maxBurstCount,
+      burstThreshold: entry.burstThreshold,
+      windowMinutes: entry.windowMinutes,
+      lastTriggeredAtIso: entry.lastTriggeredAtIso,
+      actions: Array.from(entry.actions).sort(),
+    }))
+    .sort(
+      (left, right) =>
+        right.triggeredEntries - left.triggeredEntries ||
+        (right.maxBurstCount ?? 0) - (left.maxBurstCount ?? 0) ||
+        String(left.signature).localeCompare(String(right.signature))
+    );
+
+  return {
+    entriesWithGovernor: governedEntries.length,
+    triggeredEntries: triggeredEntries.length,
+    triggeredUniqueSignatures: bySignature.size,
+    topTriggeredSignatures: topTriggeredSignatures.slice(0, 6),
+  };
+}
+
+export function extractCommandFromContext(context = {}) {
+  return uniqueStrings([
+    readNestedString(context, ["command"]),
+    readNestedString(context, ["commandLine"]),
+    readNestedString(context, ["shellCommand"]),
+    readNestedString(context, ["shell", "command"]),
+    readNestedString(context, ["exec", "command"]),
+    readNestedString(context, ["execution", "command"]),
+    readNestedString(context, ["request", "command"]),
+    readNestedString(context, ["process", "command"]),
+  ])[0] || "";
+}
+
+export function extractCommandShape(entry) {
+  const context = entry?.context && typeof entry.context === "object" ? entry.context : {};
+  const raw = context?.commandShape && typeof context.commandShape === "object" ? context.commandShape : null;
+  if (!raw) return null;
+  const findings = Array.isArray(raw.findings)
+    ? raw.findings
+        .map((finding) => ({
+          id: clean(finding?.id),
+          severity: clean(finding?.severity) || "warn",
+          message: clean(finding?.message),
+          suggestion: clean(finding?.suggestion),
+        }))
+        .filter((finding) => finding.id || finding.message)
+    : [];
+  return {
+    command: clean(raw.command),
+    taskClass: clean(raw.taskClass),
+    findingIds: uniqueStrings([
+      ...(Array.isArray(raw.findingIds) ? raw.findingIds : []),
+      ...findings.map((finding) => finding.id),
+    ]),
+    findings,
+    repeatSignatureCount: Math.max(0, Math.round(Number(raw.repeatSignatureCount || 0))),
+    triggered: raw.triggered === true,
+    recommendation: clean(raw.recommendation),
+    safePatterns: uniqueStrings(Array.isArray(raw.safePatterns) ? raw.safePatterns : []),
+  };
+}
+
+export function extractStartupArtifactRepair(entry) {
+  const startup = getStartupContext(entry);
+  const raw = startup?.localArtifactRepair && typeof startup.localArtifactRepair === "object"
+    ? startup.localArtifactRepair
+    : null;
+  if (!raw && startup?.localArtifactRepairApplied !== true) return null;
+  return {
+    repaired: startup?.localArtifactRepairApplied === true || raw?.repaired === true,
+    reason: clean(raw?.reason),
+    source: clean(raw?.source),
+    capturedFrom: clean(raw?.capturedFrom),
+  };
+}
+
+function isStartupObservationEntry(entry) {
+  const tool = clean(entry?.tool);
+  const startup = getStartupContext(entry);
+  return tool && (SYNTHETIC_STARTUP_TOOL_NAMES.has(tool) || LIVE_STARTUP_TOOL_NAMES.has(tool) || Object.keys(startup).length > 0);
+}
+
+function inferObservationClass(entry) {
+  const packet = getStartupPacket(entry);
+  const explicit = clean(packet?.observationClass || getStartupContext(entry)?.observationClass).toLowerCase();
+  if (explicit === "live" || explicit === "synthetic") return explicit;
+  const tool = clean(entry?.tool);
+  if (LIVE_STARTUP_TOOL_NAMES.has(tool)) return "live";
+  if (SYNTHETIC_STARTUP_TOOL_NAMES.has(tool)) return "synthetic";
+  return "synthetic";
+}
+
+function startupObservationIdentity(entry, index = 0) {
+  const startup = getStartupContext(entry);
+  const packet = getStartupPacket(entry);
+  const observationClass = inferObservationClass(entry);
+  const observationKey =
+    clean(packet?.observationKey) ||
+    clean(startup?.observationKey) ||
+    (
+      clean(startup?.threadId) && clean(startup?.rolloutPath)
+        ? `${clean(startup.threadId)}|${clean(startup.rolloutPath)}`
+        : ""
+    );
+  if (observationKey) return `${observationClass}:${observationKey}`;
+  const tsIso = clean(entry?.tsIso);
+  if (tsIso) return `${observationClass}:${tsIso}:${clean(entry?.tool)}:${clean(entry?.action)}`;
+  return `${observationClass}:raw:${index}`;
+}
+
+function entryTsMs(entry) {
+  return toMs(entry?.tsIso) ?? 0;
+}
+
+export function summarizeStartupObservationCoverage(entries = []) {
+  const rawStartupEntries = (entries || []).filter((entry) => isStartupObservationEntry(entry));
+  const syntheticRawRows = rawStartupEntries.filter((entry) => inferObservationClass(entry) === "synthetic").length;
+  const liveRawRows = rawStartupEntries.filter((entry) => inferObservationClass(entry) === "live").length;
+  const deduped = new Map();
+
+  rawStartupEntries.forEach((entry, index) => {
+    const identity = startupObservationIdentity(entry, index);
+    const existing = deduped.get(identity);
+    if (!existing || entryTsMs(entry) >= entryTsMs(existing)) {
+      deduped.set(identity, entry);
+    }
+  });
+
+  const uniqueEntries = Array.from(deduped.values());
+  const uniqueSyntheticEntries = uniqueEntries.filter((entry) => inferObservationClass(entry) === "synthetic");
+  const uniqueLiveEntries = uniqueEntries.filter((entry) => inferObservationClass(entry) === "live");
+
+  return {
+    rawStartupEntries: rawStartupEntries.length,
+    uniqueEntries,
+    uniqueSyntheticEntries,
+    uniqueLiveEntries,
+    syntheticRawRows,
+    liveRawRows,
+    syntheticUniqueObservations: uniqueSyntheticEntries.length,
+    liveUniqueObservations: uniqueLiveEntries.length,
+    duplicateObservationCount: rawStartupEntries.length - uniqueEntries.length,
+  };
+}
+
+function inferCommandTaskClass(findingIds = []) {
+  if (findingIds.some((id) => id.startsWith("rg-glob"))) return "search";
+  if (findingIds.includes("get-content-json-without-raw")) return "json-parse";
+  if (findingIds.includes("node-e-import-without-module")) return "inline-script";
+  return "command";
+}
+
+function recommendedPatternsForFindings(findingIds = []) {
+  const explicitPatterns = uniqueStrings(
+    findingIds.flatMap((id) => COMMAND_SHAPE_PATTERN_BY_FINDING[id] || [])
+  );
+  if (explicitPatterns.length > 0) return explicitPatterns;
+  return recommendedWindowsCommandPatterns().map((entry) => clean(entry.safePattern)).filter(Boolean);
+}
+
+export function enrichCommandShapeContext(payload, recentEntries = []) {
+  const context = payload?.context && typeof payload.context === "object" ? payload.context : {};
+  const existing = extractCommandShape({ context });
+  const command = clean(existing?.command || extractCommandFromContext(context));
+  const findings = command ? auditWindowsCommandShape(command) : [];
+  const findingIds = uniqueStrings([
+    ...(existing?.findingIds || []),
+    ...findings.map((finding) => finding.id),
+  ]);
+
+  if (!command || findingIds.length === 0) {
+    return payload;
+  }
+
+  const signature = `${clean(payload?.tool) || "unknown"}::${clean(payload?.action) || "unknown"}::${clean(payload?.errorType) || "none"}`;
+  const recentMatchingFailures = (recentEntries || []).filter((entry) => {
+    if (!entry || entry.ok !== false) return false;
+    const entrySignature = `${clean(entry?.tool) || "unknown"}::${clean(entry?.action) || "unknown"}::${clean(entry?.errorType) || "none"}`;
+    const tsMs = toMs(entry?.tsIso);
+    const payloadTsMs = toMs(payload?.tsIso);
+    if (payloadTsMs == null || tsMs == null) return false;
+    return entrySignature === signature && payloadTsMs - tsMs <= 15 * 60 * 1000;
+  }).length;
+  const repeatSignatureCount = recentMatchingFailures + (payload?.ok === false ? 1 : 0);
+  const taskClass = clean(existing?.taskClass || inferCommandTaskClass(findingIds)) || "command";
+  const triggered = existing?.triggered === true || (payload?.ok === false && repeatSignatureCount >= 2);
+  const recommendation =
+    clean(existing?.recommendation) ||
+    (triggered
+      ? taskClass === "inline-script"
+        ? "Stop retrying the inline command as written; move the logic into a checked-in `.mjs` or `.ps1` helper and rerun the helper instead."
+        : "Stop retrying the same Windows command shape; replace it with the safe pattern before the next attempt."
+      : "");
+
+  return {
+    ...payload,
+    context: {
+      ...context,
+      commandShape: {
+        command,
+        taskClass,
+        findingIds,
+        findings: findings.length > 0 ? findings : existing?.findings || [],
+        repeatSignatureCount,
+        triggered,
+        recommendation,
+        safePatterns: uniqueStrings([
+          ...(existing?.safePatterns || []),
+          ...recommendedPatternsForFindings(findingIds),
+        ]),
+      },
+    },
+  };
+}
+
+function buildFrictionResult(kind, signature, recommendation, entry, extra = {}) {
+  return {
+    kind,
+    signature,
+    recommendation: clean(recommendation),
+    tsIso: clean(entry?.tsIso),
+    tool: clean(entry?.tool),
+    action: clean(entry?.action),
+    errorType: clean(entry?.errorType),
+    errorMessage: clean(entry?.errorMessage),
+    ...extra,
+  };
+}
+
+export function classifyToolcallFriction(entry) {
+  if (!entry || typeof entry !== "object") return null;
+  const startup = entry?.context?.startup && typeof entry.context.startup === "object" ? entry.context.startup : {};
+  const retryGovernor = extractRetryGovernor(entry);
+  const commandShape = extractCommandShape(entry);
+  const startupArtifactRepair = extractStartupArtifactRepair(entry);
+  const degradationBuckets = Array.isArray(startup.degradationBuckets) ? startup.degradationBuckets.map(clean) : [];
+  const missingIngredients = Array.isArray(startup.missingStartupIngredients)
+    ? startup.missingStartupIngredients.map(clean)
+    : [];
+  const errorText = [
+    clean(entry?.errorType),
+    clean(entry?.errorMessage),
+    clean(startup.reasonCode),
+    clean(startup.continuityState),
+    degradationBuckets.join(" "),
+    missingIngredients.join(" "),
+  ]
+    .join("\n")
+    .toLowerCase();
+
+  if (commandShape?.findingIds?.length) {
+    return buildFrictionResult(
+      "command-shape",
+      `command-shape:${commandShape.findingIds.join("+")}`,
+      clean(commandShape.recommendation) || "Use the recommended Windows-safe pattern before retrying this command.",
+      entry,
+      {
+        findingIds: commandShape.findingIds,
+        command: clean(commandShape.command),
+        taskClass: clean(commandShape.taskClass),
+      }
+    );
+  }
+
+  if (startupArtifactRepair?.repaired) {
+    return buildFrictionResult(
+      "startup/artifact sync gap",
+      `startup-artifact-repair:${startupArtifactRepair.source || startupArtifactRepair.reason || "unknown"}`,
+      "Patch the checkpoint/handoff emitter so startup does not need to reconstruct missing local runtime artifacts from remote rows.",
+      entry,
+      {
+        repairSource: startupArtifactRepair.source,
+        repairReason: startupArtifactRepair.reason,
+        repairCapturedFrom: startupArtifactRepair.capturedFrom,
+      }
+    );
+  }
+
+  if (STARTUP_AUTH_REASON_CODES.has(clean(startup.reasonCode)) || /startup_auth_stale/.test(errorText)) {
+    return buildFrictionResult(
+      "startup/auth",
+      `startup-auth:${clean(startup.reasonCode) || clean(entry?.errorType) || "unknown"}`,
+      "Refresh Studio Brain auth/transport health before retrying startup.",
+      entry
+    );
+  }
+
+  if (clean(startup.continuityState) && clean(startup.continuityState) !== "ready") {
+    return buildFrictionResult(
+      "startup/context quality",
+      `startup-context:${clean(startup.continuityState) || "missing"}:${degradationBuckets.join("+") || "none"}`,
+      "Improve startup-ready handoff/checkpoint memory so continuity stops degrading into fallback-only context.",
+      entry,
+      {
+        degradationBuckets,
+        missingIngredients,
+      }
+    );
+  }
+
+  if (PATH_FAILURE_PATTERNS.some((pattern) => pattern.test(errorText))) {
+    return buildFrictionResult(
+      "path/glob/ENOENT",
+      `path-failure:${clean(entry?.errorType) || "unknown"}`,
+      "Fix the path or glob shape before retrying; identical ENOENT-style retries rarely self-heal.",
+      entry
+    );
+  }
+
+  if (OUTPUT_BLOAT_PATTERNS.some((pattern) => pattern.test(errorText))) {
+    return buildFrictionResult(
+      "output explosion/context bloat",
+      `output-bloat:${clean(entry?.errorType) || "unknown"}`,
+      "Trim command output or split the task before retrying so the harness does not burn context on oversized responses.",
+      entry
+    );
+  }
+
+  if (EMPTY_OUTPUT_PATTERNS.some((pattern) => pattern.test(errorText))) {
+    return buildFrictionResult(
+      "output explosion/context bloat",
+      `empty-output:${clean(entry?.errorType) || "unknown"}`,
+      "Investigate why the command returned no usable output instead of repeating the same attempt.",
+      entry
+    );
+  }
+
+  if (retryGovernor?.triggered) {
+    return buildFrictionResult(
+      "blind retry bursts",
+      `retry-burst:${clean(retryGovernor.signature)}`,
+      "Pause the retry burst, change strategy, and only rerun once the failure mode is understood.",
+      entry,
+      {
+        retrySignature: retryGovernor.signature,
+      }
+    );
+  }
+
+  return null;
+}
+
+export function buildOperatorDragMetrics(entries = []) {
+  const frictionEntries = (entries || []).map((entry) => classifyToolcallFriction(entry)).filter(Boolean);
+  const retryGovernorSignals = summarizeRetryGovernorSignals(entries);
+  const commandShapeEntries = frictionEntries.filter((entry) => entry.kind === "command-shape");
+  const outputBloatEntries = frictionEntries.filter((entry) => entry.kind === "output explosion/context bloat");
+  const emptyOutputRetryCount = (entries || []).filter((entry) => {
+    const governor = extractRetryGovernor(entry);
+    const errorText = `${clean(entry?.errorType)}\n${clean(entry?.errorMessage)}`.toLowerCase();
+    return governor && EMPTY_OUTPUT_PATTERNS.some((pattern) => pattern.test(errorText));
+  }).length;
+  const startupCoverage = summarizeStartupObservationCoverage(entries);
+  const startupArtifactRepairEntries = startupCoverage.uniqueLiveEntries.filter(
+    (entry) => extractStartupArtifactRepair(entry)?.repaired === true
+  ).length;
+
+  return {
+    repeatedCommandShapeFailures: commandShapeEntries.length,
+    commandShapeGuardTriggeredEntries: (entries || []).filter((entry) => extractCommandShape(entry)?.triggered === true).length,
+    retriesPreventedByGovernor: retryGovernorSignals.triggeredEntries,
+    startupArtifactRepairEntries,
+    rawStartupEntries: startupCoverage.rawStartupEntries,
+    syntheticRawRows: startupCoverage.syntheticRawRows,
+    liveRawRows: startupCoverage.liveRawRows,
+    syntheticStartupEntries: startupCoverage.syntheticUniqueObservations,
+    liveStartupEntries: startupCoverage.liveUniqueObservations,
+    syntheticUniqueObservations: startupCoverage.syntheticUniqueObservations,
+    liveUniqueObservations: startupCoverage.liveUniqueObservations,
+    duplicateObservationCount: startupCoverage.duplicateObservationCount,
+    syntheticVsLiveStartupRatio:
+      startupCoverage.liveUniqueObservations > 0
+        ? Number((startupCoverage.syntheticUniqueObservations / startupCoverage.liveUniqueObservations).toFixed(3))
+        : null,
+    oversizedOutputIncidents: outputBloatEntries.length,
+    emptyOutputRetryCount,
+  };
+}
+
+export function summarizeToolcallDrag(entries = [], { limit = 3 } = {}) {
+  const grouped = new Map();
+  for (const entry of entries || []) {
+    const friction = classifyToolcallFriction(entry);
+    if (!friction) continue;
+    if (!grouped.has(friction.signature)) {
+      grouped.set(friction.signature, {
+        kind: friction.kind,
+        signature: friction.signature,
+        count: 0,
+        recommendation: friction.recommendation,
+        lastSeenIso: friction.tsIso,
+        sampleError: friction.errorMessage || friction.errorType || "",
+      });
+    }
+    const item = grouped.get(friction.signature);
+    item.count += 1;
+    item.recommendation = item.recommendation || friction.recommendation;
+    if ((toMs(friction.tsIso) ?? 0) > (toMs(item.lastSeenIso) ?? 0)) {
+      item.lastSeenIso = friction.tsIso;
+      item.sampleError = friction.errorMessage || friction.errorType || item.sampleError;
+    }
+  }
+
+  return Array.from(grouped.values())
+    .sort(
+      (left, right) =>
+        right.count - left.count ||
+        (toMs(right.lastSeenIso) ?? 0) - (toMs(left.lastSeenIso) ?? 0) ||
+        String(left.signature).localeCompare(String(right.signature))
+    )
+    .slice(0, Math.max(1, Math.round(Number(limit) || 3)));
+}

--- a/scripts/lib/studio-brain-memory-write.mjs
+++ b/scripts/lib/studio-brain-memory-write.mjs
@@ -3,6 +3,7 @@ import { homedir } from "node:os";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
+  refreshLocalBootstrapArtifacts,
   codexHomePath,
   loadBootstrapArtifacts,
   normalizeContinuityEnvelope,
@@ -23,6 +24,7 @@ const REPO_ROOT = resolve(__dirname, "..", "..");
 const DEFAULT_TIMEOUT_MS = 10_000;
 const AUTH_REFRESH_MIN_INTERVAL_MS = 10_000;
 const DEFAULT_REPO_CREDENTIALS_PATH = resolve(REPO_ROOT, "secrets", "portal", "portal-agent-staff.json");
+const DEFAULT_HOME_SECRETS_CREDENTIALS_PATH = resolve(homedir(), "secrets", "portal", "portal-agent-staff.json");
 const DEFAULT_HOME_CREDENTIALS_PATH = resolve(homedir(), ".ssh", "portal-agent-staff.json");
 const REMEMBER_SOURCE_MAP = {
   fact: { source: "manual", status: "accepted", memoryType: "semantic" },
@@ -34,6 +36,7 @@ const REMEMBER_SOURCE_MAP = {
   checkpoint: { source: "codex-handoff", status: "accepted", memoryType: "episodic" },
 };
 const REMEMBER_KINDS = new Set(Object.keys(REMEMBER_SOURCE_MAP));
+const STARTUP_CONTINUITY_KINDS = new Set(["decision", "progress", "blocker", "handoff", "checkpoint"]);
 
 function clean(value) {
   return String(value ?? "").trim();
@@ -85,9 +88,45 @@ function shouldRejectSpeculative(content, metadata) {
   return /^(maybe|probably|i think|might|could be)\b/i.test(clean(content));
 }
 
+function isStartupContinuityWrite(write) {
+  return STARTUP_CONTINUITY_KINDS.has(clean(write?.kind).toLowerCase()) || write?.rememberForStartup === true;
+}
+
+function countStartupContinuityAuditRows(rows = []) {
+  return (Array.isArray(rows) ? rows : []).filter(
+    (row) => STARTUP_CONTINUITY_KINDS.has(clean(row?.kind).toLowerCase()) || row?.rememberedForStartup === true
+  ).length;
+}
+
+function inferThreadPresentationProjectLane(threadContext) {
+  return inferProjectLane({
+    text: `${clean(threadContext?.firstUserMessage)}\n${clean(threadContext?.threadTitle)}`,
+    title: clean(threadContext?.threadTitle),
+    path: clean(threadContext?.cwd),
+  });
+}
+
+function bootstrapThreadScopedItemCount(artifacts = {}) {
+  return Math.max(
+    0,
+    Math.round(
+      Number(
+        artifacts?.continuityEnvelope?.threadScopedItemCount ||
+          artifacts?.continuityEnvelope?.startup?.threadScopedItemCount ||
+          0
+      )
+    )
+  );
+}
+
 function resolveDefaultCredentialsPath(env = process.env) {
   const explicitPath = clean(env.PORTAL_AGENT_STAFF_CREDENTIALS);
-  const candidates = [explicitPath, DEFAULT_REPO_CREDENTIALS_PATH, DEFAULT_HOME_CREDENTIALS_PATH].filter(Boolean);
+  const candidates = [
+    explicitPath,
+    DEFAULT_REPO_CREDENTIALS_PATH,
+    DEFAULT_HOME_SECRETS_CREDENTIALS_PATH,
+    DEFAULT_HOME_CREDENTIALS_PATH,
+  ].filter(Boolean);
   return candidates.find((candidate) => existsSync(candidate)) || DEFAULT_REPO_CREDENTIALS_PATH;
 }
 
@@ -411,6 +450,7 @@ function buildRememberRows(rawInput, { env = process.env, threadContext, capture
 
 function buildHandoffArtifact(row, threadContext) {
   const metadata = row.request.metadata && typeof row.request.metadata === "object" ? row.request.metadata : {};
+  const paths = runtimePathsForThread(clean(threadContext.threadId));
   const blockers = Array.isArray(metadata.blockers)
     ? metadata.blockers
     : clean(metadata.blocker)
@@ -439,8 +479,15 @@ function buildHandoffArtifact(row, threadContext) {
     workCompleted: clean(metadata.workCompleted || row.content),
     blockers,
     nextRecommendedAction: clean(metadata.nextRecommendedAction),
-    artifactPointers:
-      metadata.artifactPointers && typeof metadata.artifactPointers === "object" ? metadata.artifactPointers : {},
+    artifactPointers: {
+      ...(metadata.artifactPointers && typeof metadata.artifactPointers === "object" ? metadata.artifactPointers : {}),
+      continuityEnvelopePath: clean(paths.continuityEnvelopePath),
+      bootstrapContextPath: clean(paths.bootstrapContextJsonPath),
+      bootstrapMetadataPath: clean(paths.bootstrapMetadataPath),
+      handoffPath: clean(paths.handoffPath),
+      startupContextCachePath: clean(paths.startupContextCachePath),
+      writesJsonlPath: clean(paths.writesJsonlPath),
+    },
     parentRunId: clean(metadata.parentRunId || threadContext.bootstrapArtifacts?.handoff?.parentRunId),
     handoffOwner: clean(metadata.handoffOwner || metadata.owner || threadContext.bootstrapArtifacts?.handoff?.handoffOwner),
     sourceShellId: clean(metadata.sourceShellId || threadContext.bootstrapArtifacts?.handoff?.sourceShellId),
@@ -450,6 +497,37 @@ function buildHandoffArtifact(row, threadContext) {
     threadId: clean(threadContext.threadId),
     existing: threadContext.bootstrapArtifacts?.handoff,
   });
+}
+
+function handoffCandidatePriority(write) {
+  if (!write || typeof write !== "object") return 99;
+  if (write.kind === "handoff") return 0;
+  if (write.kind === "checkpoint") return 1;
+  if (write.kind === "progress") return 2;
+  if (write.kind === "decision") return 3;
+  return 99;
+}
+
+function isStartupHandoffCandidate(write) {
+  if (!write || typeof write !== "object") return false;
+  if (write.kind === "handoff") return true;
+  if (!["checkpoint", "progress", "decision"].includes(write.kind)) return false;
+  return write.rememberForStartup === true || write.request?.metadata?.startupEligible === true;
+}
+
+function selectBestHandoffCandidate(successfulWrites) {
+  return (Array.isArray(successfulWrites) ? successfulWrites : [])
+    .filter((write) => isStartupHandoffCandidate(write))
+    .sort((left, right) => {
+      const priorityDelta = handoffCandidatePriority(left) - handoffCandidatePriority(right);
+      if (priorityDelta !== 0) return priorityDelta;
+      const leftImportance = Number(left?.request?.importance ?? left?.importance ?? 0);
+      const rightImportance = Number(right?.request?.importance ?? right?.importance ?? 0);
+      if (Number.isFinite(leftImportance) && Number.isFinite(rightImportance) && rightImportance !== leftImportance) {
+        return rightImportance - leftImportance;
+      }
+      return Number(right?.index ?? 0) - Number(left?.index ?? 0);
+    })[0] || null;
 }
 
 function mergeSignals(existing, incoming, keyName) {
@@ -472,6 +550,54 @@ function updateContinuityEnvelope(threadId, threadContext, writes) {
     threadId,
     cwd: clean(threadContext.cwd),
   });
+  const bootstrapEnvelope = normalizeContinuityEnvelope(threadContext.bootstrapArtifacts?.continuityEnvelope, {
+    threadId,
+    cwd: clean(threadContext.cwd),
+  });
+  const bootstrapMetadata =
+    threadContext.bootstrapArtifacts?.metadata && typeof threadContext.bootstrapArtifacts.metadata === "object"
+      ? threadContext.bootstrapArtifacts.metadata
+      : {};
+  const startupRelevantWrites = writes.filter((write) => isStartupContinuityWrite(write));
+  const writeAuditRows = readJsonl(paths.writesJsonlPath);
+  const writePresentationProjectLane =
+    dedupeStrings(
+      startupRelevantWrites.map((write) =>
+        clean(write.projectLane || write.request?.metadata?.projectLane || write.request?.metadata?.presentationProjectLane)
+      ),
+      4
+    )[0] || "";
+  const effectivePresentationProjectLane = clean(
+    writePresentationProjectLane ||
+      bootstrapEnvelope.presentationProjectLane ||
+      next.presentationProjectLane ||
+      inferThreadPresentationProjectLane(threadContext)
+  );
+  const effectiveThreadScopedItemCount = Math.max(
+    0,
+    Math.round(Number(next.threadScopedItemCount || next.startup?.threadScopedItemCount || 0)),
+    bootstrapThreadScopedItemCount(threadContext.bootstrapArtifacts),
+    countStartupContinuityAuditRows(writeAuditRows),
+    startupRelevantWrites.length
+  );
+  const startupSatisfiedBy = clean(
+    next.startupSatisfiedBy ||
+      bootstrapMetadata.startupGateSatisfiedBy ||
+      bootstrapEnvelope.startupSatisfiedBy ||
+      bootstrapEnvelope.startup?.satisfiedBy
+  );
+
+  next.threadTitle = clean(threadContext.threadTitle || next.threadTitle);
+  next.firstUserMessage = clean(threadContext.firstUserMessage || next.firstUserMessage);
+  if (startupSatisfiedBy) {
+    next.startupSatisfiedBy = startupSatisfiedBy;
+  }
+  if (effectivePresentationProjectLane) {
+    next.presentationProjectLane = effectivePresentationProjectLane;
+  }
+  if (effectiveThreadScopedItemCount > 0) {
+    next.threadScopedItemCount = effectiveThreadScopedItemCount;
+  }
 
   for (const write of writes) {
     const metadata = write.request.metadata && typeof write.request.metadata === "object" ? write.request.metadata : {};
@@ -525,11 +651,70 @@ function updateContinuityEnvelope(threadId, threadContext, writes) {
     );
   }
 
+  if (next.continuityState === "ready" && effectiveThreadScopedItemCount > 0) {
+    next.fallbackOnly = false;
+    next.startupSourceQuality = "thread-scoped-dominant";
+    next.laneSourceQuality = "thread-scoped-dominant";
+  }
+
+  next.artifactPointers = {
+    ...(next.artifactPointers && typeof next.artifactPointers === "object" ? next.artifactPointers : {}),
+    continuityEnvelopePath: clean(paths.continuityEnvelopePath),
+    bootstrapContextPath: clean(paths.bootstrapContextJsonPath),
+    bootstrapMetadataPath: clean(paths.bootstrapMetadataPath),
+    handoffPath: clean(paths.handoffPath),
+    startupContextCachePath: clean(paths.startupContextCachePath),
+    writesJsonlPath: clean(paths.writesJsonlPath),
+  };
+  next.startup = {
+    ...(next.startup && typeof next.startup === "object" ? next.startup : {}),
+    ...(startupSatisfiedBy ? { satisfiedBy: startupSatisfiedBy } : {}),
+    ...(effectiveThreadScopedItemCount > 0 ? { threadScopedItemCount: effectiveThreadScopedItemCount } : {}),
+    ...(clean(next.startupSourceQuality) ? { startupSourceQuality: clean(next.startupSourceQuality) } : {}),
+    fallbackOnly: next.fallbackOnly === true,
+  };
+
   writeContinuityEnvelope(threadId, normalizeContinuityEnvelope(next, {
     threadId,
     cwd: clean(threadContext.cwd),
     existing,
   }));
+}
+
+function refreshBootstrapArtifacts(threadId, threadContext, successfulWrites) {
+  if (!threadId) return null;
+  const latestEnvelope = loadBootstrapArtifacts(threadId)?.continuityEnvelope || {};
+  const satisfiedBy = clean(
+    latestEnvelope.startupSatisfiedBy ||
+      latestEnvelope.startup?.satisfiedBy ||
+      threadContext.bootstrapArtifacts?.metadata?.startupGateSatisfiedBy ||
+      "validated-local-continuity"
+  );
+  const presentationProjectLane = clean(
+    latestEnvelope.presentationProjectLane || inferThreadPresentationProjectLane(threadContext)
+  );
+  const refreshed = refreshLocalBootstrapArtifacts({
+    threadId,
+    cwd: clean(threadContext.cwd),
+    threadTitle: clean(threadContext.threadTitle),
+    firstUserMessage: clean(threadContext.firstUserMessage),
+    metadata: {
+      startupGateSatisfiedBy: satisfiedBy,
+      continuityState: clean(latestEnvelope.continuityState || "ready"),
+      presentationProjectLane,
+      threadScopedItemCount: Math.max(
+        0,
+        Number(latestEnvelope.threadScopedItemCount || latestEnvelope.startup?.threadScopedItemCount || 0)
+      ),
+      startupSourceQuality: clean(
+        latestEnvelope.startupSourceQuality || latestEnvelope.laneSourceQuality || "thread-scoped-dominant"
+      ),
+      rememberedMemoryIds: dedupeStrings(successfulWrites.map((write) => clean(write.memoryId)), 24),
+      rememberedRequestIds: dedupeStrings(successfulWrites.map((write) => clean(write.clientRequestId)), 24),
+      rememberedKinds: dedupeStrings(successfulWrites.map((write) => clean(write.kind)), 12),
+    },
+  });
+  return refreshed;
 }
 
 function appendWriteAudit(threadId, threadContext, successfulWrites) {
@@ -570,12 +755,12 @@ function syncLocalArtifacts(threadContext, successfulWrites) {
   const threadId = clean(threadContext.threadId);
   if (!threadId || successfulWrites.length === 0) return;
   appendWriteAudit(threadId, threadContext, successfulWrites);
-  for (const write of successfulWrites) {
-    if (write.kind === "handoff") {
-      writeHandoffArtifact(threadId, buildHandoffArtifact(write, threadContext));
-    }
+  const handoffCandidate = selectBestHandoffCandidate(successfulWrites);
+  if (handoffCandidate) {
+    writeHandoffArtifact(threadId, buildHandoffArtifact(handoffCandidate, threadContext));
   }
   updateContinuityEnvelope(threadId, threadContext, successfulWrites);
+  refreshBootstrapArtifacts(threadId, threadContext, successfulWrites);
 }
 
 function parseRememberResponse(response, rememberRows) {

--- a/scripts/studio-brain-memory-write.test.mjs
+++ b/scripts/studio-brain-memory-write.test.mjs
@@ -129,6 +129,11 @@ test("rememberWithStudioBrain batches multiple saves through import and updates 
     const envelope = readJson(paths.continuityEnvelopePath, {});
     assert.equal(envelope.schema, "codex-continuity-envelope.v1");
     assert.equal(envelope.continuityState, "ready");
+    assert.equal(envelope.presentationProjectLane, "monsoonfire-portal");
+    assert.equal(envelope.threadScopedItemCount, 2);
+    assert.equal(envelope.startupSourceQuality, "thread-scoped-dominant");
+    assert.equal(envelope.laneSourceQuality, "thread-scoped-dominant");
+    assert.equal(envelope.startup.threadScopedItemCount, 2);
     assert.equal(
       String(envelope.bootstrapSummary || "").includes("route new thread memory writes"),
       true
@@ -136,6 +141,27 @@ test("rememberWithStudioBrain batches multiple saves through import and updates 
     assert.equal(Array.isArray(envelope.blockers), true);
     assert.equal(envelope.blockers[0].summary, "Blocker: old threads still have ad hoc memory write habits.");
     assert.equal(envelope.nextRecommendedAction, "Ship the home instruction update.");
+
+    const handoff = readJson(paths.handoffPath, {});
+    assert.equal(handoff.schema, "codex-handoff.v1");
+    assert.equal(
+      String(handoff.summary || "").includes("Decision: route new thread memory writes through studio_brain_remember."),
+      true
+    );
+
+    const bootstrapContext = readJson(paths.bootstrapContextJsonPath, {});
+    assert.equal(bootstrapContext.schema, "codex-startup-bootstrap-context.v1");
+    assert.equal(Array.isArray(bootstrapContext.items), true);
+    assert.equal(bootstrapContext.items.some((item) => item.source === "codex-handoff"), true);
+
+    const bootstrapMetadata = readJson(paths.bootstrapMetadataPath, {});
+    assert.equal(bootstrapMetadata.threadId, threadId);
+    assert.equal(bootstrapMetadata.startupGateSatisfiedBy, "validated-local-continuity");
+    assert.equal(bootstrapMetadata.continuityState, "ready");
+    assert.equal(bootstrapMetadata.presentationProjectLane, "monsoonfire-portal");
+    assert.equal(bootstrapMetadata.threadScopedItemCount, 2);
+    assert.equal(bootstrapMetadata.artifactPointers.handoffPath, paths.handoffPath);
+    assert.equal(bootstrapMetadata.artifactPointers.startupContextCachePath, paths.startupContextCachePath);
   } finally {
     cleanupThreadRuntime(threadId);
   }
@@ -208,6 +234,61 @@ test("rememberWithStudioBrain writes handoff artifacts and keeps request ids sta
     const audit = readJsonl(paths.writesJsonlPath);
     assert.equal(audit.length, 1);
     assert.equal(audit[0].requestId, calls[0].body.clientRequestId);
+  } finally {
+    cleanupThreadRuntime(threadId);
+  }
+});
+
+test("rememberWithStudioBrain prefers an explicit handoff over startup-eligible checkpoints when both are present", async () => {
+  const threadId = "remember-handoff-priority-test";
+  const paths = cleanupThreadRuntime(threadId);
+
+  try {
+    await rememberWithStudioBrain(
+      {
+        items: [
+          {
+            kind: "checkpoint",
+            content: "Checkpoint: startup guardrails landed.",
+            rememberForStartup: true,
+            metadata: {
+              activeGoal: "Finish the startup guardrail rollout.",
+              nextRecommendedAction: "Verify preflight.",
+            },
+          },
+          {
+            kind: "handoff",
+            content: "Handoff: verify the startup guardrails end to end.",
+            rememberForStartup: true,
+            metadata: {
+              activeGoal: "Verify the startup guardrails end to end.",
+              nextRecommendedAction: "Run codex-doctor and startup-preflight.",
+            },
+          },
+        ],
+      },
+      {
+        threadId,
+        cwd: "D:\\monsoonfire-portal",
+        threadTitle: "startup handoff priority",
+        firstUserMessage: "tighten startup guardrails",
+        requestJson: async () => ({
+          ok: true,
+          result: {
+            imported: 2,
+            failed: 0,
+            results: [
+              { index: 0, ok: true, id: "mem_req_priority_1" },
+              { index: 1, ok: true, id: "mem_req_priority_2" },
+            ],
+          },
+        }),
+      }
+    );
+
+    const handoff = readJson(paths.handoffPath, {});
+    assert.equal(handoff.summary, "Handoff: verify the startup guardrails end to end.");
+    assert.equal(handoff.activeGoal, "Verify the startup guardrails end to end.");
   } finally {
     cleanupThreadRuntime(threadId);
   }

--- a/studio-brain/.env.integrity.json
+++ b/studio-brain/.env.integrity.json
@@ -1,6 +1,6 @@
 {
   "schema": "studiobrain-infra-integrity-v1",
-  "generatedAt": "2026-04-11T21:42:15.767Z",
+  "generatedAt": "2026-04-13T05:47:46.730Z",
   "generatedBy": "scripts/integrity-check.mjs",
   "allowUnknown": false,
   "metadata": {
@@ -197,13 +197,13 @@
     },
     {
       "path": "scripts/lib/codex-session-memory-utils.mjs",
-      "sha256": "0c73ad359ab50c81014ebd18a0d90809261a60e0e633ac09b01de113019256aa",
-      "size": 56997
+      "sha256": "b608ecdbe1c5da835a2fc4f44febb3906a9c6df09228a04e1462779aad0cf0d6",
+      "size": 80068
     },
     {
       "path": "scripts/lib/codex-startup-reliability.mjs",
-      "sha256": "0a006fcd95857e64c9e6e4646630d375f6d570464ea7fbdd5cd147157bc12f20",
-      "size": 6789
+      "sha256": "9285ae89f567ad389d4768a86844aea8483dcfa46e9fa5b6f6a7f4de4c26aca7",
+      "size": 15046
     },
     {
       "path": "scripts/lib/codex-worktree-utils.mjs",
@@ -227,8 +227,8 @@
     },
     {
       "path": "scripts/lib/studio-brain-memory-write.mjs",
-      "sha256": "cb8fc0cf13b108f0922d3b77284272ca2aba09c32a374f2931353698f3926a77",
-      "size": 25212
+      "sha256": "3335b32f21cfaad871f12303bbca3dad5c79e9a4dedd8caf5fbc930303f103f6",
+      "size": 33222
     },
     {
       "path": "scripts/lib/studio-brain-startup-auth.mjs",


### PR DESCRIPTION
## Summary
- harden the Codex startup continuity path so only trusted thread-scoped or validated-local continuity can publish ready-state grounding
- split trusted startup grounding from lower-authority advisory fallback and dedupe live startup observations across doctor/scorecard telemetry
- add the local-first startup cache/single-flight path, shared runtime artifact sync, and refresh the Studio Brain integrity manifest required by host deploys

## Root cause
Cross-thread fallback rows could still populate `dominantGoal` and `topBlocker`, startup coverage trusted raw duplicate observations, and the host integrity manifest no longer matched the startup continuity files after the fix landed.

## Validation
- `node --test scripts/codex-startup-reliability.test.mjs scripts/codex-doctor.test.mjs scripts/codex/open-memory-automation.test.mjs scripts/codex-session-memory-utils.test.mjs scripts/studio-brain-memory-write.test.mjs scripts/lib/codex-startup-reliability.test.mjs`
- `node scripts/codex-startup-preflight.mjs --json`
- `node scripts/codex-doctor.mjs --json`
- `npm run integrity:check -- --json`
- `npm run studio:ops:deploy`
