### PR TITLE
Add Studio Brain chief-of-staff partner layer

### DIFF
--- a/docs/runbooks/STUDIO_BRAIN_CONTROL_TOWER_V2.md
+++ b/docs/runbooks/STUDIO_BRAIN_CONTROL_TOWER_V2.md
@@ -29,6 +29,11 @@ tmux remains only for:
   - Active Rooms
   - Good Next Moves
   - Recent Events
+- `Chief-of-staff partner`
+  - owner-facing brief
+  - verified context
+  - one decision needed next
+  - open-loop controls
 - `Room detail`
   - objective
   - status
@@ -54,6 +59,10 @@ The browser UI is backed by Studio Brain HTTP routes:
 
 - `GET /api/control-tower/state`
 - `GET /api/control-tower/overview`
+- `GET /api/control-tower/partner/latest`
+- `POST /api/control-tower/partner/brief`
+- `POST /api/control-tower/partner/checkins`
+- `POST /api/control-tower/partner/open-loops/:id`
 - `GET /api/control-tower/rooms`
 - `GET /api/control-tower/rooms/:id`
 - `GET /api/control-tower/services`
@@ -71,6 +80,9 @@ Preserved artifacts and metadata:
 - `output/ops-cockpit/operator-state.json`
 - `output/ops-cockpit/agents/*.json`
 - `output/ops-cockpit/agent-status/*.json`
+- `output/studio-brain/partner/latest-brief.json`
+- `output/studio-brain/partner/checkins.jsonl`
+- `output/studio-brain/partner/open-loops.json`
 - `output/stability/heartbeat-summary.json`
 - `output/overseer/latest.json`
 - `output/overseer/discord/latest.json`

--- a/studio-brain/src/agentRuntime/contracts.ts
+++ b/studio-brain/src/agentRuntime/contracts.ts
@@ -1,0 +1,73 @@
+import type { AgentRuntimePartnerContext } from "../partner/contracts";
+
+export type AgentRuntimeRiskLane = "interactive" | "background" | "high_risk";
+export type AgentRuntimeStatus = "queued" | "running" | "blocked" | "verified" | "completed" | "failed";
+
+export type RatholeSignal = {
+  signalId: string;
+  kind: string;
+  severity: "info" | "warning" | "critical";
+  summary: string;
+  recommendedAction: string;
+  createdAt: string;
+  blocking: boolean;
+};
+
+export type GoalMiss = {
+  category:
+    | "bad_grounding"
+    | "tool_mismatch"
+    | "verification_omission"
+    | "hidden_repo_state"
+    | "memory_drift"
+    | "user_intent_miss";
+  summary: string;
+  createdAt: string;
+};
+
+export type RunLedgerEvent = {
+  schema: "agent-run-ledger-event.v1";
+  eventId: string;
+  runId: string;
+  missionId: string;
+  type: string;
+  occurredAt: string;
+  payload: Record<string, unknown>;
+};
+
+export type AgentRuntimeSummary = {
+  schema: "agent-runtime-summary.v1";
+  generatedAt?: string;
+  runId: string;
+  missionId: string;
+  status: AgentRuntimeStatus;
+  riskLane: AgentRuntimeRiskLane;
+  title: string;
+  goal: string;
+  groundingSources: string[];
+  acceptance: {
+    total: number;
+    pending: number;
+    completed: number;
+    failed: number;
+  };
+  activeBlockers: string[];
+  ratholeSignals: RatholeSignal[];
+  memoriesInfluencingRun: string[];
+  goalMisses: GoalMiss[];
+  lastEventType: string | null;
+  updatedAt: string;
+  partner?: AgentRuntimePartnerContext;
+  boardRow: {
+    id: string;
+    owner: string;
+    task: string;
+    state: string;
+    blocker: string;
+    next: string;
+    last_update: string | null;
+    contactReason?: string | null;
+    verifiedContext?: string[];
+    decisionNeeded?: string | null;
+  };
+};

--- a/studio-brain/src/agentRuntime/files.ts
+++ b/studio-brain/src/agentRuntime/files.ts
@@ -1,0 +1,84 @@
+import { appendFileSync, existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import type { AgentRuntimeSummary, RunLedgerEvent } from "./contracts";
+
+const DEFAULT_RUNS_ROOT = ["output", "agent-runs"] as const;
+
+function clean(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function readJsonFile<T>(path: string): T | null {
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, "utf8")) as T;
+  } catch {
+    return null;
+  }
+}
+
+export function agentRuntimeRunsRoot(repoRoot: string): string {
+  return resolve(repoRoot, ...DEFAULT_RUNS_ROOT);
+}
+
+export function agentRuntimeRunRoot(repoRoot: string, runId: string): string {
+  return resolve(agentRuntimeRunsRoot(repoRoot), clean(runId));
+}
+
+export function listAgentRuntimeSummaries(repoRoot: string, limit = 12): AgentRuntimeSummary[] {
+  const runsRoot = agentRuntimeRunsRoot(repoRoot);
+  if (!existsSync(runsRoot)) return [];
+  const summaries = [];
+  for (const entry of readdirSync(runsRoot, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const summary = readJsonFile<AgentRuntimeSummary>(resolve(runsRoot, entry.name, "summary.json"));
+    if (!summary) continue;
+    summaries.push(summary);
+  }
+  return summaries
+    .sort((left, right) => clean(right.updatedAt).localeCompare(clean(left.updatedAt)))
+    .slice(0, Math.max(1, limit));
+}
+
+export function readLatestAgentRuntimeSummary(repoRoot: string): AgentRuntimeSummary | null {
+  const pointer = readJsonFile<{ runId?: string }>(resolve(agentRuntimeRunsRoot(repoRoot), "latest.json"));
+  const pointerRunId = clean(pointer?.runId);
+  if (pointerRunId) {
+    const summary = readJsonFile<AgentRuntimeSummary>(resolve(agentRuntimeRunRoot(repoRoot, pointerRunId), "summary.json"));
+    if (summary) return summary;
+  }
+  return listAgentRuntimeSummaries(repoRoot, 1)[0] ?? null;
+}
+
+export function readAgentRuntimeEvents(repoRoot: string, runId: string, limit = 50): RunLedgerEvent[] {
+  const ledgerPath = resolve(agentRuntimeRunRoot(repoRoot, runId), "run-ledger.jsonl");
+  if (!existsSync(ledgerPath)) return [];
+  const events = [];
+  for (const line of readFileSync(ledgerPath, "utf8").split(/\r?\n/)) {
+    if (!line.trim()) continue;
+    try {
+      events.push(JSON.parse(line));
+    } catch {
+      continue;
+    }
+  }
+  return events.slice(-Math.max(1, limit));
+}
+
+export function appendAgentRuntimeEvent(repoRoot: string, event: RunLedgerEvent): void {
+  const runRoot = agentRuntimeRunRoot(repoRoot, event.runId);
+  mkdirSync(runRoot, { recursive: true });
+  appendFileSync(resolve(runRoot, "run-ledger.jsonl"), `${JSON.stringify(event)}\n`, "utf8");
+}
+
+export function writeAgentRuntimeSummary(repoRoot: string, summary: AgentRuntimeSummary): void {
+  const runRoot = agentRuntimeRunRoot(repoRoot, summary.runId);
+  mkdirSync(runRoot, { recursive: true });
+  writeFileSync(resolve(runRoot, "summary.json"), `${JSON.stringify(summary, null, 2)}\n`, "utf8");
+  writeFileSync(
+    resolve(agentRuntimeRunsRoot(repoRoot), "latest.json"),
+    `${JSON.stringify({ schema: "agent-runtime-pointer.v1", runId: summary.runId, updatedAt: summary.updatedAt }, null, 2)}\n`,
+    "utf8",
+  );
+}

--- a/studio-brain/src/controlTower/derive.ts
+++ b/studio-brain/src/controlTower/derive.ts
@@ -726,6 +726,8 @@ export function deriveControlTowerState(
     memoryBrief,
     startupScorecard: null,
     memoryHealth: null,
+    agentRuntime: null,
+    partner: null,
     events,
     recentChanges: events.slice(0, 6),
     actions,

--- a/studio-brain/src/controlTower/types.ts
+++ b/studio-brain/src/controlTower/types.ts
@@ -1,4 +1,6 @@
 import type { AuditEvent, OverseerRunRecord } from "../stores/interfaces";
+import type { AgentRuntimeSummary } from "../agentRuntime/contracts";
+import type { PartnerBrief } from "../partner/contracts";
 
 export type ControlTowerAgentStatus = "working" | "waiting" | "idle" | "parked" | "error";
 export type ControlTowerHealth = "healthy" | "waiting" | "error" | "neutral";
@@ -184,6 +186,9 @@ export type ControlTowerBoardRow = {
   last_update: string | null;
   roomId: string | null;
   sessionName: string | null;
+  contactReason?: string | null;
+  verifiedContext?: string[];
+  decisionNeeded?: string | null;
 };
 
 export type ControlTowerChannelSummary = {
@@ -297,6 +302,11 @@ export type ControlTowerStartupScorecard = {
   coverage: {
     gaps: string[];
   };
+  launcherCoverage: {
+    liveStartupSamples: number;
+    requiredLiveStartupSamples: number;
+    trustworthy: boolean;
+  };
   rubric: {
     overallScore: number | null;
     grade: string;
@@ -367,6 +377,9 @@ export type ControlTowerRoomSummary = {
   nextActions: ControlTowerNextAction[];
   sessionNames: string[];
   summary: string;
+  contactReason?: string | null;
+  verifiedContext?: string[];
+  decisionNeeded?: string | null;
 };
 
 export type ControlTowerRoomDetail = ControlTowerRoomSummary & {
@@ -427,6 +440,8 @@ export type ControlTowerState = {
   memoryBrief: ControlTowerMemoryBrief;
   startupScorecard: ControlTowerStartupScorecard | null;
   memoryHealth: ControlTowerMemoryHealth | null;
+  agentRuntime: AgentRuntimeSummary | null;
+  partner: PartnerBrief | null;
   events: ControlTowerEvent[];
   recentChanges: ControlTowerEvent[];
   actions: ControlTowerNextAction[];

--- a/studio-brain/src/http/server.test.ts
+++ b/studio-brain/src/http/server.test.ts
@@ -248,6 +248,7 @@ function createControlTowerFixture() {
   mkdirSync(join(root, "output", "studio-brain", "memory-brief"), { recursive: true });
   mkdirSync(join(root, "output", "studio-brain", "memory-consolidation"), { recursive: true });
   mkdirSync(join(root, "output", "qa"), { recursive: true });
+  mkdirSync(join(root, "output", "agent-runs", "run-background-1"), { recursive: true });
 
   writeFileSync(
     join(root, "output", "ops-cockpit", "agents", "sb-room.json"),
@@ -387,11 +388,152 @@ function createControlTowerFixture() {
         coverage: {
           gaps: ["Startup transcript telemetry is only partially captured; 86% of startup entries carried both Grounding and repo-read signals."],
         },
+        launcherCoverage: {
+          liveStartupSamples: 7,
+          requiredLiveStartupSamples: 5,
+          trustworthy: true,
+        },
         rubric: {
           overallScore: 98,
           grade: "A",
         },
         recommendations: ["Startup quality is within the current thresholds; keep collecting history so future regressions are easier to spot."],
+      },
+      null,
+      2,
+    )}\n`,
+    "utf8",
+  );
+
+  writeFileSync(
+    join(root, "output", "agent-runs", "run-background-1", "summary.json"),
+    `${JSON.stringify(
+      {
+        schema: "agent-runtime-summary.v1",
+        generatedAt: "2026-03-30T10:06:00.000Z",
+        runId: "run-background-1",
+        missionId: "mission-background-1",
+        status: "blocked",
+        riskLane: "high_risk",
+        title: "Portal Runtime Mission",
+        goal: "Keep the portal launch lane bounded.",
+        groundingSources: ["codex-startup-preflight", "studio-brain-memory-brief", "git-status"],
+        acceptance: {
+          total: 3,
+          pending: 1,
+          completed: 1,
+          failed: 1,
+        },
+        activeBlockers: ["Verifier checks failed."],
+        ratholeSignals: [
+          {
+            signalId: "rathole-1",
+            kind: "repeat_verifier_failure",
+            severity: "critical",
+            summary: "Verifier checks failed repeatedly without a state change.",
+            recommendedAction: "Re-ground the mission and stop retrying until the blocker is explicit.",
+            createdAt: "2026-03-30T10:06:00.000Z",
+            blocking: true,
+          },
+        ],
+        memoriesInfluencingRun: ["Portal continuity is loaded and ready for the next safe move."],
+        goalMisses: [
+          {
+            category: "verification_omission",
+            summary: "Verifier command failed: npm run startup:check",
+            createdAt: "2026-03-30T10:06:00.000Z",
+          },
+        ],
+        lastEventType: "rathole.detected",
+        updatedAt: "2026-03-30T10:06:00.000Z",
+        partner: {
+          initiativeState: "waiting_on_owner",
+          lastMeaningfulContactAt: "2026-03-30T10:01:00.000Z",
+          nextCheckInAt: "2026-03-30T12:00:00.000Z",
+          cooldownUntil: null,
+          needsOwnerDecision: true,
+          contactReason: "Studio Brain verified the blocked portal lane and is asking for one owner decision before it keeps moving.",
+          verifiedContext: [
+            "Verifier checks failed.",
+            "Portal room is still waiting for direction.",
+            "Memory brief still recommends inspecting the portal lane.",
+          ],
+          singleDecisionNeeded: "Decide whether to unblock the portal lane now or pause it until the verifier is fixed.",
+          idleBudget: {
+            policy: "one_task_at_a_time",
+            maxConcurrentTasks: 1,
+            maxAttemptsPerLoop: 2,
+            rankedBacklog: [
+              "stale blocker cleanup",
+              "unresolved review queues",
+              "memory hygiene",
+            ],
+            verifyBeforeReport: true,
+            contactOnlyOnMeaningfulChange: true,
+          },
+          openLoops: [
+            {
+              id: "room:portal",
+              title: "Portal lane waiting on decision",
+              status: "open",
+              summary: "Portal room is blocked behind verifier drift and still needs a bounded next move.",
+              next: "Inspect portal lane",
+              source: "control-tower-room:portal",
+              updatedAt: "2026-03-30T10:06:00.000Z",
+              roomId: "portal",
+              sessionName: "sb-room",
+              decisionNeeded: "Decide whether to unblock, pause, or redirect this lane.",
+              verifiedContext: [
+                "Portal room stayed attached to the operator board.",
+                "Verifier checks failed repeatedly.",
+              ],
+              evidence: ["monsoonfire-portal", "Codex", "sb-room"],
+            },
+          ],
+        },
+        boardRow: {
+          id: "agent-runtime:run-background-1",
+          owner: "agent-runtime",
+          task: "Portal Runtime Mission",
+          state: "blocked",
+          blocker: "Verifier checks failed.",
+          next: "Inspect runtime",
+          last_update: "2026-03-30T10:06:00.000Z",
+          contactReason: "Studio Brain verified the blocked portal lane and is asking for one owner decision before it keeps moving.",
+          verifiedContext: [
+            "Verifier checks failed.",
+            "Portal room is still waiting for direction.",
+          ],
+          decisionNeeded: "Decide whether to unblock the portal lane now or pause it until the verifier is fixed.",
+        },
+      },
+      null,
+      2,
+    )}\n`,
+    "utf8",
+  );
+
+  writeFileSync(
+    join(root, "output", "agent-runs", "run-background-1", "run-ledger.jsonl"),
+    `${JSON.stringify({
+      schema: "agent-run-ledger-event.v1",
+      eventId: "evt-1",
+      runId: "run-background-1",
+      missionId: "mission-background-1",
+      type: "mission.state.changed",
+      occurredAt: "2026-03-30T10:06:00.000Z",
+      payload: { status: "blocked" },
+    })}\n`,
+    "utf8",
+  );
+
+  writeFileSync(
+    join(root, "output", "agent-runs", "latest.json"),
+    `${JSON.stringify(
+      {
+        schema: "agent-runtime-pointer.v1",
+        runId: "run-background-1",
+        updatedAt: "2026-03-30T10:06:00.000Z",
       },
       null,
       2,
@@ -1229,6 +1371,58 @@ test("memory endpoints require staff auth", async () => {
     });
     assert.equal(nonStaff.status, 401);
   });
+});
+
+test("memory consolidation executes on the host control plane and records an audit event", async () => {
+  const eventStore = new MemoryEventStore();
+  await withServer(
+    {
+      eventStore,
+      adminToken: "admin-secret",
+    },
+    async (baseUrl) => {
+      const blocked = await fetch(`${baseUrl}/api/memory/consolidate`, {
+        method: "POST",
+        headers: { "content-type": "application/json", authorization: "Bearer test-staff" },
+        body: JSON.stringify({ mode: "idle", runId: "memory-consolidation-test-blocked" }),
+      });
+      assert.equal(blocked.status, 401);
+
+      const response = await fetch(`${baseUrl}/api/memory/consolidate`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: "Bearer test-staff",
+          "x-studio-brain-admin-token": "admin-secret",
+        },
+        body: JSON.stringify({
+          mode: "idle",
+          runId: "memory-consolidation-test",
+          maxCandidates: 10,
+          maxWrites: 5,
+          timeBudgetMs: 15000,
+          focusAreas: ["Portal continuity"],
+          requestOrigin: "studio-brain-mcp",
+          requestedTransport: "http",
+        }),
+      });
+
+      assert.equal(response.status, 200);
+      const payload = await response.json() as {
+        ok: boolean;
+        result: {
+          status: string;
+          focusAreas?: string[];
+        };
+      };
+      assert.equal(payload.ok, true);
+      assert.equal(typeof payload.result?.status, "string");
+      assert.equal(payload.result?.focusAreas?.includes("Portal continuity"), true);
+
+      const rows = await eventStore.listRecent(10);
+      assert.equal(rows.some((row) => row.action === "studio_brain.memory_consolidated"), true);
+    },
+  );
 });
 
 test("memory ingest endpoint is disabled by default", async () => {
@@ -3005,6 +3199,18 @@ test("control tower state routes derive browser-friendly room and service data",
               metrics: { readyRate: number | null; groundingReadyRate: number | null; blockedContinuityRate: number | null; p95LatencyMs: number | null };
               supportingSignals: { toolcalls: { telemetryCoverageRate: number | null } };
               coverage: { gaps: string[] };
+              launcherCoverage: { liveStartupSamples: number; trustworthy: boolean };
+            } | null;
+            agentRuntime: {
+              status: string;
+              boardRow: { owner: string; state: string; blocker: string };
+            } | null;
+            partner: {
+              initiativeState: string;
+              needsOwnerDecision: boolean;
+              contactReason: string;
+              singleDecisionNeeded: string | null;
+              openLoops: Array<{ id: string; status: string; roomId: string | null }>;
             } | null;
             memoryHealth: {
               severity: string;
@@ -3024,9 +3230,10 @@ test("control tower state routes derive browser-friendly room and service data",
         assert.ok(payload.state.overview.needsAttention.length >= 1);
         assert.ok(payload.state.pinnedItems.some((entry) => entry.title === "Discord Relay is down"));
         assert.ok(payload.state.services.some((entry) => entry.id === "studio-brain-discord-relay" && entry.health === "error"));
-        assert.equal(payload.state.board[0]?.owner, "Memory maintenance");
-        assert.equal(payload.state.board[1]?.owner, "Codex");
-        assert.match(payload.state.board[1]?.task ?? "", /Investigate portal issue/i);
+        assert.equal(payload.state.board[0]?.owner, "agent-runtime");
+        assert.equal(payload.state.board.some((entry) => entry.owner === "Memory maintenance"), true);
+        assert.equal(payload.state.board.some((entry) => entry.owner === "Codex"), true);
+        assert.equal(payload.state.board.find((entry) => entry.owner === "Codex")?.task?.includes("Investigate portal issue"), true);
         assert.equal(payload.state.memoryBrief.continuityState, "ready");
         assert.equal(payload.state.memoryBrief.consolidation.mode, "scheduled");
         assert.ok(payload.state.memoryBrief.consolidation.focusAreas.includes("Portal continuity"));
@@ -3044,6 +3251,17 @@ test("control tower state routes derive browser-friendly room and service data",
         assert.equal(payload.state.startupScorecard?.metrics.p95LatencyMs, 950);
         assert.equal(payload.state.startupScorecard?.supportingSignals.toolcalls.telemetryCoverageRate, 0.86);
         assert.equal(payload.state.startupScorecard?.coverage.gaps.length, 1);
+        assert.equal(payload.state.startupScorecard?.launcherCoverage.liveStartupSamples, 7);
+        assert.equal(payload.state.startupScorecard?.launcherCoverage.trustworthy, true);
+        assert.equal(payload.state.agentRuntime?.status, "blocked");
+        assert.equal(payload.state.agentRuntime?.boardRow.owner, "agent-runtime");
+        assert.equal(payload.state.board[0]?.owner, "agent-runtime");
+        assert.equal(payload.state.partner?.initiativeState, "waiting_on_owner");
+        assert.equal(payload.state.partner?.needsOwnerDecision, true);
+        assert.match(payload.state.partner?.contactReason ?? "", /owner decision/i);
+        assert.match(payload.state.partner?.singleDecisionNeeded ?? "", /unblock the portal lane|pause/i);
+        assert.equal(payload.state.partner?.openLoops[0]?.id, "room:portal");
+        assert.equal(payload.state.partner?.openLoops[0]?.roomId, "portal");
         assert.equal(payload.state.memoryHealth?.severity, "critical");
         assert.equal((payload.state.memoryHealth?.startupReadiness.startupEligibleRows ?? 0) >= 1, true);
         assert.equal((payload.state.memoryHealth?.startupReadiness.handoffRows ?? 0) >= 1, true);
@@ -3391,6 +3609,178 @@ test("control tower promotes memory next moves only when startup quality is degr
           payload.state.overview.goodNextMoves.some((entry) => entry.actionLabel === "Review memory"),
           true,
         );
+      },
+    );
+  } finally {
+    fixture.cleanup();
+  }
+});
+
+test("agent runtime routes expose latest summary and accept webhook events", async () => {
+  const fixture = createControlTowerFixture();
+  const { runner } = createControlTowerRunner();
+
+  try {
+    await withServer(
+      {
+        controlTowerRepoRoot: fixture.root,
+        controlTowerRunner: runner,
+      },
+      async (baseUrl) => {
+        const latestResponse = await fetch(`${baseUrl}/api/agent-runtime/latest`, {
+          headers: { authorization: "Bearer test-staff" },
+        });
+        assert.equal(latestResponse.status, 200);
+        const latestPayload = (await latestResponse.json()) as {
+          ok: boolean;
+          summary: { runId: string; status: string } | null;
+          events: Array<{ type: string }>;
+        };
+        assert.equal(latestPayload.ok, true);
+        assert.equal(latestPayload.summary?.runId, "run-background-1");
+        assert.equal(latestPayload.summary?.status, "blocked");
+        assert.equal(latestPayload.events[0]?.type, "mission.state.changed");
+
+        const eventResponse = await fetch(`${baseUrl}/api/agent-runtime/events`, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            authorization: "Bearer test-staff",
+          },
+          body: JSON.stringify({
+            event: {
+              schema: "agent-run-ledger-event.v1",
+              eventId: "evt-2",
+              runId: "run-background-2",
+              missionId: "mission-background-2",
+              type: "mission.started",
+              occurredAt: "2026-03-30T10:10:00.000Z",
+              payload: { title: "Second runtime mission" },
+            },
+            summary: {
+              schema: "agent-runtime-summary.v1",
+              runId: "run-background-2",
+              missionId: "mission-background-2",
+              status: "running",
+              riskLane: "background",
+              title: "Second runtime mission",
+              goal: "Stay bounded",
+              groundingSources: ["codex-startup-preflight"],
+              acceptance: { total: 1, pending: 1, completed: 0, failed: 0 },
+              activeBlockers: [],
+              ratholeSignals: [],
+              memoriesInfluencingRun: ["Memory"],
+              goalMisses: [],
+              lastEventType: "mission.started",
+              updatedAt: "2026-03-30T10:10:00.000Z",
+              boardRow: {
+                id: "agent-runtime:run-background-2",
+                owner: "agent-runtime",
+                task: "Second runtime mission",
+                state: "running",
+                blocker: "none",
+                next: "Run verifier",
+                last_update: "2026-03-30T10:10:00.000Z",
+              },
+            },
+          }),
+        });
+        assert.equal(eventResponse.status, 202);
+
+        const runsResponse = await fetch(`${baseUrl}/api/agent-runtime/runs`, {
+          headers: { authorization: "Bearer test-staff" },
+        });
+        assert.equal(runsResponse.status, 200);
+        const runsPayload = (await runsResponse.json()) as {
+          ok: boolean;
+          runs: Array<{ runId: string }>;
+        };
+        assert.equal(runsPayload.ok, true);
+        assert.equal(runsPayload.runs.some((entry) => entry.runId === "run-background-2"), true);
+      },
+    );
+  } finally {
+    fixture.cleanup();
+  }
+});
+
+test("partner routes generate briefs, record owner commands, and update open loops", async () => {
+  const fixture = createControlTowerFixture();
+  const { runner } = createControlTowerRunner();
+  const stateStore = new MemoryStateStore();
+  await stateStore.saveOverseerRun(buildSampleOverseerRun());
+
+  try {
+    await withServer(
+      {
+        stateStore,
+        controlTowerRepoRoot: fixture.root,
+        controlTowerRunner: runner,
+      },
+      async (baseUrl) => {
+        const authHeaders = {
+          authorization: "Bearer test-staff",
+          "content-type": "application/json",
+        };
+
+        const latestResponse = await fetch(`${baseUrl}/api/control-tower/partner/latest`, {
+          headers: { authorization: "Bearer test-staff" },
+        });
+        assert.equal(latestResponse.status, 200);
+        const latestPayload = (await latestResponse.json()) as {
+          ok: boolean;
+          partner: { initiativeState: string; openLoops: Array<{ id: string; status: string }> } | null;
+          checkins: Array<{ action: string }>;
+        };
+        assert.equal(latestPayload.ok, true);
+        assert.equal(latestPayload.partner?.initiativeState, "waiting_on_owner");
+        assert.equal(latestPayload.partner?.openLoops[0]?.id, "room:portal");
+        assert.equal(latestPayload.checkins.length, 0);
+
+        const snoozeResponse = await fetch(`${baseUrl}/api/control-tower/partner/checkins`, {
+          method: "POST",
+          headers: authHeaders,
+          body: JSON.stringify({ action: "snooze", snoozeMinutes: 90, note: "Quiet until after lunch." }),
+        });
+        assert.equal(snoozeResponse.status, 200);
+        const snoozePayload = (await snoozeResponse.json()) as {
+          ok: boolean;
+          partner: { initiativeState: string; cooldownUntil: string | null; nextCheckInAt: string | null } | null;
+        };
+        assert.equal(snoozePayload.ok, true);
+        assert.equal(snoozePayload.partner?.initiativeState, "cooldown");
+        assert.ok(Boolean(snoozePayload.partner?.cooldownUntil));
+        assert.equal(snoozePayload.partner?.cooldownUntil, snoozePayload.partner?.nextCheckInAt);
+
+        const delegateResponse = await fetch(`${baseUrl}/api/control-tower/partner/open-loops/${encodeURIComponent("room:portal")}`, {
+          method: "POST",
+          headers: authHeaders,
+          body: JSON.stringify({ status: "delegated", note: "Redirect this to the verifier repair lane." }),
+        });
+        assert.equal(delegateResponse.status, 200);
+        const delegatePayload = (await delegateResponse.json()) as {
+          ok: boolean;
+          partner: { openLoops: Array<{ id: string; status: string }> } | null;
+          openLoop: { id: string; status: string } | null;
+        };
+        assert.equal(delegatePayload.ok, true);
+        assert.equal(delegatePayload.openLoop?.id, "room:portal");
+        assert.equal(delegatePayload.openLoop?.status, "delegated");
+        assert.equal(delegatePayload.partner?.openLoops.find((entry) => entry.id === "room:portal")?.status, "delegated");
+
+        const latestAfterResponse = await fetch(`${baseUrl}/api/control-tower/partner/latest`, {
+          headers: { authorization: "Bearer test-staff" },
+        });
+        assert.equal(latestAfterResponse.status, 200);
+        const latestAfterPayload = (await latestAfterResponse.json()) as {
+          ok: boolean;
+          partner: { openLoops: Array<{ id: string; status: string }> } | null;
+          checkins: Array<{ action: string }>;
+        };
+        assert.equal(latestAfterPayload.ok, true);
+        assert.equal(latestAfterPayload.checkins.some((entry) => entry.action === "snooze"), true);
+        assert.equal(latestAfterPayload.checkins.some((entry) => entry.action === "redirect"), true);
+        assert.equal(latestAfterPayload.partner?.openLoops.find((entry) => entry.id === "room:portal")?.status, "delegated");
       },
     );
   } finally {

--- a/studio-brain/src/http/server.ts
+++ b/studio-brain/src/http/server.ts
@@ -78,6 +78,21 @@ import type {
   ControlTowerState,
 } from "../controlTower/types";
 import { draftDiscordSupportReply, getSupportAgentProfile } from "../supportOps/discord";
+import type { AgentRuntimeSummary, RunLedgerEvent } from "../agentRuntime/contracts";
+import {
+  appendAgentRuntimeEvent,
+  listAgentRuntimeSummaries,
+  readAgentRuntimeEvents,
+  readLatestAgentRuntimeSummary,
+  writeAgentRuntimeSummary,
+} from "../agentRuntime/files";
+import type { PartnerBrief, PartnerCheckinAction } from "../partner/contracts";
+import { readPartnerCheckins } from "../partner/files";
+import {
+  deriveAndPersistPartnerBrief,
+  recordPartnerCheckin,
+  updatePartnerOpenLoop,
+} from "../partner/service";
 
 const CONTROL_TOWER_MEMORY_BRIEF_RELATIVE_PATH = ["output", "studio-brain", "memory-brief", "latest.json"] as const;
 const CONTROL_TOWER_MEMORY_CONSOLIDATION_RELATIVE_PATH = ["output", "studio-brain", "memory-consolidation", "latest.json"] as const;
@@ -140,6 +155,21 @@ function toStringList(value: unknown, maxItems = 64): string[] {
     .map((entry) => toTrimmedString(entry))
     .filter(Boolean)
     .slice(0, Math.max(1, maxItems));
+}
+
+function isPartnerCheckinAction(value: unknown): value is PartnerCheckinAction {
+  return (
+    value === "ack"
+    || value === "snooze"
+    || value === "pause"
+    || value === "redirect"
+    || value === "why_this"
+    || value === "continue"
+  );
+}
+
+function isPartnerOpenLoopStatus(value: unknown): value is "delegated" | "paused" | "resolved" {
+  return value === "delegated" || value === "paused" || value === "resolved";
 }
 
 function readJsonFile<T>(path: string): T | null {
@@ -309,6 +339,7 @@ function readControlTowerStartupScorecard(repoRoot: string): ControlTowerStartup
   const supportingSignals = toObjectRecord(payload.supportingSignals);
   const toolcalls = toObjectRecord(supportingSignals.toolcalls);
   const coverage = toObjectRecord(payload.coverage);
+  const launcherCoverage = toObjectRecord(payload.launcherCoverage);
   const rubric = toObjectRecord(payload.rubric);
 
   return {
@@ -346,12 +377,55 @@ function readControlTowerStartupScorecard(repoRoot: string): ControlTowerStartup
     coverage: {
       gaps: toStringList(coverage.gaps, 8),
     },
+    launcherCoverage: {
+      liveStartupSamples: toBoundedInt(launcherCoverage.liveStartupSamples, 0, 0, 1_000_000),
+      requiredLiveStartupSamples: toBoundedInt(launcherCoverage.requiredLiveStartupSamples, 5, 1, 1_000_000),
+      trustworthy: toBooleanFlag(toTrimmedString(String(launcherCoverage.trustworthy ?? "")), false),
+    },
     rubric: {
       overallScore: toNullableNumber(rubric.overallScore),
       grade: toTrimmedString(rubric.grade) || "n/a",
     },
     recommendations: toStringList(payload.recommendations, 8),
   };
+}
+
+function buildAgentRuntimeAttention(agentRuntime: AgentRuntimeSummary | null): Array<{
+  id: string;
+  title: string;
+  why: string;
+  ageMinutes: number | null;
+  severity: "info" | "warning" | "critical";
+  actionLabel: string;
+  target: ControlTowerNextAction["target"];
+}> {
+  if (!agentRuntime) return [];
+  if (agentRuntime.status !== "blocked" && agentRuntime.status !== "failed") return [];
+  return [
+    {
+      id: `agent-runtime-attention:${agentRuntime.runId}`,
+      title: `Inspect ${agentRuntime.title}`,
+      why: clipText(agentRuntime.activeBlockers[0] || "The background runtime is blocked and needs an explicit next move.", 180),
+      ageMinutes: ageMinutesSince(agentRuntime.updatedAt),
+      severity: agentRuntime.status === "failed" ? "critical" : "warning",
+      actionLabel: "Inspect runtime",
+      target: { type: "ops", action: "agent-runtime" },
+    },
+  ];
+}
+
+function buildAgentRuntimeNextActions(agentRuntime: AgentRuntimeSummary | null): ControlTowerNextAction[] {
+  if (!agentRuntime) return [];
+  return [
+    {
+      id: `agent-runtime-next:${agentRuntime.runId}`,
+      title: clipText(agentRuntime.boardRow?.next || "Inspect background runtime", 120),
+      why: clipText(agentRuntime.activeBlockers[0] || agentRuntime.goal || "Background runtime state changed.", 180),
+      ageMinutes: ageMinutesSince(agentRuntime.updatedAt),
+      actionLabel: "Open runtime",
+      target: { type: "ops", action: "agent-runtime" },
+    },
+  ];
 }
 
 function buildControlTowerApprovals(
@@ -385,6 +459,7 @@ function buildControlTowerApprovals(
 function buildSyntheticControlTowerEvents(
   memoryBrief: ControlTowerMemoryBrief,
   approvals: ControlTowerApprovalItem[],
+  partner: PartnerBrief | null = null,
 ): ControlTowerEvent[] {
   const output: ControlTowerEvent[] = [];
 
@@ -487,6 +562,33 @@ function buildSyntheticControlTowerEvents(
       });
     });
 
+  if (partner) {
+    output.push({
+      id: `partner-brief:${partner.generatedAt}`,
+      at: partner.generatedAt,
+      kind: "operator",
+      type: "task.updated",
+      runId: null,
+      agentId: partner.persona.id,
+      channel: "codex",
+      occurredAt: partner.generatedAt,
+      severity: partner.needsOwnerDecision ? "warning" : "info",
+      title: partner.needsOwnerDecision ? "Chief-of-staff decision waiting" : "Chief-of-staff brief refreshed",
+      summary: clipText(partner.summary, 220),
+      actor: partner.persona.displayName,
+      roomId: partner.openLoops[0]?.roomId ?? null,
+      serviceId: null,
+      actionLabel: "Review partner brief",
+      sourceAction: "control_tower.partner_brief",
+      payload: {
+        initiativeState: partner.initiativeState,
+        needsOwnerDecision: partner.needsOwnerDecision,
+        nextCheckInAt: partner.nextCheckInAt,
+        recommendedFocus: partner.recommendedFocus,
+      },
+    });
+  }
+
   return output;
 }
 
@@ -542,6 +644,7 @@ function shouldSurfaceMemoryNextMoves(
   if (!startupScorecard) return false;
 
   if (toTrimmedString(startupScorecard.latest.sample.status).toLowerCase() !== "pass") return true;
+  if (startupScorecard.launcherCoverage.trustworthy !== true) return true;
   if (
     startupScorecard.metrics.readyRate != null &&
     startupScorecard.metrics.readyRate < 0.85
@@ -593,6 +696,9 @@ function buildMemoryActionNextMoves(
         : "",
       startupScorecard?.metrics.blockedContinuityRate != null && startupScorecard.metrics.blockedContinuityRate > 0.05
         ? `blocked continuity ${Math.round(startupScorecard.metrics.blockedContinuityRate * 100)}%`
+        : "",
+      startupScorecard && startupScorecard.launcherCoverage.trustworthy !== true
+        ? `live startup coverage ${startupScorecard.launcherCoverage.liveStartupSamples}/${startupScorecard.launcherCoverage.requiredLiveStartupSamples}`
         : "",
       toTrimmedString(memoryBrief.consolidation.actionabilityStatus).toLowerCase() &&
       toTrimmedString(memoryBrief.consolidation.actionabilityStatus).toLowerCase() !== "passed"
@@ -840,6 +946,118 @@ function buildMemoryHealthNextMoves(memoryHealth: ControlTowerMemoryHealth | nul
   }));
 }
 
+function buildPartnerAttention(partner: PartnerBrief | null): Array<{
+  id: string;
+  title: string;
+  why: string;
+  ageMinutes: number | null;
+  severity: "info" | "warning" | "critical";
+  actionLabel: string;
+  target: { type: "ops"; action: "partner" };
+}> {
+  if (!partner) return [];
+  if (partner.needsOwnerDecision) {
+    return [
+      {
+        id: "attention:partner:decision",
+        title: "Chief-of-staff decision waiting",
+        why: clipText(partner.summary, 180),
+        ageMinutes: null,
+        severity: "warning",
+        actionLabel: "Review partner brief",
+        target: { type: "ops", action: "partner" },
+      },
+    ];
+  }
+  if (partner.initiativeState === "cooldown") {
+    return [];
+  }
+  if ((partner.openLoops ?? []).some((entry) => entry.status === "open")) {
+    return [
+      {
+        id: "attention:partner:open-loop",
+        title: "Chief-of-staff open loop needs review",
+        why: clipText(partner.contactReason, 180),
+        ageMinutes: null,
+        severity: "info",
+        actionLabel: "Review partner brief",
+        target: { type: "ops", action: "partner" },
+      },
+    ];
+  }
+  return [];
+}
+
+function buildPartnerNextMoves(partner: PartnerBrief | null): ControlTowerNextAction[] {
+  if (!partner) return [];
+  const focus = clipText(partner.recommendedFocus || partner.contactReason, 160);
+  const actionLabel = partner.needsOwnerDecision ? "Review partner brief" : "Review cadence";
+  return [
+    {
+      id: "partner:review",
+      title: partner.needsOwnerDecision ? "Review chief-of-staff decision" : "Review chief-of-staff brief",
+      why: focus,
+      ageMinutes: null,
+      actionLabel,
+      target: { type: "ops", action: "partner" },
+    },
+  ];
+}
+
+function applyPartnerSignalsToRooms(
+  rooms: ControlTowerState["rooms"],
+  partner: PartnerBrief | null,
+): ControlTowerState["rooms"] {
+  if (!partner) return rooms;
+  const loopsByRoom = new Map<string, PartnerBrief["openLoops"][number]>();
+  for (const loop of partner.openLoops) {
+    if (!loop.roomId || loopsByRoom.has(loop.roomId)) continue;
+    loopsByRoom.set(loop.roomId, loop);
+  }
+  return rooms.map((room) => {
+    const loop = loopsByRoom.get(room.id);
+    if (!loop) return room;
+    return {
+      ...room,
+      contactReason: partner.contactReason,
+      verifiedContext: loop.verifiedContext,
+      decisionNeeded: loop.decisionNeeded,
+    };
+  });
+}
+
+function applyPartnerSignalsToBoard(
+  board: ControlTowerState["board"],
+  partner: PartnerBrief | null,
+): ControlTowerState["board"] {
+  if (!partner) return board;
+  const loopsByRoom = new Map<string, PartnerBrief["openLoops"][number]>();
+  for (const loop of partner.openLoops) {
+    if (!loop.roomId || loopsByRoom.has(loop.roomId)) continue;
+    loopsByRoom.set(loop.roomId, loop);
+  }
+  return board.map((row, index) => {
+    const loop = row.roomId ? loopsByRoom.get(row.roomId) : null;
+    if (loop) {
+      return {
+        ...row,
+        contactReason: partner.contactReason,
+        verifiedContext: loop.verifiedContext,
+        decisionNeeded: loop.decisionNeeded,
+      };
+    }
+    if (index === 0 && !row.roomId) {
+      return {
+        ...row,
+        contactReason: partner.contactReason,
+        verifiedContext: partner.verifiedContext,
+        decisionNeeded: partner.singleDecisionNeeded,
+      };
+    }
+    return row;
+  });
+}
+
 function enrichControlTowerState(
   state: ControlTowerState,
   syntheticEvents: ControlTowerEvent[],
@@ -847,6 +1065,8 @@ function enrichControlTowerState(
   memoryBrief: ControlTowerMemoryBrief,
   startupScorecard: ControlTowerStartupScorecard | null,
   memoryHealth: ControlTowerMemoryHealth | null,
+  agentRuntime: AgentRuntimeSummary | null,
+  partner: PartnerBrief | null,
 ): ControlTowerState {
   const mergedEvents = [...syntheticEvents, ...state.events]
     .sort((left, right) => right.occurredAt.localeCompare(left.occurredAt))
@@ -864,26 +1084,60 @@ function enrichControlTowerState(
       target: approval.target,
     }));
   const memoryAttention = buildMemoryHealthAttention(memoryHealth);
+  const agentRuntimeAttention = buildAgentRuntimeAttention(agentRuntime);
+  const partnerAttention = buildPartnerAttention(partner);
   const memoryNextMoves = buildMemoryActionNextMoves(memoryBrief, startupScorecard);
   const memoryHealthMoves = buildMemoryHealthNextMoves(memoryHealth);
-  const mergedActions = dedupeNextActions([...memoryHealthMoves, ...memoryNextMoves, ...state.actions], 6);
+  const agentRuntimeMoves = buildAgentRuntimeNextActions(agentRuntime);
+  const partnerMoves = buildPartnerNextMoves(partner);
+  const mergedActions = dedupeNextActions(
+    [...partnerMoves, ...agentRuntimeMoves, ...memoryHealthMoves, ...memoryNextMoves, ...state.actions],
+    6,
+  );
+  const mergedBoard = agentRuntime?.boardRow
+    ? [
+        {
+          roomId: null,
+          sessionName: null,
+          ...agentRuntime.boardRow,
+        },
+        ...state.board.filter((row) => row.id !== agentRuntime.boardRow.id),
+      ].slice(0, 8)
+    : state.board;
+  const nextRooms = applyPartnerSignalsToRooms(state.rooms, partner);
+  const nextBoard = applyPartnerSignalsToBoard(mergedBoard, partner);
 
   return {
     ...state,
+    rooms: nextRooms,
     approvals,
     memoryBrief,
     startupScorecard,
     memoryHealth,
+    agentRuntime,
+    partner,
+    board: nextBoard,
     events: mergedEvents,
     recentChanges: mergedEvents.slice(0, 6),
     actions: mergedActions,
     counts: {
       ...state.counts,
-      needsAttention: state.counts.needsAttention + approvalAttention.length + memoryAttention.length,
+      needsAttention:
+        state.counts.needsAttention
+        + approvalAttention.length
+        + memoryAttention.length
+        + agentRuntimeAttention.length
+        + partnerAttention.length,
     },
     overview: {
       ...state.overview,
-      needsAttention: [...memoryAttention, ...approvalAttention, ...state.overview.needsAttention].slice(0, 6),
+      needsAttention: [
+        ...partnerAttention,
+        ...agentRuntimeAttention,
+        ...memoryAttention,
+        ...approvalAttention,
+        ...state.overview.needsAttention,
+      ].slice(0, 6),
       goodNextMoves: mergedActions,
       recentEvents: mergedEvents.slice(0, 8),
     },
@@ -1471,6 +1725,19 @@ export function startHttpServer(params: {
     const initialState = deriveControlTowerState(raw, audits, { approvals });
     const memoryBrief = readControlTowerMemoryBrief(resolvedControlTowerRepoRoot, initialState.memoryBrief);
     const startupScorecard = readControlTowerStartupScorecard(resolvedControlTowerRepoRoot);
+    const agentRuntime = readLatestAgentRuntimeSummary(resolvedControlTowerRepoRoot);
+    const stateWithMemory = deriveControlTowerState(raw, audits, {
+      approvals,
+      memoryBrief,
+    });
+    const partner = deriveAndPersistPartnerBrief({
+      repoRoot: resolvedControlTowerRepoRoot,
+      generatedAt: raw.generatedAt,
+      memoryBrief,
+      rooms: stateWithMemory.rooms,
+      approvals,
+      agentRuntime,
+    });
     let memoryHealth: ControlTowerMemoryHealth | null = null;
     if (memoryService) {
       try {
@@ -1480,17 +1747,16 @@ export function startHttpServer(params: {
         logger.warn(`control tower memory health unavailable: ${message}`);
       }
     }
-    const syntheticEvents = buildSyntheticControlTowerEvents(memoryBrief, approvals);
+    const syntheticEvents = buildSyntheticControlTowerEvents(memoryBrief, approvals, partner);
     const state = enrichControlTowerState(
-      deriveControlTowerState(raw, audits, {
-        approvals,
-        memoryBrief,
-      }),
+      stateWithMemory,
       syntheticEvents,
       approvals,
       memoryBrief,
       startupScorecard,
       memoryHealth,
+      agentRuntime,
+      partner,
     );
     return { raw, state, audits };
   };
@@ -1974,6 +2240,53 @@ export function startHttpServer(params: {
           statusCode = 201;
           res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
           res.end(JSON.stringify({ ok: true, memory }));
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          const isValidation = error instanceof MemoryValidationError;
+          statusCode = isValidation ? 400 : 500;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message }));
+        }
+        return;
+      }
+
+      if (memoryService && method === "POST" && url.pathname === "/api/memory/consolidate") {
+        const auth = await assertCapabilityAuth(req);
+        if (!auth.ok) {
+          statusCode = 401;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: auth.message }));
+          return;
+        }
+
+        try {
+          const payload = toObjectRecord(await readJsonBody(req));
+          const result = await memoryService.consolidate(payload);
+          try {
+            await appendControlTowerAudit(
+              auth.principal,
+              "studio_brain.memory_consolidated",
+              "Memory consolidation executed via the Studio Brain HTTP control plane.",
+              {
+                endpoint: "/api/memory/consolidate",
+                mode: toTrimmedString(payload.mode) || "idle",
+                runId: toTrimmedString(payload.runId) || null,
+                tenantId: toTrimmedString(payload.tenantId) || null,
+                focusAreas: toStringList(payload.focusAreas, 12),
+                requestOrigin: toTrimmedString(payload.requestOrigin) || null,
+                requestedTransport: toTrimmedString(payload.requestedTransport) || null,
+                transport: toTrimmedString(payload.transport) || null,
+                status: toTrimmedString((result as Record<string, unknown>)?.status) || null,
+              },
+            );
+          } catch (auditError) {
+            logger.warn(
+              `memory consolidation audit append failed: ${auditError instanceof Error ? auditError.message : String(auditError)}`,
+            );
+          }
+          statusCode = 200;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: true, result }));
         } catch (error) {
           const message = error instanceof Error ? error.message : String(error);
           const isValidation = error instanceof MemoryValidationError;
@@ -4467,6 +4780,102 @@ export function startHttpServer(params: {
         return;
       }
 
+      if (method === "GET" && url.pathname === "/api/control-tower/partner/latest") {
+        const auth = await assertCapabilityAuth(req, { requireAdminToken: false });
+        if (!auth.ok) {
+          statusCode = 401;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: auth.message }));
+          return;
+        }
+        const { state } = await readControlTowerSnapshot();
+        statusCode = 200;
+        res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+        res.end(
+          JSON.stringify({
+            ok: true,
+            partner: state.partner,
+            checkins: readPartnerCheckins(resolvedControlTowerRepoRoot, 24),
+          }),
+        );
+        return;
+      }
+
+      if (method === "POST" && url.pathname === "/api/control-tower/partner/brief") {
+        const auth = await assertCapabilityAuth(req, { requireAdminToken: false });
+        if (!auth.ok) {
+          statusCode = 401;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: auth.message }));
+          return;
+        }
+        const { state } = await readControlTowerSnapshot();
+        statusCode = 200;
+        res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+        res.end(JSON.stringify({ ok: true, partner: state.partner }));
+        return;
+      }
+
+      if (method === "GET" && url.pathname === "/api/agent-runtime/latest") {
+        const auth = await assertCapabilityAuth(req, { requireAdminToken: false });
+        if (!auth.ok) {
+          statusCode = 401;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: auth.message }));
+          return;
+        }
+        const summary = readLatestAgentRuntimeSummary(resolvedControlTowerRepoRoot);
+        const events = summary ? readAgentRuntimeEvents(resolvedControlTowerRepoRoot, summary.runId, 24) : [];
+        statusCode = 200;
+        res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+        res.end(JSON.stringify({ ok: true, summary, events }));
+        return;
+      }
+
+      if (method === "GET" && url.pathname === "/api/agent-runtime/runs") {
+        const auth = await assertCapabilityAuth(req, { requireAdminToken: false });
+        if (!auth.ok) {
+          statusCode = 401;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: auth.message }));
+          return;
+        }
+        const limitRaw = Number(url.searchParams.get("limit") ?? "12");
+        const limit = Number.isFinite(limitRaw) ? Math.max(1, Math.min(Math.floor(limitRaw), 50)) : 12;
+        const runs = listAgentRuntimeSummaries(resolvedControlTowerRepoRoot, limit);
+        statusCode = 200;
+        res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+        res.end(JSON.stringify({ ok: true, runs }));
+        return;
+      }
+
+      if (method === "POST" && url.pathname === "/api/agent-runtime/events") {
+        const auth = await assertCapabilityAuth(req);
+        if (!auth.ok) {
+          statusCode = 401;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: auth.message }));
+          return;
+        }
+        const body = await readJsonBody(req);
+        const event = body.event && typeof body.event === "object" ? (body.event as RunLedgerEvent) : null;
+        const summary = body.summary && typeof body.summary === "object" ? (body.summary as AgentRuntimeSummary) : null;
+        if (!event || !toTrimmedString(event.runId) || !toTrimmedString(event.type)) {
+          statusCode = 400;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: "event.runId and event.type are required." }));
+          return;
+        }
+        appendAgentRuntimeEvent(resolvedControlTowerRepoRoot, event);
+        if (summary && toTrimmedString(summary.runId)) {
+          writeAgentRuntimeSummary(resolvedControlTowerRepoRoot, summary);
+        }
+        statusCode = 202;
+        res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+        res.end(JSON.stringify({ ok: true, accepted: true, runId: event.runId }));
+        return;
+      }
+
       if (method === "GET" && url.pathname === "/api/control-tower/rooms") {
         const auth = await assertCapabilityAuth(req, { requireAdminToken: false });
         if (!auth.ok) {
@@ -4621,6 +5030,110 @@ export function startHttpServer(params: {
           void pushSnapshot();
         }, CONTROL_TOWER_EVENT_STREAM_POLL_MS);
         void pushSnapshot();
+        return;
+      }
+
+      if (method === "POST" && url.pathname === "/api/control-tower/partner/checkins") {
+        const auth = await assertCapabilityAuth(req, { requireAdminToken: false });
+        if (!auth.ok) {
+          statusCode = 401;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: auth.message }));
+          return;
+        }
+        const snapshot = await readControlTowerSnapshot();
+        if (!snapshot.state.partner) {
+          statusCode = 503;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: "partner brief is unavailable" }));
+          return;
+        }
+        const body = await readJsonBody(req);
+        const action = toTrimmedString(body.action);
+        if (!isPartnerCheckinAction(action)) {
+          statusCode = 400;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: "action must be one of ack, snooze, pause, redirect, why_this, or continue." }));
+          return;
+        }
+        const partner = recordPartnerCheckin({
+          repoRoot: resolvedControlTowerRepoRoot,
+          brief: snapshot.state.partner,
+          actorId: auth.principal?.uid ?? "staff:unknown",
+          action,
+          note: toTrimmedString(body.note) || undefined,
+          snoozeMinutes: toNullableNumber(body.snoozeMinutes) ?? undefined,
+        });
+        await appendControlTowerAudit(
+          auth.principal,
+          "studio_ops.control_tower.partner_checkin",
+          `Recorded chief-of-staff command ${action}.`,
+          {
+            action,
+            note: toTrimmedString(body.note) || null,
+            snoozeMinutes: toNullableNumber(body.snoozeMinutes),
+          },
+        );
+        statusCode = 200;
+        res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+        res.end(JSON.stringify({ ok: true, partner }));
+        return;
+      }
+
+      const controlTowerPartnerOpenLoopMatch =
+        method === "POST" ? url.pathname.match(/^\/api\/control-tower\/partner\/open-loops\/([^/]+)$/) : null;
+      if (controlTowerPartnerOpenLoopMatch) {
+        const auth = await assertCapabilityAuth(req, { requireAdminToken: false });
+        if (!auth.ok) {
+          statusCode = 401;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: auth.message }));
+          return;
+        }
+        const snapshot = await readControlTowerSnapshot();
+        if (!snapshot.state.partner) {
+          statusCode = 503;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: "partner brief is unavailable" }));
+          return;
+        }
+        const loopId = decodeURIComponent(controlTowerPartnerOpenLoopMatch[1] || "");
+        const body = await readJsonBody(req);
+        const status = toTrimmedString(body.status);
+        if (!isPartnerOpenLoopStatus(status)) {
+          statusCode = 400;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: "status must be delegated, paused, or resolved." }));
+          return;
+        }
+        const loopExists = snapshot.state.partner.openLoops.some((entry) => entry.id === loopId);
+        if (!loopExists) {
+          statusCode = 404;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: `open loop ${loopId} not found` }));
+          return;
+        }
+        const partner = updatePartnerOpenLoop({
+          repoRoot: resolvedControlTowerRepoRoot,
+          brief: snapshot.state.partner,
+          loopId,
+          status,
+          actorId: auth.principal?.uid ?? "staff:unknown",
+          note: toTrimmedString(body.note) || undefined,
+        });
+        await appendControlTowerAudit(
+          auth.principal,
+          "studio_ops.control_tower.partner_open_loop_updated",
+          `Marked ${loopId} as ${status}.`,
+          {
+            loopId,
+            status,
+            note: toTrimmedString(body.note) || null,
+          },
+        );
+        statusCode = 200;
+        res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+        res.end(JSON.stringify({ ok: true, partner, openLoop: partner.openLoops.find((entry) => entry.id === loopId) ?? null }));
         return;
       }
 

--- a/studio-brain/src/partner/contracts.ts
+++ b/studio-brain/src/partner/contracts.ts
@@ -1,0 +1,119 @@
+export type PartnerInitiativeState =
+  | "quiet"
+  | "monitoring"
+  | "briefing"
+  | "executing"
+  | "cooldown"
+  | "waiting_on_owner";
+
+export type PartnerProgramId =
+  | "daily_brief"
+  | "open_loops_follow_up"
+  | "exception_escalation"
+  | "idle_time_momentum"
+  | "weekly_reflection";
+
+export type PartnerOpenLoopStatus = "open" | "delegated" | "paused" | "resolved";
+export type PartnerCheckinAction = "ack" | "snooze" | "pause" | "redirect" | "why_this" | "continue";
+
+export type PartnerPersona = {
+  id: string;
+  displayName: string;
+  relationshipModel: "chief_of_staff";
+  proactivity: "active";
+  primarySurface: "codex_desktop_thread";
+  sourceOfTruth: "control_tower";
+  toneTraits: string[];
+  summary: string;
+};
+
+export type PartnerProgram = {
+  id: PartnerProgramId;
+  label: string;
+  trigger: string;
+  scope: string;
+  approvalGate: string;
+  escalationRule: string;
+  cooldown: string;
+  stopCondition: string;
+};
+
+export type PartnerIdleBudget = {
+  policy: "one_task_at_a_time";
+  maxConcurrentTasks: number;
+  maxAttemptsPerLoop: number;
+  rankedBacklog: string[];
+  verifyBeforeReport: boolean;
+  contactOnlyOnMeaningfulChange: boolean;
+};
+
+export type PartnerOpenLoop = {
+  id: string;
+  title: string;
+  status: PartnerOpenLoopStatus;
+  summary: string;
+  next: string;
+  source: string;
+  updatedAt: string;
+  roomId: string | null;
+  sessionName: string | null;
+  decisionNeeded: string | null;
+  verifiedContext: string[];
+  evidence: string[];
+};
+
+export type PartnerCollaborationCommand = {
+  command: "pause" | "redirect" | "why this" | "continue";
+  description: string;
+};
+
+export type PartnerArtifacts = {
+  latestBriefPath: string;
+  checkinsPath: string;
+  openLoopsPath: string;
+};
+
+export type PartnerBrief = {
+  schema: "studio-brain.partner-brief.v1";
+  generatedAt: string;
+  persona: PartnerPersona;
+  summary: string;
+  initiativeState: PartnerInitiativeState;
+  lastMeaningfulContactAt: string | null;
+  nextCheckInAt: string | null;
+  cooldownUntil: string | null;
+  needsOwnerDecision: boolean;
+  contactReason: string;
+  verifiedContext: string[];
+  singleDecisionNeeded: string | null;
+  recommendedFocus: string;
+  dailyNote: string;
+  openLoops: PartnerOpenLoop[];
+  idleBudget: PartnerIdleBudget;
+  programs: PartnerProgram[];
+  collaborationCommands: PartnerCollaborationCommand[];
+  artifacts: PartnerArtifacts;
+};
+
+export type PartnerCheckinRecord = {
+  schema: "studio-brain.partner-checkin.v1";
+  id: string;
+  action: PartnerCheckinAction;
+  occurredAt: string;
+  actorId: string;
+  note: string | null;
+  snoozeUntil: string | null;
+};
+
+export type AgentRuntimePartnerContext = {
+  initiativeState: PartnerInitiativeState;
+  lastMeaningfulContactAt: string | null;
+  nextCheckInAt: string | null;
+  cooldownUntil: string | null;
+  openLoops: PartnerOpenLoop[];
+  idleBudget: PartnerIdleBudget;
+  needsOwnerDecision: boolean;
+  contactReason: string;
+  verifiedContext: string[];
+  singleDecisionNeeded: string | null;
+};

--- a/studio-brain/src/partner/files.ts
+++ b/studio-brain/src/partner/files.ts
@@ -1,0 +1,89 @@
+import { appendFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import type { PartnerBrief, PartnerCheckinRecord, PartnerOpenLoop } from "./contracts";
+
+const PARTNER_ROOT = ["output", "studio-brain", "partner"] as const;
+const LATEST_BRIEF_FILE = "latest-brief.json";
+const CHECKINS_FILE = "checkins.jsonl";
+const OPEN_LOOPS_FILE = "open-loops.json";
+
+function readJsonFile<T>(path: string): T | null {
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, "utf8")) as T;
+  } catch {
+    return null;
+  }
+}
+
+export function partnerRoot(repoRoot: string): string {
+  return resolve(repoRoot, ...PARTNER_ROOT);
+}
+
+export function partnerLatestBriefPath(repoRoot: string): string {
+  return resolve(partnerRoot(repoRoot), LATEST_BRIEF_FILE);
+}
+
+export function partnerCheckinsPath(repoRoot: string): string {
+  return resolve(partnerRoot(repoRoot), CHECKINS_FILE);
+}
+
+export function partnerOpenLoopsPath(repoRoot: string): string {
+  return resolve(partnerRoot(repoRoot), OPEN_LOOPS_FILE);
+}
+
+export function partnerArtifactPaths(): {
+  latestBriefPath: string;
+  checkinsPath: string;
+  openLoopsPath: string;
+} {
+  return {
+    latestBriefPath: [...PARTNER_ROOT, LATEST_BRIEF_FILE].join("/"),
+    checkinsPath: [...PARTNER_ROOT, CHECKINS_FILE].join("/"),
+    openLoopsPath: [...PARTNER_ROOT, OPEN_LOOPS_FILE].join("/"),
+  };
+}
+
+export function readLatestPartnerBrief(repoRoot: string): PartnerBrief | null {
+  return readJsonFile<PartnerBrief>(partnerLatestBriefPath(repoRoot));
+}
+
+export function writeLatestPartnerBrief(repoRoot: string, brief: PartnerBrief): void {
+  mkdirSync(partnerRoot(repoRoot), { recursive: true });
+  writeFileSync(partnerLatestBriefPath(repoRoot), `${JSON.stringify(brief, null, 2)}\n`, "utf8");
+}
+
+export function readPartnerOpenLoops(repoRoot: string): PartnerOpenLoop[] {
+  const payload = readJsonFile<{ schema?: string; updatedAt?: string; rows?: PartnerOpenLoop[] }>(partnerOpenLoopsPath(repoRoot));
+  return Array.isArray(payload?.rows) ? payload.rows : [];
+}
+
+export function writePartnerOpenLoops(repoRoot: string, rows: PartnerOpenLoop[], updatedAt: string): void {
+  mkdirSync(partnerRoot(repoRoot), { recursive: true });
+  writeFileSync(
+    partnerOpenLoopsPath(repoRoot),
+    `${JSON.stringify({ schema: "studio-brain.partner-open-loops.v1", updatedAt, rows }, null, 2)}\n`,
+    "utf8",
+  );
+}
+
+export function appendPartnerCheckin(repoRoot: string, record: PartnerCheckinRecord): void {
+  mkdirSync(partnerRoot(repoRoot), { recursive: true });
+  appendFileSync(partnerCheckinsPath(repoRoot), `${JSON.stringify(record)}\n`, "utf8");
+}
+
+export function readPartnerCheckins(repoRoot: string, limit = 40): PartnerCheckinRecord[] {
+  const target = partnerCheckinsPath(repoRoot);
+  if (!existsSync(target)) return [];
+  const rows: PartnerCheckinRecord[] = [];
+  for (const line of readFileSync(target, "utf8").split(/\r?\n/)) {
+    if (!line.trim()) continue;
+    try {
+      rows.push(JSON.parse(line) as PartnerCheckinRecord);
+    } catch {
+      continue;
+    }
+  }
+  return rows.slice(-Math.max(1, limit));
+}

--- a/studio-brain/src/partner/persona.ts
+++ b/studio-brain/src/partner/persona.ts
@@ -1,0 +1,105 @@
+import type {
+  PartnerCollaborationCommand,
+  PartnerIdleBudget,
+  PartnerPersona,
+  PartnerProgram,
+} from "./contracts";
+
+export const CHIEF_OF_STAFF_PERSONA: PartnerPersona = {
+  id: "wuff-chief-of-staff",
+  displayName: "Studio Brain Chief of Staff",
+  relationshipModel: "chief_of_staff",
+  proactivity: "active",
+  primarySurface: "codex_desktop_thread",
+  sourceOfTruth: "control_tower",
+  toneTraits: ["proactive", "concise", "initiative-taking", "not chatty"],
+  summary:
+    "An owner-facing operating partner that keeps initiative bounded, verifies before interrupting, and asks for one decision at a time.",
+};
+
+export const CHIEF_OF_STAFF_PROGRAMS: PartnerProgram[] = [
+  {
+    id: "daily_brief",
+    label: "Daily Brief",
+    trigger: "Scheduled morning or first meaningful operator touchpoint of the day.",
+    scope: "Summarize real Control Tower state, open loops, and one recommended focus.",
+    approvalGate: "No approval required for summaries that do not trigger external writes.",
+    escalationRule: "Escalate only if the brief contains a blocker, approval, or drift that needs owner review.",
+    cooldown: "At most one full morning brief per day unless the state changes materially.",
+    stopCondition: "Stop after one bounded brief is delivered and recorded.",
+  },
+  {
+    id: "open_loops_follow_up",
+    label: "Open Loops Follow-up",
+    trigger: "An unresolved owner-facing loop is stale or missing a clean next move.",
+    scope: "Check one open loop, verify context, then ask for the smallest useful decision or next step.",
+    approvalGate: "No approval required until the follow-up proposes a protected write or irreversible change.",
+    escalationRule: "Escalate when the loop blocks delivery, trust, or operator cadence.",
+    cooldown: "Wait for the next meaningful change before repeating the same follow-up.",
+    stopCondition: "Stop once the loop is delegated, paused, resolved, or waiting on owner input.",
+  },
+  {
+    id: "exception_escalation",
+    label: "Exception Escalation",
+    trigger: "Blocker, drift, failure, or approval need appears in Control Tower state.",
+    scope: "Interrupt with concise verified context and one explicit decision or recovery path.",
+    approvalGate: "Escalations may request approval but never execute protected writes on their own.",
+    escalationRule: "Escalate immediately for blocked rooms, degraded trust signals, or pending approvals.",
+    cooldown: "No repeat escalation until the underlying incident changes state.",
+    stopCondition: "Stop after the owner acknowledges, redirects, or resolves the exception.",
+  },
+  {
+    id: "idle_time_momentum",
+    label: "Idle-Time Momentum",
+    trigger: "The system is idle and a ranked backlog item exists.",
+    scope: "Pick one bounded task from the approved idle backlog, verify effect, and stop.",
+    approvalGate: "Stay inside low-risk backlog tasks only; do not expand scope opportunistically.",
+    escalationRule: "Escalate only when the idle task reveals a real blocker or asks for a decision.",
+    cooldown: "One task per idle slice with a hard stop after max attempts.",
+    stopCondition: "Stop after one verified task or after attempts are exhausted.",
+  },
+  {
+    id: "weekly_reflection",
+    label: "Weekly Reflection",
+    trigger: "Scheduled weekly reflection window.",
+    scope: "Summarize momentum, unresolved loops, and one systems improvement worth carrying forward.",
+    approvalGate: "No approval required unless the reflection proposes a protected operational change.",
+    escalationRule: "Escalate only if weekly review surfaces a cross-cutting risk that cannot wait.",
+    cooldown: "One reflection per weekly window.",
+    stopCondition: "Stop after the reflection is written and the next recommendation is captured.",
+  },
+];
+
+export const CHIEF_OF_STAFF_IDLE_BUDGET: PartnerIdleBudget = {
+  policy: "one_task_at_a_time",
+  maxConcurrentTasks: 1,
+  maxAttemptsPerLoop: 2,
+  rankedBacklog: [
+    "stale blocker cleanup",
+    "unresolved review queues",
+    "memory hygiene",
+    "follow-up drafting",
+    "light research tied to known open loops",
+  ],
+  verifyBeforeReport: true,
+  contactOnlyOnMeaningfulChange: true,
+};
+
+export const CHIEF_OF_STAFF_COMMANDS: PartnerCollaborationCommand[] = [
+  {
+    command: "pause",
+    description: "Quiet the chief-of-staff loop until the next scheduled check-in or explicit resume.",
+  },
+  {
+    command: "redirect",
+    description: "Redirect the current initiative without losing continuity.",
+  },
+  {
+    command: "why this",
+    description: "Ask why Studio Brain chose the current interruption or recommendation.",
+  },
+  {
+    command: "continue",
+    description: "Resume the bounded loop with the current context and constraints.",
+  },
+];

--- a/studio-brain/src/partner/service.ts
+++ b/studio-brain/src/partner/service.ts
@@ -1,0 +1,474 @@
+import crypto from "node:crypto";
+
+import type { AgentRuntimeSummary } from "../agentRuntime/contracts";
+import type {
+  ControlTowerApprovalItem,
+  ControlTowerMemoryBrief,
+  ControlTowerRoomSummary,
+} from "../controlTower/types";
+import {
+  appendPartnerCheckin,
+  partnerArtifactPaths,
+  readLatestPartnerBrief,
+  readPartnerOpenLoops,
+  writeLatestPartnerBrief,
+  writePartnerOpenLoops,
+} from "./files";
+import {
+  CHIEF_OF_STAFF_COMMANDS,
+  CHIEF_OF_STAFF_IDLE_BUDGET,
+  CHIEF_OF_STAFF_PERSONA,
+  CHIEF_OF_STAFF_PROGRAMS,
+} from "./persona";
+import type {
+  AgentRuntimePartnerContext,
+  PartnerBrief,
+  PartnerCheckinAction,
+  PartnerCheckinRecord,
+  PartnerInitiativeState,
+  PartnerOpenLoop,
+  PartnerOpenLoopStatus,
+} from "./contracts";
+
+type DerivePartnerBriefInput = {
+  repoRoot: string;
+  generatedAt: string;
+  memoryBrief: ControlTowerMemoryBrief;
+  rooms: ControlTowerRoomSummary[];
+  approvals: ControlTowerApprovalItem[];
+  agentRuntime: AgentRuntimeSummary | null;
+};
+
+type RecordPartnerCheckinInput = {
+  repoRoot: string;
+  brief: PartnerBrief;
+  actorId: string;
+  action: PartnerCheckinAction;
+  note?: string;
+  snoozeMinutes?: number;
+};
+
+type UpdatePartnerOpenLoopInput = {
+  repoRoot: string;
+  brief: PartnerBrief;
+  loopId: string;
+  status: Extract<PartnerOpenLoopStatus, "delegated" | "paused" | "resolved">;
+  actorId: string;
+  note?: string;
+};
+
+function clipText(value: string, max = 220): string {
+  const trimmed = String(value || "").trim();
+  if (!trimmed) return "";
+  return trimmed.length <= max ? trimmed : `${trimmed.slice(0, Math.max(0, max - 1)).trimEnd()}…`;
+}
+
+function addMinutes(iso: string, minutes: number): string {
+  const base = Date.parse(iso);
+  const next = Number.isFinite(base) ? base + minutes * 60_000 : Date.now() + minutes * 60_000;
+  return new Date(next).toISOString();
+}
+
+function slug(value: string): string {
+  const token = String(value || "")
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return token || "loop";
+}
+
+function dedupeStrings(values: Array<string | null | undefined>, limit = 6): string[] {
+  const seen = new Set<string>();
+  const rows: string[] = [];
+  for (const value of values) {
+    const normalized = String(value || "").trim();
+    if (!normalized) continue;
+    const key = normalized.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    rows.push(normalized);
+    if (rows.length >= limit) break;
+  }
+  return rows;
+}
+
+function runtimePartnerContext(agentRuntime: AgentRuntimeSummary | null): AgentRuntimePartnerContext | null {
+  return agentRuntime?.partner ?? null;
+}
+
+function buildFallbackRoomLoops(generatedAt: string, rooms: ControlTowerRoomSummary[]): PartnerOpenLoop[] {
+  return rooms
+    .filter((room) => room.status === "blocked" || room.status === "waiting")
+    .slice(0, 4)
+    .map((room) => ({
+      id: `room:${room.id}`,
+      title: clipText(room.objective || room.name, 120),
+      status: "open" as const,
+      summary: clipText(room.summary || room.objective || `Room ${room.name} is waiting on attention.`, 180),
+      next: clipText(room.nextActions[0]?.title || "Inspect room", 120),
+      source: `control-tower-room:${room.id}`,
+      updatedAt: room.lastActivityAt || generatedAt,
+      roomId: room.id,
+      sessionName: room.sessionNames[0] ?? null,
+      decisionNeeded:
+        room.status === "blocked"
+          ? "Decide whether to unblock, pause, or redirect this lane."
+          : "Confirm whether this lane should continue, pause, or be redirected.",
+      verifiedContext: dedupeStrings([room.summary, room.objective, `${room.project} via ${room.tool}`], 3),
+      evidence: dedupeStrings([room.project, room.tool, room.sessionNames[0] ?? null], 3),
+    }));
+}
+
+function buildFallbackMemoryLoops(generatedAt: string, memoryBrief: ControlTowerMemoryBrief): PartnerOpenLoop[] {
+  return memoryBrief.blockers.slice(0, 3).map((blocker, index) => ({
+    id: `memory:${slug(blocker)}`,
+    title: clipText(blocker, 120),
+    status: "open" as const,
+    summary: clipText(blocker, 180),
+    next: clipText(memoryBrief.recommendedNextActions[index] || memoryBrief.recommendedNextActions[0] || "Review continuity", 120),
+    source: "memory-brief",
+    updatedAt: memoryBrief.generatedAt || generatedAt,
+    roomId: null,
+    sessionName: null,
+    decisionNeeded: index === 0 ? "Decide whether this open loop should stay active, pause, or move to a different lane." : null,
+    verifiedContext: dedupeStrings([memoryBrief.goal, memoryBrief.summary, blocker], 3),
+    evidence: dedupeStrings(memoryBrief.fallbackSources, 3),
+  }));
+}
+
+function mergeOpenLoops(
+  generatedAt: string,
+  persisted: PartnerOpenLoop[],
+  runtimeLoops: PartnerOpenLoop[],
+  fallbackLoops: PartnerOpenLoop[],
+): PartnerOpenLoop[] {
+  const merged = new Map<string, PartnerOpenLoop>();
+  const upsert = (candidate: PartnerOpenLoop) => {
+    const existing = merged.get(candidate.id);
+    merged.set(candidate.id, existing
+      ? {
+          ...candidate,
+          status: existing.status || candidate.status,
+          updatedAt: existing.updatedAt && existing.updatedAt > candidate.updatedAt ? existing.updatedAt : candidate.updatedAt,
+          decisionNeeded: existing.decisionNeeded ?? candidate.decisionNeeded,
+          verifiedContext: dedupeStrings([...(candidate.verifiedContext ?? []), ...(existing.verifiedContext ?? [])], 4),
+          evidence: dedupeStrings([...(candidate.evidence ?? []), ...(existing.evidence ?? [])], 4),
+        }
+      : {
+          ...candidate,
+          updatedAt: candidate.updatedAt || generatedAt,
+        });
+  };
+
+  persisted.forEach(upsert);
+  runtimeLoops.forEach(upsert);
+  fallbackLoops.forEach(upsert);
+
+  return Array.from(merged.values())
+    .sort((left, right) => {
+      const statusRank = (value: PartnerOpenLoopStatus): number =>
+        value === "open" ? 0 : value === "delegated" ? 1 : value === "paused" ? 2 : 3;
+      const leftRank = statusRank(left.status);
+      const rightRank = statusRank(right.status);
+      if (leftRank !== rightRank) return leftRank - rightRank;
+      return String(right.updatedAt || "").localeCompare(String(left.updatedAt || ""));
+    })
+    .slice(0, 8);
+}
+
+function deriveDecisionNeeded(
+  approvals: ControlTowerApprovalItem[],
+  loops: PartnerOpenLoop[],
+  runtimeContext: AgentRuntimePartnerContext | null,
+): string | null {
+  if (runtimeContext?.singleDecisionNeeded) return runtimeContext.singleDecisionNeeded;
+  const approval = approvals.find((entry) => entry.status === "pending_approval");
+  if (approval) {
+    return clipText(`Approve or redirect ${approval.capabilityId}: ${approval.summary}`, 180);
+  }
+  return loops.find((loop) => loop.status === "open" && loop.decisionNeeded)?.decisionNeeded ?? null;
+}
+
+function deriveContactReason(
+  memoryBrief: ControlTowerMemoryBrief,
+  approvals: ControlTowerApprovalItem[],
+  loops: PartnerOpenLoop[],
+  runtimeContext: AgentRuntimePartnerContext | null,
+): string {
+  if (runtimeContext?.contactReason) return runtimeContext.contactReason;
+  if (approvals.some((entry) => entry.status === "pending_approval")) {
+    return "A bounded approval or exception path needs one owner decision before Studio Brain keeps moving.";
+  }
+  const blockedLoop = loops.find((loop) => loop.status === "open" && loop.decisionNeeded);
+  if (blockedLoop) {
+    return clipText(`Studio Brain verified enough context to ask for one decision on "${blockedLoop.title}".`, 180);
+  }
+  if (memoryBrief.continuityState !== "ready") {
+    return "Continuity is degraded, so Studio Brain is favoring a concise recovery check-in instead of extra work.";
+  }
+  return "Daily cadence is active and the next brief is focused on one meaningful move rather than ambient chatter.";
+}
+
+function deriveVerifiedContext(
+  memoryBrief: ControlTowerMemoryBrief,
+  loops: PartnerOpenLoop[],
+  runtimeContext: AgentRuntimePartnerContext | null,
+  existing: PartnerBrief | null,
+): string[] {
+  return dedupeStrings(
+    [
+      ...(runtimeContext?.verifiedContext ?? []),
+      ...(existing?.verifiedContext ?? []),
+      ...loops.flatMap((loop) => loop.verifiedContext),
+      memoryBrief.goal,
+      memoryBrief.summary,
+      memoryBrief.recentDecisions[0] ?? null,
+    ],
+    5,
+  );
+}
+
+function deriveRecommendedFocus(
+  loops: PartnerOpenLoop[],
+  singleDecisionNeeded: string | null,
+  memoryBrief: ControlTowerMemoryBrief,
+): string {
+  if (singleDecisionNeeded) return clipText(singleDecisionNeeded, 180);
+  return clipText(
+    loops.find((loop) => loop.status === "open")?.next
+      || memoryBrief.recommendedNextActions[0]
+      || "Hold cadence and wait for the next meaningful change.",
+    180,
+  );
+}
+
+function deriveInitiativeState(
+  generatedAt: string,
+  existing: PartnerBrief | null,
+  loops: PartnerOpenLoop[],
+  runtimeContext: AgentRuntimePartnerContext | null,
+  needsOwnerDecision: boolean,
+  cooldownUntil: string | null,
+): PartnerInitiativeState {
+  if (cooldownUntil && Date.parse(cooldownUntil) > Date.parse(generatedAt)) return "cooldown";
+  if (runtimeContext?.initiativeState === "executing") return "executing";
+  if (needsOwnerDecision) return "waiting_on_owner";
+  if (loops.some((loop) => loop.status === "open")) return existing ? "monitoring" : "briefing";
+  return "quiet";
+}
+
+function rehydrateBrief(
+  generatedAt: string,
+  memoryBrief: ControlTowerMemoryBrief,
+  approvals: ControlTowerApprovalItem[],
+  loops: PartnerOpenLoop[],
+  runtimeContext: AgentRuntimePartnerContext | null,
+  existing: PartnerBrief | null,
+): PartnerBrief {
+  const singleDecisionNeeded = deriveDecisionNeeded(approvals, loops, runtimeContext) ?? existing?.singleDecisionNeeded ?? null;
+  const needsOwnerDecision = Boolean(singleDecisionNeeded);
+  const cooldownUntil = existing?.cooldownUntil ?? runtimeContext?.cooldownUntil ?? null;
+  const contactReason = deriveContactReason(memoryBrief, approvals, loops, runtimeContext);
+  const verifiedContext = deriveVerifiedContext(memoryBrief, loops, runtimeContext, existing);
+  const recommendedFocus = deriveRecommendedFocus(loops, singleDecisionNeeded, memoryBrief);
+  const initiativeState = deriveInitiativeState(generatedAt, existing, loops, runtimeContext, needsOwnerDecision, cooldownUntil);
+  const openLoopCount = loops.filter((loop) => loop.status === "open").length;
+  const dailyNote = clipText(
+    openLoopCount > 0
+      ? `Studio Brain is tracking ${openLoopCount} bounded open loop${openLoopCount === 1 ? "" : "s"}. Recommended focus: ${recommendedFocus}`
+      : "No meaningful change is worth interrupting you for right now; cadence can stay quiet until the next verified shift.",
+    220,
+  );
+  const summary = clipText(
+    needsOwnerDecision
+      ? `${contactReason} Decision needed: ${singleDecisionNeeded}`
+      : `${contactReason} Recommended focus: ${recommendedFocus}`,
+    220,
+  );
+
+  return {
+    schema: "studio-brain.partner-brief.v1",
+    generatedAt,
+    persona: CHIEF_OF_STAFF_PERSONA,
+    summary,
+    initiativeState,
+    lastMeaningfulContactAt:
+      runtimeContext?.lastMeaningfulContactAt
+      || existing?.lastMeaningfulContactAt
+      || generatedAt,
+    nextCheckInAt:
+      cooldownUntil && Date.parse(cooldownUntil) > Date.parse(generatedAt)
+        ? cooldownUntil
+        : runtimeContext?.nextCheckInAt
+          || existing?.nextCheckInAt
+          || addMinutes(generatedAt, needsOwnerDecision ? 120 : openLoopCount > 0 ? 240 : 1_440),
+    cooldownUntil,
+    needsOwnerDecision,
+    contactReason,
+    verifiedContext,
+    singleDecisionNeeded,
+    recommendedFocus,
+    dailyNote,
+    openLoops: loops,
+    idleBudget: runtimeContext?.idleBudget ?? existing?.idleBudget ?? CHIEF_OF_STAFF_IDLE_BUDGET,
+    programs: CHIEF_OF_STAFF_PROGRAMS,
+    collaborationCommands: CHIEF_OF_STAFF_COMMANDS,
+    artifacts: partnerArtifactPaths(),
+  };
+}
+
+function writePartnerArtifacts(repoRoot: string, brief: PartnerBrief): PartnerBrief {
+  writeLatestPartnerBrief(repoRoot, brief);
+  writePartnerOpenLoops(repoRoot, brief.openLoops, brief.generatedAt);
+  return brief;
+}
+
+export function deriveAndPersistPartnerBrief(input: DerivePartnerBriefInput): PartnerBrief {
+  const existing = readLatestPartnerBrief(input.repoRoot);
+  const runtimeContext = runtimePartnerContext(input.agentRuntime);
+  const persistedLoops = readPartnerOpenLoops(input.repoRoot);
+  const runtimeLoops = runtimeContext?.openLoops ?? [];
+  const fallbackLoops = [
+    ...buildFallbackRoomLoops(input.generatedAt, input.rooms),
+    ...buildFallbackMemoryLoops(input.generatedAt, input.memoryBrief),
+  ];
+  const loops = mergeOpenLoops(input.generatedAt, persistedLoops, runtimeLoops, fallbackLoops);
+  const brief = rehydrateBrief(
+    input.generatedAt,
+    input.memoryBrief,
+    input.approvals,
+    loops,
+    runtimeContext,
+    existing,
+  );
+  return writePartnerArtifacts(input.repoRoot, brief);
+}
+
+function refreshBriefAfterMutation(repoRoot: string, brief: PartnerBrief): PartnerBrief {
+  const openLoops = brief.openLoops
+    .map((loop) => ({ ...loop }))
+    .sort((left, right) => String(right.updatedAt).localeCompare(String(left.updatedAt)));
+  const refreshed = rehydrateBrief(
+    new Date().toISOString(),
+    {
+      schema: "studio-brain.memory-brief.v1",
+      generatedAt: brief.generatedAt,
+      continuityState: "ready",
+      summary: brief.contactReason,
+      goal: brief.recommendedFocus,
+      blockers: openLoops.filter((loop) => loop.status === "open").map((loop) => loop.summary),
+      recentDecisions: brief.verifiedContext,
+      recommendedNextActions: openLoops.map((loop) => loop.next),
+      fallbackSources: [],
+      sourcePath: brief.artifacts.latestBriefPath,
+      layers: {
+        coreBlocks: brief.verifiedContext,
+        workingMemory: brief.verifiedContext,
+        episodicMemory: brief.verifiedContext,
+        canonicalMemory: brief.verifiedContext,
+      },
+      consolidation: {
+        mode: "idle",
+        summary: "Chief-of-staff state is being maintained by the partner layer artifacts.",
+        lastRunAt: brief.generatedAt,
+        nextRunAt: brief.nextCheckInAt,
+        focusAreas: brief.verifiedContext,
+        maintenanceActions: [],
+        outputs: [brief.artifacts.latestBriefPath, brief.artifacts.openLoopsPath],
+      },
+    },
+    [],
+    openLoops,
+    null,
+    brief,
+  );
+  return writePartnerArtifacts(repoRoot, refreshed);
+}
+
+export function recordPartnerCheckin(input: RecordPartnerCheckinInput): PartnerBrief {
+  const occurredAt = new Date().toISOString();
+  const snoozeUntil =
+    input.action === "snooze"
+      ? addMinutes(occurredAt, Math.max(15, Math.min(1_440, Math.trunc(input.snoozeMinutes ?? 120))))
+      : input.action === "pause"
+        ? addMinutes(occurredAt, 240)
+        : null;
+  const record: PartnerCheckinRecord = {
+    schema: "studio-brain.partner-checkin.v1",
+    id: crypto.randomUUID(),
+    action: input.action,
+    occurredAt,
+    actorId: input.actorId,
+    note: input.note?.trim() || null,
+    snoozeUntil,
+  };
+  appendPartnerCheckin(input.repoRoot, record);
+
+  const next = {
+    ...input.brief,
+    generatedAt: occurredAt,
+    lastMeaningfulContactAt: occurredAt,
+    cooldownUntil:
+      input.action === "continue" || input.action === "redirect" || input.action === "why_this" || input.action === "ack"
+        ? null
+        : snoozeUntil,
+    initiativeState:
+      input.action === "continue"
+        ? ("monitoring" as const)
+        : input.action === "why_this"
+          ? ("briefing" as const)
+          : input.action === "redirect"
+            ? ("waiting_on_owner" as const)
+            : snoozeUntil
+              ? ("cooldown" as const)
+              : input.brief.initiativeState,
+    nextCheckInAt:
+      input.action === "continue"
+        ? addMinutes(occurredAt, 120)
+        : snoozeUntil ?? input.brief.nextCheckInAt,
+    contactReason:
+      input.action === "why_this"
+        ? input.brief.contactReason
+        : input.action === "redirect"
+          ? clipText(input.note?.trim() || "Owner redirected the current initiative.", 180)
+          : input.brief.contactReason,
+  } satisfies PartnerBrief;
+
+  return refreshBriefAfterMutation(input.repoRoot, next);
+}
+
+export function updatePartnerOpenLoop(input: UpdatePartnerOpenLoopInput): PartnerBrief {
+  const occurredAt = new Date().toISOString();
+  const nextLoops = input.brief.openLoops.map((loop) =>
+    loop.id === input.loopId
+      ? {
+          ...loop,
+          status: input.status,
+          updatedAt: occurredAt,
+          decisionNeeded: input.status === "resolved" ? null : loop.decisionNeeded,
+          summary:
+            input.note?.trim()
+              ? clipText(`${loop.summary} ${input.note.trim()}`, 200)
+              : loop.summary,
+        }
+      : loop,
+  );
+
+  appendPartnerCheckin(input.repoRoot, {
+    schema: "studio-brain.partner-checkin.v1",
+    id: crypto.randomUUID(),
+    action: input.status === "paused" ? "pause" : input.status === "delegated" ? "redirect" : "ack",
+    occurredAt,
+    actorId: input.actorId,
+    note: input.note?.trim() || `${input.loopId} -> ${input.status}`,
+    snoozeUntil: input.status === "paused" ? addMinutes(occurredAt, 240) : null,
+  });
+
+  return refreshBriefAfterMutation(input.repoRoot, {
+    ...input.brief,
+    generatedAt: occurredAt,
+    lastMeaningfulContactAt: occurredAt,
+    openLoops: nextLoops,
+  });
+}

--- a/web/src/utils/studioBrainControlTower.ts
+++ b/web/src/utils/studioBrainControlTower.ts
@@ -69,6 +69,9 @@ export type ControlTowerBoardRow = {
   last_update: string | null;
   roomId: string | null;
   sessionName: string | null;
+  contactReason?: string | null;
+  verifiedContext?: string[];
+  decisionNeeded?: string | null;
 };
 
 export type ControlTowerChannelSummary = {
@@ -189,6 +192,88 @@ export type ControlTowerStartupScorecard = {
   recommendations: string[];
 };
 
+export type PartnerInitiativeState =
+  | "quiet"
+  | "monitoring"
+  | "briefing"
+  | "executing"
+  | "cooldown"
+  | "waiting_on_owner";
+
+export type PartnerOpenLoopStatus = "open" | "delegated" | "paused" | "resolved";
+export type PartnerCheckinAction = "ack" | "snooze" | "pause" | "redirect" | "why_this" | "continue";
+
+export type PartnerProgram = {
+  id: "daily_brief" | "open_loops_follow_up" | "exception_escalation" | "idle_time_momentum" | "weekly_reflection";
+  label: string;
+  trigger: string;
+  scope: string;
+  approvalGate: string;
+  escalationRule: string;
+  cooldown: string;
+  stopCondition: string;
+};
+
+export type PartnerOpenLoop = {
+  id: string;
+  title: string;
+  status: PartnerOpenLoopStatus;
+  summary: string;
+  next: string;
+  source: string;
+  updatedAt: string;
+  roomId: string | null;
+  sessionName: string | null;
+  decisionNeeded: string | null;
+  verifiedContext: string[];
+  evidence: string[];
+};
+
+export type PartnerBrief = {
+  schema: "studio-brain.partner-brief.v1";
+  generatedAt: string;
+  persona: {
+    id: string;
+    displayName: string;
+    relationshipModel: "chief_of_staff";
+    proactivity: "active";
+    primarySurface: "codex_desktop_thread";
+    sourceOfTruth: "control_tower";
+    toneTraits: string[];
+    summary: string;
+  };
+  summary: string;
+  initiativeState: PartnerInitiativeState;
+  lastMeaningfulContactAt: string | null;
+  nextCheckInAt: string | null;
+  cooldownUntil: string | null;
+  needsOwnerDecision: boolean;
+  contactReason: string;
+  verifiedContext: string[];
+  singleDecisionNeeded: string | null;
+  recommendedFocus: string;
+  dailyNote: string;
+  openLoops: PartnerOpenLoop[];
+  idleBudget: {
+    policy: "one_task_at_a_time";
+    maxConcurrentTasks: number;
+    maxAttemptsPerLoop: number;
+    rankedBacklog: string[];
+    verifyBeforeReport: boolean;
+    contactOnlyOnMeaningfulChange: boolean;
+  };
+  programs: PartnerProgram[];
+  collaborationCommands: Array<{
+    command: "pause" | "redirect" | "why this" | "continue";
+    description: string;
+  }>;
+  artifacts: {
+    latestBriefPath: string;
+    checkinsPath: string;
+    openLoopsPath: string;
+  };
+};
+
 export type ControlTowerRoomSummary = {
   id: string;
   name: string;
@@ -203,6 +288,9 @@ export type ControlTowerRoomSummary = {
   nextActions: ControlTowerNextAction[];
   sessionNames: string[];
   summary: string;
+  contactReason?: string | null;
+  verifiedContext?: string[];
+  decisionNeeded?: string | null;
 };
 
 export type ControlTowerServiceCard = {
@@ -271,6 +359,7 @@ export type ControlTowerState = {
   approvals: ControlTowerApprovalItem[];
   memoryBrief: ControlTowerMemoryBrief;
   startupScorecard: ControlTowerStartupScorecard | null;
+  partner: PartnerBrief | null;
   events: ControlTowerEvent[];
   recentChanges: ControlTowerEvent[];
   actions: ControlTowerNextAction[];
@@ -414,6 +503,14 @@ export async function fetchControlTowerState(options: FetchOptions): Promise<Con
   return payload.state;
 }
 
+export async function fetchControlTowerPartnerBrief(
+  options: FetchOptions,
+): Promise<{ partner: PartnerBrief | null; checkins: Array<{ action: PartnerCheckinAction; occurredAt: string; note: string | null }> }> {
+  return fetchControlTowerJson("/api/control-tower/partner/latest", options, {
+    method: "GET",
+  });
+}
+
 function parseSseBuffer(
   buffer: string,
   onEvent: (event: ControlTowerEvent) => void,
@@ -552,6 +649,36 @@ export async function ackControlTowerOverseer(note: string, options: FetchOption
   return fetchControlTowerJson("/api/control-tower/overseer/ack", options, {
     method: "POST",
     body: JSON.stringify({ note }),
+  });
+}
+
+export async function sendPartnerCheckinAction(
+  action: PartnerCheckinAction,
+  options: FetchOptions,
+  payload?: { note?: string; snoozeMinutes?: number },
+): Promise<{ ok: boolean; partner: PartnerBrief | null }> {
+  return fetchControlTowerJson("/api/control-tower/partner/checkins", options, {
+    method: "POST",
+    body: JSON.stringify({
+      action,
+      note: payload?.note,
+      snoozeMinutes: payload?.snoozeMinutes,
+    }),
+  });
+}
+
+export async function updatePartnerOpenLoopStatus(
+  loopId: string,
+  status: "delegated" | "paused" | "resolved",
+  options: FetchOptions,
+  payload?: { note?: string },
+): Promise<{ ok: boolean; partner: PartnerBrief | null; openLoop: PartnerOpenLoop | null }> {
+  return fetchControlTowerJson(`/api/control-tower/partner/open-loops/${encodeURIComponent(loopId)}`, options, {
+    method: "POST",
+    body: JSON.stringify({
+      status,
+      note: payload?.note,
+    }),
   });
 }
 

--- a/web/src/views/staff/StudioBrainControlTowerModule.test.tsx
+++ b/web/src/views/staff/StudioBrainControlTowerModule.test.tsx
@@ -131,6 +131,9 @@ function createStatePayload() {
           last_update: "2026-03-30T09:58:00.000Z",
           roomId: "portal",
           sessionName: "sb-room",
+          contactReason: "Studio Brain verified the portal lane and is asking for one owner decision before it keeps moving.",
+          verifiedContext: ["Portal lane needs direction.", "Operator direction is still pending."],
+          decisionNeeded: "Decide whether to keep the portal lane active or pause it.",
         },
       ],
       channels: [
@@ -252,6 +255,82 @@ function createStatePayload() {
         recommendations: [
           "Startup quality is within the current thresholds; keep collecting history so future regressions are easier to spot.",
         ],
+      },
+      partner: {
+        schema: "studio-brain.partner-brief.v1",
+        generatedAt: "2026-03-30T10:03:00.000Z",
+        persona: {
+          id: "wuff-chief-of-staff",
+          displayName: "Studio Brain Chief of Staff",
+          relationshipModel: "chief_of_staff",
+          proactivity: "active",
+          primarySurface: "codex_desktop_thread",
+          sourceOfTruth: "control_tower",
+          toneTraits: ["proactive", "concise", "initiative-taking", "not chatty"],
+          summary: "An owner-facing operating partner that keeps initiative bounded.",
+        },
+        summary: "Studio Brain verified the portal lane and is asking for one owner decision before it keeps moving.",
+        initiativeState: "waiting_on_owner",
+        lastMeaningfulContactAt: "2026-03-30T10:02:00.000Z",
+        nextCheckInAt: "2026-03-30T12:00:00.000Z",
+        cooldownUntil: null,
+        needsOwnerDecision: true,
+        contactReason: "Studio Brain verified the portal lane and is asking for one owner decision before it keeps moving.",
+        verifiedContext: [
+          "Portal issue is the main focus and the next safe move is inspection.",
+          "Operator direction is still pending.",
+          "Portal lane stayed active in the control tower.",
+        ],
+        singleDecisionNeeded: "Decide whether to keep the portal lane active or pause it.",
+        recommendedFocus: "Decide whether to keep the portal lane active or pause it.",
+        dailyNote: "Studio Brain is tracking 1 bounded open loop. Recommended focus: decide whether to keep the portal lane active or pause it.",
+        openLoops: [
+          {
+            id: "room:portal",
+            title: "Portal lane waiting on decision",
+            status: "open",
+            summary: "Portal room is waiting on a bounded operator decision.",
+            next: "Inspect portal",
+            source: "control-tower-room:portal",
+            updatedAt: "2026-03-30T09:58:00.000Z",
+            roomId: "portal",
+            sessionName: "sb-room",
+            decisionNeeded: "Decide whether to keep the portal lane active or pause it.",
+            verifiedContext: ["Portal lane needs direction.", "Portal lane stayed active in the control tower."],
+            evidence: ["monsoonfire-portal", "Codex", "sb-room"],
+          },
+        ],
+        idleBudget: {
+          policy: "one_task_at_a_time",
+          maxConcurrentTasks: 1,
+          maxAttemptsPerLoop: 2,
+          rankedBacklog: ["stale blocker cleanup", "unresolved review queues", "memory hygiene"],
+          verifyBeforeReport: true,
+          contactOnlyOnMeaningfulChange: true,
+        },
+        programs: [
+          {
+            id: "daily_brief",
+            label: "Daily Brief",
+            trigger: "Scheduled morning or first meaningful operator touchpoint of the day.",
+            scope: "Summarize real Control Tower state, open loops, and one recommended focus.",
+            approvalGate: "No approval required for summaries that do not trigger external writes.",
+            escalationRule: "Escalate only if the brief contains a blocker, approval, or drift that needs owner review.",
+            cooldown: "At most one full morning brief per day unless the state changes materially.",
+            stopCondition: "Stop after one bounded brief is delivered and recorded.",
+          },
+        ],
+        collaborationCommands: [
+          { command: "pause", description: "Quiet the chief-of-staff loop." },
+          { command: "redirect", description: "Redirect the current initiative without losing continuity." },
+          { command: "why this", description: "Ask why Studio Brain chose the current interruption." },
+          { command: "continue", description: "Resume the bounded loop with the current context." },
+        ],
+        artifacts: {
+          latestBriefPath: "output/studio-brain/partner/latest-brief.json",
+          checkinsPath: "output/studio-brain/partner/checkins.jsonl",
+          openLoopsPath: "output/studio-brain/partner/open-loops.json",
+        },
       },
       actions: [],
       overview: {
@@ -448,6 +527,10 @@ describe("StudioBrainControlTowerModule", () => {
     );
 
     expect(await screen.findByText("30-second operator plane")).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Chief of staff" })).toBeTruthy();
+    expect(screen.getByText("Owner commands")).toBeTruthy();
+    expect(screen.getByText("Why this contact")).toBeTruthy();
+    expect(screen.getByText("Portal lane waiting on decision")).toBeTruthy();
     expect(screen.getByRole("heading", { name: "Continuity brief" })).toBeTruthy();
     expect(screen.getByText("Next memory actions")).toBeTruthy();
     expect(screen.getByText("Startup quality")).toBeTruthy();
@@ -554,6 +637,79 @@ describe("StudioBrainControlTowerModule", () => {
     expect(screen.getByText("Review and split the unknown mail-thread cluster before the next dream pass.")).toBeTruthy();
     expect(screen.getByText("blocked continuity: 25%")).toBeTruthy();
     expect(screen.getByText("avg pre-start repo reads: 2")).toBeTruthy();
+  });
+
+  it("sends chief-of-staff commands and open-loop updates through bounded partner routes", async () => {
+    vi.spyOn(controlTowerUtils, "subscribeControlTowerEvents").mockReturnValue(() => undefined);
+    const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = new URL(String(input));
+      const method = (init?.method ?? "GET").toUpperCase();
+
+      if (method === "GET" && url.pathname === "/api/control-tower/state") {
+        return new Response(JSON.stringify(createStatePayload()), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+
+      if (method === "POST" && url.pathname === "/api/control-tower/partner/checkins") {
+        return new Response(JSON.stringify({ ok: true, partner: createStatePayload().state.partner }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+
+      if (method === "POST" && url.pathname === "/api/control-tower/partner/open-loops/room%3Aportal") {
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            partner: createStatePayload().state.partner,
+            openLoop: createStatePayload().state.partner.openLoops[0],
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
+
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    render(
+      <StudioBrainControlTowerModule
+        user={createUser()}
+        active={true}
+        disabled={false}
+        adminToken=""
+        onNavigateTarget={() => undefined}
+      />,
+    );
+
+    expect(await screen.findByRole("heading", { name: "Chief of staff" })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Pause" }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining("/api/control-tower/partner/checkins"),
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Redirect" })[0]);
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining("/api/control-tower/partner/open-loops/room%3Aportal"),
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
   });
 
   it("accepts a runtime Studio Brain base URL override and loads the tower without a rebuild", async () => {

--- a/web/src/views/staff/StudioBrainControlTowerModule.tsx
+++ b/web/src/views/staff/StudioBrainControlTowerModule.tsx
@@ -14,9 +14,11 @@ import {
   getStudioBrainControlTowerResolution,
   runControlTowerServiceAction,
   sendControlTowerInstruction,
+  sendPartnerCheckinAction,
   setControlTowerRoomPinned,
   spawnControlTowerRoom,
   subscribeControlTowerEvents,
+  updatePartnerOpenLoopStatus,
   type ControlTowerActionTarget,
   type ControlTowerRoomDetail,
   type ControlTowerServiceCard,
@@ -143,6 +145,23 @@ function actionabilityTone(status: string | null | undefined): "danger" | "warn"
   return "neutral";
 }
 
+function partnerInitiativeTone(
+  state: "quiet" | "monitoring" | "briefing" | "executing" | "cooldown" | "waiting_on_owner",
+): "danger" | "warn" | "ok" | "neutral" {
+  if (state === "waiting_on_owner") return "warn";
+  if (state === "executing") return "ok";
+  if (state === "cooldown") return "neutral";
+  if (state === "briefing") return "ok";
+  if (state === "monitoring") return "neutral";
+  return "neutral";
+}
+
+function openLoopTone(status: "open" | "delegated" | "paused" | "resolved"): "danger" | "warn" | "ok" | "neutral" {
+  if (status === "open") return "warn";
+  if (status === "resolved") return "ok";
+  return "neutral";
+}
+
 function shouldSurfaceMemoryActions(state: ControlTowerState | null): boolean {
   if (!state) return false;
   if (state.memoryBrief.continuityState !== "ready") return true;
@@ -220,6 +239,7 @@ export default function StudioBrainControlTowerModule({
   const [paletteOpen, setPaletteOpen] = useState(false);
   const servicesRef = useRef<HTMLElement | null>(null);
   const eventsRef = useRef<HTMLElement | null>(null);
+  const partnerRef = useRef<HTMLElement | null>(null);
   const streamRefreshTimerRef = useRef<number | null>(null);
 
   const fetchOptions = useMemo(
@@ -377,6 +397,10 @@ export default function StudioBrainControlTowerModule({
         eventsRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
         return;
       }
+      if (target.action === "partner") {
+        partnerRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+        return;
+      }
       if (target.action === "approvals") {
         onNavigateTarget("system");
         return;
@@ -458,6 +482,40 @@ export default function StudioBrainControlTowerModule({
     [fetchOptions, loadState, runAction],
   );
 
+  const handlePartnerCommand = useCallback(
+    async (
+      action: "ack" | "snooze" | "pause" | "redirect" | "why_this" | "continue",
+      payload?: { note?: string; snoozeMinutes?: number; successMessage?: string },
+    ) => {
+      await runAction(`partner:${action}`, async () => {
+        await sendPartnerCheckinAction(action, fetchOptions, {
+          note: payload?.note,
+          snoozeMinutes: payload?.snoozeMinutes,
+        });
+        setStatusMessage(payload?.successMessage || `Chief-of-staff command "${action}" recorded.`);
+        await loadState({ silent: true });
+      });
+    },
+    [fetchOptions, loadState, runAction],
+  );
+
+  const handlePartnerOpenLoop = useCallback(
+    async (
+      loopId: string,
+      status: "delegated" | "paused" | "resolved",
+      payload?: { note?: string; successMessage?: string },
+    ) => {
+      await runAction(`partner-loop:${loopId}:${status}`, async () => {
+        await updatePartnerOpenLoopStatus(loopId, status, fetchOptions, {
+          note: payload?.note,
+        });
+        setStatusMessage(payload?.successMessage || `Updated ${loopId} to ${status}.`);
+        await loadState({ silent: true });
+      });
+    },
+    [fetchOptions, loadState, runAction],
+  );
+
   const handleSpawnRoom = useCallback(
     async (draft: {
       name: string;
@@ -515,6 +573,8 @@ export default function StudioBrainControlTowerModule({
     escalated: 0,
   };
   const startupScorecard = state?.startupScorecard ?? null;
+  const partner = state?.partner ?? null;
+  const primaryPartnerLoop = partner?.openLoops.find((loop) => loop.status === "open") ?? partner?.openLoops[0] ?? null;
   const memoryActionRows = useMemo(() => getMemoryActionRows(state), [state]);
   const memoryActionsQuiet = memoryActionRows.length === 0;
 
@@ -790,6 +850,12 @@ export default function StudioBrainControlTowerModule({
                     <strong>{row.next}</strong>
                   </div>
                 </div>
+                {row.contactReason || row.decisionNeeded ? (
+                  <div className="control-tower-memory-list">
+                    {row.contactReason ? <span>why contacted: {row.contactReason}</span> : null}
+                    {row.decisionNeeded ? <span>decision: {row.decisionNeeded}</span> : null}
+                  </div>
+                ) : null}
                 {row.roomId ? (
                   <div className="control-tower-next-footer">
                     <span>{row.sessionName || row.roomId}</span>
@@ -874,6 +940,7 @@ export default function StudioBrainControlTowerModule({
                     </div>
                     <h3>{room.objective}</h3>
                     <p>{room.summary}</p>
+                    {room.decisionNeeded ? <p>{`Decision needed: ${room.decisionNeeded}`}</p> : null}
                     <div className="control-tower-room-footer">
                       <span>{formatRelativeAge(room.ageMinutes)}</span>
                       <span>{room.sessionNames.length} lane{room.sessionNames.length === 1 ? "" : "s"}</span>
@@ -888,6 +955,152 @@ export default function StudioBrainControlTowerModule({
           </div>
 
           <aside className="control-tower-rail">
+            <section ref={partnerRef} className="card staff-console-card control-tower-section-card">
+              <div className="control-tower-section-header">
+                <div>
+                  <div className="control-tower-kicker">Partner</div>
+                  <h2>Chief of staff</h2>
+                  <p>Codex is the relationship shell; Control Tower stays the source of truth for what was verified, why you were interrupted, and the one decision needed next.</p>
+                </div>
+              </div>
+              <div className="control-tower-memory-stack">
+                <article className="control-tower-next-card">
+                  <div className="control-tower-title-row">
+                    <h3>{partner?.recommendedFocus || "No partner brief yet."}</h3>
+                    <span className={`pill control-tower-pill-${partnerInitiativeTone(partner?.initiativeState ?? "quiet")}`}>
+                      {partner?.initiativeState || "quiet"}
+                    </span>
+                  </div>
+                  <p>{partner?.summary || "Studio Brain will keep this quiet until there is a meaningful brief to deliver."}</p>
+                  <div className="control-tower-next-footer">
+                    <span>{partner?.persona.displayName || "Chief-of-staff partner"}</span>
+                    <span>{formatTimestamp(partner?.nextCheckInAt ?? null)}</span>
+                  </div>
+                </article>
+
+                <article className="control-tower-memory-card">
+                  <div className="control-tower-title-row">
+                    <h3>Why this contact</h3>
+                    <span className={`pill control-tower-pill-${partner?.needsOwnerDecision ? "warn" : "neutral"}`}>
+                      {partner?.needsOwnerDecision ? "decision waiting" : "bounded cadence"}
+                    </span>
+                  </div>
+                  <p>{partner?.contactReason || "No partner interruption is active right now."}</p>
+                  <div className="control-tower-memory-list">
+                    <span>single decision: {partner?.singleDecisionNeeded || "None right now."}</span>
+                    <span>last meaningful contact: {formatTimestamp(partner?.lastMeaningfulContactAt ?? null)}</span>
+                    <span>next check-in: {formatTimestamp(partner?.nextCheckInAt ?? null)}</span>
+                    <span>cooldown: {formatTimestamp(partner?.cooldownUntil ?? null)}</span>
+                  </div>
+                </article>
+
+                <article className="control-tower-memory-card">
+                  <div className="control-tower-title-row">
+                    <h3>Owner commands</h3>
+                    <span className="pill control-tower-pill-neutral">Codex thread controls</span>
+                  </div>
+                  <p>These commands update the chief-of-staff loop immediately without changing the underlying Control Tower evidence.</p>
+                  <div className="control-tower-partner-command-row">
+                    <button type="button" className="btn btn-ghost btn-small" onClick={() => void handlePartnerCommand("ack", { successMessage: "Chief-of-staff nudge acknowledged." })}>
+                      Acknowledge
+                    </button>
+                    <button type="button" className="btn btn-ghost btn-small" onClick={() => void handlePartnerCommand("pause", { successMessage: "Chief-of-staff cadence paused for the current window." })}>
+                      Pause
+                    </button>
+                    <button
+                      type="button"
+                      className="btn btn-ghost btn-small"
+                      onClick={() =>
+                        primaryPartnerLoop
+                          ? void handlePartnerOpenLoop(primaryPartnerLoop.id, "delegated", {
+                              note: "Redirected from Control Tower.",
+                              successMessage: "Primary open loop redirected.",
+                            })
+                          : void handlePartnerCommand("redirect", {
+                              note: "Redirected from Control Tower.",
+                              successMessage: "Chief-of-staff direction updated.",
+                            })
+                      }
+                    >
+                      Redirect
+                    </button>
+                    <button type="button" className="btn btn-ghost btn-small" onClick={() => void handlePartnerCommand("why_this", { successMessage: "Chief-of-staff rationale refreshed." })}>
+                      Why this
+                    </button>
+                    <button type="button" className="btn btn-ghost btn-small" onClick={() => void handlePartnerCommand("continue", { successMessage: "Chief-of-staff cadence resumed." })}>
+                      Continue
+                    </button>
+                    <button type="button" className="btn btn-ghost btn-small" onClick={() => void handlePartnerCommand("snooze", { snoozeMinutes: 120, successMessage: "Chief-of-staff nudges snoozed for 2 hours." })}>
+                      Snooze 2h
+                    </button>
+                  </div>
+                </article>
+
+                <article className="control-tower-memory-card">
+                  <h3>Verified context</h3>
+                  <div className="control-tower-memory-list">
+                    {(partner?.verifiedContext ?? []).slice(0, 4).map((row) => (
+                      <span key={row}>{row}</span>
+                    ))}
+                    {!(partner?.verifiedContext ?? []).length ? <span>No verified context has been promoted yet.</span> : null}
+                  </div>
+                </article>
+
+                <article className="control-tower-memory-card">
+                  <div className="control-tower-title-row">
+                    <h3>Open loops</h3>
+                    <span className="pill control-tower-pill-neutral">{partner?.openLoops.length ?? 0} tracked</span>
+                  </div>
+                  <div className="control-tower-partner-loop-list">
+                    {(partner?.openLoops ?? []).slice(0, 4).map((loop) => (
+                      <article key={loop.id} className="control-tower-partner-loop-card">
+                        <div className="control-tower-card-top">
+                          <div>
+                            <span className="control-tower-room-name">{loop.title}</span>
+                            <span className="control-tower-room-project">{loop.source}</span>
+                          </div>
+                          <span className={`pill control-tower-pill-${openLoopTone(loop.status)}`}>{loop.status}</span>
+                        </div>
+                        <p>{loop.summary}</p>
+                        <div className="control-tower-memory-list">
+                          <span>next: {loop.next}</span>
+                          <span>decision: {loop.decisionNeeded || "None"}</span>
+                          <span>updated: {formatTimestamp(loop.updatedAt)}</span>
+                        </div>
+                        <div className="control-tower-partner-loop-actions">
+                          <button type="button" className="btn btn-ghost btn-small" onClick={() => void handlePartnerOpenLoop(loop.id, "delegated", { note: "Redirected from Control Tower.", successMessage: `${loop.title} redirected.` })}>
+                            Redirect
+                          </button>
+                          <button type="button" className="btn btn-ghost btn-small" onClick={() => void handlePartnerOpenLoop(loop.id, "paused", { note: "Paused from Control Tower.", successMessage: `${loop.title} paused.` })}>
+                            Pause loop
+                          </button>
+                          <button type="button" className="btn btn-ghost btn-small" onClick={() => void handlePartnerOpenLoop(loop.id, "resolved", { note: "Resolved from Control Tower.", successMessage: `${loop.title} resolved.` })}>
+                            Resolve
+                          </button>
+                        </div>
+                      </article>
+                    ))}
+                    {!(partner?.openLoops ?? []).length ? <div className="staff-note staff-note-ok">No owner-facing open loops are active right now.</div> : null}
+                  </div>
+                </article>
+
+                <article className="control-tower-memory-card">
+                  <div className="control-tower-title-row">
+                    <h3>Partner programs</h3>
+                    <span className="pill control-tower-pill-neutral">{partner?.programs.length ?? 0} programs</span>
+                  </div>
+                  <div className="control-tower-memory-list">
+                    {(partner?.programs ?? []).slice(0, 5).map((program) => (
+                      <span key={program.id}>
+                        <strong>{program.label}:</strong> {program.trigger}
+                      </span>
+                    ))}
+                    {!(partner?.programs ?? []).length ? <span>Partner programs will appear once the latest brief is generated.</span> : null}
+                  </div>
+                </article>
+              </div>
+            </section>
+
             <section className="card staff-console-card control-tower-section-card">
               <div className="control-tower-section-header">
                 <div>

--- a/web/src/views/staff/studioBrainControlTower.css
+++ b/web/src/views/staff/studioBrainControlTower.css
@@ -270,10 +270,28 @@
 .control-tower-next-list,
 .control-tower-pinned-list,
 .control-tower-timeline,
-.control-tower-session-list {
+.control-tower-session-list,
+.control-tower-partner-loop-list {
   display: flex;
   flex-direction: column;
   gap: 12px;
+}
+
+.control-tower-partner-command-row,
+.control-tower-partner-loop-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.control-tower-partner-loop-card {
+  padding: 14px 16px;
+  border-radius: 18px;
+  border: 1px solid rgba(136, 152, 179, 0.16);
+  background: rgba(12, 17, 24, 0.78);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
 }
 
 .control-tower-memory-card {


### PR DESCRIPTION
## Summary
- add the Studio Brain chief-of-staff partner contracts, file artifacts, and brief generation/update service
- expose bounded partner and agent-runtime control tower routes in the Studio Brain HTTP server
- render the new Chief of staff rail in the staff Control Tower with owner commands and open-loop controls

## Verification
- npm --prefix studio-brain run build
- node --test studio-brain/lib/http/server.test.js
- npm --prefix web run test -- src/views/staff/StudioBrainControlTowerModule.test.tsx
- npm --prefix web run build
- npm run deploy:namecheap:portal
- npm run studio:ops:deploy
- production visual check on https://portal.monsoonfire.com/staff/cockpit/control-tower with the current session bridge override