### PR TITLE
Surface Studio Brain conflict shadow diagnostics and stats

### DIFF
--- a/studio-brain/src/controlTower/types.ts
+++ b/studio-brain/src/controlTower/types.ts
@@ -325,6 +325,7 @@ export type ControlTowerMemoryHealth = {
     hardConflicts: number;
     quarantinedRows: number;
     conflictRecords: number;
+    retrievalShadowedRows: number;
   };
   startupReadiness: {
     startupEligibleRows: number;

--- a/studio-brain/src/http/server.test.ts
+++ b/studio-brain/src/http/server.test.ts
@@ -2700,6 +2700,7 @@ test("control tower state routes derive browser-friendly room and service data",
             memoryHealth: {
               severity: string;
               reviewBacklog: { reviewNow: number };
+              conflictBacklog: { retrievalShadowedRows: number };
               startupReadiness: { startupEligibleRows: number; handoffRows: number };
               secretExposureFindings: { canonicalBlockedRows: number };
               shadowMcpFindings: { highRiskRows: number };
@@ -2740,7 +2741,13 @@ test("control tower state routes derive browser-friendly room and service data",
         assert.equal((payload.state.memoryHealth?.secretExposureFindings.canonicalBlockedRows ?? 0) >= 1, true);
         assert.equal((payload.state.memoryHealth?.shadowMcpFindings.highRiskRows ?? 0) >= 1, true);
         assert.equal(
-          (payload.state.memoryHealth?.highlights ?? []).some((entry) => /secret-bearing memories/i.test(entry)),
+          Object.prototype.hasOwnProperty.call(payload.state.memoryHealth?.conflictBacklog ?? {}, "retrievalShadowedRows"),
+          true,
+        );
+        assert.equal(
+          (payload.state.memoryHealth?.highlights ?? []).some((entry) =>
+            /secret-bearing memories|shadowed by hard conflict retrieval rules/i.test(entry)
+          ),
           true,
         );
         assert.equal(

--- a/studio-brain/src/http/server.ts
+++ b/studio-brain/src/http/server.ts
@@ -619,6 +619,7 @@ function buildControlTowerMemoryHealth(stats: MemoryStats | null | undefined): C
     hardConflicts: toBoundedInt(stats.conflictBacklog?.hardConflicts, 0, 0, 1_000_000),
     quarantinedRows: toBoundedInt(stats.conflictBacklog?.quarantinedRows, 0, 0, 1_000_000),
     conflictRecords: toBoundedInt(stats.conflictBacklog?.conflictRecords, 0, 0, 1_000_000),
+    retrievalShadowedRows: toBoundedInt(stats.conflictBacklog?.retrievalShadowedRows, 0, 0, 1_000_000),
   };
   const startupReadiness = {
     startupEligibleRows: toBoundedInt(stats.startupReadiness?.startupEligibleRows, 0, 0, 1_000_000),
@@ -678,6 +679,9 @@ function buildControlTowerMemoryHealth(stats: MemoryStats | null | undefined): C
         : "",
       conflictBacklog.hardConflicts > 0
         ? `${conflictBacklog.hardConflicts} hard conflicts remain in the lattice`
+        : "",
+      conflictBacklog.retrievalShadowedRows > 0
+        ? `${conflictBacklog.retrievalShadowedRows} memories are being shadowed by hard conflict retrieval rules`
         : "",
       coverage.totalRows > 0 && coverage.ratio != null && coverage.ratio < 0.95
         ? `lattice coverage is ${Math.round(coverage.ratio * 100)}%`

--- a/studio-brain/src/memory/contracts.ts
+++ b/studio-brain/src/memory/contracts.ts
@@ -546,6 +546,7 @@ export type MemoryStats = {
     hardConflicts: number;
     quarantinedRows: number;
     conflictRecords: number;
+    retrievalShadowedRows?: number;
   };
   startupReadiness?: {
     startupEligibleRows: number;
@@ -807,6 +808,13 @@ export type MemoryContextResult = {
         limit?: number;
       };
       pressure?: Record<string, unknown>;
+    };
+    blockedByHardConflict?: {
+      blocked: boolean;
+      useMode: MemoryUseMode;
+      scope: string | null;
+      conflictRecordId: string | null;
+      conflictingMemoryIds: string[];
     };
   };
 };

--- a/studio-brain/src/memory/inMemoryAdapter.ts
+++ b/studio-brain/src/memory/inMemoryAdapter.ts
@@ -305,6 +305,24 @@ function normalizeMetadata(value: unknown): Record<string, unknown> {
   return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : {};
 }
 
+function readStringList(value: unknown, maxItems = 32): string[] {
+  const queue = Array.isArray(value) ? [...value] : value === undefined || value === null ? [] : [value];
+  const out: string[] = [];
+  const seen = new Set<string>();
+  while (queue.length > 0 && out.length < maxItems) {
+    const next = queue.shift();
+    if (Array.isArray(next)) {
+      queue.unshift(...next);
+      continue;
+    }
+    const normalized = String(next ?? "").trim();
+    if (!normalized || seen.has(normalized)) continue;
+    seen.add(normalized);
+    out.push(normalized);
+  }
+  return out;
+}
+
 function readLatticeValue(metadata: Record<string, unknown>, key: string): unknown {
   const nested = normalizeMetadata(metadata.memoryLattice);
   if (metadata[key] !== undefined && metadata[key] !== null && metadata[key] !== "") return metadata[key];
@@ -316,6 +334,23 @@ function mapBreakdown<T extends string>(counts: Map<T, number>, key: string): Ar
   return Array.from(counts.entries())
     .map(([value, count]) => ({ [key]: value, count }))
     .sort((left, right) => Number(right.count) - Number(left.count) || String(left[key]).localeCompare(String(right[key])));
+}
+
+function projectedConflictLinkedIds(rows: MemoryRecord[]): Set<string> {
+  const rowIds = new Set(rows.map((row) => row.id));
+  const linked = new Set<string>();
+  for (const row of rows) {
+    const metadata = normalizeMetadata(row.metadata);
+    const category = normalizeText(readLatticeValue(metadata, "memoryCategory") ?? readLatticeValue(metadata, "category"));
+    const conflictSeverity = normalizeText(readLatticeValue(metadata, "conflictSeverity"));
+    const operationalStatus = normalizeText(readLatticeValue(metadata, "operationalStatus"));
+    if (category !== "conflict-record" || conflictSeverity !== "hard") continue;
+    if (operationalStatus === "archived" || operationalStatus === "deprecated" || operationalStatus === "retired") continue;
+    for (const linkedId of readStringList(readLatticeValue(metadata, "conflictingMemoryIds"), 32)) {
+      if (rowIds.has(linkedId)) linked.add(linkedId);
+    }
+  }
+  return linked;
 }
 
 function latticeBreakdown(rows: MemoryRecord[]): MemoryStats["lattice"] {
@@ -537,6 +572,7 @@ export function createInMemoryMemoryStoreAdapter(): MemoryStoreAdapter {
         }
       }
     }
+    const retrievalShadowedRows = projectedConflictLinkedIds(rows).size;
     return {
       total: rows.length,
       lastCapturedAt: rows.length ? rows[0].createdAt : null,
@@ -552,6 +588,7 @@ export function createInMemoryMemoryStoreAdapter(): MemoryStoreAdapter {
         hardConflicts,
         quarantinedRows,
         conflictRecords,
+        retrievalShadowedRows,
       },
       startupReadiness: {
         startupEligibleRows,

--- a/studio-brain/src/memory/postgresAdapter.ts
+++ b/studio-brain/src/memory/postgresAdapter.ts
@@ -1383,11 +1383,33 @@ export function createPostgresMemoryStoreAdapter(params: AdapterParams): MemoryS
         `,
         values
       );
+      const retrievalShadow = await pool.query(
+        `
+          WITH filtered AS (
+            SELECT memory_id, category, conflict_severity, operational_status, conflicting_memory_ids
+              FROM ${latticeProjectionTable}
+             ${projectionWhereClause}
+          ),
+          linked AS (
+            SELECT DISTINCT linked.memory_id
+              FROM filtered row
+              CROSS JOIN LATERAL jsonb_array_elements_text(COALESCE(row.conflicting_memory_ids, '[]'::jsonb)) AS linked(memory_id)
+              JOIN filtered target ON target.memory_id = linked.memory_id
+             WHERE row.category = 'conflict-record'
+               AND row.conflict_severity = 'hard'
+               AND COALESCE(row.operational_status, 'active') NOT IN ('archived', 'deprecated', 'retired')
+          )
+          SELECT COUNT(*)::int AS retrieval_shadowed_rows
+            FROM linked
+        `,
+        values
+      );
 
       const total = Number(totals.rows[0]?.total ?? 0);
       const lastRaw = totals.rows[0]?.last_captured_at;
       const rowsWithLattice = Number(latticeCoverage.rows[0]?.rows_with_lattice ?? 0);
       const launchRow = launchFindings.rows[0] ?? {};
+      const retrievalShadowRow = retrievalShadow.rows[0] ?? {};
       const backlog = {
         reviewNow: Number(latticeCoverage.rows[0]?.review_now ?? 0),
         revalidate: Number(latticeCoverage.rows[0]?.revalidate ?? 0),
@@ -1444,6 +1466,7 @@ export function createPostgresMemoryStoreAdapter(params: AdapterParams): MemoryS
           hardConflicts: Number(launchRow.hard_conflicts ?? 0),
           quarantinedRows: Number(launchRow.quarantined_rows ?? 0),
           conflictRecords: Number(launchRow.conflict_records ?? 0),
+          retrievalShadowedRows: Number(retrievalShadowRow.retrieval_shadowed_rows ?? 0),
         },
         startupReadiness: {
           startupEligibleRows: Number(launchRow.startup_eligible_rows ?? 0),

--- a/studio-brain/src/memory/service.test.ts
+++ b/studio-brain/src/memory/service.test.ts
@@ -464,6 +464,22 @@ test("memory capture quarantines exact conflicting loop states and emits a confl
   assert.equal(operationalRows.some((row) => row.id === conflictRecord?.id), false);
   assert.equal(operationalContext.items.length, 0);
   assert.equal(operationalContext.summary.includes("Operational retrieval blocked by a hard conflict"), true);
+  assert.equal(operationalContext.diagnostics.blockedByHardConflict?.blocked, true);
+  assert.equal(operationalContext.diagnostics.blockedByHardConflict?.useMode, "operational");
+  assert.equal(operationalContext.diagnostics.blockedByHardConflict?.scope, "subject:startup-continuity-auth-drift");
+  assert.equal(
+    operationalContext.diagnostics.blockedByHardConflict?.conflictRecordId === null
+      || operationalContext.diagnostics.blockedByHardConflict?.conflictRecordId === conflictRecord?.id,
+    true,
+  );
+  assert.equal(
+    operationalContext.diagnostics.blockedByHardConflict?.conflictingMemoryIds.includes(resolved.id),
+    true,
+  );
+  assert.equal(
+    operationalContext.diagnostics.blockedByHardConflict?.conflictingMemoryIds.includes(conflicting.id),
+    true,
+  );
   assert.equal(planningRows.some((row) => row.id === resolved.id), true);
   assert.equal(planningRows.some((row) => row.id === conflicting.id), true);
   assert.equal(planningRows.some((row) => row.id === conflictRecord?.id), true);
@@ -477,6 +493,9 @@ test("memory capture quarantines exact conflicting loop states and emits a confl
   assert.equal(conflictRecord?.lattice?.conflictSeverity, "hard");
   assert.equal(conflictRecord?.lattice?.reviewAction, "none");
   assert.equal(stats.lattice?.backlog.resolveConflict, 1);
+  assert.equal(stats.conflictBacklog?.contestedRows, 1);
+  assert.equal(stats.conflictBacklog?.quarantinedRows, 1);
+  assert.equal(stats.conflictBacklog?.retrievalShadowedRows, 2);
 });
 
 test("memory consolidation writes explainable artifacts and relationship repairs", { concurrency: false }, async () => {

--- a/studio-brain/src/memory/service.ts
+++ b/studio-brain/src/memory/service.ts
@@ -5210,6 +5210,41 @@ function summarizeConflictBlockedContext(items: MemorySearchResult[], useMode: M
   return summary.slice(0, maxChars);
 }
 
+function deriveBlockedByHardConflictDiagnostic(
+  items: MemorySearchResult[],
+  useMode: MemoryUseMode,
+  selectedCount: number
+): {
+  blocked: boolean;
+  useMode: MemoryUseMode;
+  scope: string | null;
+  conflictRecordId: string | null;
+  conflictingMemoryIds: string[];
+} | undefined {
+  if ((useMode !== "operational" && useMode !== "safety-critical") || selectedCount > 0 || items.length === 0) {
+    return undefined;
+  }
+  const hardConflictItems = items.filter((row) => row.lattice?.conflictSeverity === "hard");
+  if (hardConflictItems.length === 0) return undefined;
+  const conflictRecord = hardConflictItems.find((row) => row.lattice?.category === "conflict-record");
+  const scope =
+    hardConflictItems
+      .map((row) => normalizeText(row.lattice?.scope))
+      .find(Boolean)
+    ?? null;
+  const conflictingMemoryIds = Array.from(new Set(hardConflictItems.flatMap((row) => row.lattice?.conflictingMemoryIds ?? []))).slice(
+    0,
+    24,
+  );
+  return {
+    blocked: true,
+    useMode,
+    scope,
+    conflictRecordId: conflictRecord?.id ?? null,
+    conflictingMemoryIds,
+  };
+}
+
 function parseQuerySignals(query: string): {
   decision: boolean;
   action: boolean;
@@ -10502,6 +10537,7 @@ export function createMemoryService(options: MemoryServiceOptions) {
       retrievalPolicy,
       temporalAnchorMs
     ).slice(0, parsed.maxItems);
+    const blockedByHardConflict = deriveBlockedByHardConflictDiagnostic(prefilteredRanked, parsed.useMode, finalSelected.length);
 
     if (query && finalSelected.length > 0) {
       writeContextFallbackCache(
@@ -10587,6 +10623,7 @@ export function createMemoryService(options: MemoryServiceOptions) {
         },
         tenantRowsTimedOut,
         degradedComputeMode,
+        blockedByHardConflict,
       },
     };
   };


### PR DESCRIPTION
## Summary
- add retrieval-shadow backlog accounting to memory stats and control tower memory health
- expose blocked-by-hard-conflict diagnostics in memory context responses
- cover the new diagnostics and conflict-shadow surfacing in memory and HTTP tests

## Validation
- npm --prefix studio-brain run build
- node --test studio-brain/lib/memory/service.test.js
- node --test studio-brain/lib/http/server.test.js