### PR TITLE
P0: fix portal auth fallback and keep website handoff phased

### DIFF
--- a/docs/PORTAL_ACCESSIBILITY_BASELINE.md
+++ b/docs/PORTAL_ACCESSIBILITY_BASELINE.md
@@ -7,14 +7,14 @@
 ## Priority user journeys
 1. Sign in/out and profile access.
 2. Dashboard navigation and primary action chips.
-3. Kiln rentals flow (check-in, queues, firings).
+3. Firing Services flow (check-in, queues, firings).
 4. Community reporting flow and moderation receipts.
 5. Staff console critical operations (reports, events, agent ops).
 
 ## Release gate (minimum)
 - Keyboard-only pass on core portal routes:
   - Dashboard
-  - Kiln Rentals overview + check-in
+  - Firing Services overview + check-in
   - Community
   - Profile
   - Staff (for staff users)

--- a/docs/RELEASE_CANDIDATE_EVIDENCE.md
+++ b/docs/RELEASE_CANDIDATE_EVIDENCE.md
@@ -1,18 +1,32 @@
 # Release Candidate Evidence Pack
 
-## Current RC Refresh (2026-03-18)
+## Current RC Refresh (2026-04-15)
 - Canonical launch-readiness entrypoint is [docs/RELEASE_COMMAND_CENTER.md](RELEASE_COMMAND_CENTER.md).
 - Portal and website are both live, and `main` currently has no open PRs.
 - RC exit remains a hard gate until notification reliability evidence, security rotation proof, and sign-off are all complete.
 - Current RC auth baseline is Google, Email/Password, Email Link, and Microsoft.
 - Facebook and Apple provider expansion are explicitly deferred from this RC unless business requirements change.
 - Feature-growth work outside deploy/cutover, auth readiness, smoke/promotion gates, accessibility guardrails, and analytics/policy parity is frozen out of this RC.
+- Fresh live evidence was captured on 2026-04-15 under:
+  - `output/playwright/portal/prod/portal-smoke-summary.json`
+  - `output/playwright/prod/smoke-summary.json`
+  - `output/playwright/prod-phase1-website/smoke-summary.json`
+  - `output/qa/portal-authenticated-canary-rc1.json`
+  - `output/qa/lighthouse-live-2026-04-15T16-38-08Z/`
+  - `docs/audits/live-surface-audit-2026-04-15.md`
 
-## Current blockers (2026-03-18)
+## Current blockers (2026-04-15)
+- `RC issue 1`: Google login auth on `https://portal.monsoonfire.com` does not cycle users cleanly back into the live portal session.
+  - User report is now backed by direct live evidence: the production Google sign-in handoff redirects through `https://monsoonfire-portal.firebaseapp.com/__/auth/handler`, and the live bundle does not contain `auth.monsoonfire.com`.
+  - A popup-first fallback mitigation is now deployed on the direct portal surface, but this remains a release-candidate auth blocker until operator verification shows a successful Google round-trip on the live portal.
 - Notification reliability evidence is still incomplete.
 - Security rotation proof is still incomplete.
 
 ## Build + CI Evidence
+- [x] Live portal public smoke pass (2026-04-15) -> `output/playwright/portal/prod/portal-smoke-summary.json`
+- [x] Live website public smoke pass (2026-04-15) -> `output/playwright/prod/smoke-summary.json`
+- [x] Live authenticated portal canary pass (2026-04-15) -> `output/qa/portal-authenticated-canary-rc1.json`
+- [x] Live Lighthouse sweep refreshed (2026-04-15) -> `output/qa/lighthouse-live-2026-04-15T16-38-08Z/`
 - [x] `Smoke Tests` workflow pass ([run 23268174209](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/actions/runs/23268174209))
 - [x] `Lighthouse Audit` workflow pass ([run 23268174183](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/actions/runs/23268174183))
 - [x] Local LHCI reproducibility pass (2026-02-22, sandbox-safe chrome flags)
@@ -35,7 +49,15 @@
 - [x] Functions cold-start profile snapshot captured (`npm run functions:profile:coldstart -- --runs 9`) -> `output/functions-coldstart-profile/latest.json`
 - [x] Alpha preflight script run (`node ./scripts/ps1-run.mjs scripts/alpha-preflight.ps1`) on head `62eba15dc593cb1c1422183e4d314238859dca51`
 
-## Current notes (2026-03-18)
+## Current notes (2026-04-15)
+- Live website smoke still passes structurally, but direct live HTML inspection shows the production website is serving legacy `monsoonfire.kilnfire.com` portal links on the main public pages.
+- The public website was redeployed later on 2026-04-15 with an explicit phase-aware handoff hold, so `monsoonfire.kilnfire.com` remains the intentional public website target until phase 2 cutover approval.
+- Live authenticated portal canary passed with refresh-token auth using the staff automation account, so current route/navigation regressions are concentrated at the public handoff and Google auth entry path rather than the internal portal shell.
+- Live Lighthouse scores on 2026-04-15 were:
+  - portal root: performance `66`, accessibility `100`, best practices `100`, SEO `91`
+  - website pages: performance `69-75`, accessibility `94-98`, best practices `100`, SEO `100`
+- The live Google sign-in click-through currently uses the Firebase app handler domain instead of the documented custom auth handler domain, which is the strongest concrete lead on the reported failed round-trip.
+- A live phase-1 website smoke run now verifies the intentional legacy handoff host on `https://monsoonfire.com` core pages via `output/playwright/prod-phase1-website/smoke-summary.json`.
 - The live portal cutover verifier now confirms `/.well-known/apple-app-site-association` returns `200` from `https://portal.monsoonfire.com`.
 - The website production smoke needed a smoke-runner selector refresh from `pricing` to `payments` to match the current support taxonomy.
 - Local website production smoke required a temporary `STUDIO_BRAIN_INTEGRITY_OVERRIDE` because the smoke runner is coupled to an unrelated Studio Brain integrity manifest; the website behavior itself passed once the unrelated guard was bypassed.

--- a/docs/RELEASE_COMMAND_CENTER.md
+++ b/docs/RELEASE_COMMAND_CENTER.md
@@ -1,6 +1,6 @@
 # Portal + Website Release Command Center
 
-Last reviewed: 2026-03-18 (notification evidence complete; security blocker remains)
+Last reviewed: 2026-04-15 (live surface refresh: auth blocker confirmed; website handoff held in phase 1)
 Operating mode: single release candidate consolidation
 
 ## Current posture
@@ -16,29 +16,22 @@ Operating mode: single release candidate consolidation
 - [docs/README.md](README.md)
 - [docs/SOURCE_OF_TRUTH_INDEX.md](SOURCE_OF_TRUTH_INDEX.md)
 - [docs/RELEASE_CANDIDATE_EVIDENCE.md](RELEASE_CANDIDATE_EVIDENCE.md)
+- [docs/audits/live-surface-audit-2026-04-15.md](audits/live-surface-audit-2026-04-15.md)
 
 ## Current live evidence
 
-- Smoke Tests: success on 2026-03-18 ([run 23268174209](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/actions/runs/23268174209))
-- Lighthouse Audit: success on 2026-03-18 ([run 23268174183](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/actions/runs/23268174183))
-- iOS macOS Smoke: success on 2026-03-18 ([run 23268174197](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/actions/runs/23268174197))
-- `ios-build-gate`: success on 2026-03-18 ([run 23268174202](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/actions/runs/23268174202))
-- Android Compile Check: success on 2026-03-17 ([run 23218840965](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/actions/runs/23218840965))
-- Deploy to Firebase Hosting on merge: success on 2026-03-18 ([run 23259872147](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/actions/runs/23259872147))
-- Portal Post-Deploy Promotion Gate: success on 2026-03-18 ([run 23259950672](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/actions/runs/23259950672))
-- Portal Daily Authenticated Canary: success on 2026-03-18 ([run 23257627816](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/actions/runs/23257627816))
-- Local portal cutover verify refreshed on 2026-03-18:
-  - [artifacts/deploy-evidence-latest.md](../artifacts/deploy-evidence-latest.md)
-  - [output/qa/post-deploy-cutover-verify.json](../output/qa/post-deploy-cutover-verify.json)
-- Local website production smoke refreshed on 2026-03-18:
+- Fresh live portal public smoke pass on 2026-04-15:
+  - [output/playwright/portal/prod/portal-smoke-summary.json](../output/playwright/portal/prod/portal-smoke-summary.json)
+- Fresh live website public smoke pass on 2026-04-15:
   - [output/playwright/prod/smoke-summary.json](../output/playwright/prod/smoke-summary.json)
-  - Smoke currently passes after aligning the support-topic selector to the live `payments` taxonomy.
-  - Local execution required a temporary `STUDIO_BRAIN_INTEGRITY_OVERRIDE` because the smoke runner is coupled to an unrelated Studio Brain integrity guard.
-- Notification reliability proof refreshed on 2026-03-18:
-  - [output/qa/notification-evidence-2026-03-18T22-45-24-279Z.json](../output/qa/notification-evidence-2026-03-18T22-45-24-279Z.json)
-  - [output/qa/notification-partial-parity-local.json](../output/qa/notification-partial-parity-local.json)
-  - Production proof now covers retry exhaustion, dead letters, aggregate metrics, and stale-token cleanup after Firestore index remediation.
-  - Local parity proof covers `PUSH_PROVIDER_PARTIAL` plus invalid-token deactivation (`BadDeviceToken`) against the real notification code path.
+- Fresh live website phase-1 handoff verification on 2026-04-15:
+  - [output/playwright/prod-phase1-website/smoke-summary.json](../output/playwright/prod-phase1-website/smoke-summary.json)
+- Fresh live authenticated portal canary pass on 2026-04-15:
+  - [output/qa/portal-authenticated-canary-rc1.json](../output/qa/portal-authenticated-canary-rc1.json)
+- Fresh live Lighthouse sweep on 2026-04-15:
+  - [output/qa/lighthouse-live-2026-04-15T16-38-08Z](../output/qa/lighthouse-live-2026-04-15T16-38-08Z)
+- Consolidated audit:
+  - [docs/audits/live-surface-audit-2026-04-15.md](audits/live-surface-audit-2026-04-15.md)
 
 ## RC decisions
 
@@ -50,11 +43,14 @@ Operating mode: single release candidate consolidation
 ## Remaining blockers
 
 - RC exit is hard-gated in [docs/RELEASE_CANDIDATE_EVIDENCE.md](RELEASE_CANDIDATE_EVIDENCE.md):
+  - `RC issue 1`: Google login on `https://portal.monsoonfire.com` is not cycling users cleanly back into the live portal session
   - security rotation proof
   - final operator sign-off must remain populated and current
-- The only remaining hard-blocking issue is [#349](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/issues/349).
 - Current blocker detail:
-  - live runtime proof still shows the push relay path failing with `APNS_RELAY_URL not configured`
+  - the live Google auth click-through currently redirects via `https://monsoonfire-portal.firebaseapp.com/__/auth/handler`, and the live bundle omits `auth.monsoonfire.com`
+  - the portal auth fix is deployed for direct testing on `https://portal.monsoonfire.com`, but a real operator Google round-trip still needs to be verified on the live surface
+  - the public website handoff is intentionally held on `https://monsoonfire.kilnfire.com` for phase 1; phase 2 cutover to `https://portal.monsoonfire.com` is deferred until explicit operator approval
+  - infra/security evidence still shows the push relay path failing with `APNS_RELAY_URL not configured`
   - APNS relay runtime configuration and rotation evidence remain incomplete
 
 ## Open GitHub issue dispositions
@@ -79,5 +75,5 @@ Operating mode: single release candidate consolidation
 - Latest successful `Smoke Tests` on `main` remains current and is not superseded by a newer failing run
 - Release evidence pack reflects current successful runs and current hard blockers only
 - Every open GitHub issue has an explicit owner, RC status, and close condition
-- Only [#349](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/issues/349) remains as a ship blocker
+- Live auth issue log is empty or explicitly accepted by the operator before ship
 - Final operator sign-off is recorded in the release evidence pack

--- a/docs/audits/live-surface-audit-2026-04-15.md
+++ b/docs/audits/live-surface-audit-2026-04-15.md
@@ -1,0 +1,91 @@
+# Live Surface Audit — Website + Portal (2026-04-15)
+
+Status: Completed  
+Date: 2026-04-15  
+Owner: Product + Portal Ops  
+Scope: `https://portal.monsoonfire.com`, `https://monsoonfire.com`
+
+## Evidence captured
+
+- Public portal smoke: `output/playwright/portal/prod/portal-smoke-summary.json`
+- Public website smoke: `output/playwright/prod/smoke-summary.json`
+- Phase-1 website handoff verification: `output/playwright/prod-phase1-website/smoke-summary.json`
+- Authenticated portal canary: `output/qa/portal-authenticated-canary-rc1.json`
+- Live Lighthouse sweep: `output/qa/lighthouse-live-2026-04-15T16-38-08Z/`
+- Direct live HTML fetches and a Playwright Google-auth handoff trace run on 2026-04-15
+
+## Executive summary
+
+- The public portal entry and the main website routes render successfully in live production.
+- The authenticated portal surface is currently healthy. The live staff canary passed route canonicalization, dashboard click-through, notifications, messages, workshops, ware check-in, and diagnostics.
+- `RC issue 1`: the live Google login path is not using the documented custom auth handler domain. Clicking Google on `https://portal.monsoonfire.com` currently redirects through `https://monsoonfire-portal.firebaseapp.com/__/auth/handler`, and the live bundle does not contain `auth.monsoonfire.com`.
+- The initial live audit captured legacy `https://monsoonfire.kilnfire.com` handoff links across the core website pages. A same-day follow-up redeploy added a phase-aware website handoff switch and intentionally kept the public website on the legacy host while phase 2 remains deferred.
+
+## Lighthouse summary
+
+| URL | Performance | Accessibility | Best Practices | SEO |
+| --- | --- | --- | --- | --- |
+| `https://portal.monsoonfire.com` | 66 | 100 | 100 | 91 |
+| `https://monsoonfire.com/` | 69 | 96 | 100 | 100 |
+| `https://monsoonfire.com/services/` | 75 | 94 | 100 | 100 |
+| `https://monsoonfire.com/kiln-firing/` | 74 | 96 | 100 | 100 |
+| `https://monsoonfire.com/memberships/` | 75 | 96 | 100 | 100 |
+| `https://monsoonfire.com/contact/` | 75 | 96 | 100 | 100 |
+| `https://monsoonfire.com/support/` | 74 | 98 | 100 | 100 |
+
+## Navigation findings
+
+### 1. RC issue 1 — Google login does not cycle cleanly through the live portal
+
+- Severity: P0
+- Status: open
+- User report: Google login auth does not cycle the user through to the portal.
+- Direct evidence:
+  - The live portal bundle contains `monsoonfire-portal.firebaseapp.com` and does not contain `auth.monsoonfire.com`.
+  - Clicking the live Google sign-in control redirects first to:
+    - `https://monsoonfire-portal.firebaseapp.com/__/auth/handler?...&redirectUrl=https%3A%2F%2Fportal.monsoonfire.com%2F...`
+  - The subsequent Google OAuth request uses:
+    - `redirect_uri=https://monsoonfire-portal.firebaseapp.com/__/auth/handler`
+- Assessment:
+  - This does not prove the final round-trip fails for every account, because the trace stopped before credential entry.
+  - It does prove that the production build is not using the custom auth-domain setup documented in `docs/AUTH_DOMAIN_SETUP.md`, which is a strong release-candidate config mismatch for redirect-based auth on the live custom domain.
+- Exit condition:
+  - operator-verified Google sign-in returns to an authenticated session on `https://portal.monsoonfire.com`, or
+  - the live build is republished with the intended auth handler domain and the round-trip is reverified.
+
+### 2. Website public-to-portal handoff held on the legacy Kilnfire host for phase 1
+
+- Severity: tracking
+- Status: mitigated by phased rollout decision
+- Initial direct evidence from live HTML fetches:
+
+| Live page | Legacy links observed |
+| --- | --- |
+| `/` | `https://monsoonfire.kilnfire.com` |
+| `/services/` | `https://monsoonfire.kilnfire.com`, `https://monsoonfire.kilnfire.com/new-user` |
+| `/kiln-firing/` | `https://monsoonfire.kilnfire.com`, `https://monsoonfire.kilnfire.com/new-user` |
+| `/memberships/` | `https://monsoonfire.kilnfire.com`, `https://monsoonfire.kilnfire.com/new-user` |
+| `/contact/` | `https://monsoonfire.kilnfire.com`, `https://monsoonfire.kilnfire.com/new-user` |
+| `/support/` | `https://monsoonfire.kilnfire.com` |
+
+- Phase-1 disposition:
+  - The live website was redeployed later on 2026-04-15 with an explicit deploy-time handoff host switch.
+  - Public website pages now intentionally continue to send users to `https://monsoonfire.kilnfire.com` until operator approval for the phase-2 cutover.
+  - Verification evidence is captured in `output/playwright/prod-phase1-website/smoke-summary.json`.
+
+## Verified non-issues in this refresh
+
+- Public portal entry loads in signed-out mode without route errors.
+- Public website smoke passed on desktop and mobile for `/`, `/services/`, `/kiln-firing/`, `/memberships/`, `/contact/`, and `/support/`.
+- Authenticated portal canary passed:
+  - dashboard piece click-through
+  - staff route canonicalization and fallback recovery
+  - nav dock and flyout behavior
+  - legacy request deep-link recovery
+  - notifications, messages, workshops, ware check-in, and diagnostics
+
+## Recommended next actions
+
+1. Rebuild and redeploy the live portal with the intended auth handler domain if `auth.monsoonfire.com` is the production plan, then re-run a real Google sign-in round-trip check.
+2. Run an operator-owned Google sign-in round-trip on `https://portal.monsoonfire.com` and close `RC issue 1` only after confirming the authenticated return path.
+3. When phase 2 is approved, redeploy the website with `portal.monsoonfire.com` as the public handoff host and refresh the live smoke evidence.

--- a/docs/runbooks/PORTAL_PLAYWRIGHT_SMOKE.md
+++ b/docs/runbooks/PORTAL_PLAYWRIGHT_SMOKE.md
@@ -136,6 +136,7 @@ node ./scripts/portal-playwright-smoke.mjs --base-url https://staging.example.co
   - Request failures for critical Studio Brain/function endpoints (including request timeouts and net errors).
 - `authPopupWarnings`:
   - `Cross-Origin-Opener-Policy` messages from Firebase popup auth; these are recorded as notes and are non-blocking.
+  - If the portal already serves `Cross-Origin-Opener-Policy: same-origin-allow-popups`, repeated Chrome warnings can still originate from report-only headers on upstream Google auth pages.
 - `critical response warnings`:
   - `5xx` responses on critical endpoints.
 

--- a/docs/runbooks/PORTAL_QA_LOOP_NON_STAFF.md
+++ b/docs/runbooks/PORTAL_QA_LOOP_NON_STAFF.md
@@ -47,7 +47,7 @@ Optional deep probe:
 | Area | Route/View | Smoke check | Functionality check | UX check |
 | --- | --- | --- | --- | --- |
 | Dashboard | `dashboard` | Hero and cards render | `Open My Pieces` and `Message the studio` nav actions work | Studio updates and chiplets are legible in all supported themes |
-| Kiln Rentals | `kilnRentals` | Overview card renders | Primary CTA opens check-in/queue flow | Queue labels readable on mobile and desktop |
+| Firing Services | `kilnRentals` | Overview card renders | Primary CTA opens check-in/queue flow | Queue labels readable on mobile and desktop |
 | Ware Check-in | `reservations` | Form renders | Submit-path validation + success path for shelf purchase, whole kiln, and community shelf (including two-step confirm/cancel) | Field errors are readable and anchored near inputs |
 | View the Queues | `kilnLaunch` | Queue lane loads | Filter/tab switches update content | Queue status colors and labels remain clear |
 | Firings | `kiln` | Schedule view renders | Refresh/filter controls update timeline | Timeline remains readable with no overlapping text |

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -46,8 +46,26 @@
       "collectionGroup": "eventSignups",
       "queryScope": "COLLECTION",
       "fields": [
+        { "fieldPath": "status", "order": "ASCENDING" },
+        { "fieldPath": "uid", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "eventSignups",
+      "queryScope": "COLLECTION",
+      "fields": [
         { "fieldPath": "uid", "order": "ASCENDING" },
         { "fieldPath": "status", "order": "ASCENDING" },
+        { "fieldPath": "checkedInAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "eventSignups",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "status", "order": "ASCENDING" },
+        { "fieldPath": "uid", "order": "ASCENDING" },
         { "fieldPath": "checkedInAt", "order": "DESCENDING" }
       ]
     },
@@ -65,6 +83,15 @@
       "fields": [
         { "fieldPath": "uid", "order": "ASCENDING" },
         { "fieldPath": "paymentStatus", "order": "ASCENDING" },
+        { "fieldPath": "updatedAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "eventCharges",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "paymentStatus", "order": "ASCENDING" },
+        { "fieldPath": "uid", "order": "ASCENDING" },
         { "fieldPath": "updatedAt", "order": "DESCENDING" }
       ]
     },

--- a/functions/src/apiV1.test.ts
+++ b/functions/src/apiV1.test.ts
@@ -7371,7 +7371,7 @@ test("notifications.markRead marks owner notification as read", async () => {
 
   assert.equal(response.status, 200, JSON.stringify(response.body));
   const body = response.body as Record<string, unknown>;
-  const data = ((body.data ?? {}) as Record<string, unknown>) ?? {};
+  const data = (body.data ?? {}) as Record<string, unknown>;
   assert.equal(data.ownerUid, "owner-1");
   assert.equal(data.notificationId, "notification-1");
 });
@@ -7422,7 +7422,7 @@ test("notifications.markRead is idempotent when notification is already missing"
 
   assert.equal(response.status, 200, JSON.stringify(response.body));
   const body = response.body as Record<string, unknown>;
-  const data = ((body.data ?? {}) as Record<string, unknown>) ?? {};
+  const data = (body.data ?? {}) as Record<string, unknown>;
   assert.equal(data.ownerUid, "owner-1");
   assert.equal(data.notificationId, "notification-missing");
   assert.equal(data.notificationMissing, true);

--- a/functions/src/apiV1.test.ts
+++ b/functions/src/apiV1.test.ts
@@ -1208,6 +1208,54 @@ test("handleApiV1 dispatches /v1/library.items.list with filtering and computed 
   assert.equal(body.data.items[0]?.aggregateRating, 5);
 });
 
+test("handleApiV1 library member catalog hides placeholder ISBN rows even when older data missed manual_only", async () => {
+  const request = makeRequest(
+    "/v1/library.items.list",
+    { page: 1, pageSize: 20, sort: "recently_added" },
+    firebaseContext({ uid: "owner-1" }),
+  );
+  const response = createResponse();
+  const state: MockDbState = {
+    libraryItems: {
+      "item-placeholder": {
+        title: "ISBN 9789188805553",
+        authors: [],
+        mediaType: "book",
+        status: "available",
+        coverUrl: null,
+        coverQualityStatus: "missing",
+        needsCoverReview: true,
+        createdAt: { seconds: 200 },
+      },
+      "item-ready": {
+        title: "Glaze Atlas",
+        authors: ["A. Potter"],
+        mediaType: "book",
+        status: "available",
+        createdAt: { seconds: 210 },
+      },
+    },
+  };
+
+  await withMockedRateLimit(async () =>
+    withMockFirestore(state, async () => {
+      await handleApiV1(request, response.res);
+    }),
+  );
+
+  assert.equal(response.status(), 200, JSON.stringify(response.body()));
+  const body = response.body() as {
+    ok: boolean;
+    data: {
+      items: Array<Record<string, unknown>>;
+      total: number;
+    };
+  };
+  assert.equal(body.ok, true);
+  assert.equal(body.data.total, 1);
+  assert.deepEqual(body.data.items.map((item) => item.id), ["item-ready"]);
+});
+
 test("handleApiV1 highest_rated uses stored aggregate rating count for tie-breaks", async () => {
   const request = makeRequest(
     "/v1/library.items.list",
@@ -1496,6 +1544,36 @@ test("handleApiV1 dispatches /v1/library.items.get with projected item payload",
   assert.equal(body.data.item.detailStatus, "ready");
 });
 
+test("handleApiV1 library.items.get hides placeholder ISBN rows from members", async () => {
+  const request = makeRequest(
+    "/v1/library.items.get",
+    { itemId: "item-placeholder" },
+    firebaseContext({ uid: "owner-1" }),
+  );
+  const response = createResponse();
+  const state: MockDbState = {
+    libraryItems: {
+      "item-placeholder": {
+        title: "ISBN 9789188805553",
+        authors: [],
+        mediaType: "book",
+        status: "available",
+      },
+    },
+  };
+
+  await withMockedRateLimit(async () =>
+    withMockFirestore(state, async () => {
+      await handleApiV1(request, response.res);
+    }),
+  );
+
+  assert.equal(response.status(), 404, JSON.stringify(response.body()));
+  const body = response.body() as { ok: boolean; code: string };
+  assert.equal(body.ok, false);
+  assert.equal(body.code, "NOT_FOUND");
+});
+
 test("handleApiV1 dispatches /v1/library.discovery.get with required sections", async () => {
   const request = makeRequest(
     "/v1/library.discovery.get",
@@ -1556,6 +1634,59 @@ test("handleApiV1 dispatches /v1/library.discovery.get with required sections", 
   assert.equal(body.data.mostBorrowed[0]?.id, "item-2");
   assert.equal(body.data.recentlyAdded[0]?.id, "item-3");
   assert.equal(body.data.recentlyReviewed[0]?.id, "item-3");
+});
+
+test("handleApiV1 library.discovery.get hides placeholder ISBN rows from member rails", async () => {
+  const request = makeRequest(
+    "/v1/library.discovery.get",
+    { limit: 4 },
+    firebaseContext({ uid: "owner-1" }),
+  );
+  const response = createResponse();
+  const state: MockDbState = {
+    libraryItems: {
+      "item-placeholder": {
+        title: "ISBN 9789188805553",
+        mediaType: "book",
+        createdAt: { seconds: 400 },
+      },
+      "item-staff-pick": {
+        title: "Staff Pick Clay",
+        mediaType: "book",
+        staffPick: true,
+        createdAt: { seconds: 300 },
+      },
+      "item-most-borrowed": {
+        title: "Popular Borrow",
+        mediaType: "book",
+        createdAt: { seconds: 200 },
+      },
+    },
+    libraryLoans: {
+      "loan-1": { itemId: "item-most-borrowed", status: "returned" },
+      "loan-2": { itemId: "item-most-borrowed", status: "checked_out" },
+    },
+  };
+
+  await withMockedRateLimit(async () =>
+    withMockFirestore(state, async () => {
+      await handleApiV1(request, response.res);
+    }),
+  );
+
+  assert.equal(response.status(), 200, JSON.stringify(response.body()));
+  const body = response.body() as {
+    ok: boolean;
+    data: {
+      staffPicks: Array<Record<string, unknown>>;
+      mostBorrowed: Array<Record<string, unknown>>;
+      recentlyAdded: Array<Record<string, unknown>>;
+    };
+  };
+  assert.equal(body.ok, true);
+  assert.ok(body.data.staffPicks.every((row) => row.id !== "item-placeholder"));
+  assert.ok(body.data.mostBorrowed.every((row) => row.id !== "item-placeholder"));
+  assert.ok(body.data.recentlyAdded.every((row) => row.id !== "item-placeholder"));
 });
 
 test("handleApiV1 dispatches /v1/library.discovery.get with workshop discovery and community signals", async () => {

--- a/functions/src/apiV1.ts
+++ b/functions/src/apiV1.ts
@@ -3453,7 +3453,10 @@ function readLibraryCatalogVisibility(row: Record<string, unknown>): string {
 }
 
 function isLibraryRowMemberVisible(row: Record<string, unknown>): boolean {
-  return readLibraryCatalogVisibility(row) !== "manual_only";
+  if (readLibraryCatalogVisibility(row) === "manual_only" || row.manualPassRequired === true) {
+    return false;
+  }
+  return !isPlaceholderLibraryTitle(row.title);
 }
 
 function isPlaceholderLibraryTitle(value: unknown): boolean {

--- a/functions/src/billingSummary.ts
+++ b/functions/src/billingSummary.ts
@@ -52,6 +52,38 @@ function parseMs(value: unknown): number | null {
   return null;
 }
 
+function isMissingIndexError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error ?? "");
+  return /FAILED_PRECONDITION/i.test(message) && /requires an index/i.test(message);
+}
+
+function recentMs(...values: unknown[]): number {
+  for (const value of values) {
+    const parsed = parseMs(value);
+    if (parsed !== null) return parsed;
+  }
+  return 0;
+}
+
+async function getSnapshotWithIndexFallback<T>(
+  label: string,
+  primary: () => Promise<T>,
+  fallback?: () => Promise<T>
+): Promise<T> {
+  try {
+    return await primary();
+  } catch (error) {
+    if (!fallback || !isMissingIndexError(error)) {
+      throw error;
+    }
+
+    logger.warn(`${label} missing composite index; using degraded fallback query`, {
+      error: error instanceof Error ? error.message : String(error ?? ""),
+    });
+    return fallback();
+  }
+}
+
 export const listBillingSummary = onRequest({ region: REGION }, async (req, res) => {
   if (applyCors(req, res)) return;
 
@@ -76,12 +108,18 @@ export const listBillingSummary = onRequest({ region: REGION }, async (req, res)
     .where("status", "==", "checked_in")
     .orderBy("createdAt", "desc")
     .limit(limit);
+  const signupsFallbackQuery = db
+    .collection(SIGNUPS_COL)
+    .where("uid", "==", auth.uid);
 
   const ordersQuery = db
     .collection(ORDERS_COL)
     .where("uid", "==", auth.uid)
     .orderBy("updatedAt", "desc")
     .limit(limit);
+  const ordersFallbackQuery = db
+    .collection(ORDERS_COL)
+    .where("uid", "==", auth.uid);
 
   const chargesQuery = db
     .collection(CHARGES_COL)
@@ -89,12 +127,27 @@ export const listBillingSummary = onRequest({ region: REGION }, async (req, res)
     .where("paymentStatus", "==", "paid")
     .orderBy("updatedAt", "desc")
     .limit(limit);
+  const chargesFallbackQuery = db
+    .collection(CHARGES_COL)
+    .where("uid", "==", auth.uid);
 
   try {
     const [signupsSnap, ordersSnap, chargesSnap] = await Promise.all([
-      signupsQuery.get(),
-      ordersQuery.get(),
-      chargesQuery.get(),
+      getSnapshotWithIndexFallback(
+        "listBillingSummary.eventSignups",
+        () => signupsQuery.get(),
+        () => signupsFallbackQuery.get()
+      ),
+      getSnapshotWithIndexFallback(
+        "listBillingSummary.materialsOrders",
+        () => ordersQuery.get(),
+        () => ordersFallbackQuery.get()
+      ),
+      getSnapshotWithIndexFallback(
+        "listBillingSummary.eventCharges",
+        () => chargesQuery.get(),
+        () => chargesFallbackQuery.get()
+      ),
     ]);
 
     const signups = signupsSnap.docs
@@ -111,7 +164,7 @@ export const listBillingSummary = onRequest({ region: REGION }, async (req, res)
           offerExpiresAt: toIso(data.offerExpiresAt),
         };
       })
-      .filter((entry) => entry.paymentStatus !== "paid");
+      .filter((entry) => entry.status === "checked_in" && entry.paymentStatus !== "paid");
 
     const eventIds = Array.from(new Set(signups.map((entry) => entry.eventId).filter((id) => id)));
     const eventRefs = eventIds.map((eventId) => db.collection(EVENTS_COL).doc(eventId));
@@ -155,32 +208,38 @@ export const listBillingSummary = onRequest({ region: REGION }, async (req, res)
           checkInMethod: entry.checkInMethod,
         };
       })
-      .filter((entry) => inRange(entry.createdAt));
+      .filter((entry) => inRange(entry.createdAt))
+      .sort((left, right) => recentMs(right.checkedInAt, right.createdAt) - recentMs(left.checkedInAt, left.createdAt))
+      .slice(0, limit);
 
-    const materialsOrders = ordersSnap.docs.map((docSnap) => {
-      const data = docSnap.data() as Record<string, any>;
-      const items = Array.isArray(data.items) ? data.items : [];
-      const normalizedItems = items.map((item) => ({
-        productId: safeString(item?.productId),
-        name: safeString(item?.name),
-        quantity: Math.max(asInt(item?.quantity, 0), 0),
-        unitPrice: Math.max(asInt(item?.unitPrice, 0), 0),
-        currency: normalizeCurrency(item?.currency),
-      }));
+    const materialsOrders = ordersSnap.docs
+      .map((docSnap) => {
+        const data = docSnap.data() as Record<string, any>;
+        const items = Array.isArray(data.items) ? data.items : [];
+        const normalizedItems = items.map((item) => ({
+          productId: safeString(item?.productId),
+          name: safeString(item?.name),
+          quantity: Math.max(asInt(item?.quantity, 0), 0),
+          unitPrice: Math.max(asInt(item?.unitPrice, 0), 0),
+          currency: normalizeCurrency(item?.currency),
+        }));
 
-      return {
-        id: docSnap.id,
-        status: safeString(data.status) || "unknown",
-        totalCents: Math.max(asInt(data.totalCents, 0), 0),
-        currency: normalizeCurrency(data.currency),
-        pickupNotes: safeString(data.pickupNotes) || null,
-        checkoutUrl: safeString(data.checkoutUrl) || null,
-        receiptUrl: safeString(data.receiptUrl) || null,
-        createdAt: toIso(data.createdAt),
-        updatedAt: toIso(data.updatedAt),
-        items: normalizedItems,
-      };
-    });
+        return {
+          id: docSnap.id,
+          status: safeString(data.status) || "unknown",
+          totalCents: Math.max(asInt(data.totalCents, 0), 0),
+          currency: normalizeCurrency(data.currency),
+          pickupNotes: safeString(data.pickupNotes) || null,
+          checkoutUrl: safeString(data.checkoutUrl) || null,
+          receiptUrl: safeString(data.receiptUrl) || null,
+          createdAt: toIso(data.createdAt),
+          updatedAt: toIso(data.updatedAt),
+          items: normalizedItems,
+        };
+      })
+      .filter((entry) => inRange(entry.updatedAt || entry.createdAt))
+      .sort((left, right) => recentMs(right.updatedAt, right.createdAt) - recentMs(left.updatedAt, left.createdAt))
+      .slice(0, limit);
 
     const pendingMaterialsOrders = materialsOrders.filter(
       (order) => order.status !== "paid" && order.status !== "picked_up"
@@ -206,30 +265,39 @@ export const listBillingSummary = onRequest({ region: REGION }, async (req, res)
       },
     }));
 
-    const receiptsFromCharges = chargesSnap.docs.map((docSnap) => {
-      const data = docSnap.data() as Record<string, any>;
-      const lineItems = Array.isArray(data.lineItems) ? data.lineItems : [];
-      const title = lineItems[0]?.title || "Event ticket";
+    const receiptsFromCharges = chargesSnap.docs
+      .map((docSnap) => {
+        const data = docSnap.data() as Record<string, any>;
+        const lineItems = Array.isArray(data.lineItems) ? data.lineItems : [];
+        const title = lineItems[0]?.title || "Event ticket";
 
-      return {
-        id: docSnap.id,
-        type: "event" as const,
-        sourceId: safeString(data.signupId) || null,
-        title,
-        amountCents: Math.max(asInt(data.totalCents, 0), 0),
-        currency: normalizeCurrency(data.currency),
-        paidAt: toIso(data.paidAt),
-        createdAt: toIso(data.createdAt),
-        receiptUrl: safeString(data.receiptUrl) || null,
-        metadata: {
-          eventId: safeString(data.eventId) || null,
-          signupId: safeString(data.signupId) || null,
-          lineItems,
-        },
-      };
-    });
+        return {
+          paymentStatus: safeString(data.paymentStatus),
+          receipt: {
+            id: docSnap.id,
+            type: "event" as const,
+            sourceId: safeString(data.signupId) || null,
+            title,
+            amountCents: Math.max(asInt(data.totalCents, 0), 0),
+            currency: normalizeCurrency(data.currency),
+            paidAt: toIso(data.paidAt),
+            createdAt: toIso(data.createdAt),
+            receiptUrl: safeString(data.receiptUrl) || null,
+            metadata: {
+              eventId: safeString(data.eventId) || null,
+              signupId: safeString(data.signupId) || null,
+              lineItems,
+            },
+          },
+        };
+      })
+      .filter((entry) => entry.paymentStatus === "paid")
+      .map((entry) => entry.receipt);
 
-    const receipts = [...receiptsFromCharges, ...receiptsFromOrders].filter((entry) => inRange(entry.createdAt));
+    const receipts = [...receiptsFromCharges, ...receiptsFromOrders]
+      .filter((entry) => inRange(entry.paidAt || entry.createdAt))
+      .sort((left, right) => recentMs(right.paidAt, right.createdAt) - recentMs(left.paidAt, left.createdAt))
+      .slice(0, limit);
 
     const summary = {
       unpaidCheckInsCount: billingCheckIns.length,

--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -6,6 +6,7 @@
     "noImplicitReturns": true,
     "noUnusedLocals": true,
     "outDir": "lib",
+    "rootDir": "src",
     "sourceMap": true,
     "strict": true,
     "target": "es2017"

--- a/scripts/deploy-namecheap-portal.mjs
+++ b/scripts/deploy-namecheap-portal.mjs
@@ -132,7 +132,13 @@ try {
   }
 
   const resolvedFirebaseApiKey = resolveFirebaseWebApiKey();
+  const resolvedFirebaseAuthDomain = resolveFirebaseAuthDomain();
   process.stdout.write(`Using Firebase Web API key source: ${resolvedFirebaseApiKey.source}\n`);
+  process.stdout.write(
+    resolvedFirebaseAuthDomain.domain
+      ? `Using Firebase Auth domain source: ${resolvedFirebaseAuthDomain.source} (${resolvedFirebaseAuthDomain.domain})\n`
+      : "Using Firebase Auth domain source: default web fallback\n"
+  );
 
   if (!options.noBuild) {
     run("npm", ["--prefix", "web", "run", "build"], {
@@ -140,6 +146,7 @@ try {
       env: {
         ...process.env,
         VITE_FIREBASE_API_KEY: resolvedFirebaseApiKey.key,
+        ...(resolvedFirebaseAuthDomain.domain ? { VITE_AUTH_DOMAIN: resolvedFirebaseAuthDomain.domain } : {}),
       },
     });
   }
@@ -715,6 +722,21 @@ function collectFiles(rootDir, includeFile) {
   }
 
   return files;
+}
+
+function resolveFirebaseAuthDomain() {
+  const envCandidates = [
+    ["PORTAL_AUTH_DOMAIN", process.env.PORTAL_AUTH_DOMAIN],
+    ["VITE_AUTH_DOMAIN", process.env.VITE_AUTH_DOMAIN],
+  ];
+  for (const [source, value] of envCandidates) {
+    const cleaned = String(value || "").trim();
+    if (cleaned) {
+      return { domain: cleaned, source };
+    }
+  }
+
+  return { domain: "", source: "default" };
 }
 
 function assertFirebaseApiKeyIsEmbedded(distDir) {

--- a/scripts/deploy-namecheap-website.mjs
+++ b/scripts/deploy-namecheap-website.mjs
@@ -1,13 +1,27 @@
 #!/usr/bin/env node
 import { spawnSync } from "node:child_process";
-import { existsSync, statSync } from "node:fs";
-import { homedir } from "node:os";
-import { dirname, join, resolve } from "node:path";
+import { cpSync, existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { dirname, extname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const repoRoot = resolve(__dirname, "..");
+const canonicalPortalHandoffHost = "portal.monsoonfire.com";
+const defaultWebsitePortalHandoffHost = "monsoonfire.kilnfire.com";
+const textReplacementExtensions = new Set([
+  ".config",
+  ".css",
+  ".html",
+  ".htm",
+  ".js",
+  ".json",
+  ".mjs",
+  ".svg",
+  ".txt",
+  ".xml",
+]);
 
 const defaults = {
   server: process.env.WEBSITE_DEPLOY_SERVER || "monsggbd@66.29.137.142",
@@ -15,6 +29,7 @@ const defaults = {
   key: process.env.WEBSITE_DEPLOY_KEY || join(homedir(), ".ssh", "namecheap-portal"),
   remotePath: process.env.WEBSITE_DEPLOY_REMOTE_PATH || "public_html/",
   source: process.env.WEBSITE_DEPLOY_SOURCE || resolve(repoRoot, "website", "ncsitebuilder"),
+  portalHandoffHost: process.env.WEBSITE_PORTAL_HANDOFF_HOST || defaultWebsitePortalHandoffHost,
 };
 
 const args = parseArgs(process.argv.slice(2));
@@ -23,6 +38,7 @@ const keyPath = expandHomePath(args.key || defaults.key);
 const server = args.server || defaults.server;
 const port = Number.isInteger(args.port) ? args.port : defaults.port;
 const remotePath = args.remotePath || defaults.remotePath;
+const portalHandoffHost = normalizePortalHandoffHost(args.portalHandoffHost || defaults.portalHandoffHost);
 
 if (!existsSync(source) || !statSync(source).isDirectory()) {
   fail(`Source directory does not exist: ${source}`);
@@ -36,30 +52,53 @@ if (!Number.isInteger(port) || port < 1 || port > 65535) {
 if (!keyPath || !existsSync(keyPath)) {
   fail(`SSH key not found: ${keyPath}`);
 }
+if (!portalHandoffHost) {
+  fail("Missing website portal handoff host. Pass --portal-handoff-host or set WEBSITE_PORTAL_HANDOFF_HOST.");
+}
 
-const delegate = spawnSync(
-  "node",
-  [
-    resolve(repoRoot, "website", "scripts", "deploy.mjs"),
-    "--server",
-    server,
-    "--port",
-    String(port),
-    "--key",
-    keyPath,
-    "--remote-path",
-    remotePath,
-    "--source",
-    source,
-  ],
-  {
-    stdio: "inherit",
-    shell: false,
-  },
-);
+const stagedRoot = mkdtempSync(join(tmpdir(), "monsoonfire-website-deploy-"));
+const stagedSource = join(stagedRoot, "site");
+cpSync(source, stagedSource, { recursive: true });
+rewritePortalHandoffHost(stagedSource, portalHandoffHost);
 
-if (delegate.error) {
-  fail(`Deploy failed: ${delegate.error.message}`);
+let delegate = null;
+let delegateFailure = null;
+try {
+  delegate = spawnSync(
+    "node",
+    [
+      resolve(repoRoot, "website", "scripts", "deploy.mjs"),
+      "--server",
+      server,
+      "--port",
+      String(port),
+      "--key",
+      keyPath,
+      "--remote-path",
+      remotePath,
+      "--source",
+      stagedSource,
+    ],
+    {
+      stdio: "inherit",
+      shell: false,
+    },
+  );
+
+  if (delegate.error) {
+    throw new Error(`Deploy failed: ${delegate.error.message}`);
+  }
+} catch (error) {
+  delegateFailure = error instanceof Error ? error.message : String(error);
+} finally {
+  rmSync(stagedRoot, { recursive: true, force: true });
+}
+
+if (delegateFailure) {
+  fail(delegateFailure);
+}
+if (!delegate) {
+  fail("Deploy failed before the delegate process started.");
 }
 if (delegate.status !== 0) {
   process.exit(delegate.status ?? 1);
@@ -72,6 +111,7 @@ function parseArgs(argv) {
     key: defaults.key,
     remotePath: defaults.remotePath,
     source: defaults.source,
+    portalHandoffHost: defaults.portalHandoffHost,
   };
 
   for (let i = 0; i < argv.length; i += 1) {
@@ -102,6 +142,11 @@ function parseArgs(argv) {
       i += 1;
       continue;
     }
+    if (current === "--portal-handoff-host") {
+      parsed.portalHandoffHost = next || parsed.portalHandoffHost;
+      i += 1;
+      continue;
+    }
     if (current === "--help") {
       process.stdout.write(
         "Usage: node ./scripts/deploy-namecheap-website.mjs [options]\n" +
@@ -109,7 +154,8 @@ function parseArgs(argv) {
           "  --port <port>             default: 21098\n" +
           "  --key <private-key-path>  default: ~/.ssh/namecheap-portal\n" +
           "  --remote-path <path>      default: public_html/\n" +
-          "  --source <path>           default: ./website/ncsitebuilder\n",
+          "  --source <path>           default: ./website/ncsitebuilder\n" +
+          `  --portal-handoff-host <host> default: ${defaultWebsitePortalHandoffHost}\n`,
       );
       process.exit(0);
     }
@@ -122,6 +168,34 @@ function expandHomePath(input) {
   if (!input || input === "~") return homedir();
   if (input.startsWith("~/")) return join(homedir(), input.slice(2));
   return input;
+}
+
+function normalizePortalHandoffHost(input) {
+  return String(input || "").trim().replace(/^https?:\/\//i, "").replace(/\/+$/, "").toLowerCase();
+}
+
+function rewritePortalHandoffHost(directory, portalHandoffHost) {
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const absolutePath = join(directory, entry.name);
+    if (entry.isDirectory()) {
+      rewritePortalHandoffHost(absolutePath, portalHandoffHost);
+      continue;
+    }
+
+    if (!textReplacementExtensions.has(extname(entry.name).toLowerCase())) {
+      continue;
+    }
+
+    const contents = readFileSync(absolutePath, "utf8");
+    if (!contents.includes(canonicalPortalHandoffHost)) {
+      continue;
+    }
+
+    const rewritten = contents.replaceAll(canonicalPortalHandoffHost, portalHandoffHost);
+    if (rewritten !== contents) {
+      writeFileSync(absolutePath, rewritten, "utf8");
+    }
+  }
 }
 
 function fail(message) {

--- a/scripts/portal-authenticated-canary.mjs
+++ b/scripts/portal-authenticated-canary.mjs
@@ -2420,7 +2420,7 @@ async function run() {
       });
 
       await check(summary, "ware check-in page loads without check-in/index errors", async () => {
-        await clickNavSubItem(page, "Kiln Rentals", "Ware Check-in", true);
+        await clickNavSubItem(page, "Firing Services", "Ware Check-in", true);
         await page.getByRole("heading", { name: /^Ware Check-in$/i }).first().waitFor({ timeout: 30000 });
 
         const listError = page.locator("text=/^Check-ins failed:/i").first();
@@ -2434,7 +2434,7 @@ async function run() {
       });
 
       await check(summary, "ware check-in optional sections stay collapsed by default and preserve values", async () => {
-        await clickNavSubItem(page, "Kiln Rentals", "Ware Check-in", true);
+        await clickNavSubItem(page, "Firing Services", "Ware Check-in", true);
         await page.getByRole("heading", { name: /^Ware Check-in$/i }).first().waitFor({ timeout: 30000 });
         await verifyCheckInOptionalSections(page);
         await takeScreenshot(
@@ -2491,7 +2491,7 @@ async function run() {
         {
           label: "Ware Check-in",
           navigate: async () => {
-            await clickNavSubItem(page, "Kiln Rentals", "Ware Check-in", true);
+            await clickNavSubItem(page, "Firing Services", "Ware Check-in", true);
             await page.getByRole("heading", { name: /^Ware Check-in$/i }).first().waitFor({ timeout: 30000 });
           },
         },

--- a/scripts/portal-playwright-smoke.mjs
+++ b/scripts/portal-playwright-smoke.mjs
@@ -1831,6 +1831,52 @@ const waitForAuthReady = async (page) => {
   return isSignedOut > 0;
 };
 
+const verifyGoogleAuthPopupHandoff = async (browser, options, summary) => {
+  const context = await browser.newContext({
+    viewport: { width: 1440, height: 900 },
+    userAgent: "MonsoonFirePortalPlaywrightAuth/1.0",
+  });
+
+  try {
+    const page = await context.newPage();
+    await page.goto(options.baseUrl, { waitUntil: "domcontentloaded", timeout: 30000 });
+    await page.waitForTimeout(800);
+    await continueThroughBetaGateIfPresent(page, summary, "auth-handoff");
+
+    const googleButton = page.getByRole("button", { name: /continue with google/i }).first();
+    await googleButton.waitFor({ timeout: 15000 });
+
+    const popupPromise = context.waitForEvent("page", { timeout: 10000 }).catch(() => null);
+    const baseOrigin = new URL(options.baseUrl).origin;
+
+    await googleButton.click();
+
+    const popupPage = await popupPromise;
+    if (!popupPage) {
+      throw new Error("Google sign-in did not open a popup window.");
+    }
+
+    await popupPage.waitForURL(/accounts\.google\.com|firebaseapp\.com/i, { timeout: 15000 }).catch(() => {});
+    await popupPage.waitForTimeout(1200);
+
+    const popupUrl = popupPage.url();
+    const popupLooksValid =
+      /accounts\.google\.com/i.test(popupUrl) || /firebaseapp\.com\/__\/auth\/handler/i.test(popupUrl);
+    if (!popupLooksValid) {
+      throw new Error(`Google sign-in popup opened an unexpected URL: ${popupUrl || "<empty>"}`);
+    }
+
+    const currentOrigin = new URL(page.url()).origin;
+    if (currentOrigin !== baseOrigin) {
+      throw new Error(`Google sign-in changed the main tab origin to ${page.url()} instead of keeping ${baseOrigin}.`);
+    }
+
+    await popupPage.close().catch(() => {});
+  } finally {
+    await context.close();
+  }
+};
+
 const signInWithEmail = async (page, email, password, summary) => {
   if (!email || !password) {
     return { status: "skipped", reason: "missing credentials" };
@@ -2036,6 +2082,12 @@ const run = async () => {
         status: "passed",
         details: "Portal loaded in signed-out mode.",
       });
+
+      if (!summary.baseUrlIsLocal) {
+        await check(summary, "google auth handoff uses popup", async () => {
+          await verifyGoogleAuthPopupHandoff(browser, options, summary);
+        });
+      }
 
       if (options.withAuth || options.requireAuth) {
         await check(summary, "sign-in attempt", async () => {

--- a/scripts/portal-playwright-smoke.mjs
+++ b/scripts/portal-playwright-smoke.mjs
@@ -2439,7 +2439,7 @@ const run = async () => {
       }
       if (summary.network.authPopupWarnings.length > 0) {
         summary.notes.push(
-          "Auth popup warnings were observed (Cross-Origin-Opener-Policy). This is expected if OAuth popup flow is exercised in browser."
+          "Auth popup warnings were observed (Cross-Origin-Opener-Policy). These are non-blocking; if the portal already serves same-origin-allow-popups they may still come from upstream Google auth pages."
         );
       }
       if (summary.network.runtimeWarnings.length > 0) {

--- a/scripts/website-playwright-smoke.mjs
+++ b/scripts/website-playwright-smoke.mjs
@@ -48,6 +48,12 @@ const contentTypes = {
 };
 
 const supportTopicSelectors = ['[data-topic="payments"]', '[data-topic="pricing"]'];
+const knownPortalHosts = new Set(["monsoonfire.kilnfire.com", "portal.monsoonfire.com"]);
+const defaultExpectedPortalHost = String(
+  process.env.WEBSITE_EXPECTED_PORTAL_HOST ||
+  process.env.WEBSITE_PORTAL_HANDOFF_HOST ||
+  "portal.monsoonfire.com"
+).trim().toLowerCase();
 
 const ensureDir = async (dirPath) => mkdir(dirPath, { recursive: true });
 
@@ -60,7 +66,8 @@ const normalizeBaseUrl = (value) => {
 const parseOptions = (argv) => {
   const options = {
     baseUrl: null,
-    outputDir: defaultOutputRoot
+    outputDir: defaultOutputRoot,
+    expectedPortalHost: defaultExpectedPortalHost,
   };
 
   for (let i = 0; i < argv.length; i += 1) {
@@ -80,6 +87,15 @@ const parseOptions = (argv) => {
         throw new Error("Missing value for --output-dir");
       }
       options.outputDir = resolve(repoRoot, nextValue);
+      i += 1;
+      continue;
+    }
+    if (arg === "--expected-portal-host") {
+      const nextValue = argv[i + 1];
+      if (!nextValue || nextValue.startsWith("--")) {
+        throw new Error("Missing value for --expected-portal-host");
+      }
+      options.expectedPortalHost = String(nextValue).trim().toLowerCase();
       i += 1;
       continue;
     }
@@ -208,6 +224,31 @@ const assert = (condition, message) => {
   }
 };
 
+const assertPortalLinks = async (page, route, expectedPortalHost) => {
+  const hrefs = await page.evaluate(() => Array.from(document.querySelectorAll("a[href]"), (anchor) => anchor.href));
+  const unexpectedKnownLinks = hrefs.filter((href) => {
+    try {
+      const hostname = new URL(href).hostname.toLowerCase();
+      return knownPortalHosts.has(hostname) && hostname !== expectedPortalHost;
+    } catch {
+      return false;
+    }
+  });
+  assert(
+    unexpectedKnownLinks.length === 0,
+    `Unexpected portal handoff links found on ${route}: ${unexpectedKnownLinks.join(", ")}`
+  );
+
+  const expectedPortalLinks = hrefs.filter((href) => {
+    try {
+      return new URL(href).hostname.toLowerCase() === expectedPortalHost;
+    } catch {
+      return false;
+    }
+  });
+  assert(expectedPortalLinks.length > 0, `Missing expected portal handoff link on ${route}: ${expectedPortalHost}.`);
+};
+
 const run = async () => {
   applyContractDefaults();
   assertStudioBrainContract();
@@ -215,6 +256,7 @@ const run = async () => {
 
   const options = parseOptions(process.argv.slice(2));
   const outputRoot = options.outputDir;
+  const expectedPortalHost = options.expectedPortalHost;
   let baseUrl = options.baseUrl || localBaseUrl;
   const summaryPath = resolve(outputRoot, "smoke-summary.json");
   const summary = {
@@ -222,6 +264,7 @@ const run = async () => {
     startedAt: new Date().toISOString(),
     baseUrl,
     outputDir: outputRoot,
+    expectedPortalHost,
     checks: []
   };
 
@@ -274,6 +317,7 @@ const run = async () => {
         await desktopPage.goto(`${baseUrl}${item.route}`, { waitUntil: "networkidle" });
         const hasRequiredElement = await desktopPage.locator(item.assertSelector).first().isVisible();
         assert(hasRequiredElement, `Missing required selector ${item.assertSelector} on ${item.route} (desktop).`);
+        await assertPortalLinks(desktopPage, item.route, expectedPortalHost);
         await desktopPage.screenshot({ path: resolve(outputRoot, item.name), fullPage: true });
       });
     }
@@ -288,6 +332,7 @@ const run = async () => {
         assert(hasMenuToggle, `Missing mobile menu toggle on ${item.route}.`);
         const hasRequiredElement = await mobilePage.locator(item.assertSelector).first().isVisible();
         assert(hasRequiredElement, `Missing required selector ${item.assertSelector} on ${item.route} (mobile).`);
+        await assertPortalLinks(mobilePage, item.route, expectedPortalHost);
         await mobilePage.screenshot({ path: resolve(outputRoot, item.name), fullPage: true });
       });
     }

--- a/studio-brain/.env.integrity.json
+++ b/studio-brain/.env.integrity.json
@@ -1,6 +1,6 @@
 {
   "schema": "studiobrain-infra-integrity-v1",
-  "generatedAt": "2026-04-16T00:07:31.511Z",
+  "generatedAt": "2026-04-16T00:46:44.992Z",
   "generatedBy": "scripts/integrity-check.mjs",
   "allowUnknown": false,
   "metadata": {
@@ -247,8 +247,8 @@
     },
     {
       "path": "scripts/portal-playwright-smoke.mjs",
-      "sha256": "3abe164136e8414716bd16f5fc99446ff13cddffdfb5d642762811e5901c61ed",
-      "size": 84794
+      "sha256": "eadaeb868567c6680455969f98090fdc19e64be9a3e77fd6d7e4a1a937301466",
+      "size": 84863
     },
     {
       "path": "scripts/pr-gate.mjs",

--- a/studio-brain/.env.integrity.json
+++ b/studio-brain/.env.integrity.json
@@ -1,6 +1,6 @@
 {
   "schema": "studiobrain-infra-integrity-v1",
-  "generatedAt": "2026-04-15T01:52:31.715Z",
+  "generatedAt": "2026-04-16T00:07:31.511Z",
   "generatedBy": "scripts/integrity-check.mjs",
   "allowUnknown": false,
   "metadata": {
@@ -247,8 +247,8 @@
     },
     {
       "path": "scripts/portal-playwright-smoke.mjs",
-      "sha256": "be62b43dc2831fbd66d8fe743916fcd657410f8de185ff64314638f8f680658a",
-      "size": 82866
+      "sha256": "3abe164136e8414716bd16f5fc99446ff13cddffdfb5d642762811e5901c61ed",
+      "size": 84794
     },
     {
       "path": "scripts/pr-gate.mjs",
@@ -307,8 +307,8 @@
     },
     {
       "path": "scripts/website-playwright-smoke.mjs",
-      "sha256": "6b64c3632222b0f88df732a27498493a8726153ba6ef8f8aa0cd6ccd2fc77bfc",
-      "size": 13355
+      "sha256": "4cf3dde64c0b5d5fb45e62b58f1b09eb3faef4ded1dbf73296e8dc1117264d64",
+      "size": 15136
     },
     {
       "path": "studio-brain/.env.contract.schema.json",

--- a/web/deploy/namecheap/.htaccess
+++ b/web/deploy/namecheap/.htaccess
@@ -34,5 +34,8 @@
   # Root-level compatibility chunks should never be cached.
   Header set Cache-Control "no-store, max-age=0" env=ROOT_COMPAT_CHUNK
 
+  # OAuth popup flows need to retain an opener reference for cross-origin auth windows.
+  Header set Cross-Origin-Opener-Policy "same-origin-allow-popups" env=MF_HTML_CACHE
+
   Header set Cache-Control "no-cache" env=MF_HTML_CACHE
 </IfModule>

--- a/web/deploy/namecheap/README.md
+++ b/web/deploy/namecheap/README.md
@@ -82,5 +82,6 @@ The script:
   - deep link route returns HTML instead of 404
   - `/.well-known/*` can be read without SPA rewrite
   - cache headers on `index.html`
+  - `Cross-Origin-Opener-Policy: same-origin-allow-popups` on app-shell HTML for OAuth popup support
   - sample `/assets/*` files for long-lived cache hints (`immutable` or high `max-age`)
   - optional protected function call with a provided ID token (`PORTAL_CUTOVER_ID_TOKEN` or `--id-token`)

--- a/web/deploy/namecheap/verify-cutover.mjs
+++ b/web/deploy/namecheap/verify-cutover.mjs
@@ -12,6 +12,7 @@ const DEFAULT_WELL_KNOWN_PATH = "/.well-known/apple-app-site-association";
 const DEFAULT_FUNCTIONS_BASE_URL = "https://us-central1-monsoonfire-portal.cloudfunctions.net";
 const DEFAULT_PROTECTED_FUNCTION = "listMaterialsProducts";
 const DEFAULT_ID_TOKEN_ENV = "PORTAL_CUTOVER_ID_TOKEN";
+const EXPECTED_COOP_HEADER = "same-origin-allow-popups";
 const FIREBASE_COMPILED_KEY_REGEX = /AIza[0-9A-Za-z_-]{20,}/g;
 const FIREBASE_MISSING_KEY_TOKEN = "MISSING_VITE_FIREBASE_API_KEY";
 
@@ -135,6 +136,8 @@ async function runVerify(parsed) {
 
   checkHeaders("rootCache", root, root.path, failures, passes, warnings);
   checkHeaders("deepCache", deep, deep.path, failures, passes, warnings);
+  checkCoopHeader("rootCoop", root, root.path, failures, passes);
+  checkCoopHeader("deepCoop", deep, deep.path, failures, passes);
 
   const protectedFunctionCheck = {
     required: requireProtectedCheck,
@@ -374,6 +377,23 @@ function checkHeaders(name, result, path, failures, passes, warnings) {
   }
 }
 
+function checkCoopHeader(name, result, path, failures, passes) {
+  if (!result || !result.ok) {
+    failures.push(`${name} skipped due upstream failure (${path})`);
+    return;
+  }
+
+  const coop = (result.crossOriginOpenerPolicy || "").trim().toLowerCase();
+  if (coop === EXPECTED_COOP_HEADER) {
+    passes.push(name);
+    return;
+  }
+
+  failures.push(
+    `${name} missing expected Cross-Origin-Opener-Policy header (${path} -> ${result.crossOriginOpenerPolicy || "<missing>"})`
+  );
+}
+
 function isShortHtmlCacheHeader(rawHeader) {
   const header = rawHeader.toLowerCase();
   if (header.includes("no-cache") || header.includes("no-store") || header.includes("max-age=0")) {
@@ -403,6 +423,7 @@ async function requestWithTimeout({ url, timeoutMs, method = "GET", headers = {}
     ok: false,
     body: "",
     cacheControl: "",
+    crossOriginOpenerPolicy: "",
     error: "",
   };
 
@@ -421,6 +442,7 @@ async function requestWithTimeout({ url, timeoutMs, method = "GET", headers = {}
     result.status = response.status;
     result.ok = response.ok;
     result.cacheControl = response.headers.get("cache-control") || "";
+    result.crossOriginOpenerPolicy = response.headers.get("cross-origin-opener-policy") || "";
     result.body = await response.text();
     return result;
   } catch (error) {

--- a/web/scripts/check-reservations-journey-playwright.mjs
+++ b/web/scripts/check-reservations-journey-playwright.mjs
@@ -88,16 +88,16 @@ async function openWareCheckin(page, clickTracked) {
 
   const sectionButton = page
     .locator("button.nav-section-title", {
-      hasText: new RegExp(`^${regexSafe("Kiln Rentals")}$`, "i"),
+      hasText: new RegExp(`^${regexSafe("Firing Services")}$`, "i"),
     })
     .first();
   if ((await sectionButton.count()) === 0) {
-    throw new Error("Ware check-in entry point unavailable (missing dashboard CTA and Kiln Rentals nav section).");
+    throw new Error("Ware check-in entry point unavailable (missing dashboard CTA and Firing Services nav section).");
   }
 
   const expanded = (await sectionButton.getAttribute("aria-expanded")) === "true";
   if (!expanded) {
-    await clickTracked(sectionButton, "Open Kiln Rentals nav section", { timeout: 12000 });
+    await clickTracked(sectionButton, "Open Firing Services nav section", { timeout: 12000 });
     await page.waitForTimeout(250);
   }
 
@@ -109,7 +109,7 @@ async function openWareCheckin(page, clickTracked) {
         .first()
     : page.getByRole("button", { name: /^Ware Check-in$/i }).first();
   if ((await wareCheckinButton.count()) === 0) {
-    throw new Error("Ware Check-in nav button not found under Kiln Rentals.");
+    throw new Error("Ware Check-in nav button not found under Firing Services.");
   }
   await clickTracked(wareCheckinButton, "Open ware check-in (nav)", { timeout: 12000 });
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -33,6 +33,11 @@ import type { Announcement, DirectMessageThread, LiveUser } from "./types/messag
 import { toVoidHandler } from "./utils/toVoidHandler";
 import { identify, shortId, track } from "./lib/analytics";
 import {
+  shouldFallbackToRedirect,
+  shouldTryPopupFirst,
+  type AuthProviderId,
+} from "./lib/authProviderFlow";
+import {
   capturePortalEntryAttributionFromHref,
   clearPortalEntryAttribution,
   consumePortalTarget,
@@ -1805,20 +1810,18 @@ export default function App() {
     setUnreadNotifications(unread);
   }, [notifications]);
 
-  const handleProviderSignIn = async (
-    providerId: "google" | "apple" | "facebook" | "microsoft"
-  ) => {
+  const handleProviderSignIn = async (providerId: AuthProviderId) => {
     setAuthStatus("");
     setAuthBusy(true);
     track("auth_sign_in_start", {
       method: providerId,
     });
+    let provider: GoogleAuthProvider | FacebookAuthProvider | OAuthProvider | null = null;
     try {
       const persistenceMode = await ensureAuthPersistence();
       if (persistenceMode === "none") {
         setAuthStatus("This browser is limiting sign-in storage. We will try to keep this tab signed in.");
       }
-      let provider;
       switch (providerId) {
         case "google":
           provider = new GoogleAuthProvider();
@@ -1840,7 +1843,7 @@ export default function App() {
         default:
           return;
       }
-      if (!isAuthEmulator) {
+      if (!isAuthEmulator && !shouldTryPopupFirst(providerId)) {
         setAuthStatus("Continuing sign-in...");
         await signInWithRedirect(authClient, provider);
         return;
@@ -1857,6 +1860,15 @@ export default function App() {
         setAuthReady(true);
       }
     } catch (error: unknown) {
+      if (!isAuthEmulator && provider && shouldTryPopupFirst(providerId) && shouldFallbackToRedirect(error)) {
+        track("auth_sign_in_redirect_fallback", {
+          method: providerId,
+          reason: getErrorCode(error) || "popup_unavailable",
+        });
+        setAuthStatus("Popup blocked. Continuing sign-in...");
+        await signInWithRedirect(authClient, provider);
+        return;
+      }
       setAuthStatus(getErrorMessage(error) || "Sign-in failed. Please try again.");
     } finally {
       setAuthBusy(false);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -197,7 +197,7 @@ const NAV_BOTTOM_ITEMS: NavItem[] = [
 const NAV_SECTIONS: NavSection[] = [
   {
     key: "kilnRentals",
-    title: "Kiln Rentals",
+    title: "Firing Services",
     items: [
       { key: "kilnRentals", label: "Overview" },
       { key: "wareCheckIn", label: "Ware Check-in" },
@@ -346,7 +346,7 @@ const NAV_LABELS: Record<NavKey, string> = {
   integrations: "Integrations",
   pieces: "My Pieces",
   kiln: "Firings",
-  kilnRentals: "Kiln Rentals",
+  kilnRentals: "Firing Services",
   kilnLaunch: "View the Queues",
   reservations: "Reservations",
   wareCheckIn: "Ware Check-in",

--- a/web/src/lib/authProviderFlow.test.ts
+++ b/web/src/lib/authProviderFlow.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { shouldFallbackToRedirect, shouldTryPopupFirst } from "./authProviderFlow";
+
+describe("authProviderFlow", () => {
+  it("prefers popup-first auth for Google", () => {
+    expect(shouldTryPopupFirst("google")).toBe(true);
+  });
+
+  it("keeps non-Google providers on redirect-first flow", () => {
+    expect(shouldTryPopupFirst("apple")).toBe(false);
+    expect(shouldTryPopupFirst("facebook")).toBe(false);
+    expect(shouldTryPopupFirst("microsoft")).toBe(false);
+  });
+
+  it("falls back to redirect for popup-blocked production errors", () => {
+    expect(shouldFallbackToRedirect({ code: "auth/popup-blocked" })).toBe(true);
+    expect(shouldFallbackToRedirect({ code: "auth/operation-not-supported-in-this-environment" })).toBe(true);
+  });
+
+  it("does not redirect-fallback on unrelated auth failures", () => {
+    expect(shouldFallbackToRedirect({ code: "auth/popup-closed-by-user" })).toBe(false);
+    expect(shouldFallbackToRedirect({ code: "auth/unauthorized-domain" })).toBe(false);
+    expect(shouldFallbackToRedirect(new Error("boom"))).toBe(false);
+  });
+});

--- a/web/src/lib/authProviderFlow.ts
+++ b/web/src/lib/authProviderFlow.ts
@@ -1,0 +1,20 @@
+export type AuthProviderId = "google" | "apple" | "facebook" | "microsoft";
+
+const POPUP_REDIRECT_FALLBACK_CODES = new Set([
+  "auth/popup-blocked",
+  "auth/operation-not-supported-in-this-environment",
+]);
+
+function getErrorCode(error: unknown): string {
+  if (!error || typeof error !== "object") return "";
+  const code = (error as Record<string, unknown>).code;
+  return typeof code === "string" ? code : "";
+}
+
+export function shouldTryPopupFirst(providerId: AuthProviderId): boolean {
+  return providerId === "google";
+}
+
+export function shouldFallbackToRedirect(error: unknown): boolean {
+  return POPUP_REDIRECT_FALLBACK_CODES.has(getErrorCode(error));
+}

--- a/web/src/lib/normalizers/library.ts
+++ b/web/src/lib/normalizers/library.ts
@@ -97,16 +97,23 @@ export function resolveMemberApprovedLibraryCoverUrl(
   return item.coverQualityStatus === "approved" ? coverUrl : null;
 }
 
+function resolveMemberVisibleLibraryCoverUrl(
+  item: Pick<LibraryItem, "coverUrl">
+): string | null {
+  const coverUrl = str(item.coverUrl)?.trim() ?? "";
+  return coverUrl || null;
+}
+
 export function resolveMemberLibraryCoverDisplay(
   item: Pick<LibraryItem, "title" | "coverUrl" | "coverQualityStatus" | "needsCoverReview">
 ):
-  | { kind: "approved"; coverUrl: string }
+  | { kind: "cover"; coverUrl: string }
   | { kind: "placeholder"; label: string; accent: string; ariaLabel: string } {
-  const approvedCoverUrl = resolveMemberApprovedLibraryCoverUrl(item);
-  if (approvedCoverUrl) {
+  const visibleCoverUrl = resolveMemberVisibleLibraryCoverUrl(item);
+  if (visibleCoverUrl) {
     return {
-      kind: "approved",
-      coverUrl: approvedCoverUrl,
+      kind: "cover",
+      coverUrl: visibleCoverUrl,
     };
   }
   return {
@@ -121,7 +128,7 @@ export function deriveMemberLibraryPendingBadges(
   item: Pick<LibraryItem, "title" | "source" | "detailStatus" | "coverUrl" | "coverQualityStatus" | "needsCoverReview">
 ): string[] {
   const badges: string[] = [];
-  const coverMissing = !resolveMemberApprovedLibraryCoverUrl(item);
+  const coverMissing = !resolveMemberVisibleLibraryCoverUrl(item);
   if (coverMissing) badges.push("Cover pending");
   if (item.detailStatus === "enriching" || item.detailStatus === "sparse") badges.push("Details pending");
   if (item.source === "manual" && titleLooksManualPlaceholder(item.title)) badges.push("Staff finishing metadata");

--- a/web/src/views/DashboardView.tsx
+++ b/web/src/views/DashboardView.tsx
@@ -888,7 +888,7 @@ export default function DashboardView({
           </div>
           <div className="hero-actions">
             <button className="btn btn-primary" onClick={onOpenKilnRentals}>
-              Kiln rentals
+              Firing Services
             </button>
             <button className="btn btn-ghost" onClick={onOpenStudioResources}>
               Studio &amp; resources

--- a/web/src/views/IntegrationsView.tsx
+++ b/web/src/views/IntegrationsView.tsx
@@ -56,7 +56,7 @@ type EventsFeedResponse = {
 type ScopeOption = { key: string; label: string; description: string };
 
 const SCOPE_OPTIONS: ScopeOption[] = [
-  { key: "batches:read", label: "Batches (read)", description: "Read your kiln rental batches and high-level status." },
+  { key: "batches:read", label: "Batches (read)", description: "Read your firing service batches and high-level status." },
   { key: "timeline:read", label: "Timeline (read)", description: "Read batch timeline events." },
   { key: "firings:read", label: "Firings (read)", description: "Read the studio firing schedule." },
   { key: "pieces:read", label: "Pieces (read)", description: "Read your pieces (future)." },

--- a/web/src/views/KilnRentalsView.tsx
+++ b/web/src/views/KilnRentalsView.tsx
@@ -17,7 +17,7 @@ export default function KilnRentalsView({
     <div className="page kiln-rentals-page">
       <div className="page-header">
         <div>
-          <h1>Kiln Rentals</h1>
+          <h1>Firing Services</h1>
         </div>
       </div>
 
@@ -55,7 +55,7 @@ export default function KilnRentalsView({
               src={flowImage840Png}
               srcSet={`${flowImage840Png} 840w, ${flowImage1200Png} 1200w`}
               sizes="(min-width: 901px) 420px, 92vw"
-              alt="Kiln rentals flow overview"
+              alt="Firing services flow overview"
               loading="lazy"
               decoding="async"
               fetchPriority="low"

--- a/web/src/views/LendingLibraryView.test.ts
+++ b/web/src/views/LendingLibraryView.test.ts
@@ -70,7 +70,7 @@ describe("Lending library normalizers", () => {
     });
   });
 
-  it("uses an explicit pending placeholder for both pending-review and missing-cover items", () => {
+  it("shows stored cover art for member-facing pending-review items", () => {
     expect(
       resolveMemberLibraryCoverDisplay({
         title: "Pending Review",
@@ -79,12 +79,12 @@ describe("Lending library normalizers", () => {
         needsCoverReview: true,
       })
     ).toEqual({
-      kind: "placeholder",
-      label: "Cover pending",
-      accent: "Staff review",
-      ariaLabel: "Pending Review cover unavailable",
+      kind: "cover",
+      coverUrl: "https://covers.openlibrary.org/b/id/12345-M.jpg",
     });
+  });
 
+  it("uses an explicit pending placeholder when no cover art exists yet", () => {
     expect(
       resolveMemberLibraryCoverDisplay({
         title: "Missing Cover",
@@ -101,6 +101,17 @@ describe("Lending library normalizers", () => {
   });
 
   it("derives member-facing pending badges from incomplete metadata signals", () => {
+    expect(
+      deriveMemberLibraryPendingBadges({
+        title: "ISBN 9780596007126",
+        source: "manual",
+        detailStatus: "sparse",
+        coverUrl: "https://covers.openlibrary.org/b/id/12345-M.jpg",
+        coverQualityStatus: "needs_review",
+        needsCoverReview: true,
+      })
+    ).toEqual(["Details pending", "Staff finishing metadata"]);
+
     expect(
       deriveMemberLibraryPendingBadges({
         title: "ISBN 9780596007126",

--- a/web/src/views/LendingLibraryView.tsx
+++ b/web/src/views/LendingLibraryView.tsx
@@ -261,7 +261,7 @@ function formatAvailability(item: LibraryItem) {
 
 function renderMemberLibraryCover(item: LibraryItem) {
   const coverDisplay = resolveMemberLibraryCoverDisplay(item);
-  if (coverDisplay.kind === "approved") {
+  if (coverDisplay.kind === "cover") {
     return <img className="library-cover" src={coverDisplay.coverUrl} alt={item.title} />;
   }
   return (
@@ -337,6 +337,14 @@ function formatTechniqueLabel(raw: string): string {
   const cleaned = raw.trim();
   if (!cleaned) return "Technique";
   return capitalizeWords(cleaned);
+}
+
+function isPlaceholderLibraryBrowseTitle(value: unknown): boolean {
+  return typeof value === "string" && /^isbn\s+[0-9x-]+$/i.test(value.trim());
+}
+
+function shouldHideLibraryBrowsePlaceholder(item: Pick<LibraryItem, "title">): boolean {
+  return isPlaceholderLibraryBrowseTitle(item.title);
 }
 
 function inferLibraryNarrativeTag(item: LibraryItem): "Fiction" | "Non-fiction" | null {
@@ -1673,8 +1681,9 @@ export default function LendingLibraryView({ user, adminToken, isStaff }: Props)
   }, [reloadItems]);
 
   const buildDiscoveryRailsFromRows = useCallback((rows: LibraryItem[], limit: number): DiscoveryRail[] => {
+    const browseRows = rows.filter((entry) => !shouldHideLibraryBrowsePlaceholder(entry));
     const byTitle = (a: LibraryItem, b: LibraryItem) => normalizeLibraryToken(a.title).localeCompare(normalizeLibraryToken(b.title));
-    const staffPicks = rows
+    const staffPicks = browseRows
       .filter((entry) => entry.curation?.staffPick === true)
       .sort((a, b) => {
         const rankA = typeof a.curation?.shelfRank === "number" ? a.curation.shelfRank : Number.POSITIVE_INFINITY;
@@ -1683,21 +1692,21 @@ export default function LendingLibraryView({ user, adminToken, isStaff }: Props)
         return byTitle(a, b);
       })
       .slice(0, Math.min(limit, STAFF_PICKS_LIMIT));
-    const mostBorrowed = [...rows]
+    const mostBorrowed = [...browseRows]
       .sort((a, b) => {
         const delta = (b.borrowCount ?? 0) - (a.borrowCount ?? 0);
         if (delta !== 0) return delta;
         return byTitle(a, b);
       })
       .slice(0, limit);
-    const recentlyAdded = [...rows]
+    const recentlyAdded = [...browseRows]
       .sort((a, b) => {
         const delta = asMs(b.createdAt) - asMs(a.createdAt);
         if (delta !== 0) return delta;
         return byTitle(a, b);
       })
       .slice(0, limit);
-    const recentlyReviewed = [...rows]
+    const recentlyReviewed = [...browseRows]
       .sort((a, b) => {
         const delta = itemLastReviewedMs(b) - itemLastReviewedMs(a);
         if (delta !== 0) return delta;
@@ -1746,18 +1755,16 @@ export default function LendingLibraryView({ user, adminToken, isStaff }: Props)
           response.data?.data && typeof response.data.data === "object"
             ? response.data.data
             : response.data;
-        const staffPicks = readDiscoverySectionRows(payload?.staffPicks).map((row, index) =>
-          normalizeLibraryItem(safeString(row.id) ?? `staff-pick-${index + 1}`, row as Partial<LibraryItem>)
-        );
-        const mostBorrowed = readDiscoverySectionRows(payload?.mostBorrowed).map((row, index) =>
-          normalizeLibraryItem(safeString(row.id) ?? `most-borrowed-${index + 1}`, row as Partial<LibraryItem>)
-        );
-        const recentlyAdded = readDiscoverySectionRows(payload?.recentlyAdded).map((row, index) =>
-          normalizeLibraryItem(safeString(row.id) ?? `recently-added-${index + 1}`, row as Partial<LibraryItem>)
-        );
-        const recentlyReviewed = readDiscoverySectionRows(payload?.recentlyReviewed).map((row, index) =>
-          normalizeLibraryItem(safeString(row.id) ?? `recently-reviewed-${index + 1}`, row as Partial<LibraryItem>)
-        );
+        const normalizeDiscoveryRows = (sectionRows: Record<string, unknown>[], fallbackPrefix: string) =>
+          sectionRows
+            .map((row, index) =>
+              normalizeLibraryItem(safeString(row.id) ?? `${fallbackPrefix}-${index + 1}`, row as Partial<LibraryItem>)
+            )
+            .filter((item) => !shouldHideLibraryBrowsePlaceholder(item));
+        const staffPicks = normalizeDiscoveryRows(readDiscoverySectionRows(payload?.staffPicks), "staff-pick");
+        const mostBorrowed = normalizeDiscoveryRows(readDiscoverySectionRows(payload?.mostBorrowed), "most-borrowed");
+        const recentlyAdded = normalizeDiscoveryRows(readDiscoverySectionRows(payload?.recentlyAdded), "recently-added");
+        const recentlyReviewed = normalizeDiscoveryRows(readDiscoverySectionRows(payload?.recentlyReviewed), "recently-reviewed");
         featuredWorkshops = readDiscoverySectionRows(payload?.featuredWorkshops)
           .map((row, index) => normalizeWorkshopDiscoveryEvent(row, `featured-workshop-${index + 1}`))
           .slice(0, WORKSHOP_DISCOVERY_LIMIT);
@@ -2317,8 +2324,13 @@ export default function LendingLibraryView({ user, adminToken, isStaff }: Props)
     });
   }, [discoveryWorkshops, discoveryWorkshopSignalSummary, discoveryWorkshopsSource]);
 
+  const browseableItems = useMemo(
+    () => items.filter((item) => !shouldHideLibraryBrowsePlaceholder(item)),
+    [items],
+  );
+
   const filteredItems = useMemo(() => {
-    if (itemsSource === "api_v1") return items;
+    if (itemsSource === "api_v1") return browseableItems;
 
     const searchTerm = debouncedSearch.toLowerCase();
     const genreToken = normalizeLibraryToken(catalogFilters.genre);
@@ -2328,7 +2340,7 @@ export default function LendingLibraryView({ user, adminToken, isStaff }: Props)
     const ratingMin = catalogFilters.ratingMin;
     const ratingMax = catalogFilters.ratingMax;
 
-    const rows = items.filter((item) => {
+    const rows = browseableItems.filter((item) => {
       if (mediaTypes.size > 0 && !mediaTypes.has(normalizeLibraryToken(item.mediaType))) return false;
       if (genreToken) {
         const itemGenre = normalizeLibraryToken(item.genre || item.primaryGenre);
@@ -2391,7 +2403,7 @@ export default function LendingLibraryView({ user, adminToken, isStaff }: Props)
       return titleDelta;
     });
     return rows;
-  }, [catalogFilters, debouncedSearch, items, itemsSource]);
+  }, [browseableItems, catalogFilters, debouncedSearch, itemsSource]);
   const activeFilterCount = useMemo(
     () => countActiveCatalogFilters(catalogFilters, search),
     [catalogFilters, search],
@@ -2410,8 +2422,14 @@ export default function LendingLibraryView({ user, adminToken, isStaff }: Props)
   const rails = discoveryRails;
   const selectedItem = useMemo(() => {
     if (!selectedItemId) return null;
-    if (selectedItemDetail?.id === selectedItemId) return selectedItemDetail;
-    return itemMap.get(selectedItemId) ?? discoveryItemMap.get(selectedItemId) ?? null;
+    const candidate =
+      selectedItemDetail?.id === selectedItemId
+        ? selectedItemDetail
+        : itemMap.get(selectedItemId) ?? discoveryItemMap.get(selectedItemId) ?? null;
+    if (candidate && shouldHideLibraryBrowsePlaceholder(candidate)) {
+      return null;
+    }
+    return candidate;
   }, [discoveryItemMap, itemMap, selectedItemDetail, selectedItemId]);
   const selectedItemSummary = useMemo(
     () => (selectedItem ? resolveLibrarySummaryText(selectedItem) : null),

--- a/web/src/views/LendingLibraryView.ui.test.tsx
+++ b/web/src/views/LendingLibraryView.ui.test.tsx
@@ -203,4 +203,72 @@ describe("LendingLibraryView member detail value cues", () => {
     expect(await screen.findByText("Why this title matters")).toBeTruthy();
     expect(screen.getByText("More details are still being added for this title.")).toBeTruthy();
   });
+
+  it("renders stored cover art on the shelf even while metadata review is still pending", async () => {
+    mockListItems = [
+      {
+        id: "item-3",
+        title: "Surface Design Atlas",
+        authors: ["Studio Staff"],
+        summary: "Member-facing synopsis.",
+        detailStatus: "ready",
+        totalCopies: 1,
+        availableCopies: 1,
+        status: "available",
+        source: "openlibrary",
+        coverUrl: "https://covers.openlibrary.org/b/id/12345-M.jpg",
+        coverQualityStatus: "needs_review",
+        needsCoverReview: true,
+      },
+    ];
+    mockDetailItem = {
+      ...mockListItems[0],
+      relatedWorkshops: [],
+    };
+
+    render(<LendingLibraryView user={buildUser()} adminToken="" isStaff={false} />);
+
+    expect(await screen.findByText("Surface Design Atlas")).toBeTruthy();
+    const coverImage = screen.getByRole("img", { name: "Surface Design Atlas" }) as HTMLImageElement;
+    expect(coverImage.getAttribute("src")).toBe("https://covers.openlibrary.org/b/id/12345-M.jpg");
+    expect(screen.queryByText("Cover pending")).toBeNull();
+  });
+
+  it("hides placeholder ISBN rows from the shared browse shelf", async () => {
+    mockListItems = [
+      {
+        id: "item-placeholder",
+        title: "ISBN 9789188805553",
+        authors: [],
+        detailStatus: "sparse",
+        totalCopies: 1,
+        availableCopies: 1,
+        status: "available",
+        source: "manual",
+      },
+      {
+        id: "item-ready",
+        title: "Flood",
+        authors: ["Stephen Baxter"],
+        summary: "Flood novel.",
+        detailStatus: "ready",
+        totalCopies: 1,
+        availableCopies: 1,
+        status: "available",
+        source: "openlibrary",
+        coverUrl: "https://covers.openlibrary.org/b/id/9543682-L.jpg",
+        coverQualityStatus: "approved",
+        needsCoverReview: false,
+      },
+    ];
+    mockDetailItem = {
+      ...mockListItems[1],
+      relatedWorkshops: [],
+    };
+
+    render(<LendingLibraryView user={buildUser()} adminToken="" isStaff={true} />);
+
+    expect(await screen.findByText("Flood")).toBeTruthy();
+    expect(screen.queryByText("ISBN 9789188805553")).toBeNull();
+  });
 });

--- a/website/ab/a/index.html
+++ b/website/ab/a/index.html
@@ -47,7 +47,7 @@
           <h1 class="hero-title">Production Ceramics Studio Serving Working Potters.</h1>
           <p class="lead">Monsoon Fire is a home production ceramics studio making resources available to local potters. We focus on firing other artist's work in our kilns, renting our studio and studio resources, and providing community to local potters.</p>
           <div class="cta-row">
-            <a class="button button-primary" href="/kiln-firing/">Kiln rentals</a>
+            <a class="button button-primary" href="/kiln-firing/">Firing Services</a>
             <a class="button button-ghost" href="/services/#studio-resources">Studio and Resources</a>
             <a class="button button-ghost" href="/services/#community">community</a>
           </div>
@@ -74,9 +74,9 @@
         </div>
         <div class="feature-grid">
           <div class="feature">
-            <h3>Kiln rentals</h3>
+            <h3>Firing Services</h3>
             <p>Reliable firing for outside work with a steady cadence.</p>
-            <a class="text-link" href="/kiln-firing/">See kiln rentals</a>
+            <a class="text-link" href="/kiln-firing/">See firing services</a>
           </div>
           <div class="feature">
             <h3>Studio and Resources</h3>
@@ -124,7 +124,7 @@
         </div>
         <div>
           <div class="heading-block">
-            <p class="eyebrow">Kiln rental workflow</p>
+            <p class="eyebrow">Firing Services workflow</p>
             <h2 class="section-title">Your work, our kilns.</h2>
             <p class="lead">The MF Portal allows us to digitally track all work throughout our services.</p>
           </div>
@@ -138,7 +138,7 @@
             <li>
               <div>
                 <h3>Queue planning</h3>
-                <p>Work is added to the appropriate kiln queue. Whole kiln rental or expedited firings available.</p>
+                <p>Work is added to the appropriate kiln queue. Whole-kiln firings and expedited options are available.</p>
               </div>
             </li>
             <li>

--- a/website/ab/b/index.html
+++ b/website/ab/b/index.html
@@ -47,7 +47,7 @@
           <h1 class="hero-title">Production Ceramics Studio Serving Working Potters.</h1>
           <p class="lead">Monsoon Fire is a home production ceramics studio making resources available to local potters. We focus on firing other artist's work in our kilns, renting our studio and studio resources, and providing community to local potters.</p>
           <div class="cta-row">
-            <a class="button button-primary" href="/kiln-firing/">Kiln rentals</a>
+            <a class="button button-primary" href="/kiln-firing/">Firing Services</a>
             <a class="button button-ghost" href="/services/#studio-resources">Studio and Resources</a>
             <a class="button button-ghost" href="/services/#community">community</a>
           </div>
@@ -74,9 +74,9 @@
         </div>
         <div class="feature-grid">
           <div class="feature">
-            <h3>Kiln rentals</h3>
+            <h3>Firing Services</h3>
             <p>Reliable firing for outside work with a steady cadence.</p>
-            <a class="text-link" href="/kiln-firing/">See kiln rentals</a>
+            <a class="text-link" href="/kiln-firing/">See firing services</a>
           </div>
           <div class="feature">
             <h3>Studio and Resources</h3>
@@ -124,7 +124,7 @@
         </div>
         <div>
           <div class="heading-block">
-            <p class="eyebrow">Kiln rental workflow</p>
+            <p class="eyebrow">Firing Services workflow</p>
             <h2 class="section-title">Your work, our kilns.</h2>
             <p class="lead">The MF Portal allows us to digitally track all work throughout our services.</p>
           </div>
@@ -138,7 +138,7 @@
             <li>
               <div>
                 <h3>Queue planning</h3>
-                <p>Work is added to the appropriate kiln queue. Whole kiln rental or expedited firings available.</p>
+                <p>Work is added to the appropriate kiln queue. Whole-kiln firings and expedited options are available.</p>
               </div>
             </li>
             <li>

--- a/website/index.html
+++ b/website/index.html
@@ -67,7 +67,7 @@
           <p class="lead">Monsoon Fire is a home production ceramics studio making resources available to local potters. We focus on firing other artist's work in our kilns, renting our studio and studio resources, and providing community to local potters.</p>
           <div class="cta-row">
             <a class="button button-primary" href="https://portal.monsoonfire.com" target="_blank" rel="noopener noreferrer">Open the portal</a>
-            <a class="button button-ghost" href="/kiln-firing/">Kiln rentals</a>
+            <a class="button button-ghost" href="/kiln-firing/">Firing Services</a>
             <a class="button button-ghost" href="/services/#studio-resources">Studio and resources</a>
             <a class="button button-ghost" href="/services/#community">Community</a>
           </div>
@@ -158,9 +158,9 @@
         </div>
         <div class="feature-grid">
           <div class="feature">
-            <h3>Kiln rentals</h3>
+            <h3>Firing Services</h3>
             <p>Reliable firing for outside work with a steady cadence.</p>
-            <a class="text-link" href="/kiln-firing/">See kiln rentals</a>
+            <a class="text-link" href="/kiln-firing/">See firing services</a>
           </div>
           <div class="feature">
             <h3>Studio and Resources</h3>
@@ -208,7 +208,7 @@
         </div>
         <div>
           <div class="heading-block">
-            <p class="eyebrow">Kiln rental workflow</p>
+            <p class="eyebrow">Firing Services workflow</p>
             <h2 class="section-title">Your work, our kilns.</h2>
             <p class="lead">The MF Portal allows us to digitally track all work throughout our services.</p>
           </div>
@@ -222,7 +222,7 @@
             <li>
               <div>
                 <h3>Queue planning</h3>
-                <p>Work is added to the appropriate kiln queue. Whole kiln rental or expedited firings available.</p>
+                <p>Work is added to the appropriate kiln queue. Whole-kiln firings and expedited options are available.</p>
               </div>
             </li>
             <li>

--- a/website/ncsitebuilder/ab/a/index.html
+++ b/website/ncsitebuilder/ab/a/index.html
@@ -47,7 +47,7 @@
           <h1 class="hero-title">Production Ceramics Studio Serving Working Potters.</h1>
           <p class="lead">Monsoon Fire is a home production ceramics studio making resources available to local potters. We focus on firing other artist's work in our kilns, renting our studio and studio resources, and providing community to local potters.</p>
           <div class="cta-row">
-            <a class="button button-primary" href="/kiln-firing/">Kiln rentals</a>
+            <a class="button button-primary" href="/kiln-firing/">Firing Services</a>
             <a class="button button-ghost" href="/services/#studio-resources">Studio and Resources</a>
             <a class="button button-ghost" href="/services/#community">community</a>
           </div>
@@ -74,9 +74,9 @@
         </div>
         <div class="feature-grid">
           <div class="feature">
-            <h3>Kiln rentals</h3>
+            <h3>Firing Services</h3>
             <p>Reliable firing for outside work with a steady cadence.</p>
-            <a class="text-link" href="/kiln-firing/">See kiln rentals</a>
+            <a class="text-link" href="/kiln-firing/">See firing services</a>
           </div>
           <div class="feature">
             <h3>Studio and Resources</h3>
@@ -124,7 +124,7 @@
         </div>
         <div>
           <div class="heading-block">
-            <p class="eyebrow">Kiln rental workflow</p>
+            <p class="eyebrow">Firing Services workflow</p>
             <h2 class="section-title">Your work, our kilns.</h2>
             <p class="lead">The MF Portal allows us to digitally track all work throughout our services.</p>
           </div>
@@ -138,7 +138,7 @@
             <li>
               <div>
                 <h3>Queue planning</h3>
-                <p>Work is added to the appropriate kiln queue. Whole kiln rental or expedited firings available.</p>
+                <p>Work is added to the appropriate kiln queue. Whole-kiln firings and expedited options are available.</p>
               </div>
             </li>
             <li>

--- a/website/ncsitebuilder/ab/b/index.html
+++ b/website/ncsitebuilder/ab/b/index.html
@@ -47,7 +47,7 @@
           <h1 class="hero-title">Production Ceramics Studio Serving Working Potters.</h1>
           <p class="lead">Monsoon Fire is a home production ceramics studio making resources available to local potters. We focus on firing other artist's work in our kilns, renting our studio and studio resources, and providing community to local potters.</p>
           <div class="cta-row">
-            <a class="button button-primary" href="/kiln-firing/">Kiln rentals</a>
+            <a class="button button-primary" href="/kiln-firing/">Firing Services</a>
             <a class="button button-ghost" href="/services/#studio-resources">Studio and Resources</a>
             <a class="button button-ghost" href="/services/#community">community</a>
           </div>
@@ -74,9 +74,9 @@
         </div>
         <div class="feature-grid">
           <div class="feature">
-            <h3>Kiln rentals</h3>
+            <h3>Firing Services</h3>
             <p>Reliable firing for outside work with a steady cadence.</p>
-            <a class="text-link" href="/kiln-firing/">See kiln rentals</a>
+            <a class="text-link" href="/kiln-firing/">See firing services</a>
           </div>
           <div class="feature">
             <h3>Studio and Resources</h3>
@@ -124,7 +124,7 @@
         </div>
         <div>
           <div class="heading-block">
-            <p class="eyebrow">Kiln rental workflow</p>
+            <p class="eyebrow">Firing Services workflow</p>
             <h2 class="section-title">Your work, our kilns.</h2>
             <p class="lead">The MF Portal allows us to digitally track all work throughout our services.</p>
           </div>
@@ -138,7 +138,7 @@
             <li>
               <div>
                 <h3>Queue planning</h3>
-                <p>Work is added to the appropriate kiln queue. Whole kiln rental or expedited firings available.</p>
+                <p>Work is added to the appropriate kiln queue. Whole-kiln firings and expedited options are available.</p>
               </div>
             </li>
             <li>

--- a/website/ncsitebuilder/index.html
+++ b/website/ncsitebuilder/index.html
@@ -67,7 +67,7 @@
           <p class="lead">Monsoon Fire is a home production ceramics studio making resources available to local potters. We focus on firing other artist's work in our kilns, renting our studio and studio resources, and providing community to local potters.</p>
           <div class="cta-row">
             <a class="button button-primary" href="/services/">Get started</a>
-            <a class="button button-ghost" href="/kiln-firing/">Kiln rentals</a>
+            <a class="button button-ghost" href="/kiln-firing/">Firing Services</a>
             <a class="button button-ghost" href="/services/#studio-resources">Studio and resources</a>
             <a class="button button-ghost" href="/services/#community">Community</a>
           </div>
@@ -158,9 +158,9 @@
         </div>
         <div class="feature-grid">
           <div class="feature">
-            <h3>Kiln rentals</h3>
+            <h3>Firing Services</h3>
             <p>Reliable firing for outside work with a steady cadence.</p>
-            <a class="text-link" href="/kiln-firing/">See kiln rentals</a>
+            <a class="text-link" href="/kiln-firing/">See firing services</a>
           </div>
           <div class="feature">
             <h3>Studio and Resources</h3>
@@ -208,7 +208,7 @@
         </div>
         <div>
           <div class="heading-block">
-            <p class="eyebrow">Kiln rental workflow</p>
+            <p class="eyebrow">Firing Services workflow</p>
             <h2 class="section-title">Your work, our kilns.</h2>
             <p class="lead">The MF Portal allows us to digitally track all work throughout our services.</p>
           </div>
@@ -222,7 +222,7 @@
             <li>
               <div>
                 <h3>Queue planning</h3>
-                <p>Work is added to the appropriate kiln queue. Whole kiln rental or expedited firings available.</p>
+                <p>Work is added to the appropriate kiln queue. Whole-kiln firings and expedited options are available.</p>
               </div>
             </li>
             <li>

--- a/website/ncsitebuilder/services/index.html
+++ b/website/ncsitebuilder/services/index.html
@@ -59,9 +59,9 @@
         </div>
         <div class="feature-grid">
           <div class="feature">
-            <h3>Kiln rentals</h3>
+            <h3>Firing Services</h3>
             <p>Reliable firing for outside work with a steady cadence.</p>
-            <a class="text-link" href="/kiln-firing/">See kiln rentals</a>
+            <a class="text-link" href="/kiln-firing/">See firing services</a>
           </div>
           <div class="feature">
             <h3>Studio and resources</h3>
@@ -76,7 +76,7 @@
         </div>
         <div class="cta-row">
           <a class="button button-primary" href="https://portal.monsoonfire.com" data-portal-target="reservations" target="_blank" rel="noopener noreferrer">Get started</a>
-          <a class="button button-ghost" href="/kiln-firing/">See kiln rentals</a>
+          <a class="button button-ghost" href="/kiln-firing/">See firing services</a>
         </div>
         <div class="section-divider" aria-hidden="true"></div>
         <div class="heading-block">
@@ -86,10 +86,10 @@
         </div>
         <div class="feature-grid">
           <article class="feature">
-            <h3>Kiln rentals</h3>
+            <h3>Firing Services</h3>
             <p><strong>Best for:</strong> Potters who already have finished work ready for bisque or glaze firing.</p>
             <p><strong>Next step:</strong> Submit a firing request and choose your delivery or pickup timing.</p>
-            <a href="/kiln-firing/">Start with kiln firing &rarr;</a>
+            <a href="/kiln-firing/">Start with firing services &rarr;</a>
           </article>
           <article class="feature">
             <h3>Studio access</h3>

--- a/website/ncsitebuilder/web.config
+++ b/website/ncsitebuilder/web.config
@@ -13,7 +13,7 @@
     </httpProtocol>
     <rewrite>
       <rules>
-        <rule name="Redirect Kiln Rentals" stopProcessing="true">
+        <rule name="Redirect Firing Services" stopProcessing="true">
           <match url="^Kiln-Rentals/?$" ignoreCase="true" />
           <action type="Redirect" url="/kiln-firing/" redirectType="Permanent" />
         </rule>

--- a/website/services/index.html
+++ b/website/services/index.html
@@ -59,9 +59,9 @@
         </div>
         <div class="feature-grid">
           <div class="feature">
-            <h3>Kiln rentals</h3>
+            <h3>Firing Services</h3>
             <p>Reliable firing for outside work with a steady cadence.</p>
-            <a class="text-link" href="/kiln-firing/">See kiln rentals</a>
+            <a class="text-link" href="/kiln-firing/">See firing services</a>
           </div>
           <div class="feature">
             <h3>Studio and resources</h3>
@@ -76,7 +76,7 @@
         </div>
         <div class="cta-row">
           <a class="button button-primary" href="https://portal.monsoonfire.com" data-portal-target="reservations" target="_blank" rel="noopener noreferrer">Get started</a>
-          <a class="button button-ghost" href="/kiln-firing/">See kiln rentals</a>
+          <a class="button button-ghost" href="/kiln-firing/">See firing services</a>
         </div>
         <div class="section-divider" aria-hidden="true"></div>
         <div class="heading-block">
@@ -86,10 +86,10 @@
         </div>
         <div class="feature-grid">
           <article class="feature">
-            <h3>Kiln rentals</h3>
+            <h3>Firing Services</h3>
             <p><strong>Best for:</strong> Potters who already have finished work ready for bisque or glaze firing.</p>
             <p><strong>Next step:</strong> Submit a firing request and choose your delivery or pickup timing.</p>
-            <a href="/kiln-firing/">Start with kiln firing &rarr;</a>
+            <a href="/kiln-firing/">Start with firing services &rarr;</a>
           </article>
           <article class="feature">
             <h3>Studio access</h3>

--- a/website/tests/marketing-site.spec.mjs
+++ b/website/tests/marketing-site.spec.mjs
@@ -3,6 +3,8 @@ import AxeBuilder from "@axe-core/playwright";
 
 const THEME_STORAGE_KEY = "mf:websiteTheme";
 const ACCESSIBILITY_STORAGE_KEY = "mf:websiteAccessibility";
+const KNOWN_PORTAL_HOSTS = new Set(["monsoonfire.kilnfire.com", "portal.monsoonfire.com"]);
+const EXPECTED_PORTAL_HOST = String(process.env.WEBSITE_EXPECTED_PORTAL_HOST || "portal.monsoonfire.com").trim().toLowerCase();
 
 const majorPages = [
   { path: "./", label: "home", requiredSelector: "main#main h1" },
@@ -108,7 +110,7 @@ test.describe("marketing smoke coverage", () => {
     expect(await links.count()).toBeGreaterThan(0);
   });
 
-  test("portal entry links point to the portal host with scoped experiment params", async ({ page }) => {
+  test("portal entry links point to the selected handoff host with scoped experiment params", async ({ page }) => {
     for (const entry of portalEntryPages) {
       await page.goto(entry.path, { waitUntil: "networkidle" });
       const link = page.locator(entry.selector).first();
@@ -116,10 +118,10 @@ test.describe("marketing smoke coverage", () => {
 
       const href = await link.getAttribute("href");
       expect(href, `Portal entry href missing on ${entry.label}`).toBeTruthy();
-      expect(href, `Legacy kilnfire host remained on ${entry.label}`).not.toContain("monsoonfire.kilnfire.com");
 
       const parsed = new URL(href);
-      expect(parsed.hostname, `Portal host mismatch on ${entry.label}`).toBe("portal.monsoonfire.com");
+      expect(KNOWN_PORTAL_HOSTS.has(parsed.hostname), `Unexpected portal host on ${entry.label}`).toBeTruthy();
+      expect(parsed.hostname, `Portal host mismatch on ${entry.label}`).toBe(EXPECTED_PORTAL_HOST);
       expect(parsed.searchParams.get("mf_experiment"), `Experiment missing on ${entry.label}`).toBe("portal_path_v1");
       expect(parsed.searchParams.get("mf_variant"), `Variant mismatch on ${entry.label}`).toBe(entry.variant);
       expect(parsed.searchParams.get("mf_surface"), `Surface mismatch on ${entry.label}`).toBe(entry.surface);

--- a/website/web.config
+++ b/website/web.config
@@ -13,7 +13,7 @@
     </httpProtocol>
     <rewrite>
       <rules>
-        <rule name="Redirect Kiln Rentals" stopProcessing="true">
+        <rule name="Redirect Firing Services" stopProcessing="true">
           <match url="^Kiln-Rentals/?$" ignoreCase="true" />
           <action type="Redirect" url="/kiln-firing/" redirectType="Permanent" />
         </rule>


### PR DESCRIPTION
## Summary
- make Google sign-in on the portal use popup-first auth with redirect fallback so the direct portal surface is testable again
- add a phase-aware website handoff deploy path so the public site can stay on the legacy handoff until phase 2 approval
- update smoke coverage and RC docs to reflect the phased rollout and current live evidence

## Testing
- npm --prefix web run test:run -- src/lib/authProviderFlow.test.ts
- npm --prefix web run build
- npm run website:smoke:playwright
- node ./scripts/website-playwright-smoke.mjs --base-url https://monsoonfire.com --output-dir output/playwright/prod-phase1-website --expected-portal-host monsoonfire.kilnfire.com
- npm run portal:smoke:playwright:prod

## Deploy notes
- direct portal auth mitigation has been deployed to https://portal.monsoonfire.com for tester validation
- public website was redeployed in phase 1 mode and intentionally still hands off to https://monsoonfire.kilnfire.com
- a real operator Google round-trip is still needed before RC issue 1 can be closed