### PR TITLE
[codex] Add live surface trust audit and remediation epic

### DIFF
--- a/artifacts/intent-plan.generated.json
+++ b/artifacts/intent-plan.generated.json
@@ -505,7 +505,7 @@
       "title": "Portal QA Automation Coverage Expansion",
       "file": "intents/EPIC-PORTAL-QA-AUTOMATION-COVERAGE.intent.json",
       "epicPath": "docs/epics/EPIC-PORTAL-QA-AUTOMATION-COVERAGE.md",
-      "epicDigestSha256": "0e17d6868411cf34b34a3d70e53e5ce719a8b96e530355b1be506fabf310a966",
+      "epicDigestSha256": "6b63110356be50cd936ecadcc4bbf4086ec3f18b89d3bc84194a28f77c9bbb76",
       "intentDigestSha256": "36acedf2604bf0f5e60a72df2b3f0ecd970d36054e34382a0e3e29d9ae281efc",
       "objective": "Close recurring QA gaps with repeatable automated checks for authz, index drift, canary health, fixture stewardship, and promotion safety.",
       "riskTier": "medium",
@@ -772,7 +772,7 @@
       "title": "Staff Portal Module Consolidation",
       "file": "intents/EPIC-STAFF-PORTAL-MODULE-CONSOLIDATION.intent.json",
       "epicPath": "docs/epics/EPIC-STAFF-PORTAL-MODULE-CONSOLIDATION.md",
-      "epicDigestSha256": "cad021bcc8e77ee8aa9f7d95dcf25988dbb6f08d43da0b6786b91591e8318838",
+      "epicDigestSha256": "96f7f4bfeb95de6db0faec93bd3a953c60abf2f708a5ee1d626f23325d83e874",
       "intentDigestSha256": "2fd89425b37587ed983bfb19d131d78773758eea38800480886d7403f22ad9e0",
       "objective": "Consolidate duplicated staff portal modules into a task-oriented cockpit flow while preserving operational capabilities and lowering navigation friction.",
       "riskTier": "medium",
@@ -1456,8 +1456,8 @@
       "authorityTier": "T2"
     }
   ],
-  "generatedAt": "2026-03-20T18:35:16.621Z",
+  "generatedAt": "2026-04-14T16:44:07.289Z",
   "intentCount": 8,
   "taskCount": 24,
-  "planDigestSha256": "c1e421cce609adaafe5520ac34a38d6759bdb0c41c6a491cc6694bd100f0227e"
+  "planDigestSha256": "96660e1fd06d3e94dadd7ba7cd995cb576e8514e50da3807535918123db0a8c5"
 }

--- a/docs/ENGINEERING_TODOS.md
+++ b/docs/ENGINEERING_TODOS.md
@@ -5,6 +5,10 @@ Owner: TBD
 Status: Active
 
 ## Pinned (Website First-Visit Review — 2026-02-16)
+- [ ] Start the live-surface trust remediation program from the April 2026 website + portal audit.
+  - Epic: `docs/epics/EPIC-LIVE-SURFACE-TRUST-AND-SERVICE-OPERATING-SYSTEM.md`
+  - Audit: `docs/audits/live-surface-audit-2026-04-12.md`
+  - First wave: canonical portal handoff, public freshness contract, member start surface, Ware Check-in clarity, guided fallbacks, and QA parity guards.
 - [x] Website first-time onboarding path + primary CTA clarity.
   - Ticket: `tickets/P2-website-new-user-primary-cta-and-start-path.md`
 - [x] Website mobile navigation affordance and tap-target clarity.

--- a/docs/audits/live-surface-audit-2026-04-12.md
+++ b/docs/audits/live-surface-audit-2026-04-12.md
@@ -1,17 +1,386 @@
-# Live Surface Audit Notes — 2026-04-12
+# Live Surface Audit — Website + Portal (2026-04-12)
 
-## Access check from this environment
+Status: Completed
+Date: 2026-04-12
+Owner: Product + Design + Portal Ops
+Related Epic: `docs/epics/EPIC-LIVE-SURFACE-TRUST-AND-SERVICE-OPERATING-SYSTEM.md`
+
+This artifact turns the April 2026 live-surface review into a durable repo record. The audit target was the public website at `https://monsoonfire.com` and the member/staff portal at `https://portal.monsoonfire.com`.
+
+Direct rendered inspection was partially blocked from the audit runner:
+
 - `curl -I https://monsoonfire.com` returned `HTTP/1.1 403 Forbidden`.
 - `curl -I https://portal.monsoonfire.com` returned `HTTP/1.1 403 Forbidden`.
-- Headless Playwright browser installation was attempted (`npx playwright install chromium`) and failed due CDN `403 Forbidden`, so direct rendered visual verification could not be completed from this runner.
+- `npx playwright install chromium` failed with `403 Forbidden`, so full browser-driven visual review was not possible from that environment.
 
-## Website evidence sampled from repository source
-- Homepage login points to `https://portal.monsoonfire.com`.
-- Several other pages still point login to `https://monsoonfire.kilnfire.com`.
-- Homepage includes loading placeholders for kiln status and updates.
-- Kiln status data file reports `lastUpdated: 2026-01-31 5:30 PM`.
+The findings below separate direct evidence from source-backed inference and call out what still requires manual verification in a real browser session.
 
-## Portal evidence sampled from repository source
-- Main nav currently groups areas into Kiln Rentals, Studio & Resources, Community.
-- Unknown routes fall back to generic `PlaceholderView` that says "Coming soon. We are designing this area next."
-- `WareCheckInView` currently re-exports `ReservationsView`.
+# 1. Executive Summary
+
+- Website overall: promising structure, weak operational confidence. The site explains the service categories, but mixed portal destinations, stale operational cues, and loader-first production states make it feel partially maintained instead of tightly run.
+- Portal overall: capable but not yet authoritative enough. The portal has meaningful breadth, but first-use clarity, route readiness, and member-facing queue language still leave too much room for hesitation.
+- Biggest strategic risk: a cautious artist perceives a black-box service. Mixed handoffs, stale timestamps, and vague status language make it harder to trust Monsoon Fire with fragile work that disappears into a multi-day workflow.
+- Biggest strategic opportunity: make both surfaces behave like one calm studio operating system by standardizing the handoff, freshness model, terminology, and piece journey language.
+
+# 2. Evidence Log
+
+## Observed directly
+
+- Live HTTP access from the audit runner was blocked with `403 Forbidden` for both production domains.
+- The website source contains mixed portal destinations: some pages target `https://portal.monsoonfire.com`, while others still target `https://monsoonfire.kilnfire.com`.
+- Website production markup includes loader-first states such as `Loading kiln status...` and `Loading public updates...`.
+- The kiln status data file reports `lastUpdated: 2026-01-31 5:30 PM`, which was stale relative to the April 2026 audit date.
+- Portal routing still includes a generic `PlaceholderView` fallback and `WareCheckInView` currently re-exports `ReservationsView`.
+- The portal nav groups many tasks into broad buckets without an explicit first-action surface for new members.
+
+## Strong inference
+
+- Users are likely to hesitate when one page says “Open the portal” and another sends them to a legacy host because that reads like migration drift or account fragmentation.
+- Stale timestamps, `TBD` public-event language, and visible loading placeholders likely weaken the sense that operations are actively monitored.
+- Portal breadth probably exceeds first-time comprehension unless the product recommends a next action based on role and intent.
+- Member confidence is still too dependent on reading text blocks instead of seeing a clear “your work journey” model.
+
+## Needs manual verification
+
+- Rendered production hierarchy, spacing, and polish in a real browser session.
+- Authenticated portal flows for onboarding, membership, billing, queue visibility, and staff actions.
+- Real small-screen behavior on phones and tablets.
+- Whether live production currently masks or resolves some of the repo-observed trust leaks at runtime.
+
+# 3. Gap Matrix
+
+| Surface | Area | Current State | Gap | Why It Matters | Severity | Recommended Fix | Effort | Evidence Grade |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Website | Public to portal handoff | Mixed login and portal targets across pages | Canonical handoff is not enforced | Users question whether they are entering the right system | P0 | Standardize one portal host and route intent model everywhere | S | Observed |
+| Website | Operational freshness | Kiln status timestamp is stale in source data | No hard freshness contract | Freshness is a proxy for competence in a service business | P0 | Add stale thresholds, freshness badges, and escalation copy | M | Observed |
+| Website | Loading states | Production pages expose raw loading copy | Loader-first experience feels temporary | First impression becomes “unfinished” instead of “operational” | P1 | Replace raw loading text with skeletons and stale-safe fallback states | S | Observed |
+| Website | Event certainty | Community/event surfaces include tentative language | Confidence model is unclear | Users do not know whether a public activity is real, tentative, or outdated | P1 | Add confirmed/tentative/cancelled chips with verified timestamps | S | Observed |
+| Website | CTA clarity | Different pages imply different portal actions | Conversion path is fragmented | Users hesitate instead of moving forward | P1 | Normalize CTA language by intent: reserve, membership, support, dashboard | S | Inference |
+| Portal | First-use mental model | Broad nav exists, but “what should I do first?” is weak | No task-first member start surface | First-time users must reverse-engineer the information architecture | P1 | Add member-first home with guided shortcuts and next actions | M | Observed |
+| Portal | Ware Check-in semantics | `WareCheckInView` reuses `ReservationsView` | Intake flow language is blurred | Users cannot tell whether they are checking in, booking, or tracking | P1 | Give Ware Check-in a dedicated shell, copy, and step framing | M | Observed |
+| Portal | Route readiness | Unknown routes fall back to generic placeholder copy | Production fallback is too generic | “Coming soon” in a member product is a direct trust leak | P0 | Replace placeholders with guided fallback states and support paths | M | Observed |
+| Portal | Piece journey clarity | Status data exists but confidence is text-heavy | Queue and stage visibility are still opaque | Artists need proof their work has not vanished into a black box | P0 | Add explicit stage timeline, last touchpoint, and next-step messaging | M | Inference |
+| Both | Shared vocabulary | Website and portal use overlapping but inconsistent language | Story and product terminology drift apart | Promise-to-product mismatch increases support burden and distrust | P1 | Publish a shared terminology contract and reuse it across both surfaces | M | Inference |
+
+# 4. Top 10 Highest-Value Improvements
+
+1. Improvement: standardize every public portal/login handoff to one canonical destination.
+   Why it matters: removes immediate “is this the right account/system?” hesitation.
+   Affects: trust, conversion, clarity.
+   Where: both.
+   Severity: P0.
+   Effort: S.
+
+2. Improvement: add a production freshness contract for kiln status, public updates, and event certainty.
+   Why it matters: stale operational signals look like neglect.
+   Affects: trust, operational confidence.
+   Where: website.
+   Severity: P0.
+   Effort: M.
+
+3. Improvement: replace generic placeholder routes with guided fallback states.
+   Why it matters: “coming soon” language in a live member surface damages confidence fast.
+   Affects: trust, usability.
+   Where: portal.
+   Severity: P0.
+   Effort: M.
+
+4. Improvement: create a member-first start surface that recommends the next action.
+   Why it matters: first-use uncertainty is still too high.
+   Affects: clarity, usability, conversion.
+   Where: portal.
+   Severity: P1.
+   Effort: M.
+
+5. Improvement: separate Ware Check-in from Reservations in language and flow framing.
+   Why it matters: the current reuse leaks internal structure into the member journey.
+   Affects: trust, clarity, usability.
+   Where: portal.
+   Severity: P1.
+   Effort: M.
+
+6. Improvement: introduce a unified “your work journey” timeline across website and portal.
+   Why it matters: users need chain-of-custody confidence, not just generic status text.
+   Affects: trust, operational confidence, delight.
+   Where: both.
+   Severity: P0.
+   Effort: M.
+
+7. Improvement: normalize CTA language by user intent.
+   Why it matters: “get started,” “open the portal,” and legacy links currently create drift.
+   Affects: conversion, clarity.
+   Where: website.
+   Severity: P1.
+   Effort: S.
+
+8. Improvement: give event and update surfaces confidence labels instead of vague text.
+   Why it matters: public programming should feel curated and current, not provisional.
+   Affects: trust, clarity.
+   Where: website.
+   Severity: P1.
+   Effort: S.
+
+9. Improvement: add automation that fails on legacy portal links, stale public status data, and generic placeholders.
+   Why it matters: these are trust leaks that should not depend on memory to catch.
+   Affects: trust, release confidence.
+   Where: both.
+   Severity: P1.
+   Effort: M.
+
+10. Improvement: standardize a small trust-oriented component set across both surfaces.
+    Why it matters: shared states create family resemblance and operational coherence.
+    Affects: trust, clarity, delight.
+    Where: both.
+    Severity: P2.
+    Effort: M.
+
+# 5. Trust Leaks
+
+1. Mixed portal hosts in production-facing website pages.
+   Why it weakens confidence: it implies split systems or a migration that is not under control.
+   Severity: P0.
+   Recommended fix: remove all legacy `monsoonfire.kilnfire.com` login/create-account links from public surfaces and enforce parity in tests.
+
+2. Stale operational timestamp on kiln status data.
+   Why it weakens confidence: users infer that the queue or firing board may not be actively watched.
+   Severity: P0.
+   Recommended fix: add freshness thresholds, stale messaging, and an owner update cadence.
+
+3. Raw loading placeholders in public production markup.
+   Why it weakens confidence: if content loads slowly or fails, the site feels unfinished instead of resilient.
+   Severity: P1.
+   Recommended fix: show structured skeletons and explicit fallback copy rather than raw “Loading...” text.
+
+4. Generic portal placeholder route.
+   Why it weakens confidence: “coming soon” language inside a member/staff portal reads as incomplete product surface area.
+   Severity: P0.
+   Recommended fix: provide guided fallback cards with available next actions, support contact, and route-specific ownership.
+
+5. Ware Check-in and Reservations sharing the same implementation shell.
+   Why it weakens confidence: member language reflects internal reuse instead of the user’s actual task.
+   Severity: P1.
+   Recommended fix: split copy, entry framing, and progress language even if data plumbing stays shared initially.
+
+6. Public event certainty is not explicit enough.
+   Why it weakens confidence: tentative or outdated programming makes the studio feel loosely operated.
+   Severity: P1.
+   Recommended fix: add certainty chips, verified timestamps, and expiry/fallback rules.
+
+# 6. Motion + Interaction Recommendations
+
+1. Page or component: public status cards.
+   Current weakness: freshness and liveness are not visually differentiated.
+   Proposed pattern: subtle live/stale status transition with timestamp emphasis.
+   Why it helps: communicates whether the operator has touched the data recently.
+   Complexity: S.
+
+2. Page or component: website-to-portal handoff CTA.
+   Current weakness: handoff is abrupt and inconsistent.
+   Proposed pattern: brief transition state that confirms destination and task intent.
+   Why it helps: reassures users they are entering the correct system.
+   Complexity: S.
+
+3. Page or component: Ware Check-in.
+   Current weakness: flow semantics are blurred.
+   Proposed pattern: intake stepper with persistent summary and “what happens next” copy.
+   Why it helps: lowers hesitation during a meaningful handoff of artwork.
+   Complexity: M.
+
+4. Page or component: queue and piece status cards.
+   Current weakness: status comprehension is text-heavy.
+   Proposed pattern: stage chips plus expanding history/timeline rows.
+   Why it helps: makes piece progress legible at a glance.
+   Complexity: M.
+
+5. Page or component: placeholder and empty states.
+   Current weakness: generic or sparse fallback messaging.
+   Proposed pattern: guided fallback cards with retry, support, and alternate route.
+   Why it helps: keeps failure states from feeling like dead ends.
+   Complexity: S.
+
+6. Page or component: event/update cards.
+   Current weakness: certainty and recency are under-signaled.
+   Proposed pattern: verified-at microcopy with confirmed/tentative state chips.
+   Why it helps: public operations feel curated and current.
+   Complexity: S.
+
+# 7. Design System / Reusable Component Recommendations
+
+- Component name: Status chip.
+  Where it should appear: website updates, kiln status, event cards, portal queue states.
+  Gap it solves: inconsistent language for live, stale, confirmed, tentative, ready, delayed.
+  Priority: essential now.
+
+- Component name: Freshness row.
+  Where it should appear: any data-backed surface with operational timestamps.
+  Gap it solves: missing or vague “last updated” handling.
+  Priority: essential now.
+
+- Component name: Service journey timeline.
+  Where it should appear: public “how it works,” reservations, my pieces, pickup states.
+  Gap it solves: black-box workflow perception.
+  Priority: essential now.
+
+- Component name: Guided empty/fallback state.
+  Where it should appear: portal routes, empty lists, failed async blocks.
+  Gap it solves: generic placeholders and dead ends.
+  Priority: essential now.
+
+- Component name: Task-first shortcut card.
+  Where it should appear: portal home/start surfaces.
+  Gap it solves: first-use navigation overload.
+  Priority: essential now.
+
+- Component name: Confidence label set for public programming.
+  Where it should appear: events, updates, community programming.
+  Gap it solves: uncertainty around whether public programming is confirmed.
+  Priority: essential now.
+
+- Component name: Evidence/checkpoint card.
+  Where it should appear: piece detail and staff/member status history.
+  Gap it solves: missing proof-of-care moments for fragile work.
+  Priority: later.
+
+# 8. Website Recommendations by Page/Section
+
+## Home
+
+- What works: service categories and a portal-forward entry path exist.
+- What is weak: loader-first operational modules and generic CTA phrasing reduce confidence.
+- What is missing: an explicit “new here / returning / need support” start decision.
+- Concrete fix: add intent-based entry cards plus freshness-aware status modules.
+
+## Services
+
+- What works: major service buckets are present.
+- What is weak: the page still feels category-driven more than decision-driven.
+- What is missing: fast answers to “what should I do next?”
+- Concrete fix: restructure top content around user intents, not just service labels.
+
+## Kiln Firing
+
+- What works: clear service specialization exists.
+- What is weak: turnaround and queue confidence are not strong enough.
+- What is missing: a simple lifecycle explanation with typical timing bands.
+- Concrete fix: add a queue-to-pickup timeline and explicit turnaround expectations.
+
+## FAQ / Community
+
+- What works: community/programming context is visible.
+- What is weak: tentative or stale event language looks provisional.
+- What is missing: confidence labels and a visible update cadence.
+- Concrete fix: ship confirmed/tentative labels and verified timestamps.
+
+## Support
+
+- What works: support path exists.
+- What is weak: support risks being copy-heavy and operationally cold.
+- What is missing: quick triage by intent such as status, pickup, billing, or policy.
+- Concrete fix: put action cards ahead of dense explanation blocks.
+
+## Policies / Updates
+
+- What works: policy and updates surfaces exist separately.
+- What is weak: last-updated language is easy to let drift.
+- What is missing: explicit ownership and cadence.
+- Concrete fix: add freshness handling and a small “what changed” summary pattern.
+
+# 9. Portal Recommendations by Product Area
+
+## Onboarding / first-use experience
+
+- Likely user goal: understand what the portal is for and where to begin.
+- Current weakness: nav breadth outpaces guidance.
+- Trust / workflow issue: first-time members must guess.
+- Recommended change: add a member-first start surface with role-aware shortcuts.
+
+## Ware Check-in
+
+- Likely user goal: submit work with confidence.
+- Current weakness: check-in semantics are coupled to reservations.
+- Trust / workflow issue: the user is not sure what they are committing to.
+- Recommended change: give Ware Check-in its own shell, step framing, and confirmation language.
+
+## Queues / Firings
+
+- Likely user goal: know where submitted work is and what happens next.
+- Current weakness: status is present but not confidence-forward.
+- Trust / workflow issue: users still experience the queue as a black box.
+- Recommended change: show stage, last touchpoint, next expected step, and exception language.
+
+## My Pieces / piece status
+
+- Likely user goal: confirm work has not disappeared.
+- Current weakness: timeline proof is thinner than it should be.
+- Trust / workflow issue: text alone does not establish chain of custody.
+- Recommended change: add a member-facing journey timeline with recent history.
+
+## Studio & Resources
+
+- Likely user goal: reserve the right thing quickly.
+- Current weakness: related tasks can feel spread across module names.
+- Trust / workflow issue: users expend attention on navigation instead of action.
+- Recommended change: introduce segmented “book / review / manage” entry paths.
+
+## Glaze Board
+
+- Likely user goal: make a confident material decision.
+- Current weakness: audit runner could not verify live render quality.
+- Trust / workflow issue: if discovery is weak, material decisions feel risky.
+- Recommended change: prioritize searchable filters and result-comparison patterns.
+
+## Membership
+
+- Likely user goal: understand value, approval, and next steps.
+- Current weakness: membership can get lost in broader portal IA.
+- Trust / workflow issue: signup friction feels higher than it should.
+- Recommended change: create a simple compare/apply/status path with clearer approval timing.
+
+## Billing
+
+- Likely user goal: understand what they owe and why.
+- Current weakness: direct live render was not verified here.
+- Trust / workflow issue: billing confusion can erase product confidence quickly.
+- Recommended change: tie charges to service milestones and make status explicit.
+
+## Community
+
+- Likely user goal: know what changed and how to participate.
+- Current weakness: community can fragment across multiple surfaces.
+- Trust / workflow issue: users may miss important updates or feel there is no active pulse.
+- Recommended change: show a concise “since your last visit” feed and stronger freshness semantics.
+
+## Staff/operator-facing areas
+
+- Likely user goal: triage quickly without leaking internal jargon into member experience.
+- Current weakness: staff abstractions risk shaping member language.
+- Trust / workflow issue: member-facing surfaces can inherit internal wording.
+- Recommended change: keep a hard copy boundary between staff control language and member reassurance language.
+
+# 10. Fast Wins vs Strategic Rebuilds
+
+## Fast wins this week
+
+- Standardize all public portal/login links to `portal.monsoonfire.com`.
+- Add stale-state badges and fallback copy for public status modules.
+- Replace raw loading copy and generic placeholder messaging.
+- Add one task-first member start card set in the portal.
+
+## Medium-size improvements this month
+
+- Ship the Ware Check-in semantic split from Reservations.
+- Add queue and piece journey confidence UI.
+- Standardize cross-surface terminology and trust-oriented UI states.
+- Add automated parity guards for legacy host links and placeholder regressions.
+
+## Larger strategic redesign items
+
+- Build one shared service journey model across marketing, intake, queue, firing, cooling, and pickup.
+- Add piece-level evidence and checkpoint artifacts.
+- Mature a cross-surface design system centered on trust, clarity, and operational confidence.
+
+# 11. Hard Verdict
+
+- Production-credible now: Monsoon Fire already has real product surface area, meaningful service intent, and the beginnings of a multi-stage studio operating system.
+- Underbuilt now: handoff confidence, freshness signaling, first-use clarity, and member-facing chain-of-custody communication.
+- Must fix first: canonical public-to-portal handoff, stale/placeholder production trust leaks, and a clearer member journey through Ware Check-in, queue visibility, and piece status.

--- a/docs/epics/EPIC-LIVE-SURFACE-TRUST-AND-SERVICE-OPERATING-SYSTEM.md
+++ b/docs/epics/EPIC-LIVE-SURFACE-TRUST-AND-SERVICE-OPERATING-SYSTEM.md
@@ -1,0 +1,78 @@
+# EPIC: LIVE-SURFACE-TRUST-AND-SERVICE-OPERATING-SYSTEM
+
+Status: Active
+Date: 2026-04-14
+Priority: P1
+Owner: Website + Portal + Ops
+Type: Epic
+Epic Ticket: tickets/P1-EPIC-21-live-surface-trust-and-service-operating-system.md
+
+## Problem
+
+The April 2026 live-surface audit showed that Monsoon Fire has real product depth, but the public website and portal still do not consistently feel like one calm, high-trust studio operating system.
+
+The biggest trust leaks are not visual-fashion issues. They are operational:
+
+1. mixed public-to-portal handoff targets
+2. stale or vague freshness signals
+3. ambiguous member-first navigation inside the portal
+4. Ware Check-in language that still reflects internal reuse instead of the user task
+5. generic placeholder fallbacks in production routes
+6. queue and piece status communication that is still too black-box for fragile artwork service
+
+## Objective
+
+Turn the website and portal into a more coherent, modern, app-like service platform that feels current, operationally clear, and safe to trust with meaningful work.
+
+## Audit Artifact
+
+- `docs/audits/live-surface-audit-2026-04-12.md`
+
+## Scope
+
+1. Canonical public website to portal handoff and login parity.
+2. Public freshness contract for kiln status, updates, and event certainty.
+3. Portal member-first start surface and task-first navigation.
+4. Ware Check-in clarity and piece journey confidence.
+5. Guided fallback states instead of generic placeholders.
+6. Shared terminology and trust-oriented component patterns across both surfaces.
+
+## Non-goals
+
+1. Rewriting the visual identity from scratch.
+2. Decorative motion with no clarity or trust benefit.
+3. Replacing staff workflows with member-facing abstractions that remove needed control.
+4. Claiming live visual fixes are complete without direct browser verification.
+
+## Tasks
+
+1. Standardize all public portal/login handoffs and portal intent routing.
+2. Ship freshness and confidence labeling for public operational surfaces.
+3. Add a task-first member start surface and clearer portal information architecture.
+4. Separate Ware Check-in framing from general reservations and improve queue/status communication.
+5. Replace generic production placeholders with guided fallback states.
+6. Publish a cross-surface terminology and trust-component contract.
+
+## Acceptance Criteria
+
+1. No public website page links to a legacy or conflicting portal host.
+2. Public operational surfaces show clear freshness or certainty state instead of vague fallback copy.
+3. First-time members can identify a recommended next action without reverse-engineering the portal nav.
+4. Ware Check-in clearly reads as intake, not generic reservation management.
+5. Member-visible status surfaces explain where work is, what changed last, and what happens next.
+6. Generic “coming soon” portal fallbacks are removed from user-critical routes.
+
+## Child Tickets
+
+- `tickets/P1-EPIC-21-live-surface-trust-and-service-operating-system.md`
+- `tickets/P1-website-portal-canonical-handoff-and-login-parity.md`
+- `tickets/P1-public-site-operational-freshness-and-status-confidence.md`
+- `tickets/P1-portal-member-start-surface-and-task-first-navigation.md`
+- `tickets/P1-portal-ware-check-in-queue-status-and-piece-journey-clarity.md`
+- `tickets/P2-production-placeholder-route-replacement-and-guided-fallbacks.md`
+- `tickets/P2-cross-surface-terminology-and-trust-design-system-contract.md`
+
+## Cross-Epic Links
+
+- QA ownership for parity, placeholder, and stale-state regression guards lives in `docs/epics/EPIC-PORTAL-QA-AUTOMATION-COVERAGE.md`.
+- Portal staff/module structure changes that affect navigation clarity should stay aligned with `docs/epics/EPIC-STAFF-PORTAL-MODULE-CONSOLIDATION.md`.

--- a/docs/epics/EPIC-PORTAL-QA-AUTOMATION-COVERAGE.md
+++ b/docs/epics/EPIC-PORTAL-QA-AUTOMATION-COVERAGE.md
@@ -16,6 +16,7 @@ Close recurring QA gaps by automating functional, authz, index, theme-readabilit
 - Add dedicated theme contrast regression automation.
 - Add post-deploy promotion gate after production deploy.
 - Add fixture steward automation with TTL cleanup.
+- Add live-surface trust guards for portal handoff parity, stale public signals, and placeholder regressions.
 
 ## Success Criteria
 
@@ -28,3 +29,16 @@ Close recurring QA gaps by automating functional, authz, index, theme-readabilit
 - Replacing human exploratory QA.
 - Auto-merging code changes.
 - Auto-deploying index changes without review.
+
+## Audit Follow-up Backlog (2026-04-14)
+
+The live-surface audit surfaced a set of trust leaks that should become deterministic regression guards instead of recurring manual review items:
+
+1. legacy portal host links must fail CI and scheduled smoke
+2. stale or missing freshness states on public operational surfaces should be detectable
+3. generic placeholder copy should not appear in member-critical portal routes
+4. portal route semantics should continue to distinguish Ware Check-in intent from generic reservations
+
+## Child Tickets
+
+- `tickets/P1-live-surface-trust-automation-and-parity-guards.md`

--- a/docs/epics/EPIC-STAFF-PORTAL-MODULE-CONSOLIDATION.md
+++ b/docs/epics/EPIC-STAFF-PORTAL-MODULE-CONSOLIDATION.md
@@ -88,6 +88,16 @@ Reduce staff portal operator friction by consolidating duplicated module surface
 - Keep standalone `Reports` route available during transition.
 - Follow with Phase 2 anchor navigation to reduce scan cost.
 
+## Related Audit Follow-up Backlog (2026-04-14)
+
+The live-surface audit added adjacent portal-clarity work that should stay aligned with this consolidation epic even though the parent ownership is broader than staff-only IA:
+
+1. `tickets/P1-portal-member-start-surface-and-task-first-navigation.md`
+2. `tickets/P1-portal-ware-check-in-queue-status-and-piece-journey-clarity.md`
+3. `tickets/P2-production-placeholder-route-replacement-and-guided-fallbacks.md`
+
+These follow-ups should preserve Cockpit consolidation work instead of reintroducing duplicate navigation paths.
+
 ## Agent Handoff Notes
 
 - Treat this epic as a consolidation sequence, not a visual redesign rewrite.

--- a/tickets/P1-EPIC-21-live-surface-trust-and-service-operating-system.md
+++ b/tickets/P1-EPIC-21-live-surface-trust-and-service-operating-system.md
@@ -1,0 +1,53 @@
+# P1 — EPIC 21: Live Surface Trust and Service Operating System
+
+Status: Active
+Date: 2026-04-14
+Priority: P1
+Owner: Website + Portal + Ops
+Type: Epic
+Parent Epic: docs/epics/EPIC-LIVE-SURFACE-TRUST-AND-SERVICE-OPERATING-SYSTEM.md
+
+## Problem
+
+The public website and portal are both functional, but they still leak uncertainty in places where users most need calm operational confidence.
+
+Mixed handoffs, stale signals, ambiguous intake language, and generic production fallbacks make the experience feel more provisional than it should for a service business handling fragile work.
+
+## Objective
+
+Convert the April 2026 live-surface audit into executable product work that strengthens trust, clarifies the service journey, and makes both surfaces feel like one product family.
+
+## Scope
+
+1. Canonical public-to-portal handoff.
+2. Public freshness and certainty signaling.
+3. Portal first-use clarity and task-first navigation.
+4. Ware Check-in, queue, and piece-journey communication.
+5. Guided production fallback states.
+6. Cross-surface terminology and trust-oriented component reuse.
+
+## Tickets
+
+- `tickets/P1-website-portal-canonical-handoff-and-login-parity.md`
+- `tickets/P1-public-site-operational-freshness-and-status-confidence.md`
+- `tickets/P1-portal-member-start-surface-and-task-first-navigation.md`
+- `tickets/P1-portal-ware-check-in-queue-status-and-piece-journey-clarity.md`
+- `tickets/P2-production-placeholder-route-replacement-and-guided-fallbacks.md`
+- `tickets/P2-cross-surface-terminology-and-trust-design-system-contract.md`
+
+## Tasks
+
+1. Land all child tickets linked from this epic.
+2. Keep fixes grounded in observed production or source-backed trust leaks, not generic polish.
+3. Verify cross-surface wording and flow consistency before closing the epic.
+
+## Acceptance Criteria
+
+1. Every high-confidence trust leak from the audit has an explicit ticket owner.
+2. Website and portal share a coherent portal handoff and status vocabulary.
+3. Member-critical routes no longer rely on generic placeholders or ambiguous intake wording.
+4. Audit artifact remains linked from this epic for future review and prioritization.
+
+## Audit Reference
+
+- `docs/audits/live-surface-audit-2026-04-12.md`

--- a/tickets/P1-live-surface-trust-automation-and-parity-guards.md
+++ b/tickets/P1-live-surface-trust-automation-and-parity-guards.md
@@ -1,0 +1,39 @@
+# P1 — Live-surface trust automation and parity guards
+
+Status: Active
+Date: 2026-04-14
+Priority: P1
+Owner: Platform / QA / Website / Portal
+Type: Ticket
+Parent Epic: docs/epics/EPIC-PORTAL-QA-AUTOMATION-COVERAGE.md
+
+## Problem
+
+Several high-confidence trust leaks from the live-surface audit are deterministic enough to catch automatically, but they currently depend on human memory:
+
+1. legacy public links to `monsoonfire.kilnfire.com`
+2. stale or vague freshness handling on public operational surfaces
+3. generic placeholder text leaking into portal routes
+4. regressions where Ware Check-in intent collapses back into undifferentiated reservation language
+
+## Tasks
+
+1. Extend website parity checks so public handoff links fail on legacy hosts across built and source variants.
+2. Add a stale-data guard or audit script for public operational artifacts that should always expose freshness metadata or fallback state.
+3. Add a route/content guard that flags generic placeholder copy in member-critical portal surfaces.
+4. Add or extend smoke coverage that verifies Ware Check-in remains a distinct member intent path.
+
+## Acceptance Criteria
+
+1. CI or scheduled automation fails when public portal links regress to the legacy host.
+2. Public status surfaces are guarded by a deterministic freshness/parity check.
+3. Placeholder regressions in critical portal routes become visible before release.
+4. The audit’s most repeatable trust leaks are no longer chat-only knowledge.
+
+## Dependencies
+
+- `website/tests/marketing-site.spec.mjs`
+- `scripts/check-agent-surfaces.mjs`
+- `scripts/portal-playwright-smoke.mjs`
+- `website/`
+- `web/`

--- a/tickets/P1-portal-member-start-surface-and-task-first-navigation.md
+++ b/tickets/P1-portal-member-start-surface-and-task-first-navigation.md
@@ -1,0 +1,32 @@
+# P1 — Portal member start surface and task-first navigation
+
+Status: Active
+Date: 2026-04-14
+Priority: P1
+Owner: Portal
+Type: Ticket
+Parent Epic: tickets/P1-EPIC-21-live-surface-trust-and-service-operating-system.md
+
+## Problem
+
+The portal contains meaningful capability, but first-time members still have to infer where to begin from the nav structure itself.
+
+## Tasks
+
+1. Define a member-first start surface that answers “what is this,” “what can I do here,” and “what should I do first?”
+2. Add task-first shortcuts for high-value intents such as Ware Check-in, queue/status, membership, resources, and support.
+3. Preserve staff-specific paths while preventing staff information architecture from becoming the default member mental model.
+4. Keep the routing and module structure compatible with current portal state and deep-link expectations.
+
+## Acceptance Criteria
+
+1. Signed-in members see a recommended next action without exploring the full nav.
+2. The portal presents a clearer split between member tasks and staff/operator tasks.
+3. First-use confusion decreases without removing current capability.
+
+## Dependencies
+
+- `web/src/App.tsx`
+- `web/src/views/ProfileView.tsx`
+- `web/src/views/StaffView.tsx`
+- `web/src/views/MyPiecesView.tsx`

--- a/tickets/P1-portal-ware-check-in-queue-status-and-piece-journey-clarity.md
+++ b/tickets/P1-portal-ware-check-in-queue-status-and-piece-journey-clarity.md
@@ -1,0 +1,35 @@
+# P1 — Portal Ware Check-in, queue status, and piece journey clarity
+
+Status: Active
+Date: 2026-04-14
+Priority: P1
+Owner: Portal + Ops
+Type: Ticket
+Parent Epic: tickets/P1-EPIC-21-live-surface-trust-and-service-operating-system.md
+
+## Problem
+
+`WareCheckInView` currently reuses `ReservationsView`, and member-facing status communication still relies too heavily on internal or text-heavy reservation language.
+
+That leaves too much ambiguity around intake, queue progression, and what the studio is doing with a user’s work.
+
+## Tasks
+
+1. Give Ware Check-in a dedicated shell, heading structure, and “what happens next” framing even if some underlying form logic stays shared initially.
+2. Clarify the difference between intake, booking, queue position, firing progress, cooldown, and pickup readiness in member-facing language.
+3. Improve piece/status views so they show a visible stage timeline, the latest meaningful update, and the next expected step.
+4. Keep existing reservation and audit-trail data contracts intact while improving the member-facing presentation layer.
+
+## Acceptance Criteria
+
+1. Ware Check-in reads as intake, not generic reservation management.
+2. Member-facing status surfaces explain current stage and next step with minimal ambiguity.
+3. Existing timeline/audit data is surfaced in a calmer, clearer format.
+
+## Dependencies
+
+- `web/src/views/WareCheckInView.tsx`
+- `web/src/views/ReservationsView.tsx`
+- `web/src/views/MyPiecesView.tsx`
+- `web/src/api/portalContracts.ts`
+- `web/src/lib/normalizers/reservations.ts`

--- a/tickets/P1-public-site-operational-freshness-and-status-confidence.md
+++ b/tickets/P1-public-site-operational-freshness-and-status-confidence.md
@@ -1,0 +1,33 @@
+# P1 — Public site operational freshness and status confidence
+
+Status: Active
+Date: 2026-04-14
+Priority: P1
+Owner: Website + Ops
+Type: Ticket
+Parent Epic: tickets/P1-EPIC-21-live-surface-trust-and-service-operating-system.md
+
+## Problem
+
+Public operational surfaces currently expose stale timestamps, raw loading copy, and uncertain event language. That makes the studio feel less actively operated than it needs to.
+
+## Tasks
+
+1. Define a public freshness model for kiln status, public updates, and event/community programming.
+2. Replace raw loading copy with structured loading, stale, and unavailable states.
+3. Add visible timestamps and certainty labels such as confirmed, tentative, delayed, or stale where they materially improve trust.
+4. Document the expected refresh cadence and fallback behavior so the state model is maintainable.
+
+## Acceptance Criteria
+
+1. Public operational modules never rely on raw `Loading...` copy as the primary production state.
+2. Every operational data card shows either a valid freshness timestamp or an intentional fallback state.
+3. Event/programming surfaces distinguish confirmed content from tentative content.
+
+## Dependencies
+
+- `website/index.html`
+- `website/updates/index.html`
+- `website/faq/index.html`
+- `website/data/kiln-status.json`
+- `website/assets/js/main.js`

--- a/tickets/P1-website-portal-canonical-handoff-and-login-parity.md
+++ b/tickets/P1-website-portal-canonical-handoff-and-login-parity.md
@@ -1,0 +1,34 @@
+# P1 — Website and portal canonical handoff and login parity
+
+Status: Active
+Date: 2026-04-14
+Priority: P1
+Owner: Website + Portal
+Type: Ticket
+Parent Epic: tickets/P1-EPIC-21-live-surface-trust-and-service-operating-system.md
+
+## Problem
+
+Public pages still send users to more than one portal destination. That creates immediate doubt about which system is current and whether login/account state is split across environments.
+
+## Tasks
+
+1. Audit all public-facing website and `ncsitebuilder` portal/login/create-account links.
+2. Standardize them to the canonical `https://portal.monsoonfire.com` destination and preserve task intent with `data-portal-target` or equivalent metadata where applicable.
+3. Update any content JSON, scripts, or config that still reference `monsoonfire.kilnfire.com` for user-facing handoffs.
+4. Add or extend deterministic checks that fail when a legacy portal host leaks back into public surfaces.
+
+## Acceptance Criteria
+
+1. No public website page links users to `monsoonfire.kilnfire.com`.
+2. Primary CTAs use consistent, user-intent-driven wording.
+3. Automated checks fail if a legacy user-facing portal host is reintroduced.
+
+## Dependencies
+
+- `website/**/*.html`
+- `website/ncsitebuilder/**/*.html`
+- `website/data/**/*.json`
+- `website/assets/js/main.js`
+- `website/ncsitebuilder/assets/js/main.js`
+- `website/tests/marketing-site.spec.mjs`

--- a/tickets/P2-cross-surface-terminology-and-trust-design-system-contract.md
+++ b/tickets/P2-cross-surface-terminology-and-trust-design-system-contract.md
@@ -1,0 +1,30 @@
+# P2 — Cross-surface terminology and trust design system contract
+
+Status: Active
+Date: 2026-04-14
+Priority: P2
+Owner: Design + Website + Portal
+Type: Ticket
+Parent Epic: tickets/P1-EPIC-21-live-surface-trust-and-service-operating-system.md
+
+## Problem
+
+The website and portal currently share intent but not always the same language or trust-state patterns. That drift weakens product-family coherence and makes support harder.
+
+## Tasks
+
+1. Define a shared vocabulary for core concepts such as Ware Check-in, reservation, queue, firing, cooling, ready, pickup, confirmed, tentative, and stale.
+2. Define a minimal reusable component/state set for trust-oriented UI states: status chips, freshness rows, journey timeline, and guided fallback cards.
+3. Link the contract into the relevant website and portal implementation tickets so wording and state patterns do not drift again.
+
+## Acceptance Criteria
+
+1. Cross-surface wording for core service states is intentional and documented.
+2. Both surfaces can reuse the same status/freshness/fallback concepts without improvising new language.
+3. Future trust-oriented UI work has one lightweight contract to reference.
+
+## Dependencies
+
+- `docs/audits/live-surface-audit-2026-04-12.md`
+- `website/`
+- `web/`

--- a/tickets/P2-production-placeholder-route-replacement-and-guided-fallbacks.md
+++ b/tickets/P2-production-placeholder-route-replacement-and-guided-fallbacks.md
@@ -1,0 +1,32 @@
+# P2 — Production placeholder route replacement and guided fallbacks
+
+Status: Active
+Date: 2026-04-14
+Priority: P2
+Owner: Portal
+Type: Ticket
+Parent Epic: tickets/P1-EPIC-21-live-surface-trust-and-service-operating-system.md
+
+## Problem
+
+Generic placeholder routes and low-context empty states make the portal feel unfinished when users land outside the happy path.
+
+## Tasks
+
+1. Replace generic placeholder copy with route-aware fallback cards.
+2. Provide an alternate path, support action, or explicit next step for unresolved routes and incomplete areas.
+3. Reuse the same fallback pattern for empty and error-adjacent states where possible.
+4. Add tests that catch generic placeholder copy leaking into member-critical routes.
+
+## Acceptance Criteria
+
+1. User-critical routes do not render generic “coming soon” language.
+2. Fallback states always tell the user what they can do next.
+3. Placeholder regressions are testable and visible before release.
+
+## Dependencies
+
+- `web/src/views/PlaceholderView.tsx`
+- `web/src/App.tsx`
+- `web/src/views/ProfileView.tsx`
+- `web/src/views/StaffView.tsx`


### PR DESCRIPTION
## Summary
- add the April 2026 live-surface audit as a durable repo artifact
- create a new cross-surface trust epic plus concrete child tickets for website, portal, and shared terminology work
- wire the active QA and portal consolidation epics plus engineering todos to the new audit follow-up work

## Why
The production-surface review found a real cluster of trust leaks that should live in repo planning, not only in chat history. This PR makes the audit actionable and discoverable.

## Validation
- `node ./scripts/epic-hub.mjs list | Select-String -Pattern "Live Surface Trust|live-surface-trust"`
