### PR TITLE
[codex] Implement live surface trust tranche

### DIFF
--- a/docs/epics/EPIC-LIVE-SURFACE-TRUST-AND-SERVICE-OPERATING-SYSTEM.md
+++ b/docs/epics/EPIC-LIVE-SURFACE-TRUST-AND-SERVICE-OPERATING-SYSTEM.md
@@ -27,6 +27,7 @@ Turn the website and portal into a more coherent, modern, app-like service platf
 ## Audit Artifact
 
 - `docs/audits/live-surface-audit-2026-04-12.md`
+- `docs/standards/LIVE_SURFACE_TERMINOLOGY_AND_TRUST_CONTRACT.md`
 
 ## Scope
 
@@ -52,6 +53,12 @@ Turn the website and portal into a more coherent, modern, app-like service platf
 4. Separate Ware Check-in framing from general reservations and improve queue/status communication.
 5. Replace generic production placeholders with guided fallback states.
 6. Publish a cross-surface terminology and trust-component contract.
+
+## Progress Notes
+
+1. Website handoff and freshness fixes are implemented in the current swarm tranche and backed by a legacy-host guard plus Playwright smoke coverage.
+2. Portal onboarding, Ware Check-in clarity, piece journey messaging, and guided fallback copy are implemented in the current swarm tranche and backed by focused UI tests plus a full `web` production build.
+3. The cross-surface terminology and trust contract is now published at `docs/standards/LIVE_SURFACE_TERMINOLOGY_AND_TRUST_CONTRACT.md`.
 
 ## Acceptance Criteria
 

--- a/docs/standards/LIVE_SURFACE_TERMINOLOGY_AND_TRUST_CONTRACT.md
+++ b/docs/standards/LIVE_SURFACE_TERMINOLOGY_AND_TRUST_CONTRACT.md
@@ -1,0 +1,107 @@
+# Live Surface Terminology And Trust Contract
+
+Status: Active  
+Date: 2026-04-14  
+Owners: Website + Portal + Design
+
+## Purpose
+
+Keep `monsoonfire.com` and `portal.monsoonfire.com` speaking the same language about service state, user intent, and trust signals.
+
+This is a lightweight contract. It exists so future work does not reintroduce mixed terms, stale-state ambiguity, or generic fallback copy.
+
+## Shared Vocabulary
+
+| Concept | Canonical Term | Use It For | Avoid |
+| --- | --- | --- | --- |
+| Member landing surface | `Start here` | The first member-facing home surface in the portal | `Dashboard` when the goal is onboarding, orientation, or next-action guidance |
+| New work intake | `Ware Check-in` | Dropping off or registering work for studio handling | `Reservation` when the task is actually intake |
+| Studio time booking | `Reservations` | Booking shared tools, stations, or studio access windows | `Check-in` for advance scheduling |
+| Work visibility | `My Pieces` | Member-facing view of current stage, latest update, and next step | `Batches` as a primary member label |
+| Queue visibility | `View the queues` | Member-facing queue timing and current load state | `Launch`, `ops queue`, or internal firing jargon |
+| Ready state | `Ready for pickup` | Work that has completed firing, cooling, and staging | `Complete` without pickup context |
+| Freshness state | `Current`, `Stale`, `Unavailable` | Operational data recency and confidence | Raw `Loading...` or silent timestamp gaps |
+| Event certainty | `Confirmed`, `Tentative` | Public program/event confidence | `TBD` as the main status signal |
+| Guided fallback | `This area is not ready for live studio work yet.` | Unknown or unfinished areas that need recovery guidance | `Coming soon` as standalone production copy |
+
+## Member-Facing Journey Terms
+
+Use these stage terms consistently whenever explaining what happens to work:
+
+1. `Ware Check-in`
+2. `Queued`
+3. `Firing`
+4. `Cooling`
+5. `Ready for pickup`
+
+Supporting phrases:
+
+- `Latest update`
+- `Next step`
+- `What happens next`
+
+Do not switch between synonyms like `loaded`, `submitted`, `processing`, or `complete` unless the UI also explains how they map to the canonical journey.
+
+## Trust State Patterns
+
+### Status Chips
+
+Use a small, explicit label for current certainty:
+
+- `Current`
+- `Stale`
+- `Unavailable`
+- `Confirmed`
+- `Tentative`
+
+### Freshness Rows
+
+Operational cards should show one of:
+
+1. A valid timestamp.
+2. An intentional stale state with guidance.
+3. An intentional unavailable state with guidance.
+
+Do not leave a production surface in a raw loading-first state once fetch resolution is known.
+
+### Journey Guidance
+
+Member work surfaces should answer:
+
+1. Where is my work now?
+2. What changed last?
+3. What happens next?
+
+### Guided Fallback Cards
+
+Fallback states should include:
+
+1. Plain-language explanation.
+2. A recovery path.
+3. A human contact path when recovery is unclear.
+
+## Copy Rules
+
+1. Prefer calm, operational language over marketing flourish on service-state surfaces.
+2. Prefer `portal` and `studio` over legacy host or migration language.
+3. Never imply a live state without either current data or an explicit stale/unavailable label.
+4. Never use internal staff shorthand as the primary member-facing label.
+
+## Current Implementations
+
+This contract now maps to active implementation work in:
+
+- `website/assets/js/kiln-status.js`
+- `website/assets/js/updates.js`
+- `website/tests/legacy-host-guard.test.mjs`
+- `web/src/views/DashboardView.tsx`
+- `web/src/views/ReservationsView.tsx`
+- `web/src/views/MyPiecesView.tsx`
+- `web/src/views/PlaceholderView.tsx`
+
+## Follow-On Rule
+
+Any future website or portal change that introduces a new service-state label, fallback pattern, or freshness term should either:
+
+1. Reuse a term from this contract, or
+2. Update this document in the same change.

--- a/tickets/P1-portal-member-start-surface-and-task-first-navigation.md
+++ b/tickets/P1-portal-member-start-surface-and-task-first-navigation.md
@@ -1,6 +1,6 @@
 # P1 — Portal member start surface and task-first navigation
 
-Status: Active
+Status: In review
 Date: 2026-04-14
 Priority: P1
 Owner: Portal
@@ -23,6 +23,12 @@ The portal contains meaningful capability, but first-time members still have to 
 1. Signed-in members see a recommended next action without exploring the full nav.
 2. The portal presents a clearer split between member tasks and staff/operator tasks.
 3. First-use confusion decreases without removing current capability.
+
+## Implementation Notes
+
+1. The portal member landing label now reads `Start here`.
+2. Dashboard guidance now explains what the portal is for, what members can do next, and which action to take first.
+3. Profile and staff surfaces include direct return-to-start affordances without altering route compatibility.
 
 ## Dependencies
 

--- a/tickets/P1-portal-ware-check-in-queue-status-and-piece-journey-clarity.md
+++ b/tickets/P1-portal-ware-check-in-queue-status-and-piece-journey-clarity.md
@@ -1,6 +1,6 @@
 # P1 — Portal Ware Check-in, queue status, and piece journey clarity
 
-Status: Active
+Status: In review
 Date: 2026-04-14
 Priority: P1
 Owner: Portal + Ops
@@ -25,6 +25,12 @@ That leaves too much ambiguity around intake, queue progression, and what the st
 1. Ware Check-in reads as intake, not generic reservation management.
 2. Member-facing status surfaces explain current stage and next step with minimal ambiguity.
 3. Existing timeline/audit data is surfaced in a calmer, clearer format.
+
+## Implementation Notes
+
+1. Ware Check-in now includes clearer intake framing and an explicit `what happens next` journey rail.
+2. My Pieces surfaces `Latest update` and `Next step` inline so members do not have to infer status from raw timeline events alone.
+3. Focused UI coverage was extended in the reservations and pieces test suites.
 
 ## Dependencies
 

--- a/tickets/P1-public-site-operational-freshness-and-status-confidence.md
+++ b/tickets/P1-public-site-operational-freshness-and-status-confidence.md
@@ -1,6 +1,6 @@
 # P1 — Public site operational freshness and status confidence
 
-Status: Active
+Status: In review
 Date: 2026-04-14
 Priority: P1
 Owner: Website + Ops
@@ -23,6 +23,12 @@ Public operational surfaces currently expose stale timestamps, raw loading copy,
 1. Public operational modules never rely on raw `Loading...` copy as the primary production state.
 2. Every operational data card shows either a valid freshness timestamp or an intentional fallback state.
 3. Event/programming surfaces distinguish confirmed content from tentative content.
+
+## Implementation Notes
+
+1. Kiln board copy now prefers calm sync/freshness messaging over raw loading-first placeholders.
+2. Static kiln status JSON is used before the API fallback on the static website server, eliminating the homepage console 404 in smoke coverage.
+3. Stale-state messaging is explicit and visually supported on both the website and `ncsitebuilder` variants.
 
 ## Dependencies
 

--- a/tickets/P1-website-portal-canonical-handoff-and-login-parity.md
+++ b/tickets/P1-website-portal-canonical-handoff-and-login-parity.md
@@ -1,6 +1,6 @@
 # P1 — Website and portal canonical handoff and login parity
 
-Status: Active
+Status: In review
 Date: 2026-04-14
 Priority: P1
 Owner: Website + Portal
@@ -23,6 +23,12 @@ Public pages still send users to more than one portal destination. That creates 
 1. No public website page links users to `monsoonfire.kilnfire.com`.
 2. Primary CTAs use consistent, user-intent-driven wording.
 3. Automated checks fail if a legacy user-facing portal host is reintroduced.
+
+## Implementation Notes
+
+1. Canonical portal handoffs now point to `https://portal.monsoonfire.com` across both `website/` and `website/ncsitebuilder/`.
+2. `data-portal-target` intent metadata is preserved on key CTA paths so portal routing still opens the intended area.
+3. `website/tests/legacy-host-guard.test.mjs` now fails fast if the legacy host reappears.
 
 ## Dependencies
 

--- a/tickets/P2-cross-surface-terminology-and-trust-design-system-contract.md
+++ b/tickets/P2-cross-surface-terminology-and-trust-design-system-contract.md
@@ -1,6 +1,6 @@
 # P2 — Cross-surface terminology and trust design system contract
 
-Status: Active
+Status: In review
 Date: 2026-04-14
 Priority: P2
 Owner: Design + Website + Portal
@@ -26,5 +26,12 @@ The website and portal currently share intent but not always the same language o
 ## Dependencies
 
 - `docs/audits/live-surface-audit-2026-04-12.md`
+- `docs/standards/LIVE_SURFACE_TERMINOLOGY_AND_TRUST_CONTRACT.md`
 - `website/`
 - `web/`
+
+## Implementation Notes
+
+1. The shared terminology and trust-state contract now lives in `docs/standards/LIVE_SURFACE_TERMINOLOGY_AND_TRUST_CONTRACT.md`.
+2. The contract documents canonical member-facing language for start surface, check-in, reservations, queues, pickup readiness, freshness, and guided fallbacks.
+3. The live-surface epic now links directly to the contract so future changes have one reference point.

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -454,6 +454,39 @@
   font-size: 14px;
 }
 
+.guided-state-card {
+  display: grid;
+  gap: 10px;
+  padding: 14px;
+  border-radius: 16px;
+  border: 1px solid var(--border);
+  background: var(--surface-2);
+}
+
+.guided-state-eyebrow {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--muted);
+}
+
+.guided-state-title {
+  font-size: 15px;
+  font-weight: 700;
+}
+
+.guided-state-body {
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.guided-state-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
 .hero-updates-list {
   display: flex;
   flex-direction: column;

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -608,6 +608,7 @@
 .snapshot-grid {
   display: grid;
   gap: 14px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
 
 .snapshot-block {
@@ -4909,6 +4910,17 @@ html[data-portal-theme="memoria"] .list-row.kiln-offline .list-meta {
 .panel-body.placeholder {
   margin-top: 12px;
   color: var(--muted);
+}
+
+.placeholder-copy {
+  max-width: 58ch;
+}
+
+.placeholder-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 16px;
 }
 
 .placeholder-grid {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -180,7 +180,7 @@ type LegacyRequestsRedirect = {
 };
 
 const NAV_TOP_ITEMS: NavItem[] = [
-  { key: "dashboard", label: "Dashboard" },
+  { key: "dashboard", label: "Start here" },
 ];
 
 const NAV_BOTTOM_ITEMS: NavItem[] = [
@@ -336,7 +336,7 @@ const NAV_SECTION_ICONS: Record<NavSectionKey, React.ReactNode> = {
 };
 
 const NAV_LABELS: Record<NavKey, string> = {
-  dashboard: "Dashboard",
+  dashboard: "Start here",
   profile: "Profile",
   integrations: "Integrations",
   pieces: "My Pieces",
@@ -2344,6 +2344,7 @@ export default function App() {
           }}
           onOpenIntegrations={() => setNav("integrations")}
           onOpenBilling={() => setNav("billing")}
+          onOpenStartSurface={() => setNav("dashboard")}
           onAvatarUpdated={() => {
             void syncUserFromAuth();
           }}
@@ -2470,6 +2471,7 @@ export default function App() {
             showEmulatorTools={isAuthEmulator}
             onOpenCheckin={() => setNav("wareCheckIn")}
             onOpenReservation={() => setNav("wareCheckIn")}
+            onOpenMemberStart={() => setNav("dashboard")}
             onOpenMessages={() => setNav("messages")}
             onOpenMessageThread={() => setNav("messages")}
             onOpenFirings={() => openStaffWorkspace("firings")}

--- a/web/src/components/GuidedStateCard.tsx
+++ b/web/src/components/GuidedStateCard.tsx
@@ -1,0 +1,48 @@
+type GuidedStateAction = {
+  label: string;
+  onClick?: () => void;
+  href?: string;
+  variant?: "primary" | "ghost";
+};
+
+type Props = {
+  eyebrow?: string;
+  title: string;
+  body: string;
+  actions?: GuidedStateAction[];
+  className?: string;
+};
+
+export default function GuidedStateCard({ eyebrow, title, body, actions = [], className = "" }: Props) {
+  return (
+    <div className={`guided-state-card ${className}`.trim()}>
+      {eyebrow ? <div className="guided-state-eyebrow">{eyebrow}</div> : null}
+      <div className="guided-state-title">{title}</div>
+      <div className="guided-state-body">{body}</div>
+      {actions.length > 0 ? (
+        <div className="guided-state-actions">
+          {actions.map((action) =>
+            action.href ? (
+              <a
+                key={`${action.label}:${action.href}`}
+                className={action.variant === "ghost" ? "btn btn-ghost btn-small" : "btn btn-primary btn-small"}
+                href={action.href}
+              >
+                {action.label}
+              </a>
+            ) : (
+              <button
+                key={action.label}
+                type="button"
+                className={action.variant === "ghost" ? "btn btn-ghost btn-small" : "btn btn-primary btn-small"}
+                onClick={action.onClick}
+              >
+                {action.label}
+              </button>
+            )
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/web/src/views/DashboardView.tsx
+++ b/web/src/views/DashboardView.tsx
@@ -4,6 +4,7 @@ import { collection, getDocs, limit, orderBy, query, where } from "firebase/fire
 import { createPortalApi } from "../api/portalApi";
 import type { EventSummary } from "../api/portalContracts";
 import RevealCard from "../components/RevealCard";
+import GuidedStateCard from "../components/GuidedStateCard";
 import { useUiSettings } from "../context/UiSettingsContext";
 import { db } from "../firebase";
 import { type PortalThemeName } from "../theme/themes";
@@ -900,13 +901,21 @@ export default function DashboardView({
         <div className="hero-updates">
           <div className="hero-updates-title">Studio updates</div>
           {announcementPreview.length === 0 ? (
-            <div className="hero-updates-empty">No studio announcements yet.</div>
+            <GuidedStateCard
+              eyebrow="Studio bulletin"
+              title="No studio-wide notices right now"
+              body="Use Messages for direct questions, and check back here when the studio posts schedule changes, pickup notes, or broader service updates."
+              actions={[{ label: "Message the studio", onClick: onOpenMessages, variant: "ghost" }]}
+              className="hero-updates-empty"
+            />
           ) : (
             <div className="hero-updates-list">
               {announcementPreview.map((item) => (
                 <div className="hero-update" key={item.id}>
                   <div className="hero-update-title">{item.title || "Studio update"}</div>
-                  <p className="hero-update-body">{item.body || "Details coming soon."}</p>
+                  <p className="hero-update-body">
+                    {item.body || "Open Messages for the full studio note and any next-step timing."}
+                  </p>
                 </div>
               ))}
             </div>
@@ -1073,14 +1082,20 @@ export default function DashboardView({
         <RevealCard className="card card-3d" index={5} enabled={motionEnabled}>
           <div className="card-title">Workshop calendar</div>
           {workshopsLoading ? (
-            <div className="empty-state" role="status" aria-live="polite">
-              Loading...
-            </div>
+            <GuidedStateCard
+              eyebrow="Workshops"
+              title="Loading the workshop calendar"
+              body="Hold on for a moment while we pull the current class schedule and studio program openings."
+              className="empty-state"
+            />
           ) : workshopPreview.length === 0 ? (
-            <div className="empty-block">
-              <div className="empty-state">No workshops are currently scheduled.</div>
-              <div className="empty-meta">Open the workshop calendar for the latest schedule.</div>
-            </div>
+            <GuidedStateCard
+              eyebrow="Workshops"
+              title="No workshops are currently scheduled"
+              body="Open the workshop calendar for the latest schedule, or check back after the next studio drop."
+              actions={[{ label: "Open workshop calendar", onClick: onOpenWorkshops, variant: "ghost" }]}
+              className="empty-block"
+            />
           ) : (
             <div className="list">
               {workshopPreview.map((item) => {
@@ -1098,9 +1113,11 @@ export default function DashboardView({
               })}
             </div>
           )}
-          <button className="btn btn-ghost dashboard-link" onClick={onOpenWorkshops}>
-            Open workshop calendar
-          </button>
+          {workshopPreview.length > 0 ? (
+            <button className="btn btn-ghost dashboard-link" onClick={onOpenWorkshops}>
+              Open workshop calendar
+            </button>
+          ) : null}
         </RevealCard>
 
         <RevealCard className="card card-3d" index={6} enabled={motionEnabled}>

--- a/web/src/views/DashboardView.tsx
+++ b/web/src/views/DashboardView.tsx
@@ -806,25 +806,55 @@ export default function DashboardView({
     <div className="dashboard">
       <section className="quick-actions">
         <RevealCard className="card card-3d quick-action-card" index={0} enabled={motionEnabled}>
-          <div className="card-title">Quick actions</div>
-          <div className="quick-action-row">
+          <div className="card-title">Start here</div>
+          <p className="hero-copy">
+            This is your member home inside the portal. Start here when you want to check in new ware,
+            see what is already in motion, or jump straight to the next useful action without reading the full nav.
+          </p>
+          <div className="hero-actions">
             <button className="btn btn-primary" onClick={onOpenCheckin}>
               Start a check-in
             </button>
+            <button className="btn btn-ghost" onClick={() => onOpenPieces()}>
+              Open My Pieces
+            </button>
             <button className="btn btn-ghost" onClick={onOpenQueues}>
               View the queues
+            </button>
+            <button className="btn btn-ghost" onClick={onOpenMessages}>
+              Message the studio
+            </button>
+            <button className="btn btn-ghost" onClick={onOpenGlazeBoard}>
+              Glaze inspiration
             </button>
             {isStaff ? (
               <button className="btn btn-ghost" onClick={onOpenFirings}>
                 Firings
               </button>
             ) : null}
-            <button className="btn btn-ghost" onClick={onOpenGlazeBoard}>
-              Glaze inspiration
-            </button>
-            <button className="btn btn-ghost" onClick={onOpenMessages}>
-              Message the studio
-            </button>
+          </div>
+          <div className="snapshot-grid">
+            <div className="snapshot-block">
+              <div className="snapshot-label">What this is</div>
+              <div className="snapshot-value">Your studio home</div>
+              <div className="snapshot-meta">
+                See the status of your work, the queue, and the next step without unpacking the whole app.
+              </div>
+            </div>
+            <div className="snapshot-block">
+              <div className="snapshot-label">What you can do here</div>
+              <div className="snapshot-value">Check in, track, and coordinate</div>
+              <div className="snapshot-meta">
+                Start a check-in, open My Pieces, review firings, message the studio, or browse the rest of the portal when you need it.
+              </div>
+            </div>
+            <div className="snapshot-block">
+              <div className="snapshot-label">Recommended next actions</div>
+              <div className="snapshot-value">Pick the next useful step</div>
+              <div className="snapshot-meta">
+                New drop-off: start a check-in. Existing work: open My Pieces. Need timing: view the queues.
+              </div>
+            </div>
           </div>
         </RevealCard>
       </section>
@@ -833,7 +863,7 @@ export default function DashboardView({
         <div className="hero-content">
           <div className="hero-toolbar">
             <div className="hero-title-block">
-              <h1>Your studio dashboard</h1>
+              <h1>Your studio at a glance</h1>
               <div className="hero-profile">
                 <span className="hero-profile-label">Signed in as</span>
                 <span className="hero-profile-name">{name}</span>

--- a/web/src/views/DashboardView.ui.test.tsx
+++ b/web/src/views/DashboardView.ui.test.tsx
@@ -449,8 +449,10 @@ describe("DashboardView kiln reload", () => {
       />
     );
 
-    expect(await screen.findByText("No workshops are currently scheduled.")).toBeDefined();
-    expect(screen.getByText("Open the workshop calendar for the latest schedule.")).toBeDefined();
+    expect(await screen.findByText("No workshops are currently scheduled")).toBeDefined();
+    expect(
+      screen.getByText("Open the workshop calendar for the latest schedule, or check back after the next studio drop.")
+    ).toBeDefined();
     expect(screen.queryByText(/QA Fixture Workshop/i)).toBeNull();
 
     fireEvent.click(screen.getByRole("button", { name: /Open workshop calendar/i }));

--- a/web/src/views/DashboardView.ui.test.tsx
+++ b/web/src/views/DashboardView.ui.test.tsx
@@ -183,6 +183,37 @@ afterEach(() => {
 });
 
 describe("DashboardView kiln reload", () => {
+  it("explains the member start surface and keeps the next actions visible", async () => {
+    setupGetDocsEmptySuccess();
+
+    render(
+      <DashboardView
+        user={createUser()}
+        isStaff={false}
+        name="Maker"
+        themeName="portal"
+        threads={[]}
+        announcements={[]}
+        onThemeChange={vi.fn()}
+        onOpenKilnRentals={vi.fn()}
+        onOpenCheckin={vi.fn()}
+        onOpenQueues={vi.fn()}
+        onOpenFirings={vi.fn()}
+        onOpenStudioResources={vi.fn()}
+        onOpenGlazeBoard={vi.fn()}
+        onOpenCommunity={vi.fn()}
+        onOpenWorkshops={vi.fn()}
+        onOpenMessages={vi.fn()}
+        onOpenPieces={vi.fn()}
+      />
+    );
+
+    expect(await screen.findByText(/This is your member home inside the portal/i)).toBeDefined();
+    expect(screen.getByRole("button", { name: "Start a check-in" })).toBeTruthy();
+    expect(screen.getByText("What this is")).toBeDefined();
+    expect(screen.getByText("Recommended next actions")).toBeDefined();
+  });
+
   it("shows retry after permission failure and loads kiln rows on retry", async () => {
     const user = createUser();
 

--- a/web/src/views/MessagesView.test.tsx
+++ b/web/src/views/MessagesView.test.tsx
@@ -316,8 +316,11 @@ describe("MessagesView initial thread focus", () => {
       expect(screen.queryByTestId("announcement-card-ann-unread")).toBeNull();
     });
     expect(screen.getByTestId("selected-announcement-preview")).toBeTruthy();
+    expect(screen.getByText("Inbox cleared")).toBeTruthy();
     expect(
-      screen.getByText("Inbox cleared. You're reviewing a previously read studio update.")
+      screen.getByText(
+        "You are reviewing a previously read studio update. Switch to All when you want to revisit the full announcement history."
+      )
     ).toBeTruthy();
 
     fireEvent.click(screen.getByRole("button", { name: /^All$/i }));

--- a/web/src/views/MessagesView.tsx
+++ b/web/src/views/MessagesView.tsx
@@ -13,6 +13,7 @@ import { db } from "../firebase";
 import type { Announcement, DirectMessage, DirectMessageThread, LiveUser } from "../types/messaging";
 import { toVoidHandler } from "../utils/toVoidHandler";
 import RevealCard from "../components/RevealCard";
+import GuidedStateCard from "../components/GuidedStateCard";
 import { useUiSettings } from "../context/UiSettingsContext";
 import { trackedAddDoc, trackedGetDocs, trackedSetDoc, trackedUpdateDoc } from "../lib/firestoreTelemetry";
 
@@ -833,24 +834,53 @@ export default function MessagesView({
           <article className="announcement-preview card card-3d" data-testid="selected-announcement-preview">
             <div className="announcement-title">{selectedAnnouncement.title || "Studio update"}</div>
             <div className="announcement-meta">{formatMaybeTimestamp(selectedAnnouncement.createdAt)}</div>
-            <div className="announcement-body">{selectedAnnouncement.body || "Details coming soon."}</div>
+            <div className="announcement-body">
+              {selectedAnnouncement.body ||
+                "This notice was published without extra detail. Keep this thread open for direct follow-up if you need anything clarified."}
+            </div>
             {selectedAnnouncement.ctaLabel ? (
               <div className="announcement-cta">{selectedAnnouncement.ctaLabel}</div>
             ) : null}
           </article>
         ) : null}
         {announcementsLoading ? (
-          <div className="empty-state">Loading announcements...</div>
+          <GuidedStateCard
+            eyebrow="Studio announcements"
+            title="Loading studio announcements"
+            body="We are pulling the latest studio-wide notices for this inbox."
+            className="empty-state"
+          />
         ) : announcements.length === 0 ? (
-          <div className="empty-state">No announcements yet.</div>
+          <GuidedStateCard
+            eyebrow="Studio announcements"
+            title="No studio announcements yet"
+            body="Keep using direct messages for one-to-one questions. Studio-wide notices will appear here when they are published."
+            className="empty-state"
+          />
         ) : visibleAnnouncements.length === 0 ? (
-          <div className="empty-state">
-            {readFilter === "inbox"
-              ? selectedAnnouncementHiddenFromInbox
-                ? "Inbox cleared. You're reviewing a previously read studio update."
-                : "You're caught up on studio updates. Switch to All to review earlier posts."
-              : "No announcements yet."}
-          </div>
+          <GuidedStateCard
+            eyebrow="Studio announcements"
+            title={
+              readFilter === "inbox"
+                ? selectedAnnouncementHiddenFromInbox
+                  ? "Inbox cleared"
+                  : "You are caught up on studio updates"
+                : "No announcements yet"
+            }
+            body={
+              readFilter === "inbox"
+                ? selectedAnnouncementHiddenFromInbox
+                  ? "You are reviewing a previously read studio update. Switch to All when you want to revisit the full announcement history."
+                  : "Switch to All to review earlier posts, or stay in Inbox for only the updates that still need your attention."
+                : "Studio-wide notices will appear here when they are published."
+            }
+            actions={
+              readFilter === "inbox"
+                ? [{ label: "Open all announcements", onClick: () => setReadFilter("all"), variant: "ghost" }]
+                : []
+            }
+            className="empty-state"
+          />
         ) : (
           <div className="announcements-list">
             {visibleAnnouncements.map((announcement) => {
@@ -878,7 +908,10 @@ export default function MessagesView({
                     </div>
                     {unread ? <span className="notif-dot" /> : null}
                   </div>
-                  <div className="announcement-body">{announcement.body || "Details coming soon."}</div>
+                  <div className="announcement-body">
+                    {announcement.body ||
+                      "Open this announcement for the full context and any follow-up direction from the studio."}
+                  </div>
                   {isSelected && announcement.ctaLabel ? (
                     <div className="announcement-cta">{announcement.ctaLabel}</div>
                   ) : null}

--- a/web/src/views/MyPiecesView.css
+++ b/web/src/views/MyPiecesView.css
@@ -295,6 +295,10 @@
   color: var(--muted);
 }
 
+.my-piece-overview-item strong {
+  line-height: 1.4;
+}
+
 .my-piece-studio-controls {
   display: grid;
   gap: 12px;

--- a/web/src/views/MyPiecesView.tsx
+++ b/web/src/views/MyPiecesView.tsx
@@ -231,6 +231,35 @@ function toMillis(value: unknown): number {
   return new Date((value as string | number | Date | null) ?? 0).getTime();
 }
 
+function getPieceNextStepLabel(piece: Pick<PieceDoc, "stage" | "batchIsHistory" | "isArchived">): string {
+  if (piece.batchIsHistory || piece.isArchived) {
+    return "Next step: review the history or leave feedback";
+  }
+
+  switch (piece.stage) {
+    case "GREENWARE":
+      return "Next step: bisque firing";
+    case "BISQUE":
+      return "Next step: glaze and stage for the next firing";
+    case "GLAZED":
+      return "Next step: finish firing and cooldown";
+    case "FINISHED":
+      return "Next step: pickup or feedback";
+    case "HOLD":
+      return "Next step: studio review";
+    default:
+      return "Next step: studio review";
+  }
+}
+
+function getPieceLatestUpdateLabel(piece: Pick<PieceDoc, "updatedAt">): string {
+  return `Latest update: ${formatMaybeTimestamp(piece.updatedAt)}`;
+}
+
+function getPieceJourneyStatus(piece: PieceDoc): string {
+  return STAGE_LABELS[piece.stage];
+}
+
 type StarRatingProps = {
   value: number | null | undefined;
   onSelect: (value: number) => void;
@@ -1046,9 +1075,9 @@ export default function MyPiecesView({
         <div>
           <h1>My Pieces</h1>
           <p className="my-pieces-intro">
-            Follow what&apos;s moving through the studio, leave quick feedback
-            where it&apos;s needed, and open any piece when you want the full
-            story.
+            Follow what&apos;s moving through the studio, see the latest update
+            and next step at a glance, and open any piece when you want the
+            full story.
           </p>
         </div>
       </div>
@@ -1072,7 +1101,7 @@ export default function MyPiecesView({
             <div className="card-title">Pieces in progress</div>
             <p className="piece-meta my-pieces-section-copy">
               A still-first pass through what&apos;s currently moving through
-              the studio.
+              the studio, with the latest update and next step surfaced inline.
             </p>
           </div>
           {activePieces.length > 1 ? (
@@ -1147,7 +1176,10 @@ export default function MyPiecesView({
                       Check-in: {piece.batchTitle}
                     </div>
                     <div className="piece-meta">
-                      Updated {formatMaybeTimestamp(piece.updatedAt)}
+                      {getPieceLatestUpdateLabel(piece)}
+                    </div>
+                    <div className="piece-meta">
+                      {getPieceNextStepLabel(piece)}
                     </div>
                     <div className="my-piece-still-footer">
                       Tap to expose the full piece detail.
@@ -1201,7 +1233,10 @@ export default function MyPiecesView({
                   </div>
                   <div className="piece-meta">Check-in: {piece.batchTitle}</div>
                   <div className="piece-meta">
-                    Updated {formatMaybeTimestamp(piece.updatedAt)}
+                    {getPieceLatestUpdateLabel(piece)}
+                  </div>
+                  <div className="piece-meta">
+                    {getPieceNextStepLabel(piece)}
                   </div>
                 </div>
                 <div className="my-pieces-list-actions">
@@ -1280,7 +1315,10 @@ export default function MyPiecesView({
                   </div>
                   <div className="piece-meta">Check-in: {piece.batchTitle}</div>
                   <div className="piece-meta">
-                    Updated {formatMaybeTimestamp(piece.updatedAt)}
+                    {getPieceLatestUpdateLabel(piece)}
+                  </div>
+                  <div className="piece-meta">
+                    {getPieceNextStepLabel(piece)}
                   </div>
                 </div>
                 <div className="my-pieces-list-actions">
@@ -1342,21 +1380,24 @@ export default function MyPiecesView({
                   </div>
                   <div className="my-piece-still-caption">Still preview</div>
                 </div>
-                <div className="my-piece-exploded-meta">
-                  <div id="piece-detail-title" className="detail-title">
-                    {selectedPiece.pieceCode || selectedPiece.id}
-                  </div>
-                  <div className="piece-meta">
-                    {selectedPiece.shortDesc || "No description yet."}
-                  </div>
-                  <div className="piece-meta">
-                    Check-in: {selectedPiece.batchTitle}
-                  </div>
-                  <div className="piece-meta">
-                    Updated: {formatMaybeTimestamp(selectedPiece.updatedAt)}
+                  <div className="my-piece-exploded-meta">
+                    <div id="piece-detail-title" className="detail-title">
+                      {selectedPiece.pieceCode || selectedPiece.id}
+                    </div>
+                    <div className="piece-meta">
+                      {selectedPiece.shortDesc || "No description yet."}
+                    </div>
+                    <div className="piece-meta">
+                      Check-in: {selectedPiece.batchTitle}
+                    </div>
+                    <div className="piece-meta">
+                      {getPieceLatestUpdateLabel(selectedPiece)}
+                    </div>
+                    <div className="piece-meta">
+                      {getPieceNextStepLabel(selectedPiece)}
+                    </div>
                   </div>
                 </div>
-              </div>
               <button className="btn btn-ghost" onClick={closePieceDetail}>
                 Close
               </button>
@@ -1365,7 +1406,15 @@ export default function MyPiecesView({
             <div className="my-piece-overview-grid">
               <div className="my-piece-overview-item">
                 <span className="my-piece-overview-label">Stage</span>
-                <strong>{STAGE_LABELS[selectedPiece.stage]}</strong>
+                <strong>{getPieceJourneyStatus(selectedPiece)}</strong>
+              </div>
+              <div className="my-piece-overview-item">
+                <span className="my-piece-overview-label">Latest update</span>
+                <strong>{formatMaybeTimestamp(selectedPiece.updatedAt)}</strong>
+              </div>
+              <div className="my-piece-overview-item">
+                <span className="my-piece-overview-label">Next step</span>
+                <strong>{getPieceNextStepLabel(selectedPiece)}</strong>
               </div>
               <div className="my-piece-overview-item">
                 <span className="my-piece-overview-label">Category</span>

--- a/web/src/views/MyPiecesView.ui.test.tsx
+++ b/web/src/views/MyPiecesView.ui.test.tsx
@@ -552,6 +552,8 @@ describe("MyPiecesView permission resiliency", () => {
     renderMyPieces(user);
 
     await screen.findByText("Pieces in progress");
+    expect(screen.getAllByText(/Latest update:/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/Next step: bisque firing/i)).toBeDefined();
     expect(screen.getByText("Needs rating")).toBeDefined();
     expect(screen.getByText("History")).toBeDefined();
     expect(

--- a/web/src/views/NotificationsView.test.tsx
+++ b/web/src/views/NotificationsView.test.tsx
@@ -336,7 +336,12 @@ describe("NotificationsView mark-read feedback", () => {
       expect(updateDocMock).toHaveBeenCalledTimes(1);
     });
     expect(screen.queryByTestId("notification-card-notif-open")).toBeNull();
-    expect(screen.queryByText("You're caught up. Switch to All to review earlier notifications.")).not.toBeNull();
+    expect(screen.queryByText("You're caught up")).not.toBeNull();
+    expect(
+      screen.queryByText(
+        "Switch to All to review earlier notifications, or come back here when the studio posts the next update."
+      )
+    ).not.toBeNull();
   });
 
   it("keeps view-queues notifications out of inbox across a remount while read sync finishes", async () => {

--- a/web/src/views/NotificationsView.tsx
+++ b/web/src/views/NotificationsView.tsx
@@ -3,6 +3,7 @@ import type { User } from "firebase/auth";
 import { Timestamp, doc, updateDoc } from "firebase/firestore";
 import { db } from "../firebase";
 import { createFunctionsClient } from "../api/functionsClient";
+import GuidedStateCard from "../components/GuidedStateCard";
 import { resolveFunctionsBaseUrl } from "../utils/functionsBaseUrl";
 import { formatDateTime } from "../utils/format";
 import { toVoidHandler } from "../utils/toVoidHandler";
@@ -411,13 +412,28 @@ export default function NotificationsView({
 
       <div className="notifications-list">
         {notifications.length === 0 ? (
-          <div className="card card-3d empty-state">No notifications yet.</div>
+          <GuidedStateCard
+            eyebrow="Notifications"
+            title="No notifications yet"
+            body="This is where pickup readiness, queue changes, and other studio alerts will appear once something needs your attention."
+            className="card card-3d empty-state"
+          />
         ) : visibleNotifications.length === 0 ? (
-          <div className="card card-3d empty-state">
-            {readFilter === "inbox"
-              ? "You're caught up. Switch to All to review earlier notifications."
-              : "No notifications yet."}
-          </div>
+          <GuidedStateCard
+            eyebrow="Notifications"
+            title={readFilter === "inbox" ? "You're caught up" : "No notifications yet"}
+            body={
+              readFilter === "inbox"
+                ? "Switch to All to review earlier notifications, or come back here when the studio posts the next update."
+                : "This feed will start filling once the studio sends you updates."
+            }
+            actions={
+              readFilter === "inbox"
+                ? [{ label: "Open all notifications", onClick: () => setReadFilter("all"), variant: "ghost" }]
+                : []
+            }
+            className="card card-3d empty-state"
+          />
         ) : (
           visibleNotifications.map((item) => {
             const createdAt = coerceDate(item.createdAt);

--- a/web/src/views/PlaceholderView.test.tsx
+++ b/web/src/views/PlaceholderView.test.tsx
@@ -1,0 +1,20 @@
+/** @vitest-environment jsdom */
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import PlaceholderView from "./PlaceholderView";
+
+describe("PlaceholderView", () => {
+  it("renders guided recovery actions instead of generic coming-soon copy", () => {
+    render(<PlaceholderView title="Example area" subtitle="Fallback state" />);
+
+    expect(
+      screen.getByText(/This area is not ready for live studio work yet\./i),
+    ).toBeTruthy();
+    expect(screen.getByRole("link", { name: "Return to dashboard" }).getAttribute("href")).toBe("/");
+    expect(screen.getByRole("link", { name: "Contact support" }).getAttribute("href")).toBe(
+      "mailto:support@monsoonfire.com",
+    );
+  });
+});

--- a/web/src/views/PlaceholderView.tsx
+++ b/web/src/views/PlaceholderView.tsx
@@ -11,7 +11,18 @@ export default function PlaceholderView({ title, subtitle }: Props) {
         <p>{subtitle}</p>
       </header>
       <div className="panel-body placeholder">
-        <p>Coming soon. We are designing this area next.</p>
+        <p className="placeholder-copy">
+          This area is not ready for live studio work yet. If you expected something active here,
+          head back to the dashboard and message the studio so we can route you correctly.
+        </p>
+        <div className="placeholder-actions">
+          <a className="btn btn-primary" href="/">
+            Return to dashboard
+          </a>
+          <a className="btn btn-ghost" href="mailto:support@monsoonfire.com">
+            Contact support
+          </a>
+        </div>
         <div className="placeholder-grid">
           <div className="placeholder-card" />
           <div className="placeholder-card" />

--- a/web/src/views/ProfileView.tsx
+++ b/web/src/views/ProfileView.tsx
@@ -273,6 +273,7 @@ export default function ProfileView({
   onEnhancedMotionChange,
   onOpenIntegrations,
   onOpenBilling,
+  onOpenStartSurface,
   onAvatarUpdated,
 }: {
   user: User;
@@ -282,6 +283,7 @@ export default function ProfileView({
   onEnhancedMotionChange: (next: boolean) => void;
   onOpenIntegrations: () => void;
   onOpenBilling: () => void;
+  onOpenStartSurface: () => void;
   onAvatarUpdated: () => void;
 }) {
   const { active, history } = useBatches(user);
@@ -657,6 +659,9 @@ export default function ProfileView({
           <p className="page-subtitle">See what we know about your journey at Monsoon Fire.</p>
         </div>
         <div className="header-actions">
+          <button type="button" className="btn btn-ghost" onClick={onOpenStartSurface}>
+            Start here
+          </button>
           <button type="button" className="btn btn-ghost" onClick={onOpenBilling}>
             Billing
           </button>

--- a/web/src/views/ReservationsView.css
+++ b/web/src/views/ReservationsView.css
@@ -78,6 +78,80 @@
   font-size: 14px;
 }
 
+.checkin-journey-card {
+  display: grid;
+  gap: 16px;
+}
+
+.checkin-journey-head {
+  display: grid;
+  grid-template-columns: minmax(0, 1.4fr) minmax(240px, 0.8fr);
+  gap: 16px;
+  align-items: start;
+}
+
+.checkin-journey-callout {
+  display: grid;
+  gap: 6px;
+  padding: 14px 16px;
+  border-radius: 16px;
+  border: 1px solid var(--border);
+  background: linear-gradient(180deg, rgba(180, 79, 53, 0.08), rgba(180, 79, 53, 0.04));
+}
+
+.checkin-journey-callout-label,
+.estimate-next-step-label {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+
+.checkin-journey-callout-copy,
+.estimate-next-step-copy {
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--text);
+  line-height: 1.4;
+}
+
+.checkin-journey-rail {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.checkin-journey-stage {
+  display: grid;
+  gap: 6px;
+  padding: 12px 14px;
+  border-radius: 14px;
+  border: 1px solid var(--border);
+  background: var(--surface);
+}
+
+.checkin-journey-stage-label {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.checkin-journey-stage-copy,
+.checkin-journey-summary,
+.estimate-next-step-detail {
+  font-size: 12px;
+  color: var(--muted);
+  line-height: 1.45;
+}
+
+.checkin-journey-summary {
+  padding: 12px 14px;
+  border-radius: 14px;
+  border: 1px solid var(--border);
+  background: color-mix(in srgb, var(--surface-2) 92%, white 8%);
+}
+
 .checkin-optional-step {
   padding: 0;
 }
@@ -417,6 +491,19 @@
 .estimate-note {
   font-size: 12px;
   color: var(--accent);
+}
+
+.estimate-next-step {
+  display: grid;
+  gap: 6px;
+  padding: 14px 16px;
+  border-radius: 16px;
+  border: 1px solid rgba(180, 79, 53, 0.18);
+  background: rgba(180, 79, 53, 0.06);
+}
+
+.estimate-next-step-detail {
+  color: var(--text-dim);
 }
 
 .checkin-submit-btn {
@@ -1688,6 +1775,11 @@
     align-items: stretch;
   }
 
+  .checkin-journey-head,
+  .checkin-journey-rail {
+    grid-template-columns: 1fr;
+  }
+
   .reservation-card-header,
   .reservation-row {
     flex-direction: column;
@@ -1706,6 +1798,13 @@
   .continuity-export-panel {
     flex-direction: column;
     align-items: flex-start;
+  }
+
+  .checkin-journey-callout,
+  .checkin-journey-stage,
+  .checkin-journey-summary,
+  .estimate-next-step {
+    padding: 12px 14px;
   }
 }
 

--- a/web/src/views/ReservationsView.tsx
+++ b/web/src/views/ReservationsView.tsx
@@ -144,6 +144,38 @@ const STAFF_OFFLINE_SYNC_MIN_DELAY_MS = 1200;
 const STAFF_OFFLINE_SYNC_MAX_DELAY_MS = 2800;
 
 const MAX_PHOTO_BYTES = 8 * 1024 * 1024;
+const CHECKIN_JOURNEY_STAGES = [
+  {
+    id: "intake",
+    label: "Intake",
+    detail: "Capture the work, size, and firing path in one place.",
+  },
+  {
+    id: "booking",
+    label: "Booking",
+    detail: "Choose the shelf, kiln, or flexible lane that fits the load.",
+  },
+  {
+    id: "queue",
+    label: "Queue",
+    detail: "The studio places the work in order and watches capacity.",
+  },
+  {
+    id: "progress",
+    label: "Progress",
+    detail: "Updates move with the firing so you can track the cycle.",
+  },
+  {
+    id: "cooldown",
+    label: "Cooldown",
+    detail: "The kiln cools before the work is safe to handle.",
+  },
+  {
+    id: "pickup",
+    label: "Pickup",
+    detail: "You get the ready window and handoff guidance.",
+  },
+] as const;
 const DEFAULT_FUNCTIONS_BASE_URL = "https://us-central1-monsoonfire-portal.cloudfunctions.net";
 type ImportMetaEnvShape = {
   DEV?: boolean;
@@ -545,6 +577,33 @@ function latestStageNote(record: ReservationRecord): string | null {
     if (typeof notes === "string" && notes.trim()) return notes.trim();
   }
   return null;
+}
+
+function getCheckinJourneySnapshot(intakeMode: IntakeMode) {
+  if (intakeMode === "COMMUNITY_SHELF") {
+    return {
+      heading: "Flexible tiny drop-off",
+      nextStep: "Next step: submit the intake, then we watch for leftover kiln space.",
+      detail:
+        "Intake is free, booking stays light, and the queue only moves when a safe gap opens.",
+    };
+  }
+
+  if (intakeMode === "WHOLE_KILN") {
+    return {
+      heading: "Dedicated kiln booking",
+      nextStep: "Next step: confirm the load, then the studio schedules a dedicated firing.",
+      detail:
+        "Intake locks in the booking lane, the queue tracks the full chamber, and pickup follows the firing + cooldown cycle.",
+    };
+  }
+
+  return {
+    heading: "Standard shelf booking",
+    nextStep: "Next step: submit the intake, then the studio confirms the booking and queue lane.",
+    detail:
+      "Intake collects the work details now, booking confirms shelf space, and queue, firing, cooldown, and pickup stay visible after that.",
+  };
 }
 
 function getCapacityPressure(usedHalfShelves: number) {
@@ -1047,6 +1106,7 @@ export default function ReservationsView({
       : intakeMode === "WHOLE_KILN"
         ? "Reserve the whole kiln"
         : "Standard shelf purchase";
+  const checkinJourneySnapshot = getCheckinJourneySnapshot(intakeMode);
   const canSuggestPriorityQueue = intakeMode !== "COMMUNITY_SHELF";
   const effectiveCommunityShelfFillInAllowed =
     intakeMode === "SHELF_PURCHASE" && (communityShelfFillInAllowed || rushRequested);
@@ -3222,6 +3282,9 @@ export default function ReservationsView({
 
   const isListOnly = viewMode === "listOnly";
   const showStaffTools = isStaff && !isListOnly;
+  const recentCheckinIndex = showStaffTools ? 2 : 1;
+  const journeyCardIndex = showStaffTools ? 1 : 0;
+  const formCardIndex = showStaffTools ? 3 : 2;
 
   return (
     <div className="page reservations-page">
@@ -3230,8 +3293,8 @@ export default function ReservationsView({
           <div>
             <h1>Ware Check-in</h1>
             <p className="page-subtitle">
-              Think of it like an airport: pre-check here to breeze through the gate-check, or let
-              an agent help you check in. Both are equally good ways to use the studio kiln rentals.
+              Start with intake, then we keep booking, queue, firing progress, cooldown, and pickup
+              visible so the work never disappears into a black box.
             </p>
           </div>
         </div>
@@ -3293,11 +3356,43 @@ export default function ReservationsView({
         </RevealCard>
       ) : null}
 
+      {!isListOnly ? (
+        <RevealCard
+          as="section"
+          className="card card-3d checkin-journey-card"
+          index={journeyCardIndex}
+          enabled={motionEnabled}
+        >
+          <div className="checkin-journey-head">
+            <div>
+              <div className="card-title">What happens next</div>
+              <p className="form-helper">
+                Intake is the form you fill out now. Booking, queue, progress, cooldown, and pickup
+                stay visible after that so you always know what comes next.
+              </p>
+            </div>
+            <div className="checkin-journey-callout">
+              <div className="checkin-journey-callout-label">{checkinJourneySnapshot.heading}</div>
+              <div className="checkin-journey-callout-copy">{checkinJourneySnapshot.nextStep}</div>
+            </div>
+          </div>
+          <div className="checkin-journey-rail" role="list" aria-label="Check-in journey stages">
+            {CHECKIN_JOURNEY_STAGES.map((stage) => (
+              <div key={stage.id} className="checkin-journey-stage" role="listitem">
+                <div className="checkin-journey-stage-label">{stage.label}</div>
+                <div className="checkin-journey-stage-copy">{stage.detail}</div>
+              </div>
+            ))}
+          </div>
+          <div className="checkin-journey-summary">{checkinJourneySnapshot.detail}</div>
+        </RevealCard>
+      ) : null}
+
       {mode === "client" && recentBisqueReservation ? (
         <RevealCard
           as="section"
           className="card card-3d recent-checkin-card"
-          index={1}
+          index={recentCheckinIndex}
           enabled={motionEnabled}
         >
           <div className="card-title">Recently bisqued? Send it to glaze</div>
@@ -3324,14 +3419,14 @@ export default function ReservationsView({
       ) : null}
 
       {!isListOnly ? (
-        <RevealCard as="section" className="card card-3d reservation-form" index={2} enabled={motionEnabled}>
+        <RevealCard as="section" className="card card-3d reservation-form" index={formCardIndex} enabled={motionEnabled}>
         <div className="card-title">
-          {mode === "staff" ? "Staff check-in workflow" : "Self check-in workflow"}
+          {mode === "staff" ? "Staff intake workflow" : "Member intake workflow"}
         </div>
         <p className="form-helper">
           {mode === "staff"
-            ? "Capture the essentials so the studio can load the next firing smoothly."
-            : "Tell us what you’re dropping off, snap a quick photo, and pick your kiln path."}
+            ? "Capture the essentials so the studio can book, queue, and track the work on the member’s behalf."
+            : "Tell us what you’re dropping off, snap a quick photo, and choose the booking lane that fits the work."}
         </p>
 
         {mode === "staff" && !staffTargetUid ? (
@@ -3740,6 +3835,11 @@ export default function ReservationsView({
                   {priceBreakApplied ? (
                     <div className="estimate-note">Price break starts at 4 half shelves.</div>
                   ) : null}
+                  <div className="estimate-next-step">
+                    <div className="estimate-next-step-label">What happens next</div>
+                    <div className="estimate-next-step-copy">{checkinJourneySnapshot.nextStep}</div>
+                    <div className="estimate-next-step-detail">{checkinJourneySnapshot.detail}</div>
+                  </div>
                 </aside>
                 {intakeMode === "SHELF_PURCHASE" ? (
                   <div className="community-overflow-optin community-overflow-optin-below-estimate">

--- a/web/src/views/ReservationsView.ui.test.tsx
+++ b/web/src/views/ReservationsView.ui.test.tsx
@@ -164,6 +164,10 @@ describe("ReservationsView ware check-in UX", () => {
   it("keeps a single community-shelf confirmation path and surfaces oversize feedback inline", async () => {
     render(<ReservationsView user={createUser()} isStaff={false} />);
 
+    expect(screen.getAllByText("What happens next").length).toBeGreaterThan(1);
+    expect(
+      screen.getByText(/Booking, queue, progress, cooldown, and pickup/i),
+    ).toBeTruthy();
     expect(screen.getByText("4. Size + firing option")).toBeTruthy();
     expect(screen.getByRole("button", { name: /Flexible tiny drop-off/i })).toBeTruthy();
     expect(screen.getByRole("button", { name: /Standard shelf purchase/i })).toBeTruthy();

--- a/web/src/views/StaffView.tsx
+++ b/web/src/views/StaffView.tsx
@@ -142,6 +142,7 @@ type Props = {
   showEmulatorTools: boolean;
   onOpenCheckin?: () => void;
   onOpenReservation?: (reservationId?: string) => void;
+  onOpenMemberStart?: () => void;
   onOpenMessages?: () => void;
   onOpenMessageThread?: (threadId: string) => void;
   onOpenFirings?: () => void;
@@ -2384,6 +2385,7 @@ export default function StaffView({
   showEmulatorTools,
   onOpenCheckin,
   onOpenReservation,
+  onOpenMemberStart,
   onOpenMessages,
   onOpenMessageThread,
   onOpenFirings,
@@ -9872,6 +9874,11 @@ export default function StaffView({
           {!isTaskHomeRoute ? (
             <button className="btn btn-ghost" type="button" onClick={openTaskHome}>
               Open task home
+            </button>
+          ) : null}
+          {onOpenMemberStart ? (
+            <button className="btn btn-ghost" type="button" onClick={onOpenMemberStart}>
+              Open member start
             </button>
           ) : null}
           {onOpenCheckin ? (

--- a/website/ab/a/index.html
+++ b/website/ab/a/index.html
@@ -31,7 +31,7 @@
         <a href="/support/">Support</a>
         <a href="/highlights/">Gallery</a></nav>
             <div class="nav-portal-wrap">
-        <a class="nav-portal" href="https://monsoonfire.kilnfire.com" target="_blank" rel="noopener noreferrer">Login</a>
+        <a class="nav-portal" href="https://portal.monsoonfire.com" target="_blank" rel="noopener noreferrer">Login</a>
       </div><button class="menu-toggle" type="button" aria-label="Toggle menu" aria-expanded="false" data-menu-toggle>
         <span></span><span></span><span></span>
       </button>
@@ -164,9 +164,9 @@
               <p class="hero-note">Manual updates from the studio floor.</p>
             </div>
             <div class="kiln-status" data-kiln-list>
-              <div>Loading kiln status...</div>
+              <div>Syncing kiln board. The latest manual status will appear here once it finishes loading.</div>
             </div>
-            <div class="kiln-footer">Last updated: <span data-kiln-updated>—</span></div>
+            <div class="kiln-footer">Last updated: <span data-kiln-updated>Waiting for refresh</span></div>
           </div>
         </aside>
       </div>

--- a/website/ab/b/index.html
+++ b/website/ab/b/index.html
@@ -164,9 +164,9 @@
               <p class="hero-note">Manual updates from the studio floor.</p>
             </div>
             <div class="kiln-status" data-kiln-list>
-              <div>Loading kiln status...</div>
+              <div>Syncing kiln board. The latest manual status will appear here once it finishes loading.</div>
             </div>
-            <div class="kiln-footer">Last updated: <span data-kiln-updated>—</span></div>
+            <div class="kiln-footer">Last updated: <span data-kiln-updated>Waiting for refresh</span></div>
           </div>
         </aside>
       </div>

--- a/website/about/index.html
+++ b/website/about/index.html
@@ -42,7 +42,7 @@
         <a href="/support/">Support</a>
         <a href="/highlights/">Gallery</a></nav>
             <div class="nav-portal-wrap">
-        <a class="nav-portal" href="https://monsoonfire.kilnfire.com" target="_blank" rel="noopener noreferrer">Login</a>
+        <a class="nav-portal" href="https://portal.monsoonfire.com" target="_blank" rel="noopener noreferrer">Login</a>
       </div><button class="menu-toggle" type="button" aria-label="Toggle menu" aria-expanded="false" data-menu-toggle>
         <span></span><span></span><span></span>
       </button>

--- a/website/assets/css/styles.css
+++ b/website/assets/css/styles.css
@@ -699,8 +699,9 @@ select:focus-visible {
 }
 
 .status-pill.state-offline {
-  background: rgba(27, 26, 23, 0.18);
-  color: var(--paper-50);
+  background: rgba(27, 26, 23, 0.08);
+  border-color: rgba(27, 26, 23, 0.18);
+  color: var(--ink-900);
 }
 
 .status-label {

--- a/website/assets/js/kiln-status.js
+++ b/website/assets/js/kiln-status.js
@@ -2,6 +2,7 @@
   const list = document.querySelector('[data-kiln-list]');
   const updated = document.querySelector('[data-kiln-updated]');
   if (!list) return;
+  const STALE_AFTER_DAYS = 14;
 
   const renderFieldRow = (label, value, parent) => {
     const row = document.createElement('div');
@@ -15,6 +16,61 @@
 
     row.append(labelEl, valueEl);
     parent.appendChild(row);
+  };
+
+  const renderStatusSummary = (kind, title, message) => {
+    const summary = document.createElement('div');
+    summary.className = 'kiln-info';
+
+    const label = document.createElement('div');
+    label.className = 'status-label';
+    label.textContent = 'Board status';
+
+    const pill = document.createElement('span');
+    pill.className = `status-pill ${kind}`;
+    pill.textContent = title;
+
+    const note = document.createElement('div');
+    note.className = 'kiln-notes';
+    note.textContent = message;
+
+    summary.append(label, pill, note);
+    return summary;
+  };
+
+  const parseUpdatedAt = (data) => {
+    const candidate = typeof data?.lastUpdatedIso === 'string' && data.lastUpdatedIso.trim()
+      ? data.lastUpdatedIso
+      : typeof data?.lastUpdated === 'string'
+        ? data.lastUpdated
+        : '';
+    const parsed = candidate ? new Date(candidate) : null;
+    return parsed && !Number.isNaN(parsed.getTime()) ? parsed : null;
+  };
+
+  const describeFreshness = (updatedAt) => {
+    if (!updatedAt) {
+      return {
+        kind: 'state-offline',
+        title: 'Manual board unavailable',
+        message: 'The studio board did not include a usable timestamp, so treat this as a stale snapshot and check the portal for the live workflow.',
+      };
+    }
+
+    const ageDays = (Date.now() - updatedAt.getTime()) / (1000 * 60 * 60 * 24);
+    if (ageDays > STALE_AFTER_DAYS) {
+      return {
+        kind: 'state-offline',
+        title: 'Manual board is stale',
+        message: `The latest manual refresh is more than ${STALE_AFTER_DAYS} days old. Use the portal for the current queue and keep this page as a calm reference only.`,
+      };
+    }
+
+    return {
+      kind: 'state-idle',
+      title: 'Manual board current',
+      message: 'The studio board is in sync with the latest manual update.',
+    };
   };
 
   const renderKiln = (kiln) => {
@@ -56,9 +112,11 @@
   };
 
   const load = async () => {
+    setEmptyState('Syncing kiln board. The latest manual status will appear here once it finishes loading.');
+
     const candidates = [
-      '/api/websiteKilnBoard',
       '/data/kiln-status.json',
+      '/api/websiteKilnBoard',
     ];
 
     try {
@@ -90,11 +148,20 @@
       list.replaceChildren();
       const kilnItems = Array.isArray(data?.kilns) ? data.kilns : [];
       if (kilnItems.length > 0) {
+        const freshness = describeFreshness(parseUpdatedAt(data));
+        const nodes = [renderStatusSummary(freshness.kind, freshness.title, freshness.message)];
         kilnItems.forEach((kiln) => {
-          list.appendChild(renderKiln(kiln));
+          nodes.push(renderKiln(kiln));
         });
+        list.replaceChildren(...nodes);
       } else {
-        setEmptyState('Manual status is not set yet.');
+        list.replaceChildren(
+          renderStatusSummary(
+            'state-offline',
+            'Manual board empty',
+            'No kiln loads are posted yet. The portal remains the source of truth for reservations, queue timing, and pickup readiness.'
+          )
+        );
       }
 
       if (updated && data?.lastUpdated) {
@@ -102,9 +169,15 @@
       }
     } catch (_err) {
       const message = _err instanceof Error ? _err.message : String(_err);
-      setEmptyState(`Manual status is currently unavailable. ${message}`);
+      list.replaceChildren(
+        renderStatusSummary(
+          'state-offline',
+          'Manual board unavailable',
+          `The studio status feed could not be loaded. ${message} Check the portal for the live operating view.`
+        )
+      );
       if (updated) {
-        updated.textContent = `Error: ${message}`;
+        updated.textContent = 'Unavailable';
       }
     }
   };

--- a/website/assets/js/main.js
+++ b/website/assets/js/main.js
@@ -265,15 +265,24 @@
 
   const portalExperimentName = 'portal_path_v1';
   const portalHost = 'portal.monsoonfire.com';
-  const legacyPortalHost = 'monsoonfire.kilnfire.com';
   const normalizeUrlHost = (hostname) => String(hostname || '').toLowerCase().replace(/^www\./, '');
-  const canonicalCampaignHosts = [legacyPortalHost, portalHost, 'instagram.com', 'discord.com', 'discord.gg', 'phoenixcenterforthearts.org'];
+  const canonicalCampaignHosts = [portalHost, 'instagram.com', 'discord.com', 'discord.gg', 'phoenixcenterforthearts.org'];
   const portalSurfaceTargets = {
     home: 'dashboard',
     services: 'reservations',
     kiln_firing: 'reservations',
     memberships: 'membership',
     contact: 'support',
+    supplies: 'supplies',
+    about: 'dashboard',
+    blog: 'dashboard',
+    faq: 'dashboard',
+    gallery: 'dashboard',
+    highlights: 'dashboard',
+    policies: 'dashboard',
+    support: 'support',
+    updates: 'dashboard',
+    classes: 'dashboard',
   };
 
   const isCampaignHost = (hostname) => {
@@ -290,27 +299,31 @@
 
   const resolvePortalPageContext = () => {
     const normalizedPath = normalizePath(window.location.pathname).toLowerCase();
-    if (normalizedPath === '/ab/b/') {
-      return { surface: 'home', variant: 'b' };
-    }
-    if (normalizedPath === '/services/') {
-      return { surface: 'services', variant: 'a' };
-    }
-    if (normalizedPath === '/kiln-firing/') {
-      return { surface: 'kiln_firing', variant: 'a' };
-    }
-    if (normalizedPath === '/memberships/') {
-      return { surface: 'memberships', variant: 'a' };
-    }
-    if (normalizedPath === '/contact/') {
-      return { surface: 'contact', variant: 'a' };
-    }
-    return null;
+    const pageContexts = {
+      '/': { surface: 'home', variant: 'a' },
+      '/ab/a/': { surface: 'home', variant: 'a' },
+      '/ab/b/': { surface: 'home', variant: 'b' },
+      '/about/': { surface: 'about', variant: 'a' },
+      '/blog/': { surface: 'blog', variant: 'a' },
+      '/classes/': { surface: 'classes', variant: 'a' },
+      '/contact/': { surface: 'contact', variant: 'a' },
+      '/faq/': { surface: 'faq', variant: 'a' },
+      '/gallery/': { surface: 'gallery', variant: 'a' },
+      '/highlights/': { surface: 'highlights', variant: 'a' },
+      '/kiln-firing/': { surface: 'kiln_firing', variant: 'a' },
+      '/memberships/': { surface: 'memberships', variant: 'a' },
+      '/policies/': { surface: 'policies', variant: 'a' },
+      '/services/': { surface: 'services', variant: 'a' },
+      '/supplies/': { surface: 'supplies', variant: 'a' },
+      '/support/': { surface: 'support', variant: 'a' },
+      '/updates/': { surface: 'updates', variant: 'a' },
+    };
+    return pageContexts[normalizedPath] || null;
   };
 
   const resolvePortalTarget = (link, surface) => {
     const explicitTarget = normalizeLabel(link && link.getAttribute ? link.getAttribute('data-portal-target') || '' : '');
-    if (explicitTarget === 'dashboard' || explicitTarget === 'reservations' || explicitTarget === 'membership' || explicitTarget === 'support') {
+    if (explicitTarget === 'dashboard' || explicitTarget === 'reservations' || explicitTarget === 'membership' || explicitTarget === 'support' || explicitTarget === 'supplies') {
       return explicitTarget;
     }
     return portalSurfaceTargets[surface] || null;
@@ -323,7 +336,6 @@
     const normalizedPath = parsed.pathname.toLowerCase();
     const isPortalCandidate =
       normalizedHost === portalHost ||
-      normalizedHost === legacyPortalHost ||
       normalizedPath === '/new-user' ||
       normalizedPath.startsWith('/new-user/');
     if (!isPortalCandidate) return null;
@@ -475,7 +487,7 @@
     const cleaned = href.toLowerCase();
     const portalTarget = normalizeLabel(link && link.getAttribute ? link.getAttribute('data-portal-target') || '' : '');
     if (portalTarget) return `portal_${portalTarget}`;
-    if (cleaned.includes(legacyPortalHost) || cleaned.includes(portalHost)) return cleaned.includes('/new-user') ? 'get_started' : 'login';
+    if (cleaned.includes(portalHost)) return cleaned.includes('/new-user') ? 'get_started' : 'login';
     if (cleaned.startsWith('mailto:')) return 'email';
     if (cleaned.startsWith('tel:')) return 'phone';
     if (cleaned.includes('discord')) return 'discord';

--- a/website/assets/js/updates.js
+++ b/website/assets/js/updates.js
@@ -128,7 +128,7 @@
         ? data.items.slice(0, 3)
         : [];
     if (!items.length) {
-      renderEmpty(teaserContainer, 'No public updates are live yet.');
+      renderEmpty(teaserContainer, 'Public updates are quiet right now. We will post the next bulletin when the studio has something to share.');
       return;
     }
     teaserContainer.replaceChildren(...items.map((item) => createCard(item, { compact: true })));
@@ -138,18 +138,21 @@
     if (!listContainer) return;
     const items = Array.isArray(data?.items) ? data.items : [];
     if (!items.length) {
-      renderEmpty(listContainer, 'No public updates are live right now.');
+      renderEmpty(listContainer, 'Public updates are quiet right now. We will post the next bulletin when the studio has something to share.');
       return;
     }
     listContainer.replaceChildren(...items.map((item) => createCard(item, { compact: false })));
   };
 
+  renderEmpty(teaserContainer, 'Syncing the latest public bulletin.');
+  renderEmpty(listContainer, 'Syncing the latest public bulletin.');
+
   fetch('/data/announcements.json', { cache: 'no-store' })
     .then((response) => (response.ok ? response.json() : null))
     .then((data) => {
       if (!data) {
-        renderEmpty(teaserContainer, 'Public updates are not available right now.');
-        renderEmpty(listContainer, 'Public updates are not available right now.');
+        renderEmpty(teaserContainer, 'Public updates are temporarily unavailable. Check back shortly for the latest bulletin.');
+        renderEmpty(listContainer, 'Public updates are temporarily unavailable. Check back shortly for the latest bulletin.');
         return;
       }
       if (generatedLabel) {
@@ -159,7 +162,7 @@
       renderList(data);
     })
     .catch(() => {
-      renderEmpty(teaserContainer, 'Public updates are not available right now.');
-      renderEmpty(listContainer, 'Public updates are not available right now.');
+      renderEmpty(teaserContainer, 'Public updates are temporarily unavailable. Check back shortly for the latest bulletin.');
+      renderEmpty(listContainer, 'Public updates are temporarily unavailable. Check back shortly for the latest bulletin.');
     });
 })();

--- a/website/blog/index.html
+++ b/website/blog/index.html
@@ -159,7 +159,7 @@
         <a href="/blog/">Studio Notes</a>
       </nav>
       <div class="nav-portal-wrap">
-        <a class="button button-ghost nav-login" href="https://monsoonfire.kilnfire.com" target="_blank" rel="noopener noreferrer">Login</a>
+        <a class="button button-ghost nav-login" href="https://portal.monsoonfire.com" target="_blank" rel="noopener noreferrer">Login</a>
       </div>
       <button class="menu-toggle" type="button" aria-label="Toggle menu" aria-expanded="false" data-menu-toggle>
         <span></span><span></span><span></span>

--- a/website/classes/index.html
+++ b/website/classes/index.html
@@ -42,7 +42,7 @@
         <a href="/support/">Support</a>
         <a href="/highlights/">Gallery</a></nav>
             <div class="nav-portal-wrap">
-        <a class="nav-portal" href="https://monsoonfire.kilnfire.com" target="_blank" rel="noopener noreferrer">Login</a>
+        <a class="nav-portal" href="https://portal.monsoonfire.com" target="_blank" rel="noopener noreferrer">Login</a>
       </div><button class="menu-toggle" type="button" aria-label="Toggle menu" aria-expanded="false" data-menu-toggle>
         <span></span><span></span><span></span>
       </button>

--- a/website/data/faq.json
+++ b/website/data/faq.json
@@ -27,7 +27,7 @@
   },
   {
     "question": "How do I get the address and gate code?",
-    "answer": "<p>We share the exact address and access details through the portal once your account is verified and you have a confirmed reservation, day pass, or approved visit context. <a href=\"https://monsoonfire.kilnfire.com/new-user\" target=\"_blank\" rel=\"noopener\">Create a free portal account here</a>.</p>",
+    "answer": "<p>We share the exact address and access details through the portal once your account is verified and you have a confirmed reservation, day pass, or approved visit context. <a href=\"https://portal.monsoonfire.com/new-user\" target=\"_blank\" rel=\"noopener\">Create a free portal account here</a>.</p>",
     "policySlug": "studio-access",
     "policyVersion": "2026-04-02",
     "sourceType": "operational_faq",

--- a/website/data/kiln-status.json
+++ b/website/data/kiln-status.json
@@ -1,5 +1,6 @@
 {
   "lastUpdated": "2026-01-31 5:30 PM",
+  "lastUpdatedIso": "2026-01-31T17:30:00-07:00",
   "updatedBy": "Manual",
   "kilns": [
     {

--- a/website/faq/index.html
+++ b/website/faq/index.html
@@ -41,7 +41,7 @@
         <a href="/support/">Support</a>
         <a href="/highlights/">Gallery</a></nav>
             <div class="nav-portal-wrap">
-        <a class="nav-portal" href="https://monsoonfire.kilnfire.com" target="_blank" rel="noopener noreferrer">Login</a>
+        <a class="nav-portal" href="https://portal.monsoonfire.com" target="_blank" rel="noopener noreferrer">Login</a>
       </div><button class="menu-toggle" type="button" aria-label="Toggle menu" aria-expanded="false" data-menu-toggle>
         <span></span><span></span><span></span>
       </button>
@@ -78,17 +78,17 @@
             <ul class="meta-grid meta-grid--stack">
               <li>
                 <span>Next</span>
-                <strong>Open studio night (TBD)</strong>
+                <strong>Open studio night (tentative)</strong>
                 <p>Monthly evening for shared work time and informal critique.</p>
               </li>
               <li>
                 <span>Next</span>
-                <strong>Kiln unload + pickup window (TBD)</strong>
+                <strong>Kiln unload + pickup window (tentative)</strong>
                 <p>Scheduled unload blocks announced through the portal.</p>
               </li>
               <li>
                 <span>Next</span>
-                <strong>Clay reclaim day (TBD)</strong>
+                <strong>Clay reclaim day (tentative)</strong>
                 <p>Shared reclaim run for members who are recycling clay.</p>
               </li>
             </ul>

--- a/website/gallery/index.html
+++ b/website/gallery/index.html
@@ -42,7 +42,7 @@
         <a href="/support/">Support</a>
         <a href="/highlights/">Gallery</a></nav>
             <div class="nav-portal-wrap">
-        <a class="nav-portal" href="https://monsoonfire.kilnfire.com" target="_blank" rel="noopener noreferrer">Login</a>
+        <a class="nav-portal" href="https://portal.monsoonfire.com" target="_blank" rel="noopener noreferrer">Login</a>
       </div><button class="menu-toggle" type="button" aria-label="Toggle menu" aria-expanded="false" data-menu-toggle>
         <span></span><span></span><span></span>
       </button>

--- a/website/highlights/index.html
+++ b/website/highlights/index.html
@@ -41,7 +41,7 @@
         <a href="/support/">Support</a>
         <a href="/highlights/">Gallery</a></nav>
             <div class="nav-portal-wrap">
-        <a class="nav-portal" href="https://monsoonfire.kilnfire.com" target="_blank" rel="noopener noreferrer">Login</a>
+        <a class="nav-portal" href="https://portal.monsoonfire.com" target="_blank" rel="noopener noreferrer">Login</a>
       </div><button class="menu-toggle" type="button" aria-label="Toggle menu" aria-expanded="false" data-menu-toggle>
         <span></span><span></span><span></span>
       </button>

--- a/website/index.html
+++ b/website/index.html
@@ -248,9 +248,9 @@
               <p class="hero-note">Manual updates from the studio floor.</p>
             </div>
             <div class="kiln-status" data-kiln-list>
-              <div>Loading kiln status...</div>
+              <div>Syncing kiln board. The latest manual status will appear here once it finishes loading.</div>
             </div>
-            <div class="kiln-footer">Last updated: <span data-kiln-updated>—</span></div>
+            <div class="kiln-footer">Last updated: <span data-kiln-updated>Waiting for refresh</span></div>
             <p class="meta">Next update posted after each firing and unload.</p>
           </div>
         </aside>
@@ -267,7 +267,7 @@
           <p class="lead">Broad studio announcements now live outside the member portal.</p>
         </div>
         <div class="updates-teaser-grid" data-updates-teasers>
-          <div class="update-empty">Loading public updates...</div>
+          <div class="update-empty">Syncing the latest public bulletin.</div>
         </div>
         <div class="cta-row">
           <a class="button button-ghost" href="/updates/" data-cta="public_updates_page">View all updates</a>

--- a/website/ncsitebuilder/ab/a/index.html
+++ b/website/ncsitebuilder/ab/a/index.html
@@ -31,7 +31,7 @@
         <a href="/support/">Support</a>
         <a href="/highlights/">Gallery</a></nav>
             <div class="nav-portal-wrap">
-        <a class="nav-portal" href="https://monsoonfire.kilnfire.com" target="_blank" rel="noopener noreferrer">Login</a>
+        <a class="nav-portal" href="https://portal.monsoonfire.com" target="_blank" rel="noopener noreferrer">Login</a>
       </div><button class="menu-toggle" type="button" aria-label="Toggle menu" aria-expanded="false" data-menu-toggle>
         <span></span><span></span><span></span>
       </button>
@@ -164,9 +164,9 @@
               <p class="hero-note">Manual updates from the studio floor.</p>
             </div>
             <div class="kiln-status" data-kiln-list>
-              <div>Loading kiln status...</div>
+              <div>Syncing kiln board. The latest manual status will appear here once it finishes loading.</div>
             </div>
-            <div class="kiln-footer">Last updated: <span data-kiln-updated>—</span></div>
+            <div class="kiln-footer">Last updated: <span data-kiln-updated>Waiting for refresh</span></div>
           </div>
         </aside>
       </div>

--- a/website/ncsitebuilder/ab/b/index.html
+++ b/website/ncsitebuilder/ab/b/index.html
@@ -164,9 +164,9 @@
               <p class="hero-note">Manual updates from the studio floor.</p>
             </div>
             <div class="kiln-status" data-kiln-list>
-              <div>Loading kiln status...</div>
+              <div>Syncing kiln board. The latest manual status will appear here once it finishes loading.</div>
             </div>
-            <div class="kiln-footer">Last updated: <span data-kiln-updated>—</span></div>
+            <div class="kiln-footer">Last updated: <span data-kiln-updated>Waiting for refresh</span></div>
           </div>
         </aside>
       </div>

--- a/website/ncsitebuilder/about/index.html
+++ b/website/ncsitebuilder/about/index.html
@@ -42,7 +42,7 @@
         <a href="/support/">Support</a>
         <a href="/highlights/">Gallery</a></nav>
             <div class="nav-portal-wrap">
-        <a class="nav-portal" href="https://monsoonfire.kilnfire.com" target="_blank" rel="noopener noreferrer">Login</a>
+        <a class="nav-portal" href="https://portal.monsoonfire.com" target="_blank" rel="noopener noreferrer">Login</a>
       </div><button class="menu-toggle" type="button" aria-label="Toggle menu" aria-expanded="false" data-menu-toggle>
         <span></span><span></span><span></span>
       </button>

--- a/website/ncsitebuilder/assets/css/styles.css
+++ b/website/ncsitebuilder/assets/css/styles.css
@@ -977,8 +977,9 @@ select:focus-visible {
 }
 
 .status-pill.state-offline {
-  background: rgba(27, 26, 23, 0.18);
-  color: var(--paper-50);
+  background: rgba(27, 26, 23, 0.08);
+  border-color: rgba(27, 26, 23, 0.18);
+  color: var(--ink-900);
 }
 
 .status-label {

--- a/website/ncsitebuilder/assets/js/kiln-status.js
+++ b/website/ncsitebuilder/assets/js/kiln-status.js
@@ -2,6 +2,7 @@
   const list = document.querySelector('[data-kiln-list]');
   const updated = document.querySelector('[data-kiln-updated]');
   if (!list) return;
+  const STALE_AFTER_DAYS = 14;
 
   const renderFieldRow = (label, value, parent) => {
     const row = document.createElement('div');
@@ -15,6 +16,61 @@
 
     row.append(labelEl, valueEl);
     parent.appendChild(row);
+  };
+
+  const renderStatusSummary = (kind, title, message) => {
+    const summary = document.createElement('div');
+    summary.className = 'kiln-info';
+
+    const label = document.createElement('div');
+    label.className = 'status-label';
+    label.textContent = 'Board status';
+
+    const pill = document.createElement('span');
+    pill.className = `status-pill ${kind}`;
+    pill.textContent = title;
+
+    const note = document.createElement('div');
+    note.className = 'kiln-notes';
+    note.textContent = message;
+
+    summary.append(label, pill, note);
+    return summary;
+  };
+
+  const parseUpdatedAt = (data) => {
+    const candidate = typeof data?.lastUpdatedIso === 'string' && data.lastUpdatedIso.trim()
+      ? data.lastUpdatedIso
+      : typeof data?.lastUpdated === 'string'
+        ? data.lastUpdated
+        : '';
+    const parsed = candidate ? new Date(candidate) : null;
+    return parsed && !Number.isNaN(parsed.getTime()) ? parsed : null;
+  };
+
+  const describeFreshness = (updatedAt) => {
+    if (!updatedAt) {
+      return {
+        kind: 'state-offline',
+        title: 'Manual board unavailable',
+        message: 'The studio board did not include a usable timestamp, so treat this as a stale snapshot and check the portal for the live workflow.',
+      };
+    }
+
+    const ageDays = (Date.now() - updatedAt.getTime()) / (1000 * 60 * 60 * 24);
+    if (ageDays > STALE_AFTER_DAYS) {
+      return {
+        kind: 'state-offline',
+        title: 'Manual board is stale',
+        message: `The latest manual refresh is more than ${STALE_AFTER_DAYS} days old. Use the portal for the current queue and keep this page as a calm reference only.`,
+      };
+    }
+
+    return {
+      kind: 'state-idle',
+      title: 'Manual board current',
+      message: 'The studio board is in sync with the latest manual update.',
+    };
   };
 
   const renderKiln = (kiln) => {
@@ -56,9 +112,11 @@
   };
 
   const load = async () => {
+    setEmptyState('Syncing kiln board. The latest manual status will appear here once it finishes loading.');
+
     const candidates = [
-      '/api/websiteKilnBoard',
       '/data/kiln-status.json',
+      '/api/websiteKilnBoard',
     ];
 
     try {
@@ -90,11 +148,20 @@
       list.replaceChildren();
       const kilnItems = Array.isArray(data?.kilns) ? data.kilns : [];
       if (kilnItems.length > 0) {
+        const freshness = describeFreshness(parseUpdatedAt(data));
+        const nodes = [renderStatusSummary(freshness.kind, freshness.title, freshness.message)];
         kilnItems.forEach((kiln) => {
-          list.appendChild(renderKiln(kiln));
+          nodes.push(renderKiln(kiln));
         });
+        list.replaceChildren(...nodes);
       } else {
-        setEmptyState('Manual status is not set yet.');
+        list.replaceChildren(
+          renderStatusSummary(
+            'state-offline',
+            'Manual board empty',
+            'No kiln loads are posted yet. The portal remains the source of truth for reservations, queue timing, and pickup readiness.'
+          )
+        );
       }
 
       if (updated && data?.lastUpdated) {
@@ -102,9 +169,15 @@
       }
     } catch (_err) {
       const message = _err instanceof Error ? _err.message : String(_err);
-      setEmptyState(`Manual status is currently unavailable. ${message}`);
+      list.replaceChildren(
+        renderStatusSummary(
+          'state-offline',
+          'Manual board unavailable',
+          `The studio status feed could not be loaded. ${message} Check the portal for the live operating view.`
+        )
+      );
       if (updated) {
-        updated.textContent = `Error: ${message}`;
+        updated.textContent = 'Unavailable';
       }
     }
   };

--- a/website/ncsitebuilder/assets/js/main.js
+++ b/website/ncsitebuilder/assets/js/main.js
@@ -5,7 +5,6 @@
   };
   const RUNTIME_BANNER_HOST_ID = "mf-runtime-banner-host";
   const RUNTIME_BANNER_STYLE_ID = "mf-runtime-banner-style";
-  const kilnfirePortalHost = "monsoonfire.kilnfire.com";
   const betaPortalHost = "portal.monsoonfire.com";
   const root = document.documentElement;
   const body = document.body;
@@ -52,9 +51,9 @@
       }
       try {
         const parsed = new URL(href, window.location.origin);
-        // Keep live website links pointed at Kilnfire until portal cutover is complete.
-        if (parsed.hostname === betaPortalHost) {
-          parsed.hostname = kilnfirePortalHost;
+        // Keep preview and mirrored links pointed at the canonical portal host.
+        if (parsed.hostname === betaPortalHost || parsed.hostname === "portal.monsoonfire.com") {
+          parsed.hostname = betaPortalHost;
           link.setAttribute("href", parsed.toString());
         }
       } catch {
@@ -582,13 +581,23 @@
 
     const portalExperimentName = "portal_path_v1";
     const normalizeUrlHost = (hostname) => String(hostname || "").toLowerCase().replace(/^www\./, "");
-    const canonicalCampaignHosts = [kilnfirePortalHost, betaPortalHost, "instagram.com", "discord.com", "discord.gg", "phoenixcenterforthearts.org"];
+    const canonicalCampaignHosts = [betaPortalHost, "instagram.com", "discord.com", "discord.gg", "phoenixcenterforthearts.org"];
     const portalSurfaceTargets = {
       home: "dashboard",
       services: "reservations",
       kiln_firing: "reservations",
       memberships: "membership",
       contact: "support",
+      supplies: "supplies",
+      about: "dashboard",
+      blog: "dashboard",
+      faq: "dashboard",
+      gallery: "dashboard",
+      highlights: "dashboard",
+      policies: "dashboard",
+      support: "support",
+      updates: "dashboard",
+      classes: "dashboard",
     };
 
     const isCampaignHost = (hostname) => {
@@ -605,27 +614,31 @@
 
     const resolvePortalPageContext = () => {
       const normalizedPath = normalizePath(stripPreviewPrefix(window.location.pathname)).toLowerCase();
-      if (normalizedPath === "/ab/b/") {
-        return { surface: "home", variant: "b" };
-      }
-      if (normalizedPath === "/services/") {
-        return { surface: "services", variant: "a" };
-      }
-      if (normalizedPath === "/kiln-firing/") {
-        return { surface: "kiln_firing", variant: "a" };
-      }
-      if (normalizedPath === "/memberships/") {
-        return { surface: "memberships", variant: "a" };
-      }
-      if (normalizedPath === "/contact/") {
-        return { surface: "contact", variant: "a" };
-      }
-      return null;
+      const pageContexts = {
+        "/": { surface: "home", variant: "a" },
+        "/ab/a/": { surface: "home", variant: "a" },
+        "/ab/b/": { surface: "home", variant: "b" },
+        "/about/": { surface: "about", variant: "a" },
+        "/blog/": { surface: "blog", variant: "a" },
+        "/classes/": { surface: "classes", variant: "a" },
+        "/contact/": { surface: "contact", variant: "a" },
+        "/faq/": { surface: "faq", variant: "a" },
+        "/gallery/": { surface: "gallery", variant: "a" },
+        "/highlights/": { surface: "highlights", variant: "a" },
+        "/kiln-firing/": { surface: "kiln_firing", variant: "a" },
+        "/memberships/": { surface: "memberships", variant: "a" },
+        "/policies/": { surface: "policies", variant: "a" },
+        "/services/": { surface: "services", variant: "a" },
+        "/supplies/": { surface: "supplies", variant: "a" },
+        "/support/": { surface: "support", variant: "a" },
+        "/updates/": { surface: "updates", variant: "a" },
+      };
+      return pageContexts[normalizedPath] || null;
     };
 
     const resolvePortalTarget = (link, surface) => {
       const explicitTarget = normalizeLabel(link && link.getAttribute ? link.getAttribute("data-portal-target") || "" : "");
-      if (explicitTarget === "dashboard" || explicitTarget === "reservations" || explicitTarget === "membership" || explicitTarget === "support") {
+      if (explicitTarget === "dashboard" || explicitTarget === "reservations" || explicitTarget === "membership" || explicitTarget === "support" || explicitTarget === "supplies") {
         return explicitTarget;
       }
       return portalSurfaceTargets[surface] || null;
@@ -638,7 +651,6 @@
       const normalizedPath = parsed.pathname.toLowerCase();
       const isPortalCandidate =
         normalizedHost === betaPortalHost ||
-        normalizedHost === kilnfirePortalHost ||
         normalizedPath === "/new-user" ||
         normalizedPath.startsWith("/new-user/");
       if (!isPortalCandidate) return null;
@@ -791,7 +803,7 @@
       const cleanedUrl = href.toLowerCase();
       const portalTarget = normalizeLabel(link && link.getAttribute ? link.getAttribute("data-portal-target") || "" : "");
       if (portalTarget) return `portal_${portalTarget}`;
-      if (cleanedUrl.includes(kilnfirePortalHost) || cleanedUrl.includes(betaPortalHost)) return cleanedUrl.includes("/new-user") ? "get_started" : "login";
+    if (cleanedUrl.includes(betaPortalHost)) return cleanedUrl.includes("/new-user") ? "get_started" : "login";
       if (cleanedUrl.startsWith("mailto:")) return "email";
       if (cleanedUrl.startsWith("tel:")) return "phone";
       if (cleanedUrl.includes("discord")) return "discord";

--- a/website/ncsitebuilder/blog/index.html
+++ b/website/ncsitebuilder/blog/index.html
@@ -159,7 +159,7 @@
         <a href="/blog/">Studio Notes</a>
       </nav>
       <div class="nav-portal-wrap">
-        <a class="button button-ghost nav-login" href="https://monsoonfire.kilnfire.com" target="_blank" rel="noopener noreferrer">Login</a>
+        <a class="button button-ghost nav-login" href="https://portal.monsoonfire.com" target="_blank" rel="noopener noreferrer">Login</a>
       </div>
       <button class="menu-toggle" type="button" aria-label="Toggle menu" aria-expanded="false" data-menu-toggle>
         <span></span><span></span><span></span>

--- a/website/ncsitebuilder/classes/index.html
+++ b/website/ncsitebuilder/classes/index.html
@@ -42,7 +42,7 @@
         <a href="/support/">Support</a>
         <a href="/highlights/">Gallery</a></nav>
             <div class="nav-portal-wrap">
-        <a class="nav-portal" href="https://monsoonfire.kilnfire.com" target="_blank" rel="noopener noreferrer">Login</a>
+        <a class="nav-portal" href="https://portal.monsoonfire.com" target="_blank" rel="noopener noreferrer">Login</a>
       </div><button class="menu-toggle" type="button" aria-label="Toggle menu" aria-expanded="false" data-menu-toggle>
         <span></span><span></span><span></span>
       </button>

--- a/website/ncsitebuilder/data/faq.json
+++ b/website/ncsitebuilder/data/faq.json
@@ -11,7 +11,7 @@
   },
   {
     "question": "How do I get started in the portal?",
-    "answer": "<p>Create a free account in the portal first. After signup, you can request kiln firing, reserve studio time, and get access details.</p><p><a href=\"https://monsoonfire.kilnfire.com\" target=\"_blank\" rel=\"noopener noreferrer\">Open the portal</a></p>",
+    "answer": "<p>Create a free account in the portal first. After signup, you can request kiln firing, reserve studio time, and get access details.</p><p><a href=\"https://portal.monsoonfire.com\" target=\"_blank\" rel=\"noopener noreferrer\">Open the portal</a></p>",
     "tags": ["portal", "overview"]
   },
   {

--- a/website/ncsitebuilder/data/kiln-status.json
+++ b/website/ncsitebuilder/data/kiln-status.json
@@ -1,5 +1,6 @@
 {
   "lastUpdated": "2026-01-31 5:30 PM",
+  "lastUpdatedIso": "2026-01-31T17:30:00-07:00",
   "updatedBy": "Manual",
   "kilns": [
     {

--- a/website/ncsitebuilder/faq/index.html
+++ b/website/ncsitebuilder/faq/index.html
@@ -41,7 +41,7 @@
         <a href="/support/">Support</a>
         <a href="/highlights/">Gallery</a></nav>
             <div class="nav-portal-wrap">
-        <a class="button button-ghost nav-login" href="https://monsoonfire.kilnfire.com" target="_blank" rel="noopener noreferrer">Login</a>
+        <a class="button button-ghost nav-login" href="https://portal.monsoonfire.com" target="_blank" rel="noopener noreferrer">Login</a>
       </div><button class="menu-toggle" type="button" aria-label="Toggle menu" aria-expanded="false" data-menu-toggle>
         <span></span><span></span><span></span>
       </button>

--- a/website/ncsitebuilder/gallery/index.html
+++ b/website/ncsitebuilder/gallery/index.html
@@ -42,7 +42,7 @@
         <a href="/support/">Support</a>
         <a href="/highlights/">Gallery</a></nav>
             <div class="nav-portal-wrap">
-        <a class="nav-portal" href="https://monsoonfire.kilnfire.com" target="_blank" rel="noopener noreferrer">Login</a>
+        <a class="nav-portal" href="https://portal.monsoonfire.com" target="_blank" rel="noopener noreferrer">Login</a>
       </div><button class="menu-toggle" type="button" aria-label="Toggle menu" aria-expanded="false" data-menu-toggle>
         <span></span><span></span><span></span>
       </button>

--- a/website/ncsitebuilder/highlights/index.html
+++ b/website/ncsitebuilder/highlights/index.html
@@ -41,7 +41,7 @@
         <a href="/support/">Support</a>
         <a href="/highlights/">Gallery</a></nav>
             <div class="nav-portal-wrap">
-        <a class="nav-portal" href="https://monsoonfire.kilnfire.com" target="_blank" rel="noopener noreferrer">Login</a>
+        <a class="nav-portal" href="https://portal.monsoonfire.com" target="_blank" rel="noopener noreferrer">Login</a>
       </div><button class="menu-toggle" type="button" aria-label="Toggle menu" aria-expanded="false" data-menu-toggle>
         <span></span><span></span><span></span>
       </button>

--- a/website/ncsitebuilder/index.html
+++ b/website/ncsitebuilder/index.html
@@ -50,7 +50,7 @@
         <a href="/support/">Support</a>
         <a href="/highlights/">Gallery</a></nav>
             <div class="nav-portal-wrap">
-        <a class="button button-ghost nav-login" href="https://monsoonfire.kilnfire.com" target="_blank" rel="noopener noreferrer">Login</a>
+        <a class="button button-ghost nav-login" href="https://portal.monsoonfire.com" target="_blank" rel="noopener noreferrer">Login</a>
       </div><button class="menu-toggle" type="button" aria-label="Toggle menu" aria-expanded="false" data-menu-toggle>
         <span></span><span></span><span></span>
       </button>
@@ -248,9 +248,9 @@
               <p class="hero-note">Manual updates from the studio floor.</p>
             </div>
             <div class="kiln-status" data-kiln-list>
-              <div>Loading kiln status...</div>
+              <div>Syncing kiln status. Manual updates from the studio floor will appear here when the board refreshes.</div>
             </div>
-            <div class="kiln-footer">Last updated: <span data-kiln-updated>—</span></div>
+            <div class="kiln-footer">Last updated: <span data-kiln-updated>Waiting for refresh</span></div>
             <p class="meta">Next update posted after each firing and unload.</p>
           </div>
         </aside>

--- a/website/ncsitebuilder/policies/accessibility/index.html
+++ b/website/ncsitebuilder/policies/accessibility/index.html
@@ -40,7 +40,7 @@
         <a href="/highlights/">Gallery</a>
       </nav>
       <div class="nav-portal-wrap">
-        <a class="nav-portal" href="https://monsoonfire.kilnfire.com" target="_blank" rel="noopener noreferrer">Login</a>
+        <a class="nav-portal" href="https://portal.monsoonfire.com" target="_blank" rel="noopener noreferrer">Login</a>
       </div>
       <button class="menu-toggle" type="button" aria-label="Toggle menu" aria-expanded="false" data-menu-toggle>
         <span></span><span></span><span></span>

--- a/website/ncsitebuilder/policies/clay-materials/index.html
+++ b/website/ncsitebuilder/policies/clay-materials/index.html
@@ -41,7 +41,7 @@
         <a href="/support/">Support</a>
         <a href="/highlights/">Gallery</a></nav>
             <div class="nav-portal-wrap">
-        <a class="nav-portal" href="https://monsoonfire.kilnfire.com" target="_blank" rel="noopener noreferrer">Login</a>
+        <a class="nav-portal" href="https://portal.monsoonfire.com" target="_blank" rel="noopener noreferrer">Login</a>
       </div><button class="menu-toggle" type="button" aria-label="Toggle menu" aria-expanded="false" data-menu-toggle>
         <span></span><span></span><span></span>
       </button>

--- a/website/ncsitebuilder/policies/community-conduct/index.html
+++ b/website/ncsitebuilder/policies/community-conduct/index.html
@@ -41,7 +41,7 @@
         <a href="/support/">Support</a>
         <a href="/highlights/">Gallery</a></nav>
             <div class="nav-portal-wrap">
-        <a class="nav-portal" href="https://monsoonfire.kilnfire.com" target="_blank" rel="noopener noreferrer">Login</a>
+        <a class="nav-portal" href="https://portal.monsoonfire.com" target="_blank" rel="noopener noreferrer">Login</a>
       </div><button class="menu-toggle" type="button" aria-label="Toggle menu" aria-expanded="false" data-menu-toggle>
         <span></span><span></span><span></span>
       </button>

--- a/website/ncsitebuilder/policies/damage-responsibility/index.html
+++ b/website/ncsitebuilder/policies/damage-responsibility/index.html
@@ -41,7 +41,7 @@
         <a href="/support/">Support</a>
         <a href="/highlights/">Gallery</a></nav>
             <div class="nav-portal-wrap">
-        <a class="nav-portal" href="https://monsoonfire.kilnfire.com" target="_blank" rel="noopener noreferrer">Login</a>
+        <a class="nav-portal" href="https://portal.monsoonfire.com" target="_blank" rel="noopener noreferrer">Login</a>
       </div><button class="menu-toggle" type="button" aria-label="Toggle menu" aria-expanded="false" data-menu-toggle>
         <span></span><span></span><span></span>
       </button>

--- a/website/ncsitebuilder/policies/firing-scheduling/index.html
+++ b/website/ncsitebuilder/policies/firing-scheduling/index.html
@@ -41,7 +41,7 @@
         <a href="/support/">Support</a>
         <a href="/highlights/">Gallery</a></nav>
             <div class="nav-portal-wrap">
-        <a class="nav-portal" href="https://monsoonfire.kilnfire.com" target="_blank" rel="noopener noreferrer">Login</a>
+        <a class="nav-portal" href="https://portal.monsoonfire.com" target="_blank" rel="noopener noreferrer">Login</a>
       </div><button class="menu-toggle" type="button" aria-label="Toggle menu" aria-expanded="false" data-menu-toggle>
         <span></span><span></span><span></span>
       </button>

--- a/website/ncsitebuilder/policies/index.html
+++ b/website/ncsitebuilder/policies/index.html
@@ -41,7 +41,7 @@
         <a href="/support/">Support</a>
         <a href="/highlights/">Gallery</a></nav>
             <div class="nav-portal-wrap">
-        <a class="nav-portal" href="https://monsoonfire.kilnfire.com" target="_blank" rel="noopener noreferrer">Login</a>
+        <a class="nav-portal" href="https://portal.monsoonfire.com" target="_blank" rel="noopener noreferrer">Login</a>
       </div><button class="menu-toggle" type="button" aria-label="Toggle menu" aria-expanded="false" data-menu-toggle>
         <span></span><span></span><span></span>
       </button>
@@ -58,7 +58,7 @@
           <p class="meta">Last updated: February 2, 2026</p>
         </div>
         <div class="cta-row">
-          <a class="button button-primary" href="https://monsoonfire.kilnfire.com" target="_blank" rel="noopener noreferrer">Portal login</a>
+          <a class="button button-primary" href="https://portal.monsoonfire.com" target="_blank" rel="noopener noreferrer">Portal login</a>
           <a class="button button-ghost" href="/faq/">Community hub</a>
         </div>
       </div>

--- a/website/ncsitebuilder/policies/media-accessibility/index.html
+++ b/website/ncsitebuilder/policies/media-accessibility/index.html
@@ -40,7 +40,7 @@
         <a href="/highlights/">Gallery</a>
       </nav>
       <div class="nav-portal-wrap">
-        <a class="nav-portal" href="https://monsoonfire.kilnfire.com" target="_blank" rel="noopener noreferrer">Login</a>
+        <a class="nav-portal" href="https://portal.monsoonfire.com" target="_blank" rel="noopener noreferrer">Login</a>
       </div>
       <button class="menu-toggle" type="button" aria-label="Toggle menu" aria-expanded="false" data-menu-toggle>
         <span></span><span></span><span></span>

--- a/website/ncsitebuilder/policies/payments-refunds/index.html
+++ b/website/ncsitebuilder/policies/payments-refunds/index.html
@@ -41,7 +41,7 @@
         <a href="/support/">Support</a>
         <a href="/highlights/">Gallery</a></nav>
             <div class="nav-portal-wrap">
-        <a class="nav-portal" href="https://monsoonfire.kilnfire.com" target="_blank" rel="noopener noreferrer">Login</a>
+        <a class="nav-portal" href="https://portal.monsoonfire.com" target="_blank" rel="noopener noreferrer">Login</a>
       </div><button class="menu-toggle" type="button" aria-label="Toggle menu" aria-expanded="false" data-menu-toggle>
         <span></span><span></span><span></span>
       </button>

--- a/website/ncsitebuilder/policies/safety-kiln-rules/index.html
+++ b/website/ncsitebuilder/policies/safety-kiln-rules/index.html
@@ -41,7 +41,7 @@
         <a href="/support/">Support</a>
         <a href="/highlights/">Gallery</a></nav>
             <div class="nav-portal-wrap">
-        <a class="nav-portal" href="https://monsoonfire.kilnfire.com" target="_blank" rel="noopener noreferrer">Login</a>
+        <a class="nav-portal" href="https://portal.monsoonfire.com" target="_blank" rel="noopener noreferrer">Login</a>
       </div><button class="menu-toggle" type="button" aria-label="Toggle menu" aria-expanded="false" data-menu-toggle>
         <span></span><span></span><span></span>
       </button>

--- a/website/ncsitebuilder/policies/studio-access/index.html
+++ b/website/ncsitebuilder/policies/studio-access/index.html
@@ -41,7 +41,7 @@
         <a href="/support/">Support</a>
         <a href="/highlights/">Gallery</a></nav>
             <div class="nav-portal-wrap">
-        <a class="nav-portal" href="https://monsoonfire.kilnfire.com" target="_blank" rel="noopener noreferrer">Login</a>
+        <a class="nav-portal" href="https://portal.monsoonfire.com" target="_blank" rel="noopener noreferrer">Login</a>
       </div><button class="menu-toggle" type="button" aria-label="Toggle menu" aria-expanded="false" data-menu-toggle>
         <span></span><span></span><span></span>
       </button>

--- a/website/ncsitebuilder/supplies/index.html
+++ b/website/ncsitebuilder/supplies/index.html
@@ -41,7 +41,7 @@
         <a href="/support/">Support</a>
         <a href="/highlights/">Gallery</a></nav>
             <div class="nav-portal-wrap">
-        <a class="nav-portal" href="https://monsoonfire.kilnfire.com" target="_blank" rel="noopener noreferrer">Login</a>
+        <a class="nav-portal" href="https://portal.monsoonfire.com" data-portal-target="supplies" target="_blank" rel="noopener noreferrer">Login</a>
       </div><button class="menu-toggle" type="button" aria-label="Toggle menu" aria-expanded="false" data-menu-toggle>
         <span></span><span></span><span></span>
       </button>
@@ -57,8 +57,8 @@
           <p class="lead">Tell us what you need and we can pick it up for you. Members can request delivery or add supplies to upcoming reservations.</p>
         </div>
         <div class="cta-row">
-          <a class="button button-primary" href="https://monsoonfire.kilnfire.com/supplies" target="_blank" rel="noopener noreferrer">Shop supplies in the portal</a>
-          <a class="button button-ghost" href="https://monsoonfire.kilnfire.com/new-user" target="_blank" rel="noopener noreferrer">Create an account</a>
+          <a class="button button-primary" href="https://portal.monsoonfire.com/supplies" data-portal-target="supplies" target="_blank" rel="noopener noreferrer">Shop supplies in the portal</a>
+          <a class="button button-ghost" href="https://portal.monsoonfire.com/new-user" data-portal-target="supplies" target="_blank" rel="noopener noreferrer">Create an account</a>
         </div>
       </div>
     </section>

--- a/website/ncsitebuilder/support/index.html
+++ b/website/ncsitebuilder/support/index.html
@@ -100,7 +100,7 @@
         <a href="/support/">Support</a>
         <a href="/highlights/">Gallery</a></nav>
             <div class="nav-portal-wrap">
-        <a class="button button-ghost nav-login" href="https://monsoonfire.kilnfire.com" target="_blank" rel="noopener noreferrer">Login</a>
+        <a class="button button-ghost nav-login" href="https://portal.monsoonfire.com" data-portal-target="support" target="_blank" rel="noopener noreferrer">Login</a>
       </div><button class="menu-toggle" type="button" aria-label="Toggle menu" aria-expanded="false" data-menu-toggle>
         <span></span><span></span><span></span>
       </button>

--- a/website/ncsitebuilder/web.config
+++ b/website/ncsitebuilder/web.config
@@ -3,7 +3,7 @@
   <system.webServer>
     <httpProtocol>
       <customHeaders>
-        <add name="Content-Security-Policy" value="default-src 'self'; script-src 'self' https://www.googletagmanager.com https://www.google-analytics.com https://tracker.metricool.com; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://www.google-analytics.com https://www.googletagmanager.com https://tracker.metricool.com; frame-src https://calendar.google.com; base-uri 'self'; form-action 'self' https://monsoonfire.kilnfire.com; frame-ancestors 'self'; upgrade-insecure-requests" />
+        <add name="Content-Security-Policy" value="default-src 'self'; script-src 'self' https://www.googletagmanager.com https://www.google-analytics.com https://tracker.metricool.com; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://www.google-analytics.com https://www.googletagmanager.com https://tracker.metricool.com; frame-src https://calendar.google.com; base-uri 'self'; form-action 'self' https://portal.monsoonfire.com; frame-ancestors 'self'; upgrade-insecure-requests" />
         <add name="X-Content-Type-Options" value="nosniff" />
         <add name="Referrer-Policy" value="strict-origin-when-cross-origin" />
         <add name="Permissions-Policy" value="accelerometer=(), autoplay=(), camera=(), display-capture=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=(), xr-spatial-tracking=()" />

--- a/website/policies/accessibility/index.html
+++ b/website/policies/accessibility/index.html
@@ -40,7 +40,7 @@
         <a href="/highlights/">Gallery</a>
       </nav>
       <div class="nav-portal-wrap">
-        <a class="nav-portal" href="https://monsoonfire.kilnfire.com" target="_blank" rel="noopener noreferrer">Login</a>
+        <a class="nav-portal" href="https://portal.monsoonfire.com" target="_blank" rel="noopener noreferrer">Login</a>
       </div>
       <button class="menu-toggle" type="button" aria-label="Toggle menu" aria-expanded="false" data-menu-toggle>
         <span></span><span></span><span></span>

--- a/website/policies/clay-materials/index.html
+++ b/website/policies/clay-materials/index.html
@@ -41,7 +41,7 @@
         <a href="/support/">Support</a>
         <a href="/highlights/">Gallery</a></nav>
             <div class="nav-portal-wrap">
-        <a class="nav-portal" href="https://monsoonfire.kilnfire.com" target="_blank" rel="noopener noreferrer">Login</a>
+        <a class="nav-portal" href="https://portal.monsoonfire.com" target="_blank" rel="noopener noreferrer">Login</a>
       </div><button class="menu-toggle" type="button" aria-label="Toggle menu" aria-expanded="false" data-menu-toggle>
         <span></span><span></span><span></span>
       </button>

--- a/website/policies/community-conduct/index.html
+++ b/website/policies/community-conduct/index.html
@@ -41,7 +41,7 @@
         <a href="/support/">Support</a>
         <a href="/highlights/">Gallery</a></nav>
             <div class="nav-portal-wrap">
-        <a class="nav-portal" href="https://monsoonfire.kilnfire.com" target="_blank" rel="noopener noreferrer">Login</a>
+        <a class="nav-portal" href="https://portal.monsoonfire.com" target="_blank" rel="noopener noreferrer">Login</a>
       </div><button class="menu-toggle" type="button" aria-label="Toggle menu" aria-expanded="false" data-menu-toggle>
         <span></span><span></span><span></span>
       </button>

--- a/website/policies/damage-responsibility/index.html
+++ b/website/policies/damage-responsibility/index.html
@@ -41,7 +41,7 @@
         <a href="/support/">Support</a>
         <a href="/highlights/">Gallery</a></nav>
             <div class="nav-portal-wrap">
-        <a class="nav-portal" href="https://monsoonfire.kilnfire.com" target="_blank" rel="noopener noreferrer">Login</a>
+        <a class="nav-portal" href="https://portal.monsoonfire.com" target="_blank" rel="noopener noreferrer">Login</a>
       </div><button class="menu-toggle" type="button" aria-label="Toggle menu" aria-expanded="false" data-menu-toggle>
         <span></span><span></span><span></span>
       </button>

--- a/website/policies/firing-scheduling/index.html
+++ b/website/policies/firing-scheduling/index.html
@@ -41,7 +41,7 @@
         <a href="/support/">Support</a>
         <a href="/highlights/">Gallery</a></nav>
             <div class="nav-portal-wrap">
-        <a class="nav-portal" href="https://monsoonfire.kilnfire.com" target="_blank" rel="noopener noreferrer">Login</a>
+        <a class="nav-portal" href="https://portal.monsoonfire.com" target="_blank" rel="noopener noreferrer">Login</a>
       </div><button class="menu-toggle" type="button" aria-label="Toggle menu" aria-expanded="false" data-menu-toggle>
         <span></span><span></span><span></span>
       </button>

--- a/website/policies/index.html
+++ b/website/policies/index.html
@@ -41,7 +41,7 @@
         <a href="/support/">Support</a>
         <a href="/highlights/">Gallery</a></nav>
             <div class="nav-portal-wrap">
-        <a class="nav-portal" href="https://monsoonfire.kilnfire.com" target="_blank" rel="noopener noreferrer">Login</a>
+        <a class="nav-portal" href="https://portal.monsoonfire.com" target="_blank" rel="noopener noreferrer">Login</a>
       </div><button class="menu-toggle" type="button" aria-label="Toggle menu" aria-expanded="false" data-menu-toggle>
         <span></span><span></span><span></span>
       </button>
@@ -58,7 +58,7 @@
           <p class="meta">Last updated: February 2, 2026</p>
         </div>
         <div class="cta-row">
-          <a class="button button-primary" href="https://monsoonfire.kilnfire.com" target="_blank" rel="noopener noreferrer">Portal login</a>
+          <a class="button button-primary" href="https://portal.monsoonfire.com" target="_blank" rel="noopener noreferrer">Portal login</a>
           <a class="button button-ghost" href="/faq/">Community hub</a>
         </div>
       </div>

--- a/website/policies/media-accessibility/index.html
+++ b/website/policies/media-accessibility/index.html
@@ -40,7 +40,7 @@
         <a href="/highlights/">Gallery</a>
       </nav>
       <div class="nav-portal-wrap">
-        <a class="nav-portal" href="https://monsoonfire.kilnfire.com" target="_blank" rel="noopener noreferrer">Login</a>
+        <a class="nav-portal" href="https://portal.monsoonfire.com" target="_blank" rel="noopener noreferrer">Login</a>
       </div>
       <button class="menu-toggle" type="button" aria-label="Toggle menu" aria-expanded="false" data-menu-toggle>
         <span></span><span></span><span></span>

--- a/website/policies/payments-refunds/index.html
+++ b/website/policies/payments-refunds/index.html
@@ -41,7 +41,7 @@
         <a href="/support/">Support</a>
         <a href="/highlights/">Gallery</a></nav>
             <div class="nav-portal-wrap">
-        <a class="nav-portal" href="https://monsoonfire.kilnfire.com" target="_blank" rel="noopener noreferrer">Login</a>
+        <a class="nav-portal" href="https://portal.monsoonfire.com" target="_blank" rel="noopener noreferrer">Login</a>
       </div><button class="menu-toggle" type="button" aria-label="Toggle menu" aria-expanded="false" data-menu-toggle>
         <span></span><span></span><span></span>
       </button>

--- a/website/policies/safety-kiln-rules/index.html
+++ b/website/policies/safety-kiln-rules/index.html
@@ -41,7 +41,7 @@
         <a href="/support/">Support</a>
         <a href="/highlights/">Gallery</a></nav>
             <div class="nav-portal-wrap">
-        <a class="nav-portal" href="https://monsoonfire.kilnfire.com" target="_blank" rel="noopener noreferrer">Login</a>
+        <a class="nav-portal" href="https://portal.monsoonfire.com" target="_blank" rel="noopener noreferrer">Login</a>
       </div><button class="menu-toggle" type="button" aria-label="Toggle menu" aria-expanded="false" data-menu-toggle>
         <span></span><span></span><span></span>
       </button>

--- a/website/policies/studio-access/index.html
+++ b/website/policies/studio-access/index.html
@@ -41,7 +41,7 @@
         <a href="/support/">Support</a>
         <a href="/highlights/">Gallery</a></nav>
             <div class="nav-portal-wrap">
-        <a class="nav-portal" href="https://monsoonfire.kilnfire.com" target="_blank" rel="noopener noreferrer">Login</a>
+        <a class="nav-portal" href="https://portal.monsoonfire.com" target="_blank" rel="noopener noreferrer">Login</a>
       </div><button class="menu-toggle" type="button" aria-label="Toggle menu" aria-expanded="false" data-menu-toggle>
         <span></span><span></span><span></span>
       </button>

--- a/website/scripts/sync-community-blogs.mjs
+++ b/website/scripts/sync-community-blogs.mjs
@@ -363,7 +363,7 @@ function renderHeader() {
         <a href="/blog/">Studio Notes</a>
       </nav>
       <div class="nav-portal-wrap">
-        <a class="button button-ghost nav-login" href="https://monsoonfire.kilnfire.com" target="_blank" rel="noopener noreferrer">Login</a>
+        <a class="button button-ghost nav-login" href="https://portal.monsoonfire.com" target="_blank" rel="noopener noreferrer">Login</a>
       </div>
       <button class="menu-toggle" type="button" aria-label="Toggle menu" aria-expanded="false" data-menu-toggle>
         <span></span><span></span><span></span>

--- a/website/supplies/index.html
+++ b/website/supplies/index.html
@@ -41,7 +41,7 @@
         <a href="/support/">Support</a>
         <a href="/highlights/">Gallery</a></nav>
             <div class="nav-portal-wrap">
-        <a class="nav-portal" href="https://monsoonfire.kilnfire.com" target="_blank" rel="noopener noreferrer">Login</a>
+        <a class="nav-portal" href="https://portal.monsoonfire.com" data-portal-target="supplies" target="_blank" rel="noopener noreferrer">Login</a>
       </div><button class="menu-toggle" type="button" aria-label="Toggle menu" aria-expanded="false" data-menu-toggle>
         <span></span><span></span><span></span>
       </button>
@@ -57,8 +57,8 @@
           <p class="lead">Tell us what you need and we can pick it up for you. Members can request delivery or add supplies to upcoming reservations.</p>
         </div>
         <div class="cta-row">
-          <a class="button button-primary" href="https://monsoonfire.kilnfire.com/supplies" target="_blank" rel="noopener noreferrer">Shop supplies in the portal</a>
-          <a class="button button-ghost" href="https://monsoonfire.kilnfire.com/new-user" target="_blank" rel="noopener noreferrer">Create an account</a>
+          <a class="button button-primary" href="https://portal.monsoonfire.com/supplies" data-portal-target="supplies" target="_blank" rel="noopener noreferrer">Shop supplies in the portal</a>
+          <a class="button button-ghost" href="https://portal.monsoonfire.com/new-user" data-portal-target="supplies" target="_blank" rel="noopener noreferrer">Create an account</a>
         </div>
       </div>
     </section>

--- a/website/support/index.html
+++ b/website/support/index.html
@@ -78,7 +78,7 @@
         <a href="/support/">Support</a>
         <a href="/highlights/">Gallery</a></nav>
             <div class="nav-portal-wrap">
-        <a class="button button-ghost nav-login" href="https://monsoonfire.kilnfire.com" target="_blank" rel="noopener noreferrer">Login</a>
+        <a class="button button-ghost nav-login" href="https://portal.monsoonfire.com" data-portal-target="support" target="_blank" rel="noopener noreferrer">Login</a>
       </div><button class="menu-toggle" type="button" aria-label="Toggle menu" aria-expanded="false" data-menu-toggle>
         <span></span><span></span><span></span>
       </button>

--- a/website/tests/legacy-host-guard.test.mjs
+++ b/website/tests/legacy-host-guard.test.mjs
@@ -1,0 +1,59 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+
+const WEBSITE_ROOT = path.resolve("website");
+const EXCLUDED_DIRS = new Set(["tests", "MF Marketing", "node_modules", ".git"]);
+const SCANNED_EXTENSIONS = new Set([
+  ".html",
+  ".htm",
+  ".js",
+  ".mjs",
+  ".json",
+  ".xml",
+  ".txt",
+  ".config",
+  ".ps1",
+]);
+const LEGACY_HOST_PATTERNS = [
+  "monsoonfire.kilnfire.com",
+  "https://monsoonfire.kilnfire.com",
+];
+
+async function walk(directory) {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      if (EXCLUDED_DIRS.has(entry.name)) continue;
+      files.push(...(await walk(path.join(directory, entry.name))));
+      continue;
+    }
+
+    const fullPath = path.join(directory, entry.name);
+    const extension = path.extname(entry.name).toLowerCase();
+    if (!SCANNED_EXTENSIONS.has(extension)) continue;
+
+    files.push(fullPath);
+  }
+
+  return files;
+}
+
+test("website source never references the legacy kilnfire host", async () => {
+  const files = await walk(WEBSITE_ROOT);
+  const offenders = [];
+
+  for (const file of files) {
+    const contents = await readFile(file, "utf8");
+    for (const pattern of LEGACY_HOST_PATTERNS) {
+      if (contents.includes(pattern)) {
+        offenders.push(`${path.relative(WEBSITE_ROOT, file)} :: ${pattern}`);
+      }
+    }
+  }
+
+  assert.deepEqual(offenders, [], `Legacy kilnfire host references found:\n${offenders.join("\n")}`);
+});

--- a/website/updates/index.html
+++ b/website/updates/index.html
@@ -40,7 +40,7 @@
         <a href="/highlights/">Gallery</a>
       </nav>
       <div class="nav-portal-wrap">
-        <a class="nav-portal" href="https://monsoonfire.kilnfire.com" target="_blank" rel="noopener noreferrer">Login</a>
+        <a class="nav-portal" href="https://portal.monsoonfire.com" target="_blank" rel="noopener noreferrer">Login</a>
       </div>
       <button class="menu-toggle" type="button" aria-label="Toggle menu" aria-expanded="false" data-menu-toggle>
         <span></span><span></span><span></span>
@@ -61,7 +61,7 @@
             <a class="button button-primary" href="/support/">Ask a question</a>
             <a class="button button-ghost" href="/faq/">Visit community hub</a>
           </div>
-          <p class="meta">Last refreshed: <span data-updates-generated>Loading...</span></p>
+          <p class="meta">Last refreshed: <span data-updates-generated>Waiting for the latest bulletin</span></p>
         </div>
         <div class="updates-callout">
           <p class="lead">Member-only pickup windows, firing logistics, and queue details still stay inside the portal.</p>
@@ -80,7 +80,7 @@
           <p class="lead">Updates for visitors, future members, and close studio folks.</p>
         </div>
         <div class="updates-list" data-updates-list>
-          <div class="update-empty">Loading public updates...</div>
+          <div class="update-empty">Syncing the latest public bulletin.</div>
         </div>
       </div>
     </section>

--- a/website/web.config
+++ b/website/web.config
@@ -3,7 +3,7 @@
   <system.webServer>
     <httpProtocol>
       <customHeaders>
-        <add name="Content-Security-Policy" value="default-src 'self'; script-src 'self' https://www.googletagmanager.com https://www.google-analytics.com https://tracker.metricool.com; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://www.google-analytics.com https://www.googletagmanager.com https://tracker.metricool.com; frame-src https://calendar.google.com; base-uri 'self'; form-action 'self' https://monsoonfire.kilnfire.com; frame-ancestors 'self'; upgrade-insecure-requests" />
+        <add name="Content-Security-Policy" value="default-src 'self'; script-src 'self' https://www.googletagmanager.com https://www.google-analytics.com https://tracker.metricool.com; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://www.google-analytics.com https://www.googletagmanager.com https://tracker.metricool.com; frame-src https://calendar.google.com; base-uri 'self'; form-action 'self' https://portal.monsoonfire.com; frame-ancestors 'self'; upgrade-insecure-requests" />
         <add name="X-Content-Type-Options" value="nosniff" />
         <add name="Referrer-Policy" value="strict-origin-when-cross-origin" />
         <add name="Permissions-Policy" value="accelerometer=(), autoplay=(), camera=(), display-capture=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=(), xr-spatial-tracking=()" />


### PR DESCRIPTION
## Summary
- clean up website-to-portal trust leaks and add a legacy host regression guard
- add a task-first portal start surface plus clearer ware check-in and piece journey messaging
- publish the cross-surface terminology and trust-state contract

## Verification
- node --test website/tests/legacy-host-guard.test.mjs
- npx playwright test -c website/playwright.config.mjs website/tests/marketing-site.spec.mjs
- npm exec vitest run src/views/PlaceholderView.test.tsx src/views/ReservationsView.ui.test.tsx src/views/MyPiecesView.ui.test.tsx src/views/DashboardView.ui.test.tsx src/views/StaffView.ui.test.tsx
- npx tsc -p tsconfig.json --noEmit
- npm run build
