### PR TITLE
Add autonomous ops portal and fold staff workflows into /ops

### DIFF
--- a/studio-brain/migrations/023_ops_autonomous_foundation.sql
+++ b/studio-brain/migrations/023_ops_autonomous_foundation.sql
@@ -1,0 +1,242 @@
+CREATE TABLE IF NOT EXISTS brain_ops_ingest_receipts (
+  id text PRIMARY KEY,
+  source_system text NOT NULL,
+  source_event_id text NOT NULL,
+  payload_hash text NOT NULL,
+  auth_principal text NOT NULL,
+  received_at timestamptz NOT NULL,
+  timestamp_skew_seconds integer NOT NULL DEFAULT 0,
+  raw_payload jsonb NOT NULL DEFAULT '{}'::jsonb
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_brain_ops_ingest_receipts_source_event
+  ON brain_ops_ingest_receipts (source_system, source_event_id);
+CREATE INDEX IF NOT EXISTS idx_brain_ops_ingest_receipts_received
+  ON brain_ops_ingest_receipts (received_at DESC);
+
+CREATE TABLE IF NOT EXISTS brain_ops_events (
+  id text PRIMARY KEY,
+  event_type text NOT NULL,
+  event_version integer NOT NULL DEFAULT 1,
+  entity_kind text NOT NULL,
+  entity_id text NOT NULL,
+  case_id text NULL,
+  source_system text NOT NULL,
+  source_event_id text NOT NULL,
+  dedupe_key text NOT NULL,
+  room_id text NULL,
+  actor_kind text NOT NULL,
+  actor_id text NOT NULL,
+  confidence real NOT NULL DEFAULT 0.5,
+  occurred_at timestamptz NOT NULL,
+  ingested_at timestamptz NOT NULL,
+  verification_class text NOT NULL CHECK (verification_class IN ('observed', 'inferred', 'planned', 'claimed', 'confirmed')),
+  artifact_refs jsonb NOT NULL DEFAULT '[]'::jsonb,
+  raw_payload jsonb NOT NULL DEFAULT '{}'::jsonb
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_brain_ops_events_source_event
+  ON brain_ops_events (source_system, source_event_id);
+CREATE INDEX IF NOT EXISTS idx_brain_ops_events_case
+  ON brain_ops_events (case_id, occurred_at DESC);
+CREATE INDEX IF NOT EXISTS idx_brain_ops_events_entity
+  ON brain_ops_events (entity_kind, entity_id, occurred_at DESC);
+
+CREATE TABLE IF NOT EXISTS brain_ops_auth_receipts (
+  id text PRIMARY KEY,
+  source_system text NOT NULL,
+  actor_id text NOT NULL,
+  actor_kind text NOT NULL,
+  status text NOT NULL CHECK (status IN ('authorized', 'denied', 'degraded')),
+  observed_at timestamptz NOT NULL,
+  expires_at timestamptz NULL,
+  raw_payload jsonb NOT NULL DEFAULT '{}'::jsonb
+);
+
+CREATE INDEX IF NOT EXISTS idx_brain_ops_auth_receipts_observed
+  ON brain_ops_auth_receipts (observed_at DESC);
+CREATE INDEX IF NOT EXISTS idx_brain_ops_auth_receipts_actor
+  ON brain_ops_auth_receipts (actor_id, observed_at DESC);
+
+CREATE TABLE IF NOT EXISTS brain_ops_cases (
+  id text PRIMARY KEY,
+  kind text NOT NULL CHECK (kind IN ('kiln_run', 'arrival', 'support_thread', 'event', 'anomaly', 'complaint', 'growth_experiment', 'improvement_case', 'station_session', 'general')),
+  title text NOT NULL,
+  status text NOT NULL CHECK (status IN ('open', 'active', 'blocked', 'awaiting_approval', 'resolved', 'canceled')),
+  priority text NOT NULL CHECK (priority IN ('p0', 'p1', 'p2', 'p3')),
+  lane text NOT NULL CHECK (lane IN ('owner', 'manager', 'hands', 'internet', 'ceo', 'forge')),
+  owner_role text NULL,
+  verification_class text NOT NULL CHECK (verification_class IN ('observed', 'inferred', 'planned', 'claimed', 'confirmed')),
+  freshest_at timestamptz NULL,
+  confidence real NOT NULL DEFAULT 0.5,
+  degrade_reason text NULL,
+  due_at timestamptz NULL,
+  linked_entity_kind text NULL,
+  linked_entity_id text NULL,
+  memory_scope text NULL,
+  created_at timestamptz NOT NULL,
+  updated_at timestamptz NOT NULL,
+  raw_payload jsonb NOT NULL DEFAULT '{}'::jsonb
+);
+
+CREATE INDEX IF NOT EXISTS idx_brain_ops_cases_status
+  ON brain_ops_cases (status, updated_at DESC);
+CREATE INDEX IF NOT EXISTS idx_brain_ops_cases_lane
+  ON brain_ops_cases (lane, updated_at DESC);
+CREATE INDEX IF NOT EXISTS idx_brain_ops_cases_priority
+  ON brain_ops_cases (priority, updated_at DESC);
+
+CREATE TABLE IF NOT EXISTS brain_ops_case_notes (
+  id text PRIMARY KEY,
+  case_id text NOT NULL REFERENCES brain_ops_cases(id) ON DELETE CASCADE,
+  actor_id text NOT NULL,
+  actor_kind text NOT NULL,
+  body text NOT NULL,
+  created_at timestamptz NOT NULL,
+  raw_payload jsonb NOT NULL DEFAULT '{}'::jsonb
+);
+
+CREATE INDEX IF NOT EXISTS idx_brain_ops_case_notes_case_created
+  ON brain_ops_case_notes (case_id, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS brain_ops_tasks (
+  id text PRIMARY KEY,
+  case_id text NULL REFERENCES brain_ops_cases(id) ON DELETE SET NULL,
+  title text NOT NULL,
+  status text NOT NULL CHECK (status IN ('proposed', 'queued', 'claimed', 'in_progress', 'blocked', 'proof_pending', 'verified', 'reopened', 'canceled')),
+  priority text NOT NULL CHECK (priority IN ('p0', 'p1', 'p2', 'p3')),
+  surface text NOT NULL CHECK (surface IN ('hands', 'internet', 'manager', 'owner')),
+  role text NOT NULL,
+  zone text NOT NULL,
+  due_at timestamptz NULL,
+  eta_minutes integer NULL,
+  interruptibility text NOT NULL CHECK (interruptibility IN ('now', 'soon', 'queue')),
+  verification_class text NOT NULL CHECK (verification_class IN ('observed', 'inferred', 'planned', 'claimed', 'confirmed')),
+  freshest_at timestamptz NULL,
+  confidence real NOT NULL DEFAULT 0.5,
+  degrade_reason text NULL,
+  claimed_by text NULL,
+  claimed_at timestamptz NULL,
+  completed_at timestamptz NULL,
+  blocker_reason text NULL,
+  created_at timestamptz NOT NULL,
+  updated_at timestamptz NOT NULL,
+  raw_payload jsonb NOT NULL DEFAULT '{}'::jsonb
+);
+
+CREATE INDEX IF NOT EXISTS idx_brain_ops_tasks_status
+  ON brain_ops_tasks (status, updated_at DESC);
+CREATE INDEX IF NOT EXISTS idx_brain_ops_tasks_case
+  ON brain_ops_tasks (case_id, updated_at DESC);
+CREATE INDEX IF NOT EXISTS idx_brain_ops_tasks_surface_zone
+  ON brain_ops_tasks (surface, zone, updated_at DESC);
+
+CREATE TABLE IF NOT EXISTS brain_ops_task_proofs (
+  id text PRIMARY KEY,
+  task_id text NOT NULL REFERENCES brain_ops_tasks(id) ON DELETE CASCADE,
+  mode text NOT NULL CHECK (mode IN ('manual_confirm', 'qr_scan', 'camera_snapshot', 'sensor_transition', 'dual_confirm')),
+  actor_id text NOT NULL,
+  verification_status text NOT NULL CHECK (verification_status IN ('submitted', 'accepted', 'rejected')),
+  note text NULL,
+  artifact_refs jsonb NOT NULL DEFAULT '[]'::jsonb,
+  created_at timestamptz NOT NULL,
+  raw_payload jsonb NOT NULL DEFAULT '{}'::jsonb
+);
+
+CREATE INDEX IF NOT EXISTS idx_brain_ops_task_proofs_task_created
+  ON brain_ops_task_proofs (task_id, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS brain_ops_approvals (
+  id text PRIMARY KEY,
+  case_id text NULL REFERENCES brain_ops_cases(id) ON DELETE SET NULL,
+  title text NOT NULL,
+  status text NOT NULL CHECK (status IN ('pending', 'approved', 'rejected', 'executed', 'expired')),
+  action_class text NOT NULL,
+  requested_by text NOT NULL,
+  required_role text NOT NULL,
+  verification_class text NOT NULL CHECK (verification_class IN ('observed', 'inferred', 'planned', 'claimed', 'confirmed')),
+  freshest_at timestamptz NULL,
+  confidence real NOT NULL DEFAULT 0.5,
+  degrade_reason text NULL,
+  created_at timestamptz NOT NULL,
+  updated_at timestamptz NOT NULL,
+  resolved_at timestamptz NULL,
+  resolved_by text NULL,
+  raw_payload jsonb NOT NULL DEFAULT '{}'::jsonb
+);
+
+CREATE INDEX IF NOT EXISTS idx_brain_ops_approvals_status
+  ON brain_ops_approvals (status, updated_at DESC);
+CREATE INDEX IF NOT EXISTS idx_brain_ops_approvals_case
+  ON brain_ops_approvals (case_id, updated_at DESC);
+
+CREATE TABLE IF NOT EXISTS brain_ops_action_effect_receipts (
+  id text PRIMARY KEY,
+  action_id text NOT NULL,
+  source_system text NOT NULL,
+  effect_type text NOT NULL,
+  verification_class text NOT NULL CHECK (verification_class IN ('observed', 'inferred', 'planned', 'claimed', 'confirmed')),
+  observed_at timestamptz NOT NULL,
+  raw_payload jsonb NOT NULL DEFAULT '{}'::jsonb
+);
+
+CREATE INDEX IF NOT EXISTS idx_brain_ops_action_effect_receipts_action
+  ON brain_ops_action_effect_receipts (action_id, observed_at DESC);
+
+CREATE TABLE IF NOT EXISTS brain_ops_growth_experiments (
+  id text PRIMARY KEY,
+  status text NOT NULL CHECK (status IN ('proposed', 'running', 'paused', 'completed')),
+  owner text NOT NULL,
+  updated_at timestamptz NOT NULL,
+  raw_payload jsonb NOT NULL DEFAULT '{}'::jsonb
+);
+
+CREATE INDEX IF NOT EXISTS idx_brain_ops_growth_experiments_status
+  ON brain_ops_growth_experiments (status, updated_at DESC);
+
+CREATE TABLE IF NOT EXISTS brain_ops_improvement_cases (
+  id text PRIMARY KEY,
+  status text NOT NULL CHECK (status IN ('open', 'evaluating', 'approved', 'shadow', 'rejected', 'shipped')),
+  updated_at timestamptz NOT NULL,
+  raw_payload jsonb NOT NULL DEFAULT '{}'::jsonb
+);
+
+CREATE INDEX IF NOT EXISTS idx_brain_ops_improvement_cases_status
+  ON brain_ops_improvement_cases (status, updated_at DESC);
+
+CREATE TABLE IF NOT EXISTS brain_ops_station_sessions (
+  id text PRIMARY KEY,
+  station_id text NOT NULL,
+  room_id text NOT NULL,
+  surface_mode text NOT NULL CHECK (surface_mode IN ('ambient_board', 'focus_task', 'proof_station')),
+  current_task_id text NULL REFERENCES brain_ops_tasks(id) ON DELETE SET NULL,
+  actor_id text NULL,
+  last_seen_at timestamptz NOT NULL,
+  raw_payload jsonb NOT NULL DEFAULT '{}'::jsonb
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_brain_ops_station_sessions_station
+  ON brain_ops_station_sessions (station_id);
+CREATE INDEX IF NOT EXISTS idx_brain_ops_station_sessions_last_seen
+  ON brain_ops_station_sessions (last_seen_at DESC);
+
+CREATE TABLE IF NOT EXISTS brain_ops_degraded_modes (
+  mode text PRIMARY KEY CHECK (mode IN ('observe_only', 'draft_only', 'no_human_tasking', 'manual_dispatch_only', 'internet_pause', 'growth_pause', 'forge_pause')),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS brain_ops_source_freshness (
+  source_key text PRIMARY KEY,
+  freshest_at timestamptz NULL,
+  freshness_seconds integer NULL,
+  budget_seconds integer NOT NULL,
+  status text NOT NULL CHECK (status IN ('healthy', 'warning', 'critical')),
+  reason text NULL,
+  raw_payload jsonb NOT NULL DEFAULT '{}'::jsonb
+);
+
+CREATE TABLE IF NOT EXISTS brain_ops_watchdogs (
+  id text PRIMARY KEY,
+  status text NOT NULL CHECK (status IN ('healthy', 'warning', 'critical')),
+  raw_payload jsonb NOT NULL DEFAULT '{}'::jsonb
+);

--- a/studio-brain/migrations/024_ops_staff_replacement_foundation.sql
+++ b/studio-brain/migrations/024_ops_staff_replacement_foundation.sql
@@ -1,0 +1,63 @@
+ALTER TABLE brain_ops_task_proofs
+  DROP CONSTRAINT IF EXISTS brain_ops_task_proofs_verification_status_check;
+
+ALTER TABLE brain_ops_task_proofs
+  ADD CONSTRAINT brain_ops_task_proofs_verification_status_check
+  CHECK (verification_status IN ('submitted', 'accepted', 'rejected', 'readback_pending'));
+
+CREATE TABLE IF NOT EXISTS brain_ops_task_escapes (
+  id text PRIMARY KEY,
+  task_id text NOT NULL REFERENCES brain_ops_tasks(id) ON DELETE CASCADE,
+  case_id text NULL REFERENCES brain_ops_cases(id) ON DELETE SET NULL,
+  actor_id text NOT NULL,
+  escape_hatch text NOT NULL,
+  status text NOT NULL,
+  created_at timestamptz NOT NULL,
+  resolved_at timestamptz NULL,
+  resolved_by text NULL,
+  raw_payload jsonb NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_brain_ops_task_escapes_task_created
+  ON brain_ops_task_escapes (task_id, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS brain_ops_overrides (
+  id text PRIMARY KEY,
+  actor_id text NOT NULL,
+  scope text NOT NULL,
+  required_role text NOT NULL,
+  status text NOT NULL,
+  expires_at timestamptz NULL,
+  created_at timestamptz NOT NULL,
+  resolved_at timestamptz NULL,
+  resolved_by text NULL,
+  raw_payload jsonb NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_brain_ops_overrides_created
+  ON brain_ops_overrides (created_at DESC);
+
+CREATE TABLE IF NOT EXISTS brain_ops_member_audits (
+  id text PRIMARY KEY,
+  uid text NOT NULL,
+  kind text NOT NULL,
+  actor_id text NOT NULL,
+  created_at timestamptz NOT NULL,
+  raw_payload jsonb NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_brain_ops_member_audits_uid_created
+  ON brain_ops_member_audits (uid, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS brain_ops_reservation_bundles (
+  id text PRIMARY KEY,
+  reservation_id text NOT NULL UNIQUE,
+  status text NOT NULL,
+  due_at timestamptz NULL,
+  owner_uid text NULL,
+  updated_at timestamptz NOT NULL,
+  raw_payload jsonb NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_brain_ops_reservation_bundles_due
+  ON brain_ops_reservation_bundles (due_at ASC, updated_at DESC);

--- a/studio-brain/src/agentRuntime/contracts.ts
+++ b/studio-brain/src/agentRuntime/contracts.ts
@@ -2,6 +2,7 @@ import type { AgentRuntimePartnerContext } from "../partner/contracts";
 
 export type AgentRuntimeRiskLane = "interactive" | "background" | "high_risk";
 export type AgentRuntimeStatus = "queued" | "running" | "blocked" | "verified" | "completed" | "failed";
+export type AgentRuntimeEnvironment = "local" | "server";
 
 export type RatholeSignal = {
   signalId: string;
@@ -40,6 +41,9 @@ export type AgentRuntimeSummary = {
   generatedAt?: string;
   runId: string;
   missionId: string;
+  hostId?: string | null;
+  agentId?: string | null;
+  environment?: AgentRuntimeEnvironment | null;
   status: AgentRuntimeStatus;
   riskLane: AgentRuntimeRiskLane;
   title: string;
@@ -66,8 +70,74 @@ export type AgentRuntimeSummary = {
     blocker: string;
     next: string;
     last_update: string | null;
+    runId?: string | null;
     contactReason?: string | null;
     verifiedContext?: string[];
     decisionNeeded?: string | null;
   };
+};
+
+export type AgentRuntimeTraceStepStatus =
+  | "pending"
+  | "running"
+  | "succeeded"
+  | "failed"
+  | "blocked"
+  | "skipped"
+  | "info";
+
+export type AgentRuntimeTraceStep = {
+  stepId: string;
+  runId: string;
+  title: string;
+  kind: "mission" | "verification" | "tool" | "diagnostic" | "event";
+  status: AgentRuntimeTraceStepStatus;
+  startedAt: string | null;
+  finishedAt: string | null;
+  summary: string;
+  evidenceRefs: string[];
+  rawEventIds: string[];
+};
+
+export type AgentRuntimeToolCall = {
+  toolCallId: string;
+  runId: string;
+  toolName: string;
+  status: "requested" | "streaming" | "completed" | "failed";
+  requestedAt: string | null;
+  completedAt: string | null;
+  summary: string;
+  sideEffectClass: "read" | "write" | "unknown";
+};
+
+export type AgentRuntimeArtifact = {
+  artifactId: string;
+  runId: string;
+  label: string;
+  kind: "json" | "ledger" | "text" | "file";
+  path: string;
+  sizeBytes: number | null;
+  updatedAt: string | null;
+  preview: string | null;
+};
+
+export type AgentRuntimeDiagnostic = {
+  id: string;
+  severity: "info" | "warning" | "critical";
+  title: string;
+  summary: string;
+  recommendedAction: string | null;
+};
+
+export type AgentRuntimeRunDetail = {
+  schema: "agent-runtime-run-detail.v1";
+  generatedAt: string;
+  runId: string;
+  summary: AgentRuntimeSummary | null;
+  events: RunLedgerEvent[];
+  steps: AgentRuntimeTraceStep[];
+  toolCalls: AgentRuntimeToolCall[];
+  diagnostics: AgentRuntimeDiagnostic[];
+  artifacts: AgentRuntimeArtifact[];
+  whyStuck: string | null;
 };

--- a/studio-brain/src/agentRuntime/detail.ts
+++ b/studio-brain/src/agentRuntime/detail.ts
@@ -1,0 +1,232 @@
+import type {
+  AgentRuntimeDiagnostic,
+  AgentRuntimeRunDetail,
+  AgentRuntimeToolCall,
+  AgentRuntimeTraceStep,
+  AgentRuntimeTraceStepStatus,
+  RunLedgerEvent,
+} from "./contracts";
+import { listAgentRuntimeArtifacts, readAgentRuntimeEvents, readAgentRuntimeSummary } from "./files";
+
+function clean(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function clipText(value: string, max = 180): string {
+  const normalized = value.trim();
+  if (!normalized) return "";
+  return normalized.length <= max ? normalized : `${normalized.slice(0, max - 1)}…`;
+}
+
+function toRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
+}
+
+function stepTitleForEvent(event: RunLedgerEvent): string {
+  const payload = toRecord(event.payload);
+  const command = clean(payload.command);
+  const summary = clean(payload.summary);
+  if (command) return command;
+  if (summary) return summary;
+  return event.type.replaceAll(".", " ");
+}
+
+function stepSummaryForEvent(event: RunLedgerEvent): string {
+  const payload = toRecord(event.payload);
+  const summary = clean(payload.summary);
+  const reason = clean(payload.reason);
+  const blocker = clean(payload.blocker);
+  const next = clean(payload.next);
+  const status = clean(payload.status);
+  return (
+    summary ||
+    blocker ||
+    next ||
+    reason ||
+    status ||
+    clipText(JSON.stringify(payload), 200) ||
+    event.type
+  );
+}
+
+function stepKindForEvent(event: RunLedgerEvent): AgentRuntimeTraceStep["kind"] {
+  if (event.type.startsWith("verification.")) return "verification";
+  if (event.type.startsWith("tool.") || clean(toRecord(event.payload).toolName)) return "tool";
+  if (event.type.startsWith("rathole.") || event.type.startsWith("goal.")) return "diagnostic";
+  if (event.type.startsWith("mission.")) return "mission";
+  return "event";
+}
+
+function stepStatusForTerminalEvent(event: RunLedgerEvent): AgentRuntimeTraceStepStatus {
+  const payload = toRecord(event.payload);
+  const eventStatus = clean(payload.status).toLowerCase();
+  if (event.type.endsWith(".started")) return "running";
+  if (event.type.endsWith(".completed")) {
+    if (eventStatus === "failed" || eventStatus === "error") return "failed";
+    if (eventStatus === "skipped") return "skipped";
+    return "succeeded";
+  }
+  if (event.type === "mission.completed") return "succeeded";
+  if (event.type === "mission.failed") return "failed";
+  if (event.type === "rathole.detected") return clean(payload.blocking).toLowerCase() === "true" ? "blocked" : "info";
+  if (event.type === "mission.state.changed") {
+    if (eventStatus === "blocked") return "blocked";
+    if (eventStatus === "failed") return "failed";
+    if (eventStatus === "running") return "running";
+    if (eventStatus === "verified" || eventStatus === "completed") return "succeeded";
+  }
+  return "info";
+}
+
+function stepCorrelationKey(event: RunLedgerEvent): string {
+  const payload = toRecord(event.payload);
+  const baseType = event.type.replace(/\.(started|completed)$/u, "");
+  const command = clean(payload.command);
+  const signalId = clean(payload.signalId);
+  const index = Number.isFinite(Number(payload.index)) ? String(payload.index) : "";
+  return [baseType, command, signalId, index].filter(Boolean).join("|") || `${baseType}|${event.eventId}`;
+}
+
+function projectSteps(events: RunLedgerEvent[]): AgentRuntimeTraceStep[] {
+  const pending = new Map<string, AgentRuntimeTraceStep>();
+  const output: AgentRuntimeTraceStep[] = [];
+
+  for (const event of events) {
+    const key = stepCorrelationKey(event);
+    if (event.type.endsWith(".started")) {
+      pending.set(key, {
+        stepId: key,
+        runId: event.runId,
+        title: stepTitleForEvent(event),
+        kind: stepKindForEvent(event),
+        status: "running",
+        startedAt: event.occurredAt,
+        finishedAt: null,
+        summary: stepSummaryForEvent(event),
+        evidenceRefs: [],
+        rawEventIds: [event.eventId],
+      });
+      continue;
+    }
+
+    const prior = pending.get(key);
+    const payload = toRecord(event.payload);
+    const evidenceRefs = [];
+    const command = clean(payload.command);
+    const signalId = clean(payload.signalId);
+    if (command) evidenceRefs.push(command);
+    if (signalId) evidenceRefs.push(signalId);
+
+    const step: AgentRuntimeTraceStep = {
+      stepId: prior?.stepId || key,
+      runId: event.runId,
+      title: prior?.title || stepTitleForEvent(event),
+      kind: prior?.kind || stepKindForEvent(event),
+      status: stepStatusForTerminalEvent(event),
+      startedAt: prior?.startedAt || event.occurredAt,
+      finishedAt: event.type.endsWith(".started") ? null : event.occurredAt,
+      summary: stepSummaryForEvent(event),
+      evidenceRefs,
+      rawEventIds: [...(prior?.rawEventIds ?? []), event.eventId],
+    };
+    output.push(step);
+    pending.delete(key);
+  }
+
+  for (const step of pending.values()) {
+    output.push(step);
+  }
+
+  return output
+    .sort((left, right) => String(right.startedAt || right.finishedAt || "").localeCompare(String(left.startedAt || left.finishedAt || "")))
+    .slice(0, 18);
+}
+
+function projectToolCalls(events: RunLedgerEvent[]): AgentRuntimeToolCall[] {
+  return events
+    .filter((event) => event.type.startsWith("tool.") || clean(toRecord(event.payload).toolName))
+    .map((event) => {
+      const payload = toRecord(event.payload);
+      const toolName = clean(payload.toolName) || clean(payload.command) || event.type.replaceAll(".", " ");
+      const eventStatus = clean(payload.status).toLowerCase();
+      const status: AgentRuntimeToolCall["status"] =
+        event.type.endsWith(".started")
+          ? "requested"
+          : eventStatus === "failed" || event.type.endsWith(".failed")
+            ? "failed"
+            : eventStatus === "running"
+              ? "streaming"
+              : "completed";
+      const sideEffectClass: AgentRuntimeToolCall["sideEffectClass"] =
+        clean(payload.sideEffectClass) === "write"
+          ? "write"
+          : clean(payload.sideEffectClass) === "read"
+            ? "read"
+            : "unknown";
+      return {
+        toolCallId: event.eventId,
+        runId: event.runId,
+        toolName,
+        status,
+        requestedAt: event.type.endsWith(".started") ? event.occurredAt : null,
+        completedAt: event.type.endsWith(".started") ? null : event.occurredAt,
+        summary: stepSummaryForEvent(event),
+        sideEffectClass,
+      };
+    })
+    .slice(0, 18);
+}
+
+function buildDiagnostics(runId: string, detail: ReturnType<typeof readAgentRuntimeSummary>): AgentRuntimeDiagnostic[] {
+  if (!detail) return [];
+  const diagnostics: AgentRuntimeDiagnostic[] = [];
+  detail.activeBlockers.forEach((blocker, index) => {
+    diagnostics.push({
+      id: `blocker:${index}`,
+      severity: detail.status === "failed" ? "critical" : "warning",
+      title: "Active blocker",
+      summary: blocker,
+      recommendedAction: detail.boardRow?.next || null,
+    });
+  });
+  detail.ratholeSignals.forEach((signal) => {
+    diagnostics.push({
+      id: signal.signalId,
+      severity: signal.severity,
+      title: signal.kind.replaceAll("_", " "),
+      summary: signal.summary,
+      recommendedAction: signal.recommendedAction,
+    });
+  });
+  detail.goalMisses.forEach((goalMiss, index) => {
+    diagnostics.push({
+      id: `goal-miss:${index}`,
+      severity: "warning",
+      title: goalMiss.category.replaceAll("_", " "),
+      summary: goalMiss.summary,
+      recommendedAction: detail.boardRow?.next || null,
+    });
+  });
+  return diagnostics.slice(0, 12);
+}
+
+export function buildAgentRuntimeRunDetail(repoRoot: string, runId: string): AgentRuntimeRunDetail {
+  const summary = readAgentRuntimeSummary(repoRoot, runId);
+  const events = readAgentRuntimeEvents(repoRoot, runId, 120);
+  return {
+    schema: "agent-runtime-run-detail.v1",
+    generatedAt: new Date().toISOString(),
+    runId,
+    summary,
+    events,
+    steps: projectSteps(events),
+    toolCalls: projectToolCalls(events),
+    diagnostics: buildDiagnostics(runId, summary),
+    artifacts: listAgentRuntimeArtifacts(repoRoot, runId, 18),
+    whyStuck:
+      summary?.activeBlockers[0] ||
+      summary?.ratholeSignals[0]?.summary ||
+      summary?.goalMisses[0]?.summary ||
+      null,
+  };
+}

--- a/studio-brain/src/agentRuntime/files.ts
+++ b/studio-brain/src/agentRuntime/files.ts
@@ -1,7 +1,7 @@
-import { appendFileSync, existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { appendFileSync, existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { extname, relative, resolve } from "node:path";
 
-import type { AgentRuntimeSummary, RunLedgerEvent } from "./contracts";
+import type { AgentRuntimeArtifact, AgentRuntimeSummary, RunLedgerEvent } from "./contracts";
 
 const DEFAULT_RUNS_ROOT = ["output", "agent-runs"] as const;
 
@@ -16,6 +16,19 @@ function readJsonFile<T>(path: string): T | null {
   } catch {
     return null;
   }
+}
+
+function isPreviewableArtifact(path: string): boolean {
+  const extension = extname(path).toLowerCase();
+  return [".json", ".jsonl", ".log", ".md", ".txt", ".yaml", ".yml"].includes(extension);
+}
+
+function artifactKind(path: string): AgentRuntimeArtifact["kind"] {
+  const extension = extname(path).toLowerCase();
+  if (extension === ".json") return "json";
+  if (extension === ".jsonl" || extension === ".log") return "ledger";
+  if ([".md", ".txt", ".yaml", ".yml"].includes(extension)) return "text";
+  return "file";
 }
 
 export function agentRuntimeRunsRoot(repoRoot: string): string {
@@ -41,11 +54,15 @@ export function listAgentRuntimeSummaries(repoRoot: string, limit = 12): AgentRu
     .slice(0, Math.max(1, limit));
 }
 
+export function readAgentRuntimeSummary(repoRoot: string, runId: string): AgentRuntimeSummary | null {
+  return readJsonFile<AgentRuntimeSummary>(resolve(agentRuntimeRunRoot(repoRoot, runId), "summary.json"));
+}
+
 export function readLatestAgentRuntimeSummary(repoRoot: string): AgentRuntimeSummary | null {
   const pointer = readJsonFile<{ runId?: string }>(resolve(agentRuntimeRunsRoot(repoRoot), "latest.json"));
   const pointerRunId = clean(pointer?.runId);
   if (pointerRunId) {
-    const summary = readJsonFile<AgentRuntimeSummary>(resolve(agentRuntimeRunRoot(repoRoot, pointerRunId), "summary.json"));
+    const summary = readAgentRuntimeSummary(repoRoot, pointerRunId);
     if (summary) return summary;
   }
   return listAgentRuntimeSummaries(repoRoot, 1)[0] ?? null;
@@ -81,4 +98,43 @@ export function writeAgentRuntimeSummary(repoRoot: string, summary: AgentRuntime
     `${JSON.stringify({ schema: "agent-runtime-pointer.v1", runId: summary.runId, updatedAt: summary.updatedAt }, null, 2)}\n`,
     "utf8",
   );
+}
+
+export function listAgentRuntimeArtifacts(repoRoot: string, runId: string, limit = 18): AgentRuntimeArtifact[] {
+  const runRoot = agentRuntimeRunRoot(repoRoot, runId);
+  if (!existsSync(runRoot)) return [];
+  const queue = [runRoot];
+  const artifacts: AgentRuntimeArtifact[] = [];
+
+  while (queue.length && artifacts.length < Math.max(1, limit)) {
+    const current = queue.shift() as string;
+    for (const entry of readdirSync(current, { withFileTypes: true })) {
+      if (artifacts.length >= Math.max(1, limit)) break;
+      const absolutePath = resolve(current, entry.name);
+      if (entry.isDirectory()) {
+        if (relative(runRoot, absolutePath).split(/[\\/]/).length <= 2) {
+          queue.push(absolutePath);
+        }
+        continue;
+      }
+      if (!entry.isFile()) continue;
+      const stats = statSync(absolutePath);
+      const preview =
+        isPreviewableArtifact(absolutePath) && stats.size <= 128_000
+          ? readFileSync(absolutePath, "utf8").slice(0, 1_200)
+          : null;
+      artifacts.push({
+        artifactId: relative(runRoot, absolutePath).replaceAll("\\", "/"),
+        runId,
+        label: entry.name,
+        kind: artifactKind(absolutePath),
+        path: relative(repoRoot, absolutePath).replaceAll("\\", "/"),
+        sizeBytes: stats.size,
+        updatedAt: Number.isFinite(stats.mtimeMs) ? new Date(stats.mtimeMs).toISOString() : null,
+        preview,
+      });
+    }
+  }
+
+  return artifacts.sort((left, right) => String(right.updatedAt || "").localeCompare(String(left.updatedAt || "")));
 }

--- a/studio-brain/src/config/env.ts
+++ b/studio-brain/src/config/env.ts
@@ -149,6 +149,13 @@ const EnvSchema = z.object({
 
   STUDIO_BRAIN_ENABLE_WRITE_EXECUTION: BoolFromString.default(false),
   STUDIO_BRAIN_REQUIRE_APPROVAL_FOR_EXTERNAL_WRITES: BoolFromString.default(true),
+  STUDIO_BRAIN_ENABLE_OPS_PORTAL: BoolFromString.default(false),
+  STUDIO_BRAIN_REQUIRE_STAFF_FOR_OPS_PORTAL: BoolFromString.default(true),
+  STUDIO_BRAIN_ENABLE_OPS_PORTAL_CHOICE: BoolFromString.default(true),
+  STUDIO_BRAIN_OPS_PORTAL_LEGACY_URL: z.string().default(""),
+  STUDIO_BRAIN_OPS_PORTAL_DEFAULT_SURFACE: z
+    .enum(["manager", "owner", "hands", "internet", "ceo", "forge"])
+    .default("manager"),
   STUDIO_BRAIN_FUNCTIONS_BASE_URL: z.string().default("https://us-central1-monsoonfire-portal.cloudfunctions.net"),
   STUDIO_BRAIN_SUPPORT_EMAIL_ENABLED: BoolFromString.default(false),
   STUDIO_BRAIN_SUPPORT_EMAIL_STARTUP_SYNC: BoolFromString.default(true),

--- a/studio-brain/src/controlTower/derive.ts
+++ b/studio-brain/src/controlTower/derive.ts
@@ -727,6 +727,7 @@ export function deriveControlTowerState(
     startupScorecard: null,
     memoryHealth: null,
     agentRuntime: null,
+    hosts: [],
     partner: null,
     events,
     recentChanges: events.slice(0, 6),

--- a/studio-brain/src/controlTower/hosts.ts
+++ b/studio-brain/src/controlTower/hosts.ts
@@ -1,0 +1,127 @@
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import type { ControlTowerHostCard, ControlTowerHostConnectivity, ControlTowerHostHealth } from "./types";
+
+const DEFAULT_HOSTS_ROOT = ["output", "ops-cockpit", "hosts"] as const;
+
+export type ControlTowerHostHeartbeat = {
+  schema: "control-tower-host-heartbeat.v1";
+  hostId: string;
+  label: string;
+  environment: "local" | "server";
+  role: string;
+  health: ControlTowerHostHealth;
+  lastSeenAt: string;
+  currentRunId?: string | null;
+  agentCount?: number;
+  version?: string | null;
+  metrics?: {
+    cpuPct?: number | null;
+    memoryPct?: number | null;
+    load1?: number | null;
+  };
+};
+
+function clean(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function hostRoots(repoRoot: string): string {
+  return resolve(repoRoot, ...DEFAULT_HOSTS_ROOT);
+}
+
+function readJsonFile<T>(path: string): T | null {
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, "utf8")) as T;
+  } catch {
+    return null;
+  }
+}
+
+function minutesSince(value: string | null, nowMs = Date.now()): number | null {
+  if (!value) return null;
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) return null;
+  return Math.max(0, Math.floor((nowMs - parsed) / 60_000));
+}
+
+function deriveConnectivity(ageMinutes: number | null): ControlTowerHostConnectivity {
+  if (ageMinutes === null) return "offline";
+  if (ageMinutes <= 2) return "online";
+  if (ageMinutes <= 10) return "stale";
+  return "offline";
+}
+
+function summaryForHeartbeat(heartbeat: ControlTowerHostHeartbeat, connectivity: ControlTowerHostConnectivity): string {
+  const runLabel = clean(heartbeat.currentRunId);
+  const agentCount = Math.max(0, Number(heartbeat.agentCount ?? 0));
+  const presence =
+    connectivity === "online"
+      ? "fresh heartbeat"
+      : connectivity === "stale"
+        ? "heartbeat stale"
+        : "heartbeat offline";
+  const runSummary = runLabel ? `run ${runLabel}` : "no active run";
+  return `${presence} · ${runSummary} · ${agentCount} agent${agentCount === 1 ? "" : "s"}`;
+}
+
+export function writeControlTowerHostHeartbeat(repoRoot: string, heartbeat: ControlTowerHostHeartbeat): void {
+  mkdirSync(hostRoots(repoRoot), { recursive: true });
+  const normalized: ControlTowerHostHeartbeat = {
+    schema: "control-tower-host-heartbeat.v1",
+    hostId: clean(heartbeat.hostId),
+    label: clean(heartbeat.label) || clean(heartbeat.hostId),
+    environment: heartbeat.environment === "server" ? "server" : "local",
+    role: clean(heartbeat.role) || "operator-host",
+    health: heartbeat.health,
+    lastSeenAt: clean(heartbeat.lastSeenAt) || new Date().toISOString(),
+    currentRunId: clean(heartbeat.currentRunId) || null,
+    agentCount: Math.max(0, Number(heartbeat.agentCount ?? 0)),
+    version: clean(heartbeat.version) || null,
+    metrics: {
+      cpuPct: Number.isFinite(Number(heartbeat.metrics?.cpuPct)) ? Number(heartbeat.metrics?.cpuPct) : null,
+      memoryPct: Number.isFinite(Number(heartbeat.metrics?.memoryPct)) ? Number(heartbeat.metrics?.memoryPct) : null,
+      load1: Number.isFinite(Number(heartbeat.metrics?.load1)) ? Number(heartbeat.metrics?.load1) : null,
+    },
+  };
+  writeFileSync(
+    resolve(hostRoots(repoRoot), `${normalized.hostId}.json`),
+    `${JSON.stringify(normalized, null, 2)}\n`,
+    "utf8",
+  );
+}
+
+export function listControlTowerHostHeartbeats(repoRoot: string, nowMs = Date.now()): ControlTowerHostCard[] {
+  const root = hostRoots(repoRoot);
+  if (!existsSync(root)) return [];
+  const hosts: ControlTowerHostCard[] = [];
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    if (!entry.isFile() || !entry.name.endsWith(".json")) continue;
+    const heartbeat = readJsonFile<ControlTowerHostHeartbeat>(resolve(root, entry.name));
+    if (!heartbeat || !clean(heartbeat.hostId)) continue;
+    const ageMinutes = minutesSince(heartbeat.lastSeenAt, nowMs);
+    const connectivity = deriveConnectivity(ageMinutes);
+    hosts.push({
+      hostId: heartbeat.hostId,
+      label: heartbeat.label || heartbeat.hostId,
+      environment: heartbeat.environment,
+      role: heartbeat.role,
+      connectivity,
+      health: connectivity === "offline" && heartbeat.health !== "maintenance" ? "offline" : heartbeat.health,
+      lastSeenAt: heartbeat.lastSeenAt,
+      ageMinutes,
+      currentRunId: clean(heartbeat.currentRunId) || null,
+      agentCount: Math.max(0, Number(heartbeat.agentCount ?? 0)),
+      version: clean(heartbeat.version) || null,
+      summary: summaryForHeartbeat(heartbeat, connectivity),
+      metrics: {
+        cpuPct: Number.isFinite(Number(heartbeat.metrics?.cpuPct)) ? Number(heartbeat.metrics?.cpuPct) : null,
+        memoryPct: Number.isFinite(Number(heartbeat.metrics?.memoryPct)) ? Number(heartbeat.metrics?.memoryPct) : null,
+        load1: Number.isFinite(Number(heartbeat.metrics?.load1)) ? Number(heartbeat.metrics?.load1) : null,
+      },
+    });
+  }
+  return hosts.sort((left, right) => String(right.lastSeenAt || "").localeCompare(String(left.lastSeenAt || "")));
+}

--- a/studio-brain/src/controlTower/types.ts
+++ b/studio-brain/src/controlTower/types.ts
@@ -24,6 +24,9 @@ export type ControlTowerEventType =
   | "health.changed";
 export type ControlTowerContinuityState = "ready" | "continuity_degraded" | "missing";
 export type ControlTowerMemoryConsolidationMode = "idle" | "scheduled" | "running" | "repair" | "unavailable";
+export type ControlTowerHostEnvironment = "local" | "server";
+export type ControlTowerHostHealth = "healthy" | "degraded" | "offline" | "maintenance";
+export type ControlTowerHostConnectivity = "online" | "stale" | "offline";
 
 export type ControlTowerTheme = {
   name: "desert-night" | "paper-day";
@@ -184,6 +187,7 @@ export type ControlTowerBoardRow = {
   blocker: string;
   next: string;
   last_update: string | null;
+  runId?: string | null;
   roomId: string | null;
   sessionName: string | null;
   contactReason?: string | null;
@@ -215,7 +219,29 @@ export type ControlTowerApprovalItem = {
   owner: string;
   approvalMode: "required" | "exempt";
   risk: "low" | "medium" | "high" | "critical";
+  previewInput?: Record<string, unknown>;
+  expectedEffects?: string[];
   target: ControlTowerActionTarget;
+};
+
+export type ControlTowerHostCard = {
+  hostId: string;
+  label: string;
+  environment: ControlTowerHostEnvironment;
+  role: string;
+  connectivity: ControlTowerHostConnectivity;
+  health: ControlTowerHostHealth;
+  lastSeenAt: string | null;
+  ageMinutes: number | null;
+  currentRunId: string | null;
+  agentCount: number;
+  version: string | null;
+  summary: string;
+  metrics: {
+    cpuPct: number | null;
+    memoryPct: number | null;
+    load1: number | null;
+  };
 };
 
 export type ControlTowerMemoryConsolidation = {
@@ -441,6 +467,7 @@ export type ControlTowerState = {
   startupScorecard: ControlTowerStartupScorecard | null;
   memoryHealth: ControlTowerMemoryHealth | null;
   agentRuntime: AgentRuntimeSummary | null;
+  hosts: ControlTowerHostCard[];
   partner: PartnerBrief | null;
   events: ControlTowerEvent[];
   recentChanges: ControlTowerEvent[];

--- a/studio-brain/src/http/server.test.ts
+++ b/studio-brain/src/http/server.test.ts
@@ -12,6 +12,8 @@ import { MemoryKilnStore } from "../kiln/memoryStore";
 import { importGenesisArtifact } from "../kiln/services/artifacts";
 import { recordOperatorAction } from "../kiln/services/manualEvents";
 import { createFiringRun } from "../kiln/services/orchestration";
+import { createHumanTaskSeed, createOpsService } from "../ops/service";
+import { MemoryOpsStore } from "../ops/store";
 import { MemoryEventStore, MemoryStateStore } from "../stores/memoryStores";
 import { CapabilityRuntime, defaultCapabilities } from "../capabilities/runtime";
 import { createInMemoryMemoryStoreAdapter } from "../memory/inMemoryAdapter";
@@ -81,6 +83,16 @@ function buildIngestHeaders(secret: string, payload: Record<string, unknown>, ti
   };
 }
 
+function buildOpsIngestHeaders(secret: string, payload: Record<string, unknown>, timestampSeconds: number = Math.trunc(Date.now() / 1000)): Record<string, string> {
+  const raw = JSON.stringify(payload);
+  const signature = crypto.createHmac("sha256", secret).update(`${timestampSeconds}.${raw}`).digest("hex");
+  return {
+    "content-type": "application/json",
+    "x-ops-ingest-timestamp": `${timestampSeconds}`,
+    "x-ops-ingest-signature": `v1=${signature}`,
+  };
+}
+
 async function withServer(
   options: Partial<Parameters<typeof startHttpServer>[0]>,
   run: (baseUrl: string) => Promise<void>
@@ -108,13 +120,81 @@ async function withServer(
     memoryService,
     verifyFirebaseAuth: async (authorizationHeader) => {
       if (authorizationHeader === "Bearer test-staff") {
-        return { uid: "staff-test-uid", isStaff: true, roles: ["staff"] };
+        return {
+          uid: "staff-test-uid",
+          isStaff: true,
+          roles: ["staff"],
+          portalRole: "staff" as const,
+          opsRoles: ["support_ops", "kiln_lead"],
+          opsCapabilities: [
+            "surface:hands",
+            "surface:internet",
+            "members:view",
+            "members:edit_profile",
+            "members:edit_membership",
+            "members:edit_role",
+            "approvals:view",
+            "tasks:claim:any",
+            "tasks:escape",
+            "proof:submit",
+            "proof:accept",
+            "reservations:view",
+            "reservations:prepare",
+            "events:view",
+            "reports:view",
+            "overrides:request",
+          ],
+        };
       }
       if (authorizationHeader === "Bearer test-admin") {
-        return { uid: "admin-test-uid", isStaff: true, roles: ["staff", "admin"] };
+        return {
+          uid: "admin-test-uid",
+          isStaff: true,
+          roles: ["staff", "admin"],
+          portalRole: "admin" as const,
+          opsRoles: ["owner"],
+          opsCapabilities: [
+            "surface:owner",
+            "surface:manager",
+            "surface:hands",
+            "surface:internet",
+            "surface:ceo",
+            "surface:forge",
+            "members:view",
+            "members:edit_profile",
+            "members:edit_membership",
+            "members:edit_role",
+            "members:edit_owner_role",
+            "approvals:view",
+            "approvals:manage",
+            "tasks:claim:any",
+            "tasks:escape",
+            "proof:submit",
+            "proof:accept",
+            "reservations:view",
+            "reservations:prepare",
+            "events:view",
+            "reports:view",
+            "lending:view",
+            "finance:view",
+            "finance:act",
+            "overrides:request",
+            "overrides:approve",
+            "identity:manage",
+            "strategy:ceo",
+            "forge:manage",
+          ],
+        };
       }
       if (authorizationHeader === "Bearer test-member") {
-        return { uid: "member-test-uid", isStaff: false, roles: [] };
+        return {
+          uid: "member-test-uid",
+          isStaff: false,
+          roles: [],
+          portalRole: "member" as const,
+          opsRoles: [],
+          opsCapabilities: [],
+        };
       }
       throw new Error("Missing Authorization header.");
     },
@@ -243,6 +323,7 @@ function createControlTowerFixture() {
   const root = mkdtempSync(join(tmpdir(), "studio-brain-control-tower-"));
   mkdirSync(join(root, "output", "ops-cockpit", "agents"), { recursive: true });
   mkdirSync(join(root, "output", "ops-cockpit", "agent-status"), { recursive: true });
+  mkdirSync(join(root, "output", "ops-cockpit", "hosts"), { recursive: true });
   mkdirSync(join(root, "output", "stability"), { recursive: true });
   mkdirSync(join(root, "output", "overseer", "discord"), { recursive: true });
   mkdirSync(join(root, "output", "studio-brain", "memory-brief"), { recursive: true });
@@ -261,6 +342,32 @@ function createControlTowerFixture() {
         room: "portal",
         summary: "Portal lane",
         objective: "Investigate portal issue and report the next safe move.",
+      },
+      null,
+      2,
+    )}\n`,
+    "utf8",
+  );
+
+  writeFileSync(
+    join(root, "output", "ops-cockpit", "hosts", "micah-laptop.json"),
+    `${JSON.stringify(
+      {
+        schema: "control-tower-host-heartbeat.v1",
+        hostId: "micah-laptop",
+        label: "Micah Laptop",
+        environment: "local",
+        role: "operator-laptop",
+        health: "healthy",
+        lastSeenAt: "2026-03-30T10:04:00.000Z",
+        currentRunId: "run-background-1",
+        agentCount: 1,
+        version: "dev",
+        metrics: {
+          cpuPct: 24,
+          memoryPct: 48,
+          load1: 0.62,
+        },
       },
       null,
       2,
@@ -413,6 +520,9 @@ function createControlTowerFixture() {
         generatedAt: "2026-03-30T10:06:00.000Z",
         runId: "run-background-1",
         missionId: "mission-background-1",
+        hostId: "studio-brain-server",
+        agentId: "agent-runtime",
+        environment: "server",
         status: "blocked",
         riskLane: "high_risk",
         title: "Portal Runtime Mission",
@@ -499,6 +609,7 @@ function createControlTowerFixture() {
           blocker: "Verifier checks failed.",
           next: "Inspect runtime",
           last_update: "2026-03-30T10:06:00.000Z",
+          runId: "run-background-1",
           contactReason: "Studio Brain verified the blocked portal lane and is asking for one owner decision before it keeps moving.",
           verifiedContext: [
             "Verifier checks failed.",
@@ -1624,6 +1735,374 @@ test("ops scorecard endpoint returns KPI status and records compute event", asyn
       assert.equal(payload.scorecard.metrics.length, 5);
       const rows = await eventStore.listRecent(10);
       assert.ok(rows.some((row) => row.action === "studio_ops.scorecard_computed"));
+    }
+  );
+});
+
+test("ops portal routes expose twin state and allow claiming tasks", async () => {
+  const opsService = createOpsService({ store: new MemoryOpsStore() });
+  const task = createHumanTaskSeed({
+    id: "task_ops_portal_claim",
+    title: "Unload kiln 1",
+    surface: "hands",
+    role: "kiln_lead",
+    zone: "Kiln Room",
+    whyNow: "Kiln 1 is ready for unload.",
+    whyYou: "Kiln leads own kiln unloading and proof.",
+    evidenceSummary: "The kiln lane says the run is ready for unload.",
+    consequenceIfDelayed: "The next firing stays blocked.",
+    instructions: ["Open the kiln safely.", "Unload the ware.", "Record proof."],
+    priority: "p0",
+    proofModes: ["manual_confirm"],
+    preferredProofMode: "manual_confirm",
+  });
+  await opsService.upsertTask(task);
+
+  await withServer(
+    {
+      opsService,
+      opsPortalConfig: {
+        enabled: true,
+        requireStaffAuth: true,
+        compareEnabled: true,
+        legacyUrl: "https://portal.monsoonfire.com/staff",
+      },
+    },
+    async (baseUrl) => {
+      const twinResponse = await fetch(`${baseUrl}/api/ops/twin`, {
+        headers: { authorization: "Bearer test-staff" },
+      });
+      assert.equal(twinResponse.status, 200);
+      const twinPayload = (await twinResponse.json()) as {
+        ok: boolean;
+        twin: { headline: string };
+      };
+      assert.equal(twinPayload.ok, true);
+      assert.equal(typeof twinPayload.twin.headline, "string");
+
+      const tasksResponse = await fetch(`${baseUrl}/api/ops/tasks`, {
+        headers: { authorization: "Bearer test-staff" },
+      });
+      assert.equal(tasksResponse.status, 200);
+      const tasksPayload = (await tasksResponse.json()) as {
+        ok: boolean;
+        rows: Array<{ id: string }>;
+      };
+      assert.equal(tasksPayload.ok, true);
+      assert.ok(tasksPayload.rows.some((row) => row.id === task.id));
+
+      const claimResponse = await fetch(`${baseUrl}/api/ops/tasks/${encodeURIComponent(task.id)}/claim`, {
+        method: "POST",
+        headers: {
+          authorization: "Bearer test-staff",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({}),
+      });
+      assert.equal(claimResponse.status, 200);
+      const claimPayload = (await claimResponse.json()) as {
+        ok: boolean;
+        task: { claimedBy: string | null; status: string };
+      };
+      assert.equal(claimPayload.ok, true);
+      assert.equal(claimPayload.task.claimedBy, "staff-test-uid");
+      assert.equal(claimPayload.task.status, "claimed");
+
+      const unauthorizedPortalResponse = await fetch(`${baseUrl}/ops`);
+      assert.equal(unauthorizedPortalResponse.status, 401);
+
+      const portalResponse = await fetch(`${baseUrl}/ops`, {
+        headers: { authorization: "Bearer test-staff" },
+      });
+      assert.equal(portalResponse.status, 200);
+      const html = await portalResponse.text();
+      assert.ok(html.includes("Studio Manager voice"));
+      assert.ok(html.includes("Hands lane"));
+
+      const choiceResponse = await fetch(`${baseUrl}/ops/choice`, {
+        headers: { authorization: "Bearer test-staff" },
+      });
+      assert.equal(choiceResponse.status, 200);
+      const choiceHtml = await choiceResponse.text();
+      assert.ok(choiceHtml.includes("Legacy staff experience"));
+      assert.ok(choiceHtml.includes("Autonomous Studio OS"));
+    }
+  );
+});
+
+test("ops staff replacement routes expose session context and member management flows", async () => {
+  const store = new MemoryOpsStore();
+  let member: {
+    uid: string;
+    email: string | null;
+    displayName: string;
+    membershipTier: string | null;
+    kilnPreferences: string | null;
+    staffNotes: string | null;
+    portalRole: "member" | "staff" | "admin";
+    opsRoles: string[];
+    opsCapabilities: string[];
+    createdAt: string | null;
+    updatedAt: string | null;
+    lastSeenAt: string | null;
+    metadata: Record<string, unknown>;
+  } = {
+    uid: "member-1",
+    email: "member@example.com",
+    displayName: "Studio Member",
+    membershipTier: "drop-in",
+    kilnPreferences: "Cone 6 preferred",
+    staffNotes: "Prefers pickup texts.",
+    portalRole: "member" as const,
+    opsRoles: [] as string[],
+    opsCapabilities: [] as string[],
+    createdAt: "2026-04-17T00:00:00.000Z",
+    updatedAt: "2026-04-17T00:00:00.000Z",
+    lastSeenAt: "2026-04-16T20:00:00.000Z",
+    metadata: {},
+  };
+
+  const opsService = createOpsService({
+    store,
+    staffDataSource: {
+      async listMembers() { return [member as never]; },
+      async getMember(uid) { return uid === member.uid ? (member as never) : null; },
+      async updateMemberProfile(input) {
+        member = {
+          ...member,
+          displayName: input.patch.displayName ?? member.displayName,
+          kilnPreferences: input.patch.kilnPreferences ?? member.kilnPreferences,
+          staffNotes: input.patch.staffNotes ?? member.staffNotes,
+          updatedAt: "2026-04-17T02:00:00.000Z",
+        };
+        return {
+          member: member as never,
+          audit: {
+            id: "audit-profile-route",
+            uid: member.uid,
+            kind: "profile",
+            actorId: input.actorId,
+            summary: "Profile updated.",
+            reason: input.reason ?? null,
+            createdAt: "2026-04-17T02:00:00.000Z",
+            payload: input.patch,
+          },
+        };
+      },
+      async updateMemberMembership(input) {
+        member = {
+          ...member,
+          membershipTier: input.membershipTier,
+          updatedAt: "2026-04-17T02:05:00.000Z",
+        };
+        return {
+          member: member as never,
+          audit: {
+            id: "audit-membership-route",
+            uid: member.uid,
+            editedByUid: input.actorId,
+            beforeTier: "drop-in",
+            afterTier: input.membershipTier,
+            reason: input.reason ?? null,
+            createdAt: "2026-04-17T02:05:00.000Z",
+            summary: "Membership updated.",
+          },
+        };
+      },
+      async updateMemberRole(input) {
+        member = {
+          ...member,
+          portalRole: input.portalRole,
+          opsRoles: input.opsRoles,
+          updatedAt: "2026-04-17T02:10:00.000Z",
+        };
+        return {
+          member: member as never,
+          audit: {
+            id: "audit-role-route",
+            uid: member.uid,
+            editedByUid: input.actorId,
+            beforePortalRole: "member",
+            afterPortalRole: input.portalRole,
+            beforeOpsRoles: [],
+            afterOpsRoles: input.opsRoles,
+            reason: input.reason ?? null,
+            createdAt: "2026-04-17T02:10:00.000Z",
+            summary: "Role updated.",
+          },
+        };
+      },
+      async getMemberActivity(uid) {
+        return {
+          uid,
+          reservations: 1,
+          libraryLoans: 0,
+          supportThreads: 1,
+          events: 2,
+          lastReservationAt: member.lastSeenAt,
+          lastLoanAt: null,
+          lastEventAt: member.lastSeenAt,
+        };
+      },
+      async listReservations() { return []; },
+      async getReservationBundle() { return null; },
+      async listEvents() { return []; },
+      async listReports() { return []; },
+      async getLendingSnapshot() {
+        return {
+          requests: [],
+          loans: [],
+          recommendationCount: 0,
+          tagSubmissionCount: 0,
+          coverReviewCount: 0,
+          generatedAt: "2026-04-17T00:00:00.000Z",
+        };
+      },
+    },
+  });
+
+  await withServer(
+    {
+      opsService,
+      opsPortalConfig: {
+        enabled: true,
+        requireStaffAuth: true,
+      },
+    },
+    async (baseUrl) => {
+      const sessionResponse = await fetch(`${baseUrl}/api/ops/session/me`, {
+        headers: { authorization: "Bearer test-staff" },
+      });
+      assert.equal(sessionResponse.status, 200);
+      const sessionPayload = (await sessionResponse.json()) as {
+        ok: boolean;
+        session: {
+          actorId: string;
+          allowedSurfaces: string[];
+          allowedModes: Record<string, string[]>;
+        };
+      };
+      assert.equal(sessionPayload.ok, true);
+      assert.equal(sessionPayload.session.actorId, "staff-test-uid");
+      assert.ok(sessionPayload.session.allowedSurfaces.includes("internet"));
+      assert.ok(sessionPayload.session.allowedModes.internet.includes("member-ops"));
+
+      const membersResponse = await fetch(`${baseUrl}/api/ops/members`, {
+        headers: { authorization: "Bearer test-staff" },
+      });
+      assert.equal(membersResponse.status, 200);
+      const membersPayload = (await membersResponse.json()) as {
+        ok: boolean;
+        rows: Array<{ uid: string; displayName: string }>;
+      };
+      assert.equal(membersPayload.ok, true);
+      assert.equal(membersPayload.rows[0]?.uid, "member-1");
+
+      const membershipResponse = await fetch(`${baseUrl}/api/ops/members/member-1/membership`, {
+        method: "POST",
+        headers: {
+          authorization: "Bearer test-staff",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          membershipTier: "community",
+          reason: "Route-level update test.",
+        }),
+      });
+      assert.equal(membershipResponse.status, 200);
+      const membershipPayload = (await membershipResponse.json()) as {
+        ok: boolean;
+        member: { membershipTier: string | null };
+      };
+      assert.equal(membershipPayload.ok, true);
+      assert.equal(membershipPayload.member.membershipTier, "community");
+
+      const activityResponse = await fetch(`${baseUrl}/api/ops/members/member-1/activity`, {
+        headers: { authorization: "Bearer test-staff" },
+      });
+      assert.equal(activityResponse.status, 200);
+      const activityPayload = (await activityResponse.json()) as {
+        ok: boolean;
+        activity: { reservations: number; supportThreads: number };
+      };
+      assert.equal(activityPayload.ok, true);
+      assert.equal(activityPayload.activity.reservations, 1);
+      assert.equal(activityPayload.activity.supportThreads, 1);
+    },
+  );
+});
+
+test("ops portal can be disabled independently from the rest of the server", async () => {
+  const opsService = createOpsService({ store: new MemoryOpsStore() });
+
+  await withServer(
+    {
+      opsService,
+      opsPortalConfig: {
+        enabled: false,
+      },
+    },
+    async (baseUrl) => {
+      const portalResponse = await fetch(`${baseUrl}/ops`, {
+        headers: { authorization: "Bearer test-staff" },
+      });
+      assert.equal(portalResponse.status, 404);
+
+      const twinResponse = await fetch(`${baseUrl}/api/ops/twin`, {
+        headers: { authorization: "Bearer test-staff" },
+      });
+      assert.equal(twinResponse.status, 404);
+    }
+  );
+});
+
+test("ops ingest endpoint accepts signed events and dedupes repeated source ids", async () => {
+  const secret = "ops-secret";
+  const opsService = createOpsService({ store: new MemoryOpsStore() });
+  const payload = {
+    sourceSystem: "kilnaid",
+    eventType: "kiln.run_status_changed",
+    entityKind: "kiln",
+    entityId: "kiln-1",
+    sourceEventId: "evt-ops-1",
+    actorKind: "machine",
+    actorId: "kilnaid-bridge",
+    payload: { phase: "ready_for_unload" },
+  };
+
+  await withServer(
+    {
+      opsService,
+      opsIngestConfig: {
+        enabled: true,
+        hmacSecret: secret,
+        allowedSources: ["kilnaid"],
+        maxSkewSeconds: 300,
+      },
+      opsPortalConfig: {
+        enabled: true,
+      },
+    },
+    async (baseUrl) => {
+      const first = await fetch(`${baseUrl}/api/ops/events/ingest`, {
+        method: "POST",
+        headers: buildOpsIngestHeaders(secret, payload),
+        body: JSON.stringify(payload),
+      });
+      assert.equal(first.status, 202);
+      const firstPayload = (await first.json()) as { ok: boolean; accepted: boolean };
+      assert.equal(firstPayload.ok, true);
+      assert.equal(firstPayload.accepted, true);
+
+      const second = await fetch(`${baseUrl}/api/ops/events/ingest`, {
+        method: "POST",
+        headers: buildOpsIngestHeaders(secret, payload),
+        body: JSON.stringify(payload),
+      });
+      assert.equal(second.status, 200);
+      const secondPayload = (await second.json()) as { ok: boolean; accepted: boolean };
+      assert.equal(secondPayload.ok, true);
+      assert.equal(secondPayload.accepted, false);
     }
   );
 });
@@ -3205,6 +3684,7 @@ test("control tower state routes derive browser-friendly room and service data",
               status: string;
               boardRow: { owner: string; state: string; blocker: string };
             } | null;
+            hosts: Array<{ hostId: string; environment: string; currentRunId: string | null }>;
             partner: {
               initiativeState: string;
               needsOwnerDecision: boolean;
@@ -3221,6 +3701,7 @@ test("control tower state routes derive browser-friendly room and service data",
               shadowMcpFindings: { highRiskRows: number };
               highlights: string[];
             } | null;
+            events: Array<{ type: string; sourceAction: string | null }>;
             recentChanges: Array<{ type: string; sourceAction: string | null }>;
           };
         };
@@ -3256,6 +3737,8 @@ test("control tower state routes derive browser-friendly room and service data",
         assert.equal(payload.state.agentRuntime?.status, "blocked");
         assert.equal(payload.state.agentRuntime?.boardRow.owner, "agent-runtime");
         assert.equal(payload.state.board[0]?.owner, "agent-runtime");
+        assert.equal(payload.state.hosts.some((entry) => entry.hostId === "studio-brain-server"), true);
+        assert.equal(payload.state.hosts.some((entry) => entry.hostId === "micah-laptop" && entry.environment === "local"), true);
         assert.equal(payload.state.partner?.initiativeState, "waiting_on_owner");
         assert.equal(payload.state.partner?.needsOwnerDecision, true);
         assert.match(payload.state.partner?.contactReason ?? "", /owner decision/i);
@@ -3295,8 +3778,8 @@ test("control tower state routes derive browser-friendly room and service data",
           ),
           true,
         );
-        assert.ok(payload.state.recentChanges.some((entry) => entry.type === "memory.promoted"));
-        assert.ok(payload.state.recentChanges.some((entry) => entry.sourceAction === "control_tower.memory_consolidation"));
+        assert.ok(payload.state.events.some((entry) => entry.type === "memory.promoted"));
+        assert.ok(payload.state.events.some((entry) => entry.sourceAction === "control_tower.memory_consolidation"));
 
         const roomResponse = await fetch(`${baseUrl}/api/control-tower/rooms/portal`, {
           headers: { authorization: "Bearer test-staff" },
@@ -3625,6 +4108,7 @@ test("agent runtime routes expose latest summary and accept webhook events", asy
       {
         controlTowerRepoRoot: fixture.root,
         controlTowerRunner: runner,
+        adminToken: "test-admin-token",
       },
       async (baseUrl) => {
         const latestResponse = await fetch(`${baseUrl}/api/agent-runtime/latest`, {
@@ -3641,11 +4125,31 @@ test("agent runtime routes expose latest summary and accept webhook events", asy
         assert.equal(latestPayload.summary?.status, "blocked");
         assert.equal(latestPayload.events[0]?.type, "mission.state.changed");
 
+        const detailResponse = await fetch(`${baseUrl}/api/agent-runtime/runs/run-background-1`, {
+          headers: { authorization: "Bearer test-staff" },
+        });
+        assert.equal(detailResponse.status, 200);
+        const detailPayload = (await detailResponse.json()) as {
+          ok: boolean;
+          detail: {
+            runId: string;
+            whyStuck: string | null;
+            steps: Array<{ kind: string }>;
+            artifacts: Array<{ artifactId: string }>;
+          };
+        };
+        assert.equal(detailPayload.ok, true);
+        assert.equal(detailPayload.detail.runId, "run-background-1");
+        assert.match(detailPayload.detail.whyStuck ?? "", /Verifier checks failed/i);
+        assert.equal(detailPayload.detail.steps.some((entry) => entry.kind === "mission"), true);
+        assert.equal(detailPayload.detail.artifacts.some((entry) => entry.artifactId === "summary.json"), true);
+
         const eventResponse = await fetch(`${baseUrl}/api/agent-runtime/events`, {
           method: "POST",
           headers: {
             "content-type": "application/json",
             authorization: "Bearer test-staff",
+            "x-studio-brain-admin-token": "test-admin-token",
           },
           body: JSON.stringify({
             event: {
@@ -3697,6 +4201,41 @@ test("agent runtime routes expose latest summary and accept webhook events", asy
         };
         assert.equal(runsPayload.ok, true);
         assert.equal(runsPayload.runs.some((entry) => entry.runId === "run-background-2"), true);
+
+        const hostHeartbeatResponse = await fetch(`${baseUrl}/api/control-tower/hosts/heartbeat`, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "x-studio-brain-admin-token": "test-admin-token",
+          },
+          body: JSON.stringify({
+            hostId: "micah-laptop",
+            label: "Micah Laptop",
+            environment: "local",
+            role: "operator-laptop",
+            health: "healthy",
+            lastSeenAt: "2026-03-30T10:11:00.000Z",
+            currentRunId: "run-background-2",
+            agentCount: 1,
+            metrics: {
+              cpuPct: 18,
+              memoryPct: 52,
+              load1: 0.5,
+            },
+          }),
+        });
+        assert.equal(hostHeartbeatResponse.status, 202);
+
+        const hostsResponse = await fetch(`${baseUrl}/api/control-tower/hosts`, {
+          headers: { authorization: "Bearer test-staff" },
+        });
+        assert.equal(hostsResponse.status, 200);
+        const hostsPayload = (await hostsResponse.json()) as {
+          ok: boolean;
+          hosts: Array<{ hostId: string; currentRunId: string | null }>;
+        };
+        assert.equal(hostsPayload.ok, true);
+        assert.equal(hostsPayload.hosts.some((entry) => entry.hostId === "micah-laptop" && entry.currentRunId === "run-background-2"), true);
       },
     );
   } finally {

--- a/studio-brain/src/http/server.ts
+++ b/studio-brain/src/http/server.ts
@@ -41,6 +41,10 @@ import { recordOperatorAction } from "../kiln/services/manualEvents";
 import { createFiringRun } from "../kiln/services/orchestration";
 import { buildFiringRunDetail, buildKilnDetail, buildKilnOverview } from "../kiln/services/overview";
 import { renderKilnCommandPage } from "../kiln/ui/renderKilnCommandPage";
+import type { OpsService } from "../ops/service";
+import type { OpsCapability, OpsDegradeMode, GrowthExperiment, ImprovementCase, OpsHumanRole, OpsPortalRole, ProofMode, TaskEscapeHatch } from "../ops/contracts";
+import { deriveOpsCapabilitiesFromClaims, deriveOpsRolesFromClaims, derivePortalRoleFromClaims } from "../ops/staffData";
+import { renderOpsPortalChoicePage, renderOpsPortalPage } from "../ops/ui/renderOpsPortalPage";
 import type { SupportOpsStore } from "../supportOps/store";
 import { MemoryValidationError } from "../memory/service";
 import {
@@ -71,14 +75,17 @@ import { deriveControlTowerState, deriveRoomDetail } from "../controlTower/deriv
 import type {
   ControlTowerApprovalItem,
   ControlTowerEvent,
+  ControlTowerHostCard,
   ControlTowerMemoryHealth,
   ControlTowerMemoryBrief,
   ControlTowerNextAction,
+  ControlTowerRawState,
   ControlTowerStartupScorecard,
   ControlTowerState,
 } from "../controlTower/types";
 import { draftDiscordSupportReply, getSupportAgentProfile } from "../supportOps/discord";
 import type { AgentRuntimeSummary, RunLedgerEvent } from "../agentRuntime/contracts";
+import { buildAgentRuntimeRunDetail } from "../agentRuntime/detail";
 import {
   appendAgentRuntimeEvent,
   listAgentRuntimeSummaries,
@@ -86,6 +93,11 @@ import {
   readLatestAgentRuntimeSummary,
   writeAgentRuntimeSummary,
 } from "../agentRuntime/files";
+import {
+  listControlTowerHostHeartbeats,
+  writeControlTowerHostHeartbeat,
+  type ControlTowerHostHeartbeat,
+} from "../controlTower/hosts";
 import type { PartnerBrief, PartnerCheckinAction } from "../partner/contracts";
 import { readPartnerCheckins } from "../partner/files";
 import {
@@ -428,6 +440,72 @@ function buildAgentRuntimeNextActions(agentRuntime: AgentRuntimeSummary | null):
   ];
 }
 
+function buildServerHostCard(raw: ControlTowerRawState, agentRuntime: AgentRuntimeSummary | null): ControlTowerHostCard {
+  const degradedServices = raw.services.filter((service) => service.status === "error").length;
+  const health: ControlTowerHostCard["health"] =
+    raw.ops.overallStatus === "error" || raw.ops.overallStatus === "waiting" ? "degraded" : "healthy";
+  return {
+    hostId: "studio-brain-server",
+    label: "Studio Brain Server",
+    environment: "server",
+    role: "control-plane",
+    connectivity: "online",
+    health,
+    lastSeenAt: raw.generatedAt,
+    ageMinutes: ageMinutesSince(raw.generatedAt),
+    currentRunId: agentRuntime?.runId ?? null,
+    agentCount: Math.max(raw.rooms.length, agentRuntime ? 1 : 0),
+    version: null,
+    summary:
+      degradedServices > 0
+        ? `${degradedServices} service${degradedServices === 1 ? "" : "s"} degraded across the control plane.`
+        : `${raw.rooms.length} active room${raw.rooms.length === 1 ? "" : "s"} visible in the control plane.`,
+    metrics: {
+      cpuPct: null,
+      memoryPct: null,
+      load1: null,
+    },
+  };
+}
+
+function dedupeHosts(hosts: ControlTowerHostCard[]): ControlTowerHostCard[] {
+  const seen = new Set<string>();
+  return hosts.filter((host) => {
+    const key = `${host.environment}:${host.hostId}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function buildHostAttention(hosts: ControlTowerHostCard[]): Array<{
+  id: string;
+  title: string;
+  why: string;
+  ageMinutes: number | null;
+  severity: "info" | "warning" | "critical";
+  actionLabel: string;
+  target: ControlTowerNextAction["target"];
+}> {
+  return hosts
+    .filter((host) => host.connectivity !== "online" || host.health === "degraded" || host.health === "offline")
+    .slice(0, 3)
+    .map((host) => ({
+      id: `attention:host:${host.hostId}`,
+      title:
+        host.connectivity === "offline"
+          ? `${host.label} went offline`
+          : host.connectivity === "stale"
+            ? `${host.label} heartbeat is stale`
+            : `${host.label} is degraded`,
+      why: clipText(host.summary, 180),
+      ageMinutes: host.ageMinutes,
+      severity: host.connectivity === "offline" || host.health === "offline" ? "critical" : "warning",
+      actionLabel: host.currentRunId ? "Open runtime" : "Inspect events",
+      target: host.currentRunId ? { type: "ops", action: "agent-runtime" } : { type: "ops", action: "events" },
+    }));
+}
+
 function buildControlTowerApprovals(
   proposals: ActionProposal[],
   capabilityDefinitions: CapabilityDefinition[],
@@ -449,6 +527,8 @@ function buildControlTowerApprovals(
         owner: policy?.owner || proposal.tenantId,
         approvalMode: policy?.approvalMode || (definition?.requiresApproval ? "required" : "exempt"),
         risk: definition?.risk || "medium",
+        previewInput: proposal.preview.input,
+        expectedEffects: proposal.preview.expectedEffects,
         target: { type: "ops", action: "approvals" },
       } satisfies ControlTowerApprovalItem;
     })
@@ -459,6 +539,8 @@ function buildControlTowerApprovals(
 function buildSyntheticControlTowerEvents(
   memoryBrief: ControlTowerMemoryBrief,
   approvals: ControlTowerApprovalItem[],
+  agentRuntime: AgentRuntimeSummary | null,
+  hosts: ControlTowerHostCard[],
   partner: PartnerBrief | null = null,
 ): ControlTowerEvent[] {
   const output: ControlTowerEvent[] = [];
@@ -558,6 +640,64 @@ function buildSyntheticControlTowerEvents(
           status: approval.status,
           approvalMode: approval.approvalMode,
           risk: approval.risk,
+        },
+      });
+    });
+
+  if (agentRuntime) {
+    output.push({
+      id: `agent-runtime:${agentRuntime.runId}:${agentRuntime.updatedAt}`,
+      at: agentRuntime.updatedAt,
+      kind: "session",
+      type: "run.status",
+      runId: agentRuntime.runId,
+      agentId: agentRuntime.agentId ?? "agent-runtime",
+      channel: "codex",
+      occurredAt: agentRuntime.updatedAt,
+      severity: agentRuntime.status === "failed" ? "critical" : agentRuntime.status === "blocked" ? "warning" : "info",
+      title: `${agentRuntime.status}: ${agentRuntime.title}`,
+      summary: clipText(agentRuntime.activeBlockers[0] || agentRuntime.boardRow?.next || agentRuntime.goal, 220),
+      actor: agentRuntime.agentId ?? "agent-runtime",
+      roomId: null,
+      serviceId: null,
+      actionLabel: "Open runtime",
+      sourceAction: "control_tower.agent_runtime",
+      payload: {
+        hostId: agentRuntime.hostId ?? null,
+        environment: agentRuntime.environment ?? null,
+        riskLane: agentRuntime.riskLane,
+        blocker: agentRuntime.activeBlockers[0] ?? null,
+      },
+    });
+  }
+
+  hosts
+    .filter((host) => host.connectivity !== "online" || host.health === "degraded" || host.health === "offline")
+    .slice(0, 4)
+    .forEach((host) => {
+      output.push({
+        id: `host:${host.hostId}:${host.lastSeenAt || host.health}`,
+        at: host.lastSeenAt || new Date().toISOString(),
+        kind: "session",
+        type: "health.changed",
+        runId: host.currentRunId,
+        agentId: null,
+        channel: "ops",
+        occurredAt: host.lastSeenAt || new Date().toISOString(),
+        severity: host.connectivity === "offline" || host.health === "offline" ? "critical" : "warning",
+        title: `${host.label} ${host.connectivity === "online" ? host.health : host.connectivity}`,
+        summary: clipText(host.summary, 220),
+        actor: host.hostId,
+        roomId: null,
+        serviceId: null,
+        actionLabel: host.currentRunId ? "Open runtime" : "Inspect events",
+        sourceAction: "control_tower.host_heartbeat",
+        payload: {
+          hostId: host.hostId,
+          environment: host.environment,
+          connectivity: host.connectivity,
+          health: host.health,
+          currentRunId: host.currentRunId,
         },
       });
     });
@@ -1066,6 +1206,7 @@ function enrichControlTowerState(
   startupScorecard: ControlTowerStartupScorecard | null,
   memoryHealth: ControlTowerMemoryHealth | null,
   agentRuntime: AgentRuntimeSummary | null,
+  hosts: ControlTowerHostCard[],
   partner: PartnerBrief | null,
 ): ControlTowerState {
   const mergedEvents = [...syntheticEvents, ...state.events]
@@ -1085,6 +1226,7 @@ function enrichControlTowerState(
     }));
   const memoryAttention = buildMemoryHealthAttention(memoryHealth);
   const agentRuntimeAttention = buildAgentRuntimeAttention(agentRuntime);
+  const hostAttention = buildHostAttention(hosts);
   const partnerAttention = buildPartnerAttention(partner);
   const memoryNextMoves = buildMemoryActionNextMoves(memoryBrief, startupScorecard);
   const memoryHealthMoves = buildMemoryHealthNextMoves(memoryHealth);
@@ -1097,6 +1239,7 @@ function enrichControlTowerState(
   const mergedBoard = agentRuntime?.boardRow
     ? [
         {
+          runId: agentRuntime.runId,
           roomId: null,
           sessionName: null,
           ...agentRuntime.boardRow,
@@ -1115,6 +1258,7 @@ function enrichControlTowerState(
     startupScorecard,
     memoryHealth,
     agentRuntime,
+    hosts,
     partner,
     board: nextBoard,
     events: mergedEvents,
@@ -1124,15 +1268,17 @@ function enrichControlTowerState(
       ...state.counts,
       needsAttention:
         state.counts.needsAttention
-        + approvalAttention.length
-        + memoryAttention.length
-        + agentRuntimeAttention.length
-        + partnerAttention.length,
+          + approvalAttention.length
+          + memoryAttention.length
+          + hostAttention.length
+          + agentRuntimeAttention.length
+          + partnerAttention.length,
     },
     overview: {
       ...state.overview,
       needsAttention: [
         ...partnerAttention,
+        ...hostAttention,
         ...agentRuntimeAttention,
         ...memoryAttention,
         ...approvalAttention,
@@ -1455,6 +1601,13 @@ export type MemoryIngestConfig = {
   allowedDiscordChannelIds?: string[];
 };
 
+export type OpsIngestConfig = {
+  enabled?: boolean;
+  hmacSecret?: string | null;
+  maxSkewSeconds?: number;
+  allowedSources?: string[];
+};
+
 type ParsedJsonBody = {
   raw: string;
   json: Record<string, unknown>;
@@ -1538,6 +1691,48 @@ function verifyHmacSignature(expectedHex: string, providedHex: string): boolean 
   }
 }
 
+function createSignedOpsSessionToken(secret: string, ttlSeconds: number): string {
+  const nowMs = Date.now();
+  const expiresAt = nowMs + Math.max(60, Math.min(3600, ttlSeconds)) * 1000;
+  const payload = {
+    aud: "studio-brain-ops",
+    iat: nowMs,
+    exp: expiresAt,
+    nonce: crypto.randomBytes(12).toString("base64url"),
+  };
+  const payloadEncoded = Buffer.from(JSON.stringify(payload), "utf8").toString("base64url");
+  const signature = crypto.createHmac("sha256", secret).update(payloadEncoded).digest("hex");
+  return `sbops.${payloadEncoded}.${signature}`;
+}
+
+function verifySignedOpsSessionToken(token: string, secret: string): boolean {
+  const trimmed = token.trim();
+  if (!trimmed.startsWith("sbops.")) return false;
+  const parts = trimmed.split(".");
+  if (parts.length !== 3) return false;
+  const payloadEncoded = parts[1] ?? "";
+  const providedSignature = parts[2] ?? "";
+  const expectedSignature = crypto.createHmac("sha256", secret).update(payloadEncoded).digest("hex");
+  if (!verifyHmacSignature(expectedSignature, providedSignature)) {
+    return false;
+  }
+  try {
+    const decoded = JSON.parse(Buffer.from(payloadEncoded, "base64url").toString("utf8")) as {
+      aud?: string;
+      exp?: number;
+      iat?: number;
+    };
+    const exp = decoded.exp ?? 0;
+    const iat = decoded.iat ?? 0;
+    if (decoded.aud !== "studio-brain-ops") return false;
+    if (!Number.isFinite(exp) || exp <= Date.now()) return false;
+    if (!Number.isFinite(iat) || iat > Date.now() + 60_000) return false;
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function toNormalizedSet(values: string[] | undefined): Set<string> {
   return new Set(
     (values ?? [])
@@ -1590,6 +1785,9 @@ type AuthPrincipal = {
   uid: string;
   isStaff: boolean;
   roles: string[];
+  portalRole: OpsPortalRole;
+  opsRoles: OpsHumanRole[];
+  opsCapabilities: OpsCapability[];
 };
 
 function ensureFirebaseAdminForAuth(): void {
@@ -1608,11 +1806,18 @@ async function verifyFirebaseAuthHeader(authorizationHeader: string | undefined)
   ensureFirebaseAdminForAuth();
   const decoded = await getAuth().verifyIdToken(match[1]);
   const roles = Array.isArray(decoded.roles) ? decoded.roles.map((value) => String(value)) : [];
-  const isStaff = decoded.staff === true || decoded.admin === true || roles.includes("staff") || roles.includes("admin");
+  const claims = decoded as Record<string, unknown>;
+  const portalRole = derivePortalRoleFromClaims(claims);
+  const opsRoles = deriveOpsRolesFromClaims(claims);
+  const opsCapabilities = deriveOpsCapabilitiesFromClaims(claims);
+  const isStaff = decoded.staff === true || decoded.admin === true || roles.includes("staff") || roles.includes("admin") || opsRoles.length > 0;
   return {
     uid: decoded.uid,
     isStaff,
     roles,
+    portalRole,
+    opsRoles,
+    opsCapabilities,
   };
 }
 
@@ -1640,6 +1845,15 @@ export function startHttpServer(params: {
   backendHealth?: () => Promise<BackendHealthReport>;
   memoryService?: MemoryService | null;
   memoryIngestConfig?: MemoryIngestConfig;
+  opsService?: OpsService | null;
+  opsIngestConfig?: OpsIngestConfig;
+  opsPortalConfig?: {
+    enabled?: boolean;
+    requireStaffAuth?: boolean;
+    compareEnabled?: boolean;
+    legacyUrl?: string;
+    defaultSurface?: string;
+  };
   endpointRateLimits?: Partial<EndpointRateLimitConfig>;
   abuseQuotaStore?: QuotaStore;
   pilotWriteExecutor?: PilotWriteExecutor | null;
@@ -1674,6 +1888,9 @@ export function startHttpServer(params: {
     backendHealth,
     memoryService = null,
     memoryIngestConfig,
+    opsService = null,
+    opsIngestConfig,
+    opsPortalConfig,
     endpointRateLimits,
     abuseQuotaStore = new InMemoryQuotaStore(),
     pilotWriteExecutor = null,
@@ -1704,6 +1921,21 @@ export function startHttpServer(params: {
     allowedDiscordGuildIds: toNormalizedSet(memoryIngestConfig?.allowedDiscordGuildIds),
     allowedDiscordChannelIds: toNormalizedSet(memoryIngestConfig?.allowedDiscordChannelIds),
   };
+  const opsIngest = {
+    enabled: opsIngestConfig?.enabled !== false,
+    hmacSecret: opsIngestConfig?.hmacSecret?.trim() ?? "",
+    maxSkewSeconds: Math.max(30, opsIngestConfig?.maxSkewSeconds ?? 300),
+    allowedSources: toNormalizedSet(opsIngestConfig?.allowedSources),
+  };
+  const opsPortal = {
+    enabled: opsPortalConfig?.enabled ?? Boolean(opsService),
+    requireStaffAuth: opsPortalConfig?.requireStaffAuth !== false,
+    compareEnabled: opsPortalConfig?.compareEnabled !== false,
+    legacyUrl: toTrimmedString(opsPortalConfig?.legacyUrl) || null,
+    defaultSurface: toTrimmedString(opsPortalConfig?.defaultSurface) || "manager",
+  };
+  const opsSessionSecret = String(process.env.STUDIO_BRAIN_OPS_SESSION_SECRET ?? adminToken ?? "").trim();
+  const opsSessionTtlSeconds = Math.max(60, Math.min(3600, Number(process.env.STUDIO_BRAIN_OPS_SESSION_TTL_SECONDS ?? "900") || 900));
 
   const readControlTowerSnapshot = async () => {
     const [overseerRun, audits, proposals] = await Promise.all([
@@ -1726,6 +1958,10 @@ export function startHttpServer(params: {
     const memoryBrief = readControlTowerMemoryBrief(resolvedControlTowerRepoRoot, initialState.memoryBrief);
     const startupScorecard = readControlTowerStartupScorecard(resolvedControlTowerRepoRoot);
     const agentRuntime = readLatestAgentRuntimeSummary(resolvedControlTowerRepoRoot);
+    const hosts = dedupeHosts([
+      buildServerHostCard(raw, agentRuntime),
+      ...listControlTowerHostHeartbeats(resolvedControlTowerRepoRoot),
+    ]);
     const stateWithMemory = deriveControlTowerState(raw, audits, {
       approvals,
       memoryBrief,
@@ -1734,10 +1970,10 @@ export function startHttpServer(params: {
       repoRoot: resolvedControlTowerRepoRoot,
       generatedAt: raw.generatedAt,
       memoryBrief,
-      rooms: stateWithMemory.rooms,
-      approvals,
-      agentRuntime,
-    });
+        rooms: stateWithMemory.rooms,
+        approvals,
+        agentRuntime,
+      });
     let memoryHealth: ControlTowerMemoryHealth | null = null;
     if (memoryService) {
       try {
@@ -1747,7 +1983,7 @@ export function startHttpServer(params: {
         logger.warn(`control tower memory health unavailable: ${message}`);
       }
     }
-    const syntheticEvents = buildSyntheticControlTowerEvents(memoryBrief, approvals, partner);
+    const syntheticEvents = buildSyntheticControlTowerEvents(memoryBrief, approvals, agentRuntime, hosts, partner);
     const state = enrichControlTowerState(
       stateWithMemory,
       syntheticEvents,
@@ -1756,6 +1992,7 @@ export function startHttpServer(params: {
       startupScorecard,
       memoryHealth,
       agentRuntime,
+      hosts,
       partner,
     );
     return { raw, state, audits };
@@ -2039,7 +2276,7 @@ export function startHttpServer(params: {
     return {
       "access-control-allow-origin": origin,
       "access-control-allow-headers":
-        "content-type, authorization, x-studio-brain-admin-token, x-memory-ingest-signature, x-memory-ingest-timestamp",
+        "content-type, authorization, x-studio-brain-admin-token, x-memory-ingest-signature, x-memory-ingest-timestamp, x-ops-ingest-signature, x-ops-ingest-timestamp, x-studio-brain-ops-session",
       "access-control-allow-methods": "GET,POST,OPTIONS",
       "access-control-max-age": "600",
       vary: "Origin",
@@ -2073,6 +2310,42 @@ export function startHttpServer(params: {
   };
   const assertKilnAccess = (req: http.IncomingMessage) =>
     assertCapabilityAuth(req, { requireAdminToken: false });
+  const assertOpsPortalAuth = async (
+    req: http.IncomingMessage,
+  ): Promise<{ ok: true; principal?: AuthPrincipal; actorId: string } | { ok: false; message: string; actorId: string }> => {
+    if (!opsPortal.requireStaffAuth) {
+      return { ok: true, actorId: "ops-portal:anonymous" };
+    }
+    const sessionToken = firstHeader(req.headers["x-studio-brain-ops-session"]);
+    if (opsSessionSecret && sessionToken && verifySignedOpsSessionToken(sessionToken, opsSessionSecret)) {
+      return { ok: true, actorId: "ops-session:local-portal" };
+    }
+    const auth = await assertCapabilityAuth(req, { requireAdminToken: false });
+    if (!auth.ok) {
+      return { ok: false, message: auth.message ?? "Unauthorized", actorId: "unknown" };
+    }
+    return { ok: true, principal: auth.principal, actorId: auth.principal?.uid ?? "staff:unknown" };
+  };
+  const assertHostHeartbeatAuth = async (
+    req: http.IncomingMessage,
+  ): Promise<{ ok: boolean; message?: string; principal?: AuthPrincipal; actorId: string }> => {
+    const provided = firstHeader(req.headers["x-studio-brain-admin-token"]);
+    if (adminToken && provided && provided === adminToken) {
+      return { ok: true, actorId: "machine:control-tower-host" };
+    }
+    const auth = await assertCapabilityAuth(req, { requireAdminToken: false });
+    if (!auth.ok) {
+      return { ok: false, message: auth.message, actorId: "unknown" };
+    }
+    return { ok: true, principal: auth.principal, actorId: auth.principal?.uid ?? "staff:unknown" };
+  };
+  const opsActorContext = (auth: { principal?: AuthPrincipal; actorId: string }) => ({
+    actorId: auth.actorId,
+    isStaff: auth.principal?.isStaff ?? false,
+    portalRole: auth.principal?.portalRole ?? "member",
+    opsRoles: auth.principal?.opsRoles ?? [],
+    opsCapabilities: auth.principal?.opsCapabilities ?? [],
+  });
   const kilnProviderSupport = () => kilnObservationProvider?.describeSupport() ?? null;
   const ensureKilnRuntime = (): { ok: true } | { ok: false; message: string } => {
     if (!kilnEnabled) {
@@ -4689,6 +4962,932 @@ export function startHttpServer(params: {
         return;
       }
 
+      if (opsPortal.enabled && opsService && method === "POST" && url.pathname === "/api/ops/events/ingest") {
+        if (!opsIngest.enabled) {
+          statusCode = 404;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: "Ops ingest endpoint is disabled." }));
+          return;
+        }
+        if (!opsIngest.hmacSecret) {
+          statusCode = 503;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: "Ops ingest endpoint is misconfigured." }));
+          return;
+        }
+        try {
+          const timestampRaw = firstHeader(req.headers["x-ops-ingest-timestamp"]);
+          const signatureRaw = firstHeader(req.headers["x-ops-ingest-signature"]);
+          const timestampSeconds = parseEpochSeconds(timestampRaw);
+          const providedSignature = normalizeHmacSignature(signatureRaw);
+          if (!timestampSeconds || !providedSignature) {
+            statusCode = 401;
+            res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+            res.end(JSON.stringify({ ok: false, message: "Missing or invalid ops ingest signature headers." }));
+            return;
+          }
+          if (!isTimestampWithinSkew(timestampSeconds, Date.now(), opsIngest.maxSkewSeconds)) {
+            statusCode = 401;
+            res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+            res.end(JSON.stringify({ ok: false, message: "Ops ingest signature timestamp is outside allowed skew." }));
+            return;
+          }
+          const parsedBody = await readJsonBodyWithRaw(req);
+          const expectedSignature = crypto
+            .createHmac("sha256", opsIngest.hmacSecret)
+            .update(`${timestampSeconds}.${parsedBody.raw}`)
+            .digest("hex");
+          if (!verifyHmacSignature(expectedSignature, providedSignature)) {
+            statusCode = 401;
+            res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+            res.end(JSON.stringify({ ok: false, message: "Invalid ops ingest signature." }));
+            return;
+          }
+          const body = parsedBody.json;
+          const sourceSystem = toTrimmedString(body.sourceSystem || body.source).toLowerCase();
+          if (!sourceSystem) {
+            statusCode = 400;
+            res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+            res.end(JSON.stringify({ ok: false, message: "sourceSystem is required." }));
+            return;
+          }
+          if (opsIngest.allowedSources.size > 0 && !opsIngest.allowedSources.has(sourceSystem)) {
+            statusCode = 403;
+            res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+            res.end(JSON.stringify({ ok: false, message: "Ops ingest source is not allowed." }));
+            return;
+          }
+          const eventType = toTrimmedString(body.eventType);
+          const entityKind = toTrimmedString(body.entityKind);
+          const entityId = toTrimmedString(body.entityId);
+          const sourceEventId = toTrimmedString(body.sourceEventId || body.clientRequestId);
+          if (!eventType || !entityKind || !entityId || !sourceEventId) {
+            statusCode = 400;
+            res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+            res.end(JSON.stringify({ ok: false, message: "eventType, entityKind, entityId, and sourceEventId are required." }));
+            return;
+          }
+          const metadata =
+            body.payload && typeof body.payload === "object" && !Array.isArray(body.payload)
+              ? (body.payload as Record<string, unknown>)
+              : body;
+          const result = await opsService.ingestWorldEvent({
+            eventType,
+            entityKind,
+            entityId,
+            sourceSystem,
+            sourceEventId,
+            actorKind: toTrimmedString(body.actorKind) || "machine",
+            actorId: toTrimmedString(body.actorId) || `machine:${sourceSystem}`,
+            payload: metadata,
+            caseId: toTrimmedString(body.caseId) || null,
+            roomId: toTrimmedString(body.roomId) || null,
+            confidence: toNullableRatio(body.confidence) ?? 0.8,
+            verificationClass:
+              toTrimmedString(body.verificationClass) === "confirmed"
+                ? "confirmed"
+                : toTrimmedString(body.verificationClass) === "claimed"
+                  ? "claimed"
+                  : toTrimmedString(body.verificationClass) === "planned"
+                    ? "planned"
+                    : toTrimmedString(body.verificationClass) === "inferred"
+                      ? "inferred"
+                      : "observed",
+            artifactRefs: toStringList(body.artifactRefs, 32),
+            authPrincipal: `hmac:${sourceSystem}`,
+            timestampSkewSeconds: Math.abs(Math.round(Date.now() / 1000) - timestampSeconds),
+          });
+          statusCode = result.accepted ? 202 : 200;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: true, accepted: result.accepted, event: result.event, receipt: result.receipt }));
+        } catch (error) {
+          statusCode = 500;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: error instanceof Error ? error.message : String(error) }));
+        }
+        return;
+      }
+
+      if (opsPortal.enabled && opsService && method === "GET" && url.pathname === "/api/ops/session/me") {
+        const auth = await assertOpsPortalAuth(req);
+        if (!auth.ok || !auth.principal) {
+          statusCode = 401;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: auth.ok ? "Unauthorized" : auth.message }));
+          return;
+        }
+        const session = await opsService.getSessionMe(opsActorContext(auth));
+        statusCode = 200;
+        res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+        res.end(JSON.stringify({ ok: true, session }));
+        return;
+      }
+
+      if (opsPortal.enabled && opsService && method === "GET" && url.pathname === "/api/ops/members") {
+        const auth = await assertOpsPortalAuth(req);
+        if (!auth.ok || !auth.principal) {
+          statusCode = 401;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: auth.ok ? "Unauthorized" : auth.message }));
+          return;
+        }
+        const rows = await opsService.listMembers(opsActorContext(auth));
+        statusCode = 200;
+        res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+        res.end(JSON.stringify({ ok: true, rows }));
+        return;
+      }
+
+      const opsMemberDetailMatch = method === "GET" ? url.pathname.match(/^\/api\/ops\/members\/([^/]+)$/) : null;
+      if (opsPortal.enabled && opsService && opsMemberDetailMatch) {
+        const auth = await assertOpsPortalAuth(req);
+        if (!auth.ok || !auth.principal) {
+          statusCode = 401;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: auth.ok ? "Unauthorized" : auth.message }));
+          return;
+        }
+        const uid = decodeURIComponent(opsMemberDetailMatch[1] ?? "");
+        const member = await opsService.getMember(uid, opsActorContext(auth));
+        if (!member) {
+          statusCode = 404;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: `Member ${uid} not found.` }));
+          return;
+        }
+        statusCode = 200;
+        res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+        res.end(JSON.stringify({ ok: true, member }));
+        return;
+      }
+
+      const opsMemberProfileMatch = method === "POST" ? url.pathname.match(/^\/api\/ops\/members\/([^/]+)\/profile$/) : null;
+      if (opsPortal.enabled && opsService && opsMemberProfileMatch) {
+        const auth = await assertOpsPortalAuth(req);
+        if (!auth.ok || !auth.principal) {
+          statusCode = 401;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: auth.ok ? "Unauthorized" : auth.message }));
+          return;
+        }
+        const uid = decodeURIComponent(opsMemberProfileMatch[1] ?? "");
+        const body = await readJsonBody(req);
+        const patch = body.patch && typeof body.patch === "object" && !Array.isArray(body.patch)
+          ? body.patch as Record<string, unknown>
+          : {};
+        const result = await opsService.updateMemberProfile({
+          uid,
+          reason: toTrimmedString(body.reason) || null,
+          patch: {
+            displayName: Object.prototype.hasOwnProperty.call(patch, "displayName") ? toTrimmedString(patch.displayName) || null : undefined,
+            membershipTier: Object.prototype.hasOwnProperty.call(patch, "membershipTier") ? toTrimmedString(patch.membershipTier) || null : undefined,
+            kilnPreferences: Object.prototype.hasOwnProperty.call(patch, "kilnPreferences") ? toTrimmedString(patch.kilnPreferences) || null : undefined,
+            staffNotes: Object.prototype.hasOwnProperty.call(patch, "staffNotes") ? toTrimmedString(patch.staffNotes) || null : undefined,
+          },
+        }, opsActorContext(auth));
+        statusCode = 200;
+        res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+        res.end(JSON.stringify({ ok: true, ...result }));
+        return;
+      }
+
+      const opsMemberMembershipMatch = method === "POST" ? url.pathname.match(/^\/api\/ops\/members\/([^/]+)\/membership$/) : null;
+      if (opsPortal.enabled && opsService && opsMemberMembershipMatch) {
+        const auth = await assertOpsPortalAuth(req);
+        if (!auth.ok || !auth.principal) {
+          statusCode = 401;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: auth.ok ? "Unauthorized" : auth.message }));
+          return;
+        }
+        const uid = decodeURIComponent(opsMemberMembershipMatch[1] ?? "");
+        const body = await readJsonBody(req);
+        const result = await opsService.updateMemberMembership({
+          uid,
+          membershipTier: toTrimmedString(body.membershipTier) || null,
+          reason: toTrimmedString(body.reason) || null,
+        }, opsActorContext(auth));
+        statusCode = 200;
+        res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+        res.end(JSON.stringify({ ok: true, ...result }));
+        return;
+      }
+
+      const opsMemberRoleMatch = method === "POST" ? url.pathname.match(/^\/api\/ops\/members\/([^/]+)\/role$/) : null;
+      if (opsPortal.enabled && opsService && opsMemberRoleMatch) {
+        const auth = await assertOpsPortalAuth(req);
+        if (!auth.ok || !auth.principal) {
+          statusCode = 401;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: auth.ok ? "Unauthorized" : auth.message }));
+          return;
+        }
+        const uid = decodeURIComponent(opsMemberRoleMatch[1] ?? "");
+        const body = await readJsonBody(req);
+        const portalRole = toTrimmedString(body.portalRole || body.role) as OpsPortalRole;
+        if (portalRole !== "member" && portalRole !== "staff" && portalRole !== "admin") {
+          statusCode = 400;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: "portalRole must be member, staff, or admin." }));
+          return;
+        }
+        const opsRoles = Array.isArray(body.opsRoles) ? body.opsRoles.map((entry) => toTrimmedString(entry)).filter(Boolean) : [];
+        const result = await opsService.updateMemberRole({
+          uid,
+          portalRole,
+          opsRoles: opsRoles as OpsHumanRole[],
+          reason: toTrimmedString(body.reason) || null,
+        }, opsActorContext(auth));
+        statusCode = 200;
+        res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+        res.end(JSON.stringify({ ok: true, ...result }));
+        return;
+      }
+
+      const opsMemberActivityMatch = method === "GET" ? url.pathname.match(/^\/api\/ops\/members\/([^/]+)\/activity$/) : null;
+      if (opsPortal.enabled && opsService && opsMemberActivityMatch) {
+        const auth = await assertOpsPortalAuth(req);
+        if (!auth.ok || !auth.principal) {
+          statusCode = 401;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: auth.ok ? "Unauthorized" : auth.message }));
+          return;
+        }
+        const uid = decodeURIComponent(opsMemberActivityMatch[1] ?? "");
+        const activity = await opsService.getMemberActivity(uid, opsActorContext(auth));
+        statusCode = 200;
+        res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+        res.end(JSON.stringify({ ok: true, activity }));
+        return;
+      }
+
+      if (opsPortal.enabled && opsService && method === "GET" && url.pathname === "/api/ops/twin") {
+        const auth = await assertOpsPortalAuth(req);
+        if (!auth.ok) {
+          statusCode = 401;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: auth.message }));
+          return;
+        }
+        const twin = await opsService.getTwin();
+        statusCode = 200;
+        res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+        res.end(JSON.stringify({ ok: true, twin }));
+        return;
+      }
+
+      if (opsPortal.enabled && opsService && method === "GET" && url.pathname === "/api/ops/truth") {
+        const auth = await assertOpsPortalAuth(req);
+        if (!auth.ok) {
+          statusCode = 401;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: auth.message }));
+          return;
+        }
+        const truth = await opsService.getTruth();
+        statusCode = 200;
+        res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+        res.end(JSON.stringify({ ok: true, truth }));
+        return;
+      }
+
+      if (opsPortal.enabled && opsService && method === "GET" && url.pathname === "/api/ops/tasks") {
+        const auth = await assertOpsPortalAuth(req);
+        if (!auth.ok) {
+          statusCode = 401;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: auth.message }));
+          return;
+        }
+        const surface = toTrimmedString(url.searchParams.get("surface"));
+        const role = toTrimmedString(url.searchParams.get("role"));
+        let rows = await opsService.listTasks(opsActorContext(auth));
+        if (surface) rows = rows.filter((entry) => entry.surface === surface);
+        if (role) rows = rows.filter((entry) => entry.role === role);
+        statusCode = 200;
+        res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+        res.end(JSON.stringify({ ok: true, rows }));
+        return;
+      }
+
+      const opsTaskClaimMatch = method === "POST" ? url.pathname.match(/^\/api\/ops\/tasks\/([^/]+)\/claim$/) : null;
+      if (opsPortal.enabled && opsService && opsTaskClaimMatch) {
+        const auth = await assertOpsPortalAuth(req);
+        if (!auth.ok) {
+          statusCode = 401;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: auth.message }));
+          return;
+        }
+        const taskId = decodeURIComponent(opsTaskClaimMatch[1] ?? "");
+        const task = await opsService.claimTask(taskId, opsActorContext(auth));
+        if (!task) {
+          statusCode = 404;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: `Task ${taskId} not found.` }));
+          return;
+        }
+        statusCode = 200;
+        res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+        res.end(JSON.stringify({ ok: true, task }));
+        return;
+      }
+
+      const opsTaskProofMatch = method === "POST" ? url.pathname.match(/^\/api\/ops\/tasks\/([^/]+)\/proof$/) : null;
+      if (opsPortal.enabled && opsService && opsTaskProofMatch) {
+        const auth = await assertOpsPortalAuth(req);
+        if (!auth.ok) {
+          statusCode = 401;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: auth.message }));
+          return;
+        }
+        const taskId = decodeURIComponent(opsTaskProofMatch[1] ?? "");
+        const body = await readJsonBody(req);
+        const mode = toTrimmedString(body.mode) as ProofMode;
+        if (!mode) {
+          statusCode = 400;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: "mode is required." }));
+          return;
+        }
+        const proof = await opsService.addTaskProof(taskId, opsActorContext(auth), mode, toTrimmedString(body.note) || null, toStringList(body.artifactRefs, 24));
+        if (!proof) {
+          statusCode = 404;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: `Task ${taskId} not found.` }));
+          return;
+        }
+        statusCode = 200;
+        res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+        res.end(JSON.stringify({ ok: true, proof }));
+        return;
+      }
+
+      const opsTaskProofAcceptMatch = method === "POST" ? url.pathname.match(/^\/api\/ops\/tasks\/([^/]+)\/proof\/accept$/) : null;
+      if (opsPortal.enabled && opsService && opsTaskProofAcceptMatch) {
+        const auth = await assertOpsPortalAuth(req);
+        if (!auth.ok || !auth.principal) {
+          statusCode = 401;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: auth.ok ? "Unauthorized" : auth.message }));
+          return;
+        }
+        const taskId = decodeURIComponent(opsTaskProofAcceptMatch[1] ?? "");
+        const body = await readJsonBody(req);
+        const proofId = toTrimmedString(body.proofId);
+        const status = toTrimmedString(body.status) || "accepted";
+        if (!proofId || (status !== "accepted" && status !== "rejected" && status !== "readback_pending")) {
+          statusCode = 400;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: "proofId and a valid status are required." }));
+          return;
+        }
+        const proof = await opsService.acceptTaskProof({
+          taskId,
+          proofId,
+          actorId: auth.actorId,
+          status: status as "accepted" | "rejected" | "readback_pending",
+          note: toTrimmedString(body.note) || null,
+        }, opsActorContext(auth));
+        if (!proof) {
+          statusCode = 404;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: `Proof ${proofId} not found for task ${taskId}.` }));
+          return;
+        }
+        statusCode = 200;
+        res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+        res.end(JSON.stringify({ ok: true, proof }));
+        return;
+      }
+
+      const opsTaskCompleteMatch = method === "POST" ? url.pathname.match(/^\/api\/ops\/tasks\/([^/]+)\/complete$/) : null;
+      if (opsPortal.enabled && opsService && opsTaskCompleteMatch) {
+        const auth = await assertOpsPortalAuth(req);
+        if (!auth.ok) {
+          statusCode = 401;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: auth.message }));
+          return;
+        }
+        const taskId = decodeURIComponent(opsTaskCompleteMatch[1] ?? "");
+        const task = await opsService.completeTask(taskId, opsActorContext(auth));
+        if (!task) {
+          statusCode = 404;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: `Task ${taskId} not found.` }));
+          return;
+        }
+        statusCode = 200;
+        res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+        res.end(JSON.stringify({ ok: true, task }));
+        return;
+      }
+
+      const opsTaskEscapeMatch = method === "POST" ? url.pathname.match(/^\/api\/ops\/tasks\/([^/]+)\/escape$/) : null;
+      if (opsPortal.enabled && opsService && opsTaskEscapeMatch) {
+        const auth = await assertOpsPortalAuth(req);
+        if (!auth.ok || !auth.principal) {
+          statusCode = 401;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: auth.ok ? "Unauthorized" : auth.message }));
+          return;
+        }
+        const taskId = decodeURIComponent(opsTaskEscapeMatch[1] ?? "");
+        const body = await readJsonBody(req);
+        const escapeHatch = toTrimmedString(body.escapeHatch || body.escape) as TaskEscapeHatch;
+        if (!escapeHatch) {
+          statusCode = 400;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: "escapeHatch is required." }));
+          return;
+        }
+        const escape = await opsService.escapeTask({
+          taskId,
+          actorId: auth.actorId,
+          escapeHatch,
+          reason: toTrimmedString(body.reason) || null,
+        }, opsActorContext(auth));
+        if (!escape) {
+          statusCode = 404;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: `Task ${taskId} not found.` }));
+          return;
+        }
+        statusCode = 200;
+        res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+        res.end(JSON.stringify({ ok: true, escape }));
+        return;
+      }
+
+      if (opsPortal.enabled && opsService && method === "GET" && url.pathname === "/api/ops/cases") {
+        const auth = await assertOpsPortalAuth(req);
+        if (!auth.ok) {
+          statusCode = 401;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: auth.message }));
+          return;
+        }
+        const rows = await opsService.listCases(opsActorContext(auth));
+        statusCode = 200;
+        res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+        res.end(JSON.stringify({ ok: true, rows }));
+        return;
+      }
+
+      const opsCaseDetailMatch = method === "GET" ? url.pathname.match(/^\/api\/ops\/cases\/([^/]+)$/) : null;
+      if (opsPortal.enabled && opsService && opsCaseDetailMatch) {
+        const auth = await assertOpsPortalAuth(req);
+        if (!auth.ok) {
+          statusCode = 401;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: auth.message }));
+          return;
+        }
+        const caseId = decodeURIComponent(opsCaseDetailMatch[1] ?? "");
+        const detail = await opsService.getCase(caseId, opsActorContext(auth));
+        if (!detail.record) {
+          statusCode = 404;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: `Case ${caseId} not found.` }));
+          return;
+        }
+        statusCode = 200;
+        res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+        res.end(JSON.stringify({ ok: true, ...detail }));
+        return;
+      }
+
+      const opsCaseNoteMatch = method === "POST" ? url.pathname.match(/^\/api\/ops\/cases\/([^/]+)\/note$/) : null;
+      if (opsPortal.enabled && opsService && opsCaseNoteMatch) {
+        const auth = await assertOpsPortalAuth(req);
+        if (!auth.ok) {
+          statusCode = 401;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: auth.message }));
+          return;
+        }
+        const caseId = decodeURIComponent(opsCaseNoteMatch[1] ?? "");
+        const body = await readJsonBody(req);
+        const noteBody = toTrimmedString(body.body);
+        if (!noteBody) {
+          statusCode = 400;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: "body is required." }));
+          return;
+        }
+        const note = await opsService.addCaseNote({
+          caseId,
+          actorId: auth.actorId,
+          body: noteBody,
+          metadata: body.metadata && typeof body.metadata === "object" && !Array.isArray(body.metadata)
+            ? (body.metadata as Record<string, unknown>)
+            : {},
+        });
+        statusCode = 200;
+        res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+        res.end(JSON.stringify({ ok: true, note }));
+        return;
+      }
+
+      if (opsPortal.enabled && opsService && method === "GET" && url.pathname === "/api/ops/approvals") {
+        const auth = await assertOpsPortalAuth(req);
+        if (!auth.ok) {
+          statusCode = 401;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: auth.message }));
+          return;
+        }
+        const rows = await opsService.listApprovals(opsActorContext(auth));
+        statusCode = 200;
+        res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+        res.end(JSON.stringify({ ok: true, rows }));
+        return;
+      }
+
+      if (opsPortal.enabled && opsService && method === "GET" && url.pathname === "/api/ops/reservations") {
+        const auth = await assertOpsPortalAuth(req);
+        if (!auth.ok || !auth.principal) {
+          statusCode = 401;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: auth.ok ? "Unauthorized" : auth.message }));
+          return;
+        }
+        const rows = await opsService.listReservations(opsActorContext(auth));
+        statusCode = 200;
+        res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+        res.end(JSON.stringify({ ok: true, rows }));
+        return;
+      }
+
+      const opsReservationBundleMatch = method === "GET" ? url.pathname.match(/^\/api\/ops\/reservations\/([^/]+)\/bundle$/) : null;
+      if (opsPortal.enabled && opsService && opsReservationBundleMatch) {
+        const auth = await assertOpsPortalAuth(req);
+        if (!auth.ok || !auth.principal) {
+          statusCode = 401;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: auth.ok ? "Unauthorized" : auth.message }));
+          return;
+        }
+        const reservationId = decodeURIComponent(opsReservationBundleMatch[1] ?? "");
+        const bundle = await opsService.getReservationBundle(reservationId, opsActorContext(auth));
+        if (!bundle) {
+          statusCode = 404;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: `Reservation ${reservationId} not found.` }));
+          return;
+        }
+        statusCode = 200;
+        res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+        res.end(JSON.stringify({ ok: true, bundle }));
+        return;
+      }
+
+      const opsReservationPrepareMatch = method === "POST" ? url.pathname.match(/^\/api\/ops\/reservations\/([^/]+)\/prepare$/) : null;
+      if (opsPortal.enabled && opsService && opsReservationPrepareMatch) {
+        const auth = await assertOpsPortalAuth(req);
+        if (!auth.ok || !auth.principal) {
+          statusCode = 401;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: auth.ok ? "Unauthorized" : auth.message }));
+          return;
+        }
+        const reservationId = decodeURIComponent(opsReservationPrepareMatch[1] ?? "");
+        const task = await opsService.prepareReservation(reservationId, opsActorContext(auth));
+        if (!task) {
+          statusCode = 404;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: `Reservation ${reservationId} not found.` }));
+          return;
+        }
+        statusCode = 200;
+        res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+        res.end(JSON.stringify({ ok: true, task }));
+        return;
+      }
+
+      if (opsPortal.enabled && opsService && method === "GET" && url.pathname === "/api/ops/events") {
+        const auth = await assertOpsPortalAuth(req);
+        if (!auth.ok || !auth.principal) {
+          statusCode = 401;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: auth.ok ? "Unauthorized" : auth.message }));
+          return;
+        }
+        const rows = await opsService.listEvents(opsActorContext(auth));
+        statusCode = 200;
+        res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+        res.end(JSON.stringify({ ok: true, rows }));
+        return;
+      }
+
+      if (opsPortal.enabled && opsService && method === "GET" && url.pathname === "/api/ops/reports") {
+        const auth = await assertOpsPortalAuth(req);
+        if (!auth.ok || !auth.principal) {
+          statusCode = 401;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: auth.ok ? "Unauthorized" : auth.message }));
+          return;
+        }
+        const rows = await opsService.listReports(opsActorContext(auth));
+        statusCode = 200;
+        res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+        res.end(JSON.stringify({ ok: true, rows }));
+        return;
+      }
+
+      if (opsPortal.enabled && opsService && method === "GET" && url.pathname === "/api/ops/lending") {
+        const auth = await assertOpsPortalAuth(req);
+        if (!auth.ok || !auth.principal) {
+          statusCode = 401;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: auth.ok ? "Unauthorized" : auth.message }));
+          return;
+        }
+        const lending = await opsService.getLending(opsActorContext(auth));
+        statusCode = 200;
+        res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+        res.end(JSON.stringify({ ok: true, lending }));
+        return;
+      }
+
+      const opsApprovalResolveMatch = method === "POST" ? url.pathname.match(/^\/api\/ops\/approvals\/([^/]+)\/resolve$/) : null;
+      if (opsPortal.enabled && opsService && opsApprovalResolveMatch) {
+        const auth = await assertOpsPortalAuth(req);
+        if (!auth.ok) {
+          statusCode = 401;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: auth.message }));
+          return;
+        }
+        const approvalId = decodeURIComponent(opsApprovalResolveMatch[1] ?? "");
+        const body = await readJsonBody(req);
+        const status = toTrimmedString(body.status);
+        if (status !== "approved" && status !== "rejected") {
+          statusCode = 400;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: "status must be approved or rejected." }));
+          return;
+        }
+        const approval = await opsService.resolveApproval({
+          approvalId,
+          status,
+          actorId: auth.actorId,
+          note: toTrimmedString(body.note) || null,
+        }, opsActorContext(auth));
+        if (!approval) {
+          statusCode = 404;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: `Approval ${approvalId} not found.` }));
+          return;
+        }
+        statusCode = 200;
+        res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+        res.end(JSON.stringify({ ok: true, approval }));
+        return;
+      }
+
+      const opsDisplayMatch = method === "GET" ? url.pathname.match(/^\/api\/ops\/displays\/([^/]+)$/) : null;
+      if (opsPortal.enabled && opsService && opsDisplayMatch) {
+        const auth = await assertOpsPortalAuth(req);
+        if (!auth.ok) {
+          statusCode = 401;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: auth.message }));
+          return;
+        }
+        const stationId = decodeURIComponent(opsDisplayMatch[1] ?? "");
+        const state = await opsService.getDisplayState(stationId);
+        statusCode = 200;
+        res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+        res.end(JSON.stringify({ ok: true, state }));
+        return;
+      }
+
+      const opsDisplayStreamMatch = method === "GET" ? url.pathname.match(/^\/api\/ops\/displays\/([^/]+)\/stream$/) : null;
+      if (opsPortal.enabled && opsService && opsDisplayStreamMatch) {
+        const auth = await assertOpsPortalAuth(req);
+        if (!auth.ok) {
+          statusCode = 401;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: auth.message }));
+          return;
+        }
+        const stationId = decodeURIComponent(opsDisplayStreamMatch[1] ?? "");
+        const wantsSse =
+          String(req.headers.accept || "")
+            .toLowerCase()
+            .includes("text/event-stream") || toBooleanFlag(url.searchParams.get("stream"), true);
+        if (!wantsSse) {
+          const state = await opsService.getDisplayState(stationId);
+          statusCode = 200;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: true, state }));
+          return;
+        }
+        statusCode = 200;
+        res.writeHead(
+          statusCode,
+          withSecurityHeaders({
+            "content-type": "text/event-stream; charset=utf-8",
+            connection: "keep-alive",
+            "x-accel-buffering": "no",
+            ...corsHeaders,
+            "x-request-id": requestId,
+          }),
+        );
+        let closed = false;
+        let lastSerialized = "";
+        const push = async () => {
+          const state = await opsService.getDisplayState(stationId);
+          const serialized = JSON.stringify({ ok: true, state });
+          if (serialized === lastSerialized) return;
+          lastSerialized = serialized;
+          res.write(`event: state\ndata: ${serialized}\n\n`);
+        };
+        const timer = setInterval(() => {
+          void push();
+        }, 10_000);
+        const heartbeat = setInterval(() => {
+          res.write(`event: heartbeat\ndata: ${JSON.stringify({ ok: true, at: new Date().toISOString() })}\n\n`);
+        }, 15_000);
+        const cleanup = () => {
+          if (closed) return;
+          closed = true;
+          clearInterval(timer);
+          clearInterval(heartbeat);
+          if (!res.writableEnded) res.end();
+        };
+        req.on("close", cleanup);
+        await push();
+        return;
+      }
+
+      const opsChatMatch = method === "POST" ? url.pathname.match(/^\/api\/ops\/chat\/([^/]+)\/send$/) : null;
+      if (opsPortal.enabled && opsService && opsChatMatch) {
+        const auth = await assertOpsPortalAuth(req);
+        if (!auth.ok) {
+          statusCode = 401;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: auth.message }));
+          return;
+        }
+        const surface = decodeURIComponent(opsChatMatch[1] ?? "manager");
+        const body = await readJsonBody(req);
+        const text = toTrimmedString(body.text);
+        if (!text) {
+          statusCode = 400;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: "text is required." }));
+          return;
+        }
+        const result = await opsService.sendChat(surface, opsActorContext(auth), text);
+        statusCode = 200;
+        res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+        res.end(JSON.stringify({ ok: true, ...result }));
+        return;
+      }
+
+      if (opsPortal.enabled && opsService && method === "POST" && url.pathname === "/api/ops/overrides") {
+        const auth = await assertOpsPortalAuth(req);
+        if (!auth.ok || !auth.principal) {
+          statusCode = 401;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: auth.ok ? "Unauthorized" : auth.message }));
+          return;
+        }
+        const body = await readJsonBody(req);
+        const scope = toTrimmedString(body.scope);
+        const reason = toTrimmedString(body.reason);
+        if (!scope || !reason) {
+          statusCode = 400;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: "scope and reason are required." }));
+          return;
+        }
+        const override = await opsService.requestOverride({
+          actorId: auth.actorId,
+          scope,
+          reason,
+          expiresAt: toTrimmedString(body.expiresAt) || null,
+          requiredRole: (toTrimmedString(body.requiredRole) || "owner") as OpsHumanRole,
+          metadata: body.metadata && typeof body.metadata === "object" && !Array.isArray(body.metadata)
+            ? body.metadata as Record<string, unknown>
+            : {},
+        }, opsActorContext(auth));
+        statusCode = 202;
+        res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+        res.end(JSON.stringify({ ok: true, override }));
+        return;
+      }
+
+      if (opsPortal.enabled && opsService && method === "GET" && url.pathname === "/api/ops/ceo") {
+        const auth = await assertOpsPortalAuth(req);
+        if (!auth.ok) {
+          statusCode = 401;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: auth.message }));
+          return;
+        }
+        const rows = await opsService.listGrowthExperiments();
+        statusCode = 200;
+        res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+        res.end(JSON.stringify({ ok: true, rows }));
+        return;
+      }
+
+      if (opsPortal.enabled && opsService && method === "POST" && url.pathname === "/api/ops/ceo/experiments") {
+        const auth = await assertOpsPortalAuth(req);
+        if (!auth.ok) {
+          statusCode = 401;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: auth.message }));
+          return;
+        }
+        const body = await readJsonBody(req);
+        const title = toTrimmedString(body.title);
+        const hypothesis = toTrimmedString(body.hypothesis);
+        if (!title || !hypothesis) {
+          statusCode = 400;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: "title and hypothesis are required." }));
+          return;
+        }
+        const generatedAt = new Date().toISOString();
+        const record: GrowthExperiment = {
+          id: `growth_${crypto.randomUUID()}`,
+          title,
+          hypothesis,
+          status: "proposed",
+          summary: hypothesis,
+          safetyBoundaries: ["draft_only", "no_money_without_approval", "no_owner_impersonation"],
+          owner: auth.actorId,
+          createdAt: generatedAt,
+          updatedAt: generatedAt,
+          metrics: {},
+        };
+        await opsService.createGrowthExperiment(record);
+        statusCode = 202;
+        res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+        res.end(JSON.stringify({ ok: true, experiment: record }));
+        return;
+      }
+
+      if (opsPortal.enabled && opsService && method === "GET" && url.pathname === "/api/ops/forge") {
+        const auth = await assertOpsPortalAuth(req);
+        if (!auth.ok) {
+          statusCode = 401;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: auth.message }));
+          return;
+        }
+        const rows = await opsService.listImprovementCases();
+        statusCode = 200;
+        res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+        res.end(JSON.stringify({ ok: true, rows }));
+        return;
+      }
+
+      if (opsPortal.enabled && opsService && method === "POST" && url.pathname === "/api/ops/forge/improvement-cases") {
+        const auth = await assertOpsPortalAuth(req);
+        if (!auth.ok) {
+          statusCode = 401;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: auth.message }));
+          return;
+        }
+        const body = await readJsonBody(req);
+        const title = toTrimmedString(body.title);
+        const problem = toTrimmedString(body.problem);
+        if (!title || !problem) {
+          statusCode = 400;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: "title and problem are required." }));
+          return;
+        }
+        const generatedAt = new Date().toISOString();
+        const record: ImprovementCase = {
+          id: `improvement_${crypto.randomUUID()}`,
+          title,
+          problem,
+          status: "open",
+          summary: problem,
+          requiredEvaluations: ["truth-readiness", "ux-clarity", "rollback"],
+          rollbackPlan: "Shadow first, then gate behind a feature flag with explicit rollback.",
+          createdAt: generatedAt,
+          updatedAt: generatedAt,
+          metadata: {
+            requestedBy: auth.actorId,
+          },
+        };
+        await opsService.createImprovementCase(record);
+        statusCode = 202;
+        res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+        res.end(JSON.stringify({ ok: true, improvementCase: record }));
+        return;
+      }
+
       if (method === "GET" && url.pathname === "/api/overseer/latest") {
         const auth = await assertCapabilityAuth(req, { requireAdminToken: false });
         if (!auth.ok) {
@@ -4832,6 +6031,29 @@ export function startHttpServer(params: {
         return;
       }
 
+      const runDetailMatch = url.pathname.match(/^\/api\/agent-runtime\/runs\/([^/]+)$/);
+      if (method === "GET" && runDetailMatch) {
+        const auth = await assertCapabilityAuth(req, { requireAdminToken: false });
+        if (!auth.ok) {
+          statusCode = 401;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: auth.message }));
+          return;
+        }
+        const runId = decodeURIComponent(runDetailMatch[1] ?? "");
+        const detail = buildAgentRuntimeRunDetail(resolvedControlTowerRepoRoot, runId);
+        if (!detail.summary && detail.events.length === 0 && detail.artifacts.length === 0) {
+          statusCode = 404;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: `No runtime detail found for ${runId}.` }));
+          return;
+        }
+        statusCode = 200;
+        res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+        res.end(JSON.stringify({ ok: true, detail }));
+        return;
+      }
+
       if (method === "GET" && url.pathname === "/api/agent-runtime/runs") {
         const auth = await assertCapabilityAuth(req, { requireAdminToken: false });
         if (!auth.ok) {
@@ -4873,6 +6095,74 @@ export function startHttpServer(params: {
         statusCode = 202;
         res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
         res.end(JSON.stringify({ ok: true, accepted: true, runId: event.runId }));
+        return;
+      }
+
+      if (method === "GET" && url.pathname === "/api/control-tower/hosts") {
+        const auth = await assertCapabilityAuth(req, { requireAdminToken: false });
+        if (!auth.ok) {
+          statusCode = 401;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: auth.message }));
+          return;
+        }
+        const { state } = await readControlTowerSnapshot();
+        statusCode = 200;
+        res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+        res.end(JSON.stringify({ ok: true, hosts: state.hosts }));
+        return;
+      }
+
+      if (method === "POST" && url.pathname === "/api/control-tower/hosts/heartbeat") {
+        const auth = await assertHostHeartbeatAuth(req);
+        if (!auth.ok) {
+          statusCode = 401;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: auth.message }));
+          return;
+        }
+        const body = await readJsonBody(req);
+        const hostId = toTrimmedString(body.hostId);
+        if (!hostId) {
+          statusCode = 400;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+          res.end(JSON.stringify({ ok: false, message: "hostId is required." }));
+          return;
+        }
+        const heartbeat: ControlTowerHostHeartbeat = {
+          schema: "control-tower-host-heartbeat.v1",
+          hostId,
+          label: toTrimmedString(body.label) || hostId,
+          environment: toTrimmedString(body.environment) === "server" ? "server" : "local",
+          role: toTrimmedString(body.role) || "operator-host",
+          health:
+            toTrimmedString(body.health) === "maintenance"
+              ? "maintenance"
+              : toTrimmedString(body.health) === "offline"
+                ? "offline"
+                : toTrimmedString(body.health) === "degraded"
+                  ? "degraded"
+                  : "healthy",
+          lastSeenAt: toTrimmedString(body.lastSeenAt) || new Date().toISOString(),
+          currentRunId: toTrimmedString(body.currentRunId) || null,
+          agentCount: Number.isFinite(Number(body.agentCount)) ? Math.max(0, Math.floor(Number(body.agentCount))) : 0,
+          version: toTrimmedString(body.version) || null,
+          metrics: {
+            cpuPct: Number.isFinite(Number((body.metrics as Record<string, unknown> | undefined)?.cpuPct))
+              ? Number((body.metrics as Record<string, unknown>).cpuPct)
+              : null,
+            memoryPct: Number.isFinite(Number((body.metrics as Record<string, unknown> | undefined)?.memoryPct))
+              ? Number((body.metrics as Record<string, unknown>).memoryPct)
+              : null,
+            load1: Number.isFinite(Number((body.metrics as Record<string, unknown> | undefined)?.load1))
+              ? Number((body.metrics as Record<string, unknown>).load1)
+              : null,
+          },
+        };
+        writeControlTowerHostHeartbeat(resolvedControlTowerRepoRoot, heartbeat);
+        statusCode = 202;
+        res.writeHead(statusCode, withSecurityHeaders({ "content-type": "application/json", ...corsHeaders, "x-request-id": requestId }));
+        res.end(JSON.stringify({ ok: true, accepted: true, hostId, actorId: auth.actorId }));
         return;
       }
 
@@ -4988,6 +6278,7 @@ export function startHttpServer(params: {
         let closed = false;
         let pollTimer: NodeJS.Timeout | null = null;
         let heartbeatTimer: NodeJS.Timeout | null = null;
+        let lastSnapshotSignature = "";
 
         const cleanup = () => {
           if (closed) return;
@@ -5007,6 +6298,55 @@ export function startHttpServer(params: {
               res.write(`id: ${event.id}\n`);
               res.write(`event: ${event.type}\n`);
               res.write(`data: ${JSON.stringify(event)}\n\n`);
+            }
+            const snapshotSignature = crypto
+              .createHash("sha1")
+              .update(
+                JSON.stringify({
+                  generatedAt: state.generatedAt,
+                  runtimeUpdatedAt: state.agentRuntime?.updatedAt ?? null,
+                  runtimeStatus: state.agentRuntime?.status ?? null,
+                  approvals: state.approvals.map((approval) => `${approval.id}:${approval.status}:${approval.createdAt}`),
+                  hosts: state.hosts.map((host) => ({
+                    hostId: host.hostId,
+                    lastSeenAt: host.lastSeenAt,
+                    health: host.health,
+                    connectivity: host.connectivity,
+                    currentRunId: host.currentRunId,
+                  })),
+                }),
+              )
+              .digest("hex");
+            if (snapshotSignature !== lastSnapshotSignature) {
+              lastSnapshotSignature = snapshotSignature;
+              const pulseEvent: ControlTowerEvent = {
+                id: `snapshot:${snapshotSignature}`,
+                at: state.generatedAt,
+                kind: "operator",
+                type: "run.status",
+                runId: state.agentRuntime?.runId ?? null,
+                agentId: state.agentRuntime?.agentId ?? null,
+                channel: "ops",
+                occurredAt: state.generatedAt,
+                severity: "info",
+                title: "Control Tower snapshot refreshed",
+                summary: "Runtime or host presence changed.",
+                actor: "control-tower",
+                roomId: null,
+                serviceId: null,
+                actionLabel: null,
+                sourceAction: "control_tower.snapshot_refreshed",
+                payload: {
+                  hostCount: state.hosts.length,
+                  approvalCount: state.approvals.length,
+                  latestRunId: state.agentRuntime?.runId ?? null,
+                },
+              };
+              if (!freshEvents.length) {
+                res.write(`id: ${pulseEvent.id}\n`);
+                res.write(`event: ${pulseEvent.type}\n`);
+                res.write(`data: ${JSON.stringify(pulseEvent)}\n\n`);
+              }
             }
             if (streamOnce) {
               cleanup();
@@ -6917,6 +8257,86 @@ export function startHttpServer(params: {
           overview,
           kilnDetails,
           uploadMaxBytes: resolvedKilnImportMaxBytes,
+        });
+        statusCode = 200;
+        res.writeHead(statusCode, withSecurityHeaders({ "content-type": "text/html; charset=utf-8", ...corsHeaders, "x-request-id": requestId }));
+        res.end(html);
+        return;
+      }
+
+      if (opsPortal.enabled && opsPortal.compareEnabled && opsService && method === "GET" && url.pathname === "/ops/choice") {
+        const auth = await assertOpsPortalAuth(req);
+        if (!auth.ok) {
+          statusCode = 401;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "text/plain; charset=utf-8", ...corsHeaders, "x-request-id": requestId }));
+          res.end(auth.message);
+          return;
+        }
+        const snapshot = await opsService.getPortalSnapshot();
+        const html = renderOpsPortalChoicePage({
+          headline: snapshot.twin.headline,
+          narrative: snapshot.twin.narrative,
+          generatedAt: snapshot.generatedAt,
+          opsUrl: `/ops?surface=${encodeURIComponent(opsPortal.defaultSurface)}`,
+          legacyUrl: opsPortal.legacyUrl,
+        });
+        statusCode = 200;
+        res.writeHead(statusCode, withSecurityHeaders({ "content-type": "text/html; charset=utf-8", ...corsHeaders, "x-request-id": requestId }));
+        res.end(html);
+        return;
+      }
+
+      const opsDisplayPageMatch = method === "GET" ? url.pathname.match(/^\/ops\/display\/([^/]+)$/) : null;
+      if (opsPortal.enabled && opsService && opsDisplayPageMatch) {
+        const stationId = decodeURIComponent(opsDisplayPageMatch[1] ?? "");
+        const auth = await assertOpsPortalAuth(req);
+        if (!auth.ok) {
+          statusCode = 401;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "text/plain; charset=utf-8", ...corsHeaders, "x-request-id": requestId }));
+          res.end(auth.message);
+          return;
+        }
+        const [snapshot, displayState] = await Promise.all([
+          opsService.getPortalSnapshot(auth.principal ? opsActorContext(auth) : undefined),
+          opsService.getDisplayState(stationId),
+        ]);
+        const sessionToken = auth.ok && opsSessionSecret ? createSignedOpsSessionToken(opsSessionSecret, opsSessionTtlSeconds) : null;
+        const html = renderOpsPortalPage({
+          snapshot,
+          displayState,
+          surface: "hands",
+          stationId,
+          sessionToken,
+        });
+        statusCode = 200;
+        res.writeHead(statusCode, withSecurityHeaders({ "content-type": "text/html; charset=utf-8", ...corsHeaders, "x-request-id": requestId }));
+        res.end(html);
+        return;
+      }
+
+      if (opsPortal.enabled && opsService && method === "GET" && url.pathname === "/ops") {
+        const stationId = toTrimmedString(url.searchParams.get("stationId")) || null;
+        const requestedSurface = toTrimmedString(url.searchParams.get("surface")) || opsPortal.defaultSurface;
+        const auth = await assertOpsPortalAuth(req);
+        if (!auth.ok) {
+          statusCode = 401;
+          res.writeHead(statusCode, withSecurityHeaders({ "content-type": "text/plain; charset=utf-8", ...corsHeaders, "x-request-id": requestId }));
+          res.end(auth.message);
+          return;
+        }
+        const snapshot = await opsService.getPortalSnapshot(auth.principal ? opsActorContext(auth) : undefined);
+        const allowedSurfaces = snapshot.session?.allowedSurfaces ?? [];
+        const resolvedSurface = allowedSurfaces.includes(requestedSurface as typeof allowedSurfaces[number])
+          ? requestedSurface
+          : allowedSurfaces[0] ?? requestedSurface;
+        const displayState = stationId ? await opsService.getDisplayState(stationId) : null;
+        const sessionToken = auth.ok && opsSessionSecret ? createSignedOpsSessionToken(opsSessionSecret, opsSessionTtlSeconds) : null;
+        const html = renderOpsPortalPage({
+          snapshot,
+          displayState,
+          surface: resolvedSurface,
+          stationId,
+          sessionToken,
         });
         statusCode = 200;
         res.writeHead(statusCode, withSecurityHeaders({ "content-type": "text/html; charset=utf-8", ...corsHeaders, "x-request-id": requestId }));

--- a/studio-brain/src/index.ts
+++ b/studio-brain/src/index.ts
@@ -43,6 +43,8 @@ import {
   type SupportEmailSyncReport,
 } from "./supportOps/service";
 import type { SupportMailboxAdapter, SupportReplySender } from "./supportOps/types";
+import { PostgresOpsStore } from "./ops/store";
+import { createOpsService } from "./ops/service";
 
 function parseArtifactPort(endpoint: string, fallback: number): number {
   try {
@@ -286,6 +288,15 @@ async function main(): Promise<void> {
     connectorRegistry
   );
   const supportOpsStore = new PostgresSupportOpsStore();
+  const opsStore = new PostgresOpsStore();
+  const opsService = createOpsService({
+    store: opsStore,
+    logger,
+    kilnStore,
+    supportOpsStore,
+    stateStore,
+    eventStore,
+  });
   const recordSupportLoopSignal = async (input: {
     loopKey: string;
     supportRequestId?: string | null;
@@ -799,6 +810,26 @@ async function main(): Promise<void> {
       allowedSources: env.STUDIO_BRAIN_MEMORY_INGEST_ALLOWED_SOURCES,
       allowedDiscordGuildIds: env.STUDIO_BRAIN_MEMORY_INGEST_ALLOWED_DISCORD_GUILD_IDS,
       allowedDiscordChannelIds: env.STUDIO_BRAIN_MEMORY_INGEST_ALLOWED_DISCORD_CHANNEL_IDS,
+    },
+    opsService,
+    opsIngestConfig: {
+      enabled: String(process.env.STUDIO_BRAIN_OPS_INGEST_ENABLED ?? "true").trim().toLowerCase() !== "false",
+      hmacSecret: String(process.env.STUDIO_BRAIN_OPS_INGEST_HMAC_SECRET ?? env.STUDIO_BRAIN_MEMORY_INGEST_HMAC_SECRET ?? "").trim(),
+      maxSkewSeconds: Math.max(
+        30,
+        Number.parseInt(String(process.env.STUDIO_BRAIN_OPS_INGEST_MAX_SKEW_SECONDS ?? env.STUDIO_BRAIN_MEMORY_INGEST_MAX_SKEW_SECONDS ?? "300"), 10) || 300
+      ),
+      allowedSources: String(process.env.STUDIO_BRAIN_OPS_INGEST_ALLOWED_SOURCES ?? "")
+        .split(",")
+        .map((entry) => entry.trim())
+        .filter(Boolean),
+    },
+    opsPortalConfig: {
+      enabled: env.STUDIO_BRAIN_ENABLE_OPS_PORTAL,
+      requireStaffAuth: env.STUDIO_BRAIN_REQUIRE_STAFF_FOR_OPS_PORTAL,
+      compareEnabled: env.STUDIO_BRAIN_ENABLE_OPS_PORTAL_CHOICE,
+      legacyUrl: env.STUDIO_BRAIN_OPS_PORTAL_LEGACY_URL,
+      defaultSurface: env.STUDIO_BRAIN_OPS_PORTAL_DEFAULT_SURFACE,
     },
     pilotWriteExecutor: env.STUDIO_BRAIN_ENABLE_WRITE_EXECUTION
       ? createPilotWriteExecutor({ functionsBaseUrl: env.STUDIO_BRAIN_FUNCTIONS_BASE_URL })

--- a/studio-brain/src/ops/contracts.ts
+++ b/studio-brain/src/ops/contracts.ts
@@ -1,0 +1,890 @@
+import crypto from "node:crypto";
+
+export const verificationClasses = ["observed", "inferred", "planned", "claimed", "confirmed"] as const;
+export type VerificationClass = (typeof verificationClasses)[number];
+
+export const opsDegradeModes = [
+  "observe_only",
+  "draft_only",
+  "no_human_tasking",
+  "manual_dispatch_only",
+  "internet_pause",
+  "growth_pause",
+  "forge_pause",
+] as const;
+export type OpsDegradeMode = (typeof opsDegradeModes)[number];
+
+export const opsSurfaceIds = ["owner", "manager", "hands", "internet", "ceo", "forge"] as const;
+export type OpsSurfaceId = (typeof opsSurfaceIds)[number];
+
+export const opsSurfaceModes = {
+  owner: ["brief", "approvals", "finance", "identity"],
+  manager: ["overview", "live", "truth", "operations", "commitments", "trust"],
+  hands: ["now", "queue", "checkins", "production", "firings", "lending", "lending-intake"],
+  internet: ["desk", "member-ops", "events", "support", "reputation"],
+  ceo: ["portfolio", "community", "campaigns"],
+  forge: ["lab", "policy-agent-ops", "telemetry", "migration"],
+} as const satisfies Record<OpsSurfaceId, readonly string[]>;
+export type OpsSurfaceModeMap = typeof opsSurfaceModes;
+export type OpsSurfaceMode = OpsSurfaceModeMap[OpsSurfaceId][number];
+
+export const opsHumanRoles = [
+  "owner",
+  "member_ops",
+  "support_ops",
+  "kiln_lead",
+  "floor_staff",
+  "events_ops",
+  "library_ops",
+  "finance_ops",
+] as const;
+export type OpsHumanRole = (typeof opsHumanRoles)[number];
+
+export type OpsAssignableRole = OpsHumanRole | "studio_manager" | "any_staff";
+
+export const opsCapabilities = [
+  "surface:owner",
+  "surface:manager",
+  "surface:hands",
+  "surface:internet",
+  "surface:ceo",
+  "surface:forge",
+  "members:view",
+  "members:edit_profile",
+  "members:edit_membership",
+  "members:edit_role",
+  "members:edit_owner_role",
+  "approvals:view",
+  "approvals:manage",
+  "tasks:claim:any",
+  "tasks:escape",
+  "proof:submit",
+  "proof:accept",
+  "reservations:view",
+  "reservations:prepare",
+  "events:view",
+  "reports:view",
+  "lending:view",
+  "finance:view",
+  "finance:act",
+  "overrides:request",
+  "overrides:approve",
+  "identity:manage",
+  "strategy:ceo",
+  "forge:manage",
+] as const;
+export type OpsCapability = (typeof opsCapabilities)[number];
+
+const roleCapabilityMap: Record<OpsHumanRole, readonly OpsCapability[]> = {
+  owner: [
+    "surface:owner",
+    "surface:manager",
+    "surface:hands",
+    "surface:internet",
+    "surface:ceo",
+    "surface:forge",
+    "members:view",
+    "members:edit_profile",
+    "members:edit_membership",
+    "members:edit_role",
+    "members:edit_owner_role",
+    "approvals:view",
+    "approvals:manage",
+    "tasks:claim:any",
+    "tasks:escape",
+    "proof:submit",
+    "proof:accept",
+    "reservations:view",
+    "reservations:prepare",
+    "events:view",
+    "reports:view",
+    "lending:view",
+    "finance:view",
+    "finance:act",
+    "overrides:request",
+    "overrides:approve",
+    "identity:manage",
+    "strategy:ceo",
+    "forge:manage",
+  ],
+  member_ops: [
+    "surface:internet",
+    "members:view",
+    "members:edit_profile",
+    "members:edit_membership",
+    "members:edit_role",
+    "approvals:view",
+    "tasks:escape",
+    "proof:submit",
+    "reservations:view",
+    "events:view",
+    "overrides:request",
+  ],
+  support_ops: [
+    "surface:internet",
+    "members:view",
+    "members:edit_profile",
+    "members:edit_membership",
+    "members:edit_role",
+    "approvals:view",
+    "tasks:claim:any",
+    "tasks:escape",
+    "proof:submit",
+    "proof:accept",
+    "reservations:view",
+    "events:view",
+    "reports:view",
+    "overrides:request",
+  ],
+  kiln_lead: [
+    "surface:hands",
+    "tasks:claim:any",
+    "tasks:escape",
+    "proof:submit",
+    "proof:accept",
+    "reservations:view",
+    "reservations:prepare",
+    "overrides:request",
+  ],
+  floor_staff: [
+    "surface:hands",
+    "tasks:claim:any",
+    "tasks:escape",
+    "proof:submit",
+    "reservations:view",
+    "overrides:request",
+  ],
+  events_ops: [
+    "surface:internet",
+    "tasks:claim:any",
+    "tasks:escape",
+    "proof:submit",
+    "reservations:view",
+    "events:view",
+    "overrides:request",
+  ],
+  library_ops: [
+    "surface:hands",
+    "tasks:claim:any",
+    "tasks:escape",
+    "proof:submit",
+    "lending:view",
+    "overrides:request",
+  ],
+  finance_ops: [
+    "surface:owner",
+    "approvals:view",
+    "finance:view",
+    "overrides:request",
+  ],
+};
+
+export function normalizeOpsHumanRole(value: unknown): OpsHumanRole | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim().toLowerCase();
+  return opsHumanRoles.find((entry) => entry === normalized) ?? null;
+}
+
+export function normalizeOpsHumanRoles(values: unknown): OpsHumanRole[] {
+  const next = new Set<OpsHumanRole>();
+  const source = Array.isArray(values) ? values : [values];
+  for (const entry of source) {
+    const normalized = normalizeOpsHumanRole(entry);
+    if (normalized) next.add(normalized);
+  }
+  return [...next];
+}
+
+export function deriveOpsCapabilities(roles: OpsHumanRole[]): OpsCapability[] {
+  const next = new Set<OpsCapability>();
+  for (const role of roles) {
+    for (const capability of roleCapabilityMap[role] ?? []) {
+      next.add(capability);
+    }
+  }
+  return [...next];
+}
+
+export function allowedSurfacesForCapabilities(capabilities: OpsCapability[]): OpsSurfaceId[] {
+  const allowed = new Set<OpsSurfaceId>();
+  for (const capability of capabilities) {
+    const match = capability.match(/^surface:(.+)$/);
+    if (!match?.[1]) continue;
+    const surface = opsSurfaceIds.find((entry) => entry === match[1]);
+    if (surface) allowed.add(surface);
+  }
+  return opsSurfaceIds.filter((entry) => allowed.has(entry));
+}
+
+export function allowedModesForSurface(surface: OpsSurfaceId, capabilities: OpsCapability[]): string[] {
+  if (!allowedSurfacesForCapabilities(capabilities).includes(surface)) return [];
+  return [...opsSurfaceModes[surface]];
+}
+
+export function hasOpsCapability(capabilities: readonly OpsCapability[], capability: OpsCapability): boolean {
+  return capabilities.includes(capability);
+}
+
+export function canAccessOpsSurface(capabilities: readonly OpsCapability[], surface: string): surface is OpsSurfaceId {
+  const normalized = opsSurfaceIds.find((entry) => entry === surface);
+  if (!normalized) return false;
+  return hasOpsCapability(capabilities, `surface:${normalized}` as OpsCapability);
+}
+
+export function canAccessOpsMode(
+  capabilities: readonly OpsCapability[],
+  surface: string,
+  mode: string,
+): boolean {
+  if (!canAccessOpsSurface(capabilities, surface)) return false;
+  return (opsSurfaceModes[surface] as readonly string[]).includes(mode);
+}
+
+export type OpsPortalRole = "member" | "staff" | "admin";
+export type OpsReadiness = "ready" | "degraded" | "blocked";
+export type OpsHealth = "healthy" | "warning" | "critical";
+
+export type OpsSourceRef = {
+  id: string;
+  system: string;
+  label: string;
+  kind?: string | null;
+  href?: string | null;
+  observedAt: string | null;
+  freshnessMs: number | null;
+};
+
+export type OpsEvidenceSummary = {
+  summary: string;
+  sources: OpsSourceRef[];
+  freshestAt: string | null;
+  confidence: number;
+  degradeReason: string | null;
+  verificationClass: VerificationClass;
+};
+
+export type OpsChecklistItem = {
+  id: string;
+  label: string;
+  detail?: string | null;
+  status: "todo" | "done" | "blocked";
+};
+
+export type OpsProofRequirement = {
+  preferredMode: ProofMode;
+  fallbackModes: ProofMode[];
+  doneDefinition: string;
+  fallbackIfSignalMissing: string;
+};
+
+export type OpsSurfacePolicy = {
+  surface: OpsSurfaceId;
+  modes: string[];
+};
+
+export type OpsSessionMe = {
+  actorId: string;
+  portalRole: OpsPortalRole;
+  isStaff: boolean;
+  opsRoles: OpsHumanRole[];
+  opsCapabilities: OpsCapability[];
+  allowedSurfaces: OpsSurfaceId[];
+  allowedModes: Record<OpsSurfaceId, string[]>;
+};
+
+export type OpsWorldEvent = {
+  id: string;
+  eventType: string;
+  eventVersion: number;
+  entityKind: string;
+  entityId: string;
+  caseId: string | null;
+  sourceSystem: string;
+  sourceEventId: string;
+  dedupeKey: string;
+  roomId: string | null;
+  actorKind: string;
+  actorId: string;
+  confidence: number;
+  occurredAt: string;
+  ingestedAt: string;
+  verificationClass: VerificationClass;
+  payload: Record<string, unknown>;
+  artifactRefs: string[];
+};
+
+export type OpsIngestReceipt = {
+  id: string;
+  sourceSystem: string;
+  sourceEventId: string;
+  payloadHash: string;
+  authPrincipal: string;
+  receivedAt: string;
+  timestampSkewSeconds: number;
+};
+
+export const opsCaseKinds = [
+  "kiln_run",
+  "arrival",
+  "support_thread",
+  "event",
+  "anomaly",
+  "complaint",
+  "growth_experiment",
+  "improvement_case",
+  "station_session",
+  "general",
+] as const;
+export type OpsCaseKind = (typeof opsCaseKinds)[number];
+
+export const opsPriorityLevels = ["p0", "p1", "p2", "p3"] as const;
+export type OpsPriority = (typeof opsPriorityLevels)[number];
+
+export const opsCaseStatuses = [
+  "open",
+  "active",
+  "blocked",
+  "awaiting_approval",
+  "resolved",
+  "canceled",
+] as const;
+export type OpsCaseStatus = (typeof opsCaseStatuses)[number];
+
+export type OpsCaseRecord = {
+  id: string;
+  kind: OpsCaseKind;
+  title: string;
+  summary: string;
+  status: OpsCaseStatus;
+  priority: OpsPriority;
+  lane: OpsSurfaceId;
+  ownerRole: string | null;
+  verificationClass: VerificationClass;
+  freshestAt: string | null;
+  sources: OpsSourceRef[];
+  confidence: number;
+  degradeReason: string | null;
+  dueAt: string | null;
+  linkedEntityKind: string | null;
+  linkedEntityId: string | null;
+  memoryScope: string | null;
+  createdAt: string;
+  updatedAt: string;
+  metadata: Record<string, unknown>;
+};
+
+export type OpsCaseNote = {
+  id: string;
+  caseId: string;
+  actorId: string;
+  actorKind: string;
+  body: string;
+  createdAt: string;
+  metadata: Record<string, unknown>;
+};
+
+export const humanTaskStatuses = [
+  "proposed",
+  "queued",
+  "claimed",
+  "in_progress",
+  "blocked",
+  "proof_pending",
+  "verified",
+  "reopened",
+  "canceled",
+] as const;
+export type HumanTaskStatus = (typeof humanTaskStatuses)[number];
+
+export const proofModes = [
+  "manual_confirm",
+  "qr_scan",
+  "camera_snapshot",
+  "sensor_transition",
+  "dual_confirm",
+] as const;
+export type ProofMode = (typeof proofModes)[number];
+
+export const approvalStatuses = ["pending", "approved", "rejected", "executed", "expired"] as const;
+export type ApprovalStatus = (typeof approvalStatuses)[number];
+
+export const taskEscapeHatches = [
+  "need_help",
+  "unsafe",
+  "missing_tool",
+  "not_my_role",
+  "already_done",
+  "defer_with_reason",
+] as const;
+export type TaskEscapeHatch = (typeof taskEscapeHatches)[number];
+
+export type HumanTaskRecord = {
+  id: string;
+  caseId: string | null;
+  title: string;
+  status: HumanTaskStatus;
+  priority: OpsPriority;
+  surface: Extract<OpsSurfaceId, "hands" | "internet" | "manager" | "owner">;
+  role: OpsAssignableRole | string;
+  zone: string;
+  dueAt: string | null;
+  etaMinutes: number | null;
+  toolsNeeded: string[];
+  interruptibility: "now" | "soon" | "queue";
+  whyNow: string;
+  whyYou: string;
+  evidenceSummary: string;
+  consequenceIfDelayed: string;
+  instructions: string[];
+  checklist: OpsChecklistItem[];
+  doneDefinition: string;
+  proofModes: ProofMode[];
+  preferredProofMode: ProofMode;
+  fallbackIfSignalMissing: string;
+  verificationClass: VerificationClass;
+  freshestAt: string | null;
+  sources: OpsSourceRef[];
+  confidence: number;
+  degradeReason: string | null;
+  claimedBy: string | null;
+  claimedAt: string | null;
+  completedAt: string | null;
+  blockerReason: string | null;
+  blockerEscapeHatches: TaskEscapeHatch[];
+  createdAt: string;
+  updatedAt: string;
+  metadata: Record<string, unknown>;
+};
+
+export type TaskProofRecord = {
+  id: string;
+  taskId: string;
+  mode: ProofMode;
+  actorId: string;
+  verificationStatus: "submitted" | "accepted" | "rejected" | "readback_pending";
+  note: string | null;
+  artifactRefs: string[];
+  createdAt: string;
+  verifiedAt?: string | null;
+  verifiedBy?: string | null;
+  readbackReceiptId?: string | null;
+};
+
+export type ProofVerificationRecord = {
+  id: string;
+  taskId: string;
+  proofId: string;
+  actorId: string;
+  status: TaskProofRecord["verificationStatus"];
+  note: string | null;
+  createdAt: string;
+  readbackReceiptId: string | null;
+};
+
+export type ReadbackReceipt = {
+  id: string;
+  taskId: string | null;
+  actionId: string | null;
+  sourceSystem: string;
+  verificationClass: VerificationClass;
+  observedAt: string;
+  summary: string;
+  payload: Record<string, unknown>;
+};
+
+export type ApprovalItem = {
+  id: string;
+  caseId: string | null;
+  title: string;
+  summary: string;
+  status: ApprovalStatus;
+  actionClass: string;
+  requestedBy: string;
+  requiredRole: OpsHumanRole | string;
+  riskSummary: string;
+  reversibility: "reversible" | "hard_to_reverse" | "irreversible";
+  verificationClass: VerificationClass;
+  freshestAt: string | null;
+  sources: OpsSourceRef[];
+  confidence: number;
+  degradeReason: string | null;
+  recommendation: string;
+  rollbackPlan: string | null;
+  createdAt: string;
+  updatedAt: string;
+  resolvedAt: string | null;
+  resolvedBy: string | null;
+  metadata: Record<string, unknown>;
+};
+
+export type ActionEffectReceipt = {
+  id: string;
+  actionId: string;
+  sourceSystem: string;
+  effectType: string;
+  verificationClass: VerificationClass;
+  observedAt: string;
+  summary: string;
+  payload: Record<string, unknown>;
+};
+
+export type GrowthExperiment = {
+  id: string;
+  title: string;
+  hypothesis: string;
+  status: "proposed" | "running" | "paused" | "completed";
+  summary: string;
+  safetyBoundaries: string[];
+  owner: string;
+  createdAt: string;
+  updatedAt: string;
+  metrics: Record<string, number | string | null>;
+};
+
+export type ImprovementCase = {
+  id: string;
+  title: string;
+  problem: string;
+  status: "open" | "evaluating" | "approved" | "shadow" | "rejected" | "shipped";
+  summary: string;
+  requiredEvaluations: string[];
+  rollbackPlan: string;
+  createdAt: string;
+  updatedAt: string;
+  metadata: Record<string, unknown>;
+};
+
+export type StationSession = {
+  id: string;
+  stationId: string;
+  roomId: string;
+  surfaceMode: "ambient_board" | "focus_task" | "proof_station";
+  capabilities: string[];
+  currentTaskId: string | null;
+  actorId: string | null;
+  lastSeenAt: string;
+};
+
+export type MemberOpsRecord = {
+  uid: string;
+  email: string | null;
+  displayName: string;
+  membershipTier: string | null;
+  kilnPreferences: string | null;
+  staffNotes: string | null;
+  portalRole: OpsPortalRole;
+  opsRoles: OpsHumanRole[];
+  opsCapabilities: OpsCapability[];
+  createdAt: string | null;
+  updatedAt: string | null;
+  lastSeenAt: string | null;
+  metadata: Record<string, unknown>;
+};
+
+export type MembershipChangeRecord = {
+  id: string;
+  uid: string;
+  editedByUid: string;
+  beforeTier: string | null;
+  afterTier: string | null;
+  reason: string | null;
+  createdAt: string;
+};
+
+export type RoleChangeRecord = {
+  id: string;
+  uid: string;
+  editedByUid: string;
+  beforePortalRole: OpsPortalRole;
+  afterPortalRole: OpsPortalRole;
+  beforeOpsRoles: OpsHumanRole[];
+  afterOpsRoles: OpsHumanRole[];
+  reason: string | null;
+  createdAt: string;
+};
+
+export type MemberActivityRecord = {
+  uid: string;
+  reservations: number;
+  libraryLoans: number;
+  supportThreads: number;
+  events: number;
+  lastReservationAt: string | null;
+  lastLoanAt: string | null;
+  lastEventAt: string | null;
+};
+
+export type OpsMemberAuditRecord = {
+  id: string;
+  uid: string;
+  kind: "profile" | "membership" | "role";
+  actorId: string;
+  summary: string;
+  reason: string | null;
+  createdAt: string;
+  payload: Record<string, unknown>;
+};
+
+export type ArrivalBundle = {
+  status: string;
+  dueAt: string | null;
+  arrivedAt: string | null;
+  summary: string;
+  confidence: number;
+  verificationClass: VerificationClass;
+};
+
+export type PrepBundle = {
+  summary: string;
+  actions: string[];
+  toolsNeeded: string[];
+  assignedRole: OpsAssignableRole | string;
+};
+
+export type ReservationBundle = {
+  id: string;
+  reservationId: string;
+  title: string;
+  status: string;
+  ownerUid: string | null;
+  displayName: string;
+  firingType: string;
+  dueAt: string | null;
+  itemCount: number;
+  shelfEquivalent: number;
+  notes: string | null;
+  arrival: ArrivalBundle;
+  prep: PrepBundle;
+  linkedTaskIds: string[];
+  verificationClass: VerificationClass;
+  freshestAt: string | null;
+  sources: OpsSourceRef[];
+  confidence: number;
+  degradeReason: string | null;
+  metadata: Record<string, unknown>;
+};
+
+export type OpsEventRecord = {
+  id: string;
+  title: string;
+  status: string;
+  startAt: string | null;
+  endAt: string | null;
+  remainingCapacity: number | null;
+  capacity: number | null;
+  waitlistCount: number | null;
+  location: string | null;
+  priceCents: number | null;
+  lastStatusReason: string | null;
+  lastStatusChangedAt: string | null;
+};
+
+export type OpsReportRecord = {
+  id: string;
+  status: string;
+  severity: string;
+  summary: string;
+  createdAt: string | null;
+  ownerUid: string | null;
+};
+
+export type OpsLendingRequestRecord = {
+  id: string;
+  status: string;
+  requesterUid: string | null;
+  requesterName: string | null;
+  title: string;
+  createdAt: string | null;
+};
+
+export type OpsLendingLoanRecord = {
+  id: string;
+  status: string;
+  borrowerUid: string | null;
+  borrowerName: string | null;
+  title: string;
+  createdAt: string | null;
+  dueAt: string | null;
+};
+
+export type OpsLendingSnapshot = {
+  requests: OpsLendingRequestRecord[];
+  loans: OpsLendingLoanRecord[];
+  recommendationCount: number;
+  tagSubmissionCount: number;
+  coverReviewCount: number;
+};
+
+export type TaskEscapeRecord = {
+  id: string;
+  taskId: string;
+  caseId: string | null;
+  actorId: string;
+  escapeHatch: TaskEscapeHatch;
+  reason: string | null;
+  status: "open" | "acknowledged" | "resolved";
+  createdAt: string;
+  resolvedAt: string | null;
+  resolvedBy: string | null;
+  metadata: Record<string, unknown>;
+};
+
+export type OverrideRequest = {
+  id: string;
+  actorId: string;
+  scope: string;
+  reason: string;
+  expiresAt: string | null;
+  requiredRole: OpsHumanRole | string;
+  metadata: Record<string, unknown>;
+};
+
+export type OverrideReceipt = OverrideRequest & {
+  status: "pending" | "active" | "expired" | "rejected";
+  createdAt: string;
+  resolvedAt: string | null;
+  resolvedBy: string | null;
+};
+
+export type OpsSourceFreshness = {
+  source: string;
+  label: string;
+  freshnessSeconds: number | null;
+  budgetSeconds: number;
+  status: OpsHealth;
+  freshestAt: string | null;
+  reason: string | null;
+};
+
+export type OpsWatchdog = {
+  id: string;
+  label: string;
+  status: OpsHealth;
+  summary: string;
+  recommendation: string;
+};
+
+export type OpsTruthState = {
+  generatedAt: string;
+  readiness: OpsReadiness;
+  summary: string;
+  degradeModes: OpsDegradeMode[];
+  sources: OpsSourceFreshness[];
+  watchdogs: OpsWatchdog[];
+  metrics: Record<string, number | string | boolean | null>;
+};
+
+export type OpsTwinZone = {
+  id: string;
+  label: string;
+  status: OpsHealth;
+  summary: string;
+  nextAction: string | null;
+  evidence: OpsEvidenceSummary;
+};
+
+export type OpsTwinState = {
+  generatedAt: string;
+  headline: string;
+  narrative: string;
+  currentRisk: string | null;
+  commitmentsDueSoon: number;
+  arrivalsExpectedSoon: number;
+  zones: OpsTwinZone[];
+  nextActions: string[];
+};
+
+export type OpsConversationThreadRecord = {
+  id: string;
+  surface: OpsSurfaceId;
+  roleMask: string;
+  senderIdentity: string;
+  latestMessageAt: string;
+  unread: boolean;
+  summary: string;
+};
+
+export type OpsPortalSnapshot = {
+  generatedAt: string;
+  session: OpsSessionMe | null;
+  twin: OpsTwinState;
+  truth: OpsTruthState;
+  tasks: HumanTaskRecord[];
+  cases: OpsCaseRecord[];
+  approvals: ApprovalItem[];
+  ceo: GrowthExperiment[];
+  forge: ImprovementCase[];
+  conversations: OpsConversationThreadRecord[];
+  members: MemberOpsRecord[];
+  reservations: ReservationBundle[];
+  events: OpsEventRecord[];
+  reports: OpsReportRecord[];
+  lending: OpsLendingSnapshot | null;
+  taskEscapes: TaskEscapeRecord[];
+  overrides: OverrideReceipt[];
+};
+
+export type StationDisplayState = {
+  generatedAt: string;
+  station: StationSession | null;
+  truth: OpsTruthState;
+  tasks: HumanTaskRecord[];
+  focusTask: HumanTaskRecord | null;
+};
+
+export function nowIso(): string {
+  return new Date().toISOString();
+}
+
+export function stableOpsHash(value: unknown): string {
+  return crypto.createHash("sha256").update(JSON.stringify(value)).digest("hex");
+}
+
+export function clampConfidence(value: unknown, fallback = 0.5): number {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.max(0, Math.min(1, parsed));
+}
+
+export function makeId(prefix: string): string {
+  return `${prefix}_${crypto.randomUUID()}`;
+}
+
+export const opsAuthStatuses = ["authorized", "denied", "degraded"] as const;
+export type OpsAuthStatus = (typeof opsAuthStatuses)[number];
+
+export type OpsAuthReceipt = {
+  id: string;
+  sourceSystem: string;
+  actorId: string;
+  actorKind: string;
+  status: OpsAuthStatus;
+  scopes: string[];
+  summary: string;
+  observedAt: string;
+  expiresAt: string | null;
+  metadata: Record<string, unknown>;
+};
+
+export type OpsCase = OpsCaseRecord;
+export type HumanTask = HumanTaskRecord;
+export type IngestReceipt = OpsIngestReceipt;
+export type AuthReceipt = OpsAuthReceipt;
+export type OpsTwinSnapshot = OpsTwinState;
+export type OpsTruthSnapshot = OpsTruthState;
+export type OpsTaskView = {
+  generatedAt: string;
+  session: OpsSessionMe | null;
+  twin: OpsTwinState;
+  truth: OpsTruthState;
+  tasks: HumanTaskRecord[];
+  cases: OpsCaseRecord[];
+  approvals: ApprovalItem[];
+  growthExperiments: GrowthExperiment[];
+  improvementCases: ImprovementCase[];
+  stations: StationSession[];
+  reservations: ReservationBundle[];
+  events: OpsEventRecord[];
+  reports: OpsReportRecord[];
+  lending: OpsLendingSnapshot | null;
+};

--- a/studio-brain/src/ops/service.test.ts
+++ b/studio-brain/src/ops/service.test.ts
@@ -1,0 +1,247 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createHumanTaskSeed, createOpsService } from "./service";
+import type { OpsCapability, OpsHumanRole } from "./contracts";
+import { MemoryOpsStore } from "./store";
+
+test("ops service claims, proofs, and completes a task", async () => {
+  const store = new MemoryOpsStore();
+  const service = createOpsService({ store });
+  const kilnLead = {
+    actorId: "staff-1",
+    isStaff: true,
+    portalRole: "staff" as const,
+    opsRoles: ["kiln_lead"] as OpsHumanRole[],
+    opsCapabilities: ["surface:hands", "tasks:claim:any", "tasks:escape", "proof:submit", "proof:accept", "reservations:view", "reservations:prepare", "overrides:request"] as OpsCapability[],
+  };
+  const task = createHumanTaskSeed({
+    title: "Unload kiln 1",
+    surface: "hands",
+    role: "kiln_lead",
+    zone: "Kiln Room",
+    whyNow: "Kiln 1 is ready for unload.",
+    whyYou: "Kiln lead owns physical kiln handling.",
+    evidenceSummary: "The kiln overlay says the run is ready for unload.",
+    consequenceIfDelayed: "The next firing cannot stage cleanly.",
+    instructions: ["Open kiln 1 safely.", "Unload ware.", "Record proof."],
+    proofModes: ["qr_scan", "manual_confirm"],
+    preferredProofMode: "qr_scan",
+    priority: "p0",
+  });
+
+  await service.upsertTask(task);
+  const claimed = await service.claimTask(task.id, kilnLead);
+  assert.ok(claimed);
+  assert.equal(claimed.claimedBy, "staff-1");
+
+  const proof = await service.addTaskProof(task.id, kilnLead, "qr_scan", "Scanned kiln QR.", []);
+  assert.ok(proof);
+
+  const completed = await service.completeTask(task.id, kilnLead);
+  assert.ok(completed);
+  assert.equal(completed.status, "proof_pending");
+
+  const accepted = await service.acceptTaskProof({
+    taskId: task.id,
+    proofId: proof!.id,
+    actorId: kilnLead.actorId,
+    status: "accepted",
+  }, kilnLead);
+  assert.ok(accepted);
+
+  const verifiedTask = await store.getTask(task.id);
+  assert.equal(verifiedTask?.status, "verified");
+});
+
+test("ops service dedupes ingest receipts by source system and event id", async () => {
+  const store = new MemoryOpsStore();
+  const service = createOpsService({ store });
+  const first = await service.ingestWorldEvent({
+    eventType: "sensor.observed",
+    entityKind: "kiln",
+    entityId: "kiln-1",
+    sourceSystem: "kilnaid",
+    sourceEventId: "evt-1",
+    actorKind: "machine",
+    actorId: "kilnaid-bridge",
+    payload: { observedAt: "2026-04-17T00:00:00.000Z" },
+    authPrincipal: "machine:kilnaid",
+    timestampSkewSeconds: 1,
+  });
+  const second = await service.ingestWorldEvent({
+    eventType: "sensor.observed",
+    entityKind: "kiln",
+    entityId: "kiln-1",
+    sourceSystem: "kilnaid",
+    sourceEventId: "evt-1",
+    actorKind: "machine",
+    actorId: "kilnaid-bridge",
+    payload: { observedAt: "2026-04-17T00:00:00.000Z" },
+    authPrincipal: "machine:kilnaid",
+    timestampSkewSeconds: 1,
+  });
+  assert.equal(first.accepted, true);
+  assert.equal(second.accepted, false);
+});
+
+test("ops service records member audits and blocks self role changes", async () => {
+  const store = new MemoryOpsStore();
+  let member: {
+    uid: string;
+    email: string | null;
+    displayName: string;
+    membershipTier: string | null;
+    kilnPreferences: string | null;
+    staffNotes: string | null;
+    portalRole: "member" | "staff" | "admin";
+    opsRoles: OpsHumanRole[];
+    opsCapabilities: OpsCapability[];
+    createdAt: string | null;
+    updatedAt: string | null;
+    lastSeenAt: string | null;
+    metadata: Record<string, unknown>;
+  } = {
+    uid: "member-1",
+    email: "member@example.com",
+    displayName: "Studio Member",
+    membershipTier: "drop-in",
+    kilnPreferences: null,
+    staffNotes: null,
+    portalRole: "member" as const,
+    opsRoles: [] as OpsHumanRole[],
+    opsCapabilities: [] as OpsCapability[],
+    createdAt: "2026-04-17T00:00:00.000Z",
+    updatedAt: "2026-04-17T00:00:00.000Z",
+    lastSeenAt: null,
+    metadata: {},
+  };
+  const service = createOpsService({
+    store,
+    staffDataSource: {
+      async listMembers() { return [member]; },
+      async getMember(uid) { return uid === member.uid ? member : null; },
+      async updateMemberProfile(input) {
+        member = {
+          ...member,
+          displayName: input.patch.displayName ?? member.displayName,
+          kilnPreferences: input.patch.kilnPreferences ?? member.kilnPreferences,
+          staffNotes: input.patch.staffNotes ?? member.staffNotes,
+          updatedAt: "2026-04-17T01:00:00.000Z",
+        };
+        return {
+          member,
+          audit: {
+            id: "audit-profile-1",
+            uid: member.uid,
+            kind: "profile",
+            actorId: input.actorId,
+            summary: "Profile updated.",
+            reason: input.reason ?? null,
+            createdAt: "2026-04-17T01:00:00.000Z",
+            payload: input.patch,
+          },
+        };
+      },
+      async updateMemberMembership(input) {
+        const beforeTier = member.membershipTier;
+        member = {
+          ...member,
+          membershipTier: input.membershipTier,
+          updatedAt: "2026-04-17T01:10:00.000Z",
+        };
+        return {
+          member,
+          audit: {
+            id: "audit-membership-1",
+            uid: member.uid,
+            editedByUid: input.actorId,
+            beforeTier,
+            afterTier: input.membershipTier,
+            reason: input.reason ?? null,
+            createdAt: "2026-04-17T01:10:00.000Z",
+            summary: "Membership updated.",
+          },
+        };
+      },
+      async updateMemberRole(input) {
+        const beforeRoles = member.opsRoles;
+        member = {
+          ...member,
+          portalRole: input.portalRole,
+          opsRoles: input.opsRoles,
+          opsCapabilities: [],
+          updatedAt: "2026-04-17T01:15:00.000Z",
+        };
+        return {
+          member,
+          audit: {
+            id: "audit-role-1",
+            uid: member.uid,
+            editedByUid: input.actorId,
+            beforePortalRole: "member",
+            afterPortalRole: input.portalRole,
+            beforeOpsRoles: beforeRoles,
+            afterOpsRoles: input.opsRoles,
+            reason: input.reason ?? null,
+            createdAt: "2026-04-17T01:15:00.000Z",
+            summary: "Role updated.",
+          },
+        };
+      },
+      async getMemberActivity(uid) {
+        return {
+          uid,
+          reservations: 1,
+          libraryLoans: 0,
+          supportThreads: 0,
+          events: 2,
+          lastReservationAt: null,
+          lastLoanAt: null,
+          lastEventAt: null,
+        };
+      },
+      async listReservations() { return []; },
+      async getReservationBundle() { return null; },
+      async listEvents() { return []; },
+      async listReports() { return []; },
+      async getLendingSnapshot() {
+        return {
+          requests: [],
+          loans: [],
+          recommendationCount: 0,
+          tagSubmissionCount: 0,
+          coverReviewCount: 0,
+          generatedAt: "2026-04-17T00:00:00.000Z",
+        };
+      },
+    },
+  });
+  const actor = {
+    actorId: "staff-1",
+    isStaff: true,
+    portalRole: "staff" as const,
+    opsRoles: ["support_ops"] as OpsHumanRole[],
+    opsCapabilities: ["surface:internet", "members:view", "members:edit_profile", "members:edit_membership", "members:edit_role"] as OpsCapability[],
+  };
+
+  const membershipResult = await service.updateMemberMembership({
+    uid: member.uid,
+    membershipTier: "community",
+    reason: "Promoted from the ops portal.",
+  }, actor);
+  assert.equal(membershipResult?.member?.membershipTier, "community");
+
+  const audits = await store.listMemberAudits(member.uid, 10);
+  assert.equal(audits.length, 1);
+  assert.equal(audits[0]?.kind, "membership");
+
+  await assert.rejects(
+    () => service.updateMemberRole({
+      uid: actor.actorId,
+      portalRole: "staff",
+      opsRoles: ["support_ops"],
+      reason: "This should fail.",
+    }, actor),
+    /change your own role/i,
+  );
+});

--- a/studio-brain/src/ops/service.ts
+++ b/studio-brain/src/ops/service.ts
@@ -1,0 +1,2330 @@
+import type { Logger } from "../config/logger";
+import { buildKilnOverview } from "../kiln/services/overview";
+import type { KilnStore } from "../kiln/store";
+import type { EventStore, StateStore, StudioStateSnapshot } from "../stores/interfaces";
+import type { SupportOpsStore } from "../supportOps/store";
+import type { SupportCaseSnapshot, SupportQueueSummary } from "../supportOps/types";
+import type { ActorType } from "../types/core";
+import {
+  allowedModesForSurface,
+  allowedSurfacesForCapabilities,
+  canAccessOpsSurface,
+  deriveOpsCapabilities,
+  hasOpsCapability,
+  clampConfidence,
+  makeId,
+  nowIso,
+  stableOpsHash,
+  type ActionEffectReceipt,
+  type ApprovalItem,
+  type GrowthExperiment,
+  type HumanTaskRecord,
+  type ImprovementCase,
+  type MemberActivityRecord,
+  type MemberOpsRecord,
+  type MembershipChangeRecord,
+  type OpsCaseNote,
+  type OpsCaseRecord,
+  type OpsCapability,
+  type OpsDegradeMode,
+  type OpsEvidenceSummary,
+  type OpsEventRecord,
+  type OpsHealth,
+  type OpsHumanRole,
+  type OpsIngestReceipt,
+  type OpsLendingSnapshot,
+  type OpsMemberAuditRecord,
+  type OpsPortalRole,
+  type OpsPortalSnapshot,
+  type OpsPriority,
+  type OpsReportRecord,
+  type OpsSessionMe,
+  type OpsSourceFreshness,
+  type OpsSourceRef,
+  type OpsTwinState,
+  type OpsTwinZone,
+  type OpsWatchdog,
+  type OpsWorldEvent,
+  type OverrideReceipt,
+  type ProofMode,
+  type ReservationBundle,
+  type RoleChangeRecord,
+  type StationDisplayState,
+  type StationSession,
+  type TaskEscapeRecord,
+  type TaskEscapeHatch,
+  type TaskProofRecord,
+  type VerificationClass,
+} from "./contracts";
+import { MemoryOpsStore, type OpsStore } from "./store";
+import { createOpsStaffDataSource, type OpsStaffDataSource } from "./staffData";
+
+type KilnOverviewSnapshot = Awaited<ReturnType<typeof buildKilnOverview>>;
+type AuditEventRecord = Awaited<ReturnType<EventStore["listRecent"]>>[number];
+
+export type AppendWorldEventInput = {
+  eventType: string;
+  entityKind: string;
+  entityId: string;
+  sourceSystem: string;
+  sourceEventId: string;
+  actorKind: string;
+  actorId: string;
+  payload: Record<string, unknown>;
+  caseId?: string | null;
+  roomId?: string | null;
+  confidence?: number;
+  verificationClass?: VerificationClass;
+  artifactRefs?: string[];
+  authPrincipal: string;
+  timestampSkewSeconds: number;
+};
+
+export type AddCaseNoteInput = {
+  caseId: string;
+  actorId: string;
+  actorKind?: ActorType | string;
+  body: string;
+  metadata?: Record<string, unknown>;
+};
+
+export type ResolveApprovalInput = {
+  approvalId: string;
+  status: "approved" | "rejected";
+  actorId: string;
+  note?: string | null;
+};
+
+export type AcceptTaskProofInput = {
+  taskId: string;
+  proofId: string;
+  actorId: string;
+  status: "accepted" | "rejected" | "readback_pending";
+  note?: string | null;
+};
+
+export type EscapeTaskInput = {
+  taskId: string;
+  actorId: string;
+  escapeHatch: TaskEscapeHatch;
+  reason?: string | null;
+};
+
+export type OverrideRequestInput = {
+  actorId: string;
+  scope: string;
+  reason: string;
+  expiresAt?: string | null;
+  requiredRole?: OpsHumanRole | string;
+  metadata?: Record<string, unknown>;
+};
+
+export type OpsActorContext = {
+  actorId: string;
+  isStaff: boolean;
+  portalRole: OpsPortalRole;
+  opsRoles: OpsHumanRole[];
+  opsCapabilities: OpsCapability[];
+};
+
+export type CaseDetail = {
+  record: OpsCaseRecord | null;
+  notes: OpsCaseNote[];
+  tasks: HumanTaskRecord[];
+  approvals: ApprovalItem[];
+};
+
+export type OpsChatResponse = {
+  reply: string;
+  note: OpsCaseNote;
+  caseId: string;
+};
+
+export type HumanTaskSeedInput = {
+  id?: string;
+  caseId?: string | null;
+  title: string;
+  status?: HumanTaskRecord["status"];
+  priority?: OpsPriority;
+  surface: HumanTaskRecord["surface"];
+  role: string;
+  zone: string;
+  dueAt?: string | null;
+  etaMinutes?: number | null;
+  toolsNeeded?: string[];
+  interruptibility?: HumanTaskRecord["interruptibility"];
+  whyNow: string;
+  whyYou: string;
+  evidenceSummary: string;
+  consequenceIfDelayed: string;
+  instructions: string[];
+  checklist?: HumanTaskRecord["checklist"];
+  doneDefinition?: string;
+  proofModes?: ProofMode[];
+  preferredProofMode?: ProofMode;
+  fallbackIfSignalMissing?: string;
+  verificationClass?: VerificationClass;
+  freshestAt?: string | null;
+  sources?: OpsSourceRef[];
+  confidence?: number;
+  degradeReason?: string | null;
+  blockerReason?: string | null;
+  blockerEscapeHatches?: TaskEscapeHatch[];
+  metadata?: Record<string, unknown>;
+};
+
+export type OpsServiceOptions = {
+  store?: OpsStore;
+  logger?: Logger | null;
+  kilnStore?: KilnStore | null;
+  supportOpsStore?: SupportOpsStore | null;
+  stateStore?: StateStore | null;
+  eventStore?: EventStore | null;
+  staffDataSource?: OpsStaffDataSource | null;
+  now?: () => string;
+};
+
+type DependencySnapshot = {
+  generatedAt: string;
+  kilnOverview: KilnOverviewSnapshot | null;
+  supportQueue: SupportQueueSummary | null;
+  supportCases: SupportCaseSnapshot[];
+  studioState: StudioStateSnapshot | null;
+  latestAuditEvent: AuditEventRecord | null;
+  reservations: ReservationBundle[];
+  events: OpsEventRecord[];
+  reports: OpsReportRecord[];
+  lending: OpsLendingSnapshot | null;
+};
+
+type DerivedState = {
+  twin: OpsTwinState;
+  truth: OpsPortalSnapshot["truth"];
+  tasks: HumanTaskRecord[];
+  cases: OpsCaseRecord[];
+  approvals: ApprovalItem[];
+  conversations: OpsPortalSnapshot["conversations"];
+  ceo: GrowthExperiment[];
+  forge: ImprovementCase[];
+  reservations: ReservationBundle[];
+  events: OpsEventRecord[];
+  reports: OpsReportRecord[];
+  lending: OpsLendingSnapshot | null;
+  taskEscapes: TaskEscapeRecord[];
+  overrides: OverrideReceipt[];
+  dependencies: DependencySnapshot;
+};
+
+const ACTIVE_TASK_ORDER: HumanTaskRecord["status"][] = [
+  "reopened",
+  "blocked",
+  "in_progress",
+  "proof_pending",
+  "claimed",
+  "queued",
+  "proposed",
+  "verified",
+  "canceled",
+];
+const ACTIVE_CASE_ORDER: OpsCaseRecord["status"][] = [
+  "blocked",
+  "awaiting_approval",
+  "active",
+  "open",
+  "resolved",
+  "canceled",
+];
+const APPROVAL_ORDER: ApprovalItem["status"][] = ["pending", "approved", "rejected", "executed", "expired"];
+const DEFAULT_ESCAPE_HATCHES: TaskEscapeHatch[] = [
+  "need_help",
+  "unsafe",
+  "missing_tool",
+  "not_my_role",
+  "already_done",
+  "defer_with_reason",
+];
+const MANAGED_BY = "ops-service";
+
+function cleanString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function cleanNullableString(value: unknown): string | null {
+  const normalized = cleanString(value);
+  return normalized.length ? normalized : null;
+}
+
+function toRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value) ? { ...(value as Record<string, unknown>) } : {};
+}
+
+function toStringArray(value: unknown, limit = 16): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter((entry): entry is string => typeof entry === "string" && entry.trim().length > 0)
+    .map((entry) => entry.trim())
+    .slice(0, limit);
+}
+
+function earliest(lhs: string | null, rhs: string | null): string | null {
+  if (!lhs) return rhs;
+  if (!rhs) return lhs;
+  return lhs.localeCompare(rhs) <= 0 ? lhs : rhs;
+}
+
+function latest(lhs: string | null, rhs: string | null): string | null {
+  if (!lhs) return rhs;
+  if (!rhs) return lhs;
+  return lhs.localeCompare(rhs) >= 0 ? lhs : rhs;
+}
+
+function freshnessMsFrom(timestamp: string | null, currentIso: string): number | null {
+  if (!timestamp) return null;
+  const then = Date.parse(timestamp);
+  const now = Date.parse(currentIso);
+  if (!Number.isFinite(then) || !Number.isFinite(now)) return null;
+  return Math.max(0, now - then);
+}
+
+function minutesUntil(timestamp: string | null): number | null {
+  if (!timestamp) return null;
+  const then = Date.parse(timestamp);
+  const now = Date.now();
+  if (!Number.isFinite(then) || !Number.isFinite(now)) return null;
+  return Math.round((then - now) / 60_000);
+}
+
+function statusWeight<T extends string>(order: readonly T[], value: T): number {
+  const index = order.indexOf(value);
+  return index >= 0 ? index : order.length + 10;
+}
+
+function priorityWeight(value: OpsPriority): number {
+  switch (value) {
+    case "p0":
+      return 0;
+    case "p1":
+      return 1;
+    case "p2":
+      return 2;
+    case "p3":
+      return 3;
+  }
+}
+
+function healthWeight(value: OpsHealth): number {
+  switch (value) {
+    case "critical":
+      return 0;
+    case "warning":
+      return 1;
+    case "healthy":
+      return 2;
+  }
+}
+
+function managedMetadata(metadata: Record<string, unknown> | undefined, signalOpen = true): Record<string, unknown> {
+  return {
+    ...(metadata ?? {}),
+    managedBy: MANAGED_BY,
+    sourceOpen: signalOpen,
+  };
+}
+
+function isManagedByOps(metadata: Record<string, unknown> | undefined): boolean {
+  return metadata?.managedBy === MANAGED_BY;
+}
+
+function buildSourceRef(
+  system: string,
+  label: string,
+  observedAt: string | null,
+  currentIso: string,
+  extra: Partial<OpsSourceRef> = {},
+): OpsSourceRef {
+  return {
+    id: cleanString(extra.id) || `${system}:${label.toLowerCase().replace(/\s+/g, "-")}`,
+    system,
+    label,
+    kind: extra.kind ?? null,
+    href: extra.href ?? null,
+    observedAt,
+    freshnessMs: freshnessMsFrom(observedAt, currentIso),
+  };
+}
+
+function buildEvidenceSummary(
+  summary: string,
+  verificationClass: VerificationClass,
+  sources: OpsSourceRef[],
+  confidence: number,
+  degradeReason: string | null,
+): OpsEvidenceSummary {
+  return {
+    summary,
+    sources,
+    freshestAt: sources.reduce<string | null>((best, row) => latest(best, row.observedAt), null),
+    confidence: clampConfidence(confidence, 0.5),
+    degradeReason,
+    verificationClass,
+  };
+}
+
+function sortTasks(rows: HumanTaskRecord[]): HumanTaskRecord[] {
+  return [...rows].sort((left, right) => {
+    const status = statusWeight(ACTIVE_TASK_ORDER, left.status) - statusWeight(ACTIVE_TASK_ORDER, right.status);
+    if (status !== 0) return status;
+    const priority = priorityWeight(left.priority) - priorityWeight(right.priority);
+    if (priority !== 0) return priority;
+    const due = String(left.dueAt ?? "9999").localeCompare(String(right.dueAt ?? "9999"));
+    if (due !== 0) return due;
+    return String(right.updatedAt).localeCompare(String(left.updatedAt));
+  });
+}
+
+function sortCases(rows: OpsCaseRecord[]): OpsCaseRecord[] {
+  return [...rows].sort((left, right) => {
+    const status = statusWeight(ACTIVE_CASE_ORDER, left.status) - statusWeight(ACTIVE_CASE_ORDER, right.status);
+    if (status !== 0) return status;
+    const priority = priorityWeight(left.priority) - priorityWeight(right.priority);
+    if (priority !== 0) return priority;
+    return String(right.updatedAt).localeCompare(String(left.updatedAt));
+  });
+}
+
+function sortApprovals(rows: ApprovalItem[]): ApprovalItem[] {
+  return [...rows].sort((left, right) => {
+    const status = statusWeight(APPROVAL_ORDER, left.status) - statusWeight(APPROVAL_ORDER, right.status);
+    if (status !== 0) return status;
+    return String(right.updatedAt).localeCompare(String(left.updatedAt));
+  });
+}
+
+function sourceHealth(freshnessSeconds: number | null, budgetSeconds: number): OpsHealth {
+  if (freshnessSeconds === null) return "critical";
+  if (freshnessSeconds <= budgetSeconds) return "healthy";
+  if (freshnessSeconds <= budgetSeconds * 3) return "warning";
+  return "critical";
+}
+
+function sourceFreshnessRow(
+  currentIso: string,
+  source: string,
+  label: string,
+  observedAt: string | null,
+  budgetSeconds: number,
+  reason: string | null,
+): OpsSourceFreshness {
+  const freshnessMs = freshnessMsFrom(observedAt, currentIso);
+  const freshnessSeconds = freshnessMs === null ? null : Math.round(freshnessMs / 1000);
+  return {
+    source,
+    label,
+    freshnessSeconds,
+    budgetSeconds,
+    status: sourceHealth(freshnessSeconds, budgetSeconds),
+    freshestAt: observedAt,
+    reason,
+  };
+}
+
+function deriveReadiness(modes: OpsDegradeMode[], sourceRows: OpsSourceFreshness[]): OpsPortalSnapshot["truth"]["readiness"] {
+  const worstSource = sourceRows.reduce<OpsHealth>((worst: OpsHealth, row: OpsSourceFreshness) => {
+    return healthWeight(row.status) < healthWeight(worst) ? row.status : worst;
+  }, "healthy");
+  if (modes.includes("observe_only") || modes.includes("no_human_tasking") || worstSource === "critical") {
+    return "blocked";
+  }
+  if (modes.length > 0 || worstSource === "warning") {
+    return "degraded";
+  }
+  return "ready";
+}
+
+function deriveZoneStatus(
+  base: OpsHealth,
+  evidence: OpsEvidenceSummary,
+  degradeModes: OpsDegradeMode[],
+  extraCritical = false,
+): OpsHealth {
+  if (extraCritical || degradeModes.includes("observe_only")) return "critical";
+  if (base === "critical") return "critical";
+  if (base === "warning" || evidence.degradeReason) return "warning";
+  return "healthy";
+}
+
+function defaultTaskProofModes(input: HumanTaskSeedInput): ProofMode[] {
+  const proofModes: ProofMode[] = input.proofModes && input.proofModes.length ? [...input.proofModes] : ["manual_confirm"];
+  return [...new Set<ProofMode>(proofModes)];
+}
+
+export function createHumanTaskSeed(input: HumanTaskSeedInput): HumanTaskRecord {
+  const createdAt = nowIso();
+  const proofModes = defaultTaskProofModes(input);
+  return {
+    id: input.id ?? makeId("ops_task"),
+    caseId: input.caseId ?? null,
+    title: cleanString(input.title) || "Untitled task",
+    status: input.status ?? "queued",
+    priority: input.priority ?? "p2",
+    surface: input.surface,
+    role: cleanString(input.role) || "staff",
+    zone: cleanString(input.zone) || "Studio",
+    dueAt: input.dueAt ?? null,
+    etaMinutes: input.etaMinutes ?? null,
+    toolsNeeded: toStringArray(input.toolsNeeded, 12),
+    interruptibility: input.interruptibility ?? "soon",
+    whyNow: cleanString(input.whyNow) || "The studio needs this next.",
+    whyYou: cleanString(input.whyYou) || "This role is the best current fit.",
+    evidenceSummary: cleanString(input.evidenceSummary) || "Evidence will appear here as signals arrive.",
+    consequenceIfDelayed: cleanString(input.consequenceIfDelayed) || "Delay increases operational surprise.",
+    instructions: toStringArray(input.instructions, 12),
+    checklist: input.checklist ?? [],
+    doneDefinition: cleanString(input.doneDefinition) || "Complete the task and verify the result.",
+    proofModes,
+    preferredProofMode: input.preferredProofMode ?? proofModes[0] ?? "manual_confirm",
+    fallbackIfSignalMissing: cleanString(input.fallbackIfSignalMissing) || "Attach a manual note and ask the manager to reconcile the signal path.",
+    verificationClass: input.verificationClass ?? "observed",
+    freshestAt: input.freshestAt ?? null,
+    sources: input.sources ?? [],
+    confidence: clampConfidence(input.confidence, 0.7),
+    degradeReason: input.degradeReason ?? null,
+    claimedBy: null,
+    claimedAt: null,
+    completedAt: null,
+    blockerReason: input.blockerReason ?? null,
+    blockerEscapeHatches: input.blockerEscapeHatches ?? DEFAULT_ESCAPE_HATCHES,
+    createdAt,
+    updatedAt: createdAt,
+    metadata: input.metadata ?? {},
+  };
+}
+
+function mergeTask(existing: HumanTaskRecord | null, seed: HumanTaskRecord, currentIso: string): HumanTaskRecord {
+  if (!existing) return seed;
+  const shouldReopen = (existing.status === "verified" || existing.status === "canceled") && seed.metadata.sourceOpen === true;
+  return {
+    ...seed,
+    status: shouldReopen ? "reopened" : existing.status,
+    claimedBy: shouldReopen ? existing.claimedBy : existing.claimedBy,
+    claimedAt: shouldReopen ? existing.claimedAt : existing.claimedAt,
+    completedAt: shouldReopen ? null : existing.completedAt,
+    blockerReason: existing.blockerReason ?? seed.blockerReason,
+    createdAt: existing.createdAt,
+    updatedAt: shouldReopen ? currentIso : currentIso,
+    metadata: {
+      ...seed.metadata,
+      reopenedFrom: shouldReopen ? existing.status : undefined,
+      previousStatus: existing.status,
+    },
+  };
+}
+
+function mergeCase(existing: OpsCaseRecord | null, seed: OpsCaseRecord, currentIso: string): OpsCaseRecord {
+  if (!existing) return seed;
+  const terminal = existing.status === "resolved" || existing.status === "canceled";
+  return {
+    ...seed,
+    status: terminal && seed.metadata.sourceOpen === true ? "active" : existing.status,
+    createdAt: existing.createdAt,
+    updatedAt: currentIso,
+    metadata: {
+      ...seed.metadata,
+      previousStatus: existing.status,
+    },
+  };
+}
+
+function mergeApproval(existing: ApprovalItem | null, seed: ApprovalItem, currentIso: string): ApprovalItem {
+  if (!existing) return seed;
+  return {
+    ...seed,
+    status: existing.status === "expired" || existing.status === "executed" ? existing.status : existing.status,
+    createdAt: existing.createdAt,
+    resolvedAt: existing.resolvedAt,
+    resolvedBy: existing.resolvedBy,
+    updatedAt: currentIso,
+    metadata: {
+      ...seed.metadata,
+      previousStatus: existing.status,
+    },
+  };
+}
+
+async function safeKilnOverview(logger: Logger | null, kilnStore: KilnStore | null | undefined): Promise<KilnOverviewSnapshot | null> {
+  if (!kilnStore) return null;
+  try {
+    return await buildKilnOverview(kilnStore, { enableSupportedWrites: false });
+  } catch (error) {
+    logger?.warn("ops-service: failed to load kiln overview", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  }
+}
+
+async function safeSupportQueue(logger: Logger | null, supportOpsStore: SupportOpsStore | null | undefined): Promise<{
+  queue: SupportQueueSummary | null;
+  cases: SupportCaseSnapshot[];
+}> {
+  if (!supportOpsStore) return { queue: null, cases: [] };
+  try {
+    const [queue, cases] = await Promise.all([
+      supportOpsStore.getQueueSummary(),
+      supportOpsStore.listRecentCases(12),
+    ]);
+    return { queue, cases };
+  } catch (error) {
+    logger?.warn("ops-service: failed to load support state", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return { queue: null, cases: [] };
+  }
+}
+
+async function safeStudioState(logger: Logger | null, stateStore: StateStore | null | undefined): Promise<StudioStateSnapshot | null> {
+  if (!stateStore) return null;
+  try {
+    return await stateStore.getLatestStudioState();
+  } catch (error) {
+    logger?.warn("ops-service: failed to load studio state", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  }
+}
+
+async function safeLatestAuditEvent(logger: Logger | null, eventStore: EventStore | null | undefined): Promise<AuditEventRecord | null> {
+  if (!eventStore) return null;
+  try {
+    const rows = await eventStore.listRecent(1);
+    return rows[0] ?? null;
+  } catch (error) {
+    logger?.warn("ops-service: failed to load audit events", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  }
+}
+
+async function safeReservations(logger: Logger | null, staffDataSource: OpsStaffDataSource | null | undefined): Promise<ReservationBundle[]> {
+  if (!staffDataSource) return [];
+  try {
+    return await staffDataSource.listReservations(60);
+  } catch (error) {
+    logger?.warn("ops-service: failed to load reservations", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return [];
+  }
+}
+
+async function safeEvents(logger: Logger | null, staffDataSource: OpsStaffDataSource | null | undefined): Promise<OpsEventRecord[]> {
+  if (!staffDataSource) return [];
+  try {
+    return await staffDataSource.listEvents(120);
+  } catch (error) {
+    logger?.warn("ops-service: failed to load events", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return [];
+  }
+}
+
+async function safeReports(logger: Logger | null, staffDataSource: OpsStaffDataSource | null | undefined): Promise<OpsReportRecord[]> {
+  if (!staffDataSource) return [];
+  try {
+    return await staffDataSource.listReports(120);
+  } catch (error) {
+    logger?.warn("ops-service: failed to load reports", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return [];
+  }
+}
+
+async function safeLending(logger: Logger | null, staffDataSource: OpsStaffDataSource | null | undefined): Promise<OpsLendingSnapshot | null> {
+  if (!staffDataSource) return null;
+  try {
+    return await staffDataSource.getLendingSnapshot();
+  } catch (error) {
+    logger?.warn("ops-service: failed to load lending state", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  }
+}
+
+function defaultActorContext(actor?: Partial<OpsActorContext> | null): OpsActorContext {
+  const opsRoles = actor?.opsRoles ?? [];
+  const opsCapabilities = actor?.opsCapabilities ?? deriveOpsCapabilities(opsRoles);
+  return {
+    actorId: cleanString(actor?.actorId) || "ops-portal:anonymous",
+    isStaff: actor?.isStaff === true || opsRoles.length > 0,
+    portalRole: actor?.portalRole ?? "member",
+    opsRoles,
+    opsCapabilities,
+  };
+}
+
+function buildSession(actor?: Partial<OpsActorContext> | null): OpsSessionMe | null {
+  if (!actor) return null;
+  const context = defaultActorContext(actor);
+  return {
+    actorId: context.actorId,
+    portalRole: context.portalRole,
+    isStaff: context.isStaff,
+    opsRoles: context.opsRoles,
+    opsCapabilities: context.opsCapabilities,
+    allowedSurfaces: allowedSurfacesForCapabilities(context.opsCapabilities),
+    allowedModes: {
+      owner: allowedModesForSurface("owner", context.opsCapabilities),
+      manager: allowedModesForSurface("manager", context.opsCapabilities),
+      hands: allowedModesForSurface("hands", context.opsCapabilities),
+      internet: allowedModesForSurface("internet", context.opsCapabilities),
+      ceo: allowedModesForSurface("ceo", context.opsCapabilities),
+      forge: allowedModesForSurface("forge", context.opsCapabilities),
+    },
+  };
+}
+
+function canActorSeeTask(actor: OpsActorContext, task: HumanTaskRecord): boolean {
+  if (task.role === "studio_manager") return hasOpsCapability(actor.opsCapabilities, "surface:manager");
+  if (task.role === "owner") return hasOpsCapability(actor.opsCapabilities, "surface:owner");
+  if (task.surface === "hands" && !hasOpsCapability(actor.opsCapabilities, "surface:hands")) return false;
+  if (task.surface === "internet" && !hasOpsCapability(actor.opsCapabilities, "surface:internet")) return false;
+  if (task.surface === "manager" && !hasOpsCapability(actor.opsCapabilities, "surface:manager")) return false;
+  if (task.surface === "owner" && !hasOpsCapability(actor.opsCapabilities, "surface:owner")) return false;
+  if (task.role === "any_staff") return actor.isStaff;
+  return task.role === "owner"
+    ? actor.opsRoles.includes("owner")
+    : actor.opsRoles.includes(task.role as OpsHumanRole) || hasOpsCapability(actor.opsCapabilities, "tasks:claim:any");
+}
+
+function canActorSeeCase(actor: OpsActorContext, record: OpsCaseRecord): boolean {
+  return canAccessOpsSurface(actor.opsCapabilities, record.lane);
+}
+
+function canActorSeeApproval(actor: OpsActorContext, approval: ApprovalItem): boolean {
+  if (!hasOpsCapability(actor.opsCapabilities, "approvals:view")) return false;
+  if (approval.requiredRole === "owner") return actor.opsRoles.includes("owner");
+  return actor.opsRoles.includes(approval.requiredRole as OpsHumanRole) || actor.opsRoles.includes("owner");
+}
+
+function assertActorCanClaimTask(actor: OpsActorContext, task: HumanTaskRecord): void {
+  if (!canActorSeeTask(actor, task)) {
+    throw new Error("This actor is not allowed to claim that task.");
+  }
+}
+
+function assertActorCanResolveApproval(actor: OpsActorContext, approval: ApprovalItem): void {
+  if (!canActorSeeApproval(actor, approval) || !hasOpsCapability(actor.opsCapabilities, "approvals:manage")) {
+    throw new Error("This actor is not allowed to resolve that approval.");
+  }
+}
+
+function assertActorCapability(actor: OpsActorContext, capability: OpsCapability, message: string): void {
+  if (!hasOpsCapability(actor.opsCapabilities, capability)) {
+    throw new Error(message);
+  }
+}
+
+function terminalTaskStatus(status: HumanTaskRecord["status"]): boolean {
+  return status === "verified" || status === "canceled";
+}
+
+function terminalCaseStatus(status: OpsCaseRecord["status"]): boolean {
+  return status === "resolved" || status === "canceled";
+}
+
+function terminalApprovalStatus(status: ApprovalItem["status"]): boolean {
+  return status === "approved" || status === "rejected" || status === "executed" || status === "expired";
+}
+
+function closeMissingManagedTask(existing: HumanTaskRecord, currentIso: string): HumanTaskRecord {
+  if (terminalTaskStatus(existing.status)) return existing;
+  return {
+    ...existing,
+    status: existing.completedAt ? "verified" : "canceled",
+    degradeReason: "The upstream signal cleared or moved elsewhere.",
+    updatedAt: currentIso,
+    metadata: {
+      ...existing.metadata,
+      sourceOpen: false,
+    },
+  };
+}
+
+function closeMissingManagedCase(existing: OpsCaseRecord, currentIso: string): OpsCaseRecord {
+  if (terminalCaseStatus(existing.status)) return existing;
+  return {
+    ...existing,
+    status: "resolved",
+    updatedAt: currentIso,
+    metadata: {
+      ...existing.metadata,
+      sourceOpen: false,
+    },
+  };
+}
+
+function expireMissingManagedApproval(existing: ApprovalItem, currentIso: string): ApprovalItem {
+  if (terminalApprovalStatus(existing.status)) return existing;
+  return {
+    ...existing,
+    status: "expired",
+    degradeReason: "The upstream approval condition cleared.",
+    updatedAt: currentIso,
+  };
+}
+
+export function createOpsService(options: OpsServiceOptions = {}) {
+  const store = options.store ?? new MemoryOpsStore();
+  const logger = options.logger ?? null;
+  const kilnStore = options.kilnStore ?? null;
+  const supportOpsStore = options.supportOpsStore ?? null;
+  const stateStore = options.stateStore ?? null;
+  const eventStore = options.eventStore ?? null;
+  const staffDataSource = options.staffDataSource ?? createOpsStaffDataSource();
+  const clock = options.now ?? nowIso;
+
+  async function loadDependencies(currentIso: string): Promise<DependencySnapshot> {
+    const [kilnOverview, supportState, studioState, latestAuditEvent, reservations, events, reports, lending] = await Promise.all([
+      safeKilnOverview(logger, kilnStore),
+      safeSupportQueue(logger, supportOpsStore),
+      safeStudioState(logger, stateStore),
+      safeLatestAuditEvent(logger, eventStore),
+      safeReservations(logger, staffDataSource),
+      safeEvents(logger, staffDataSource),
+      safeReports(logger, staffDataSource),
+      safeLending(logger, staffDataSource),
+    ]);
+    return {
+      generatedAt: currentIso,
+      kilnOverview,
+      supportQueue: supportState.queue,
+      supportCases: supportState.cases,
+      studioState,
+      latestAuditEvent,
+      reservations,
+      events,
+      reports,
+      lending,
+    };
+  }
+
+  async function ensureDerivedState(): Promise<DerivedState> {
+    const currentIso = clock();
+    const dependencies = await loadDependencies(currentIso);
+    const [persistedCases, persistedTasks, persistedApprovals, ceo, forge, manualModes, stations, recentEvents, persistedBundles, taskEscapes, overrides] = await Promise.all([
+      store.listCases(200),
+      store.listTasks(200),
+      store.listApprovals(200),
+      store.listGrowthExperiments(40),
+      store.listImprovementCases(40),
+      store.getDegradeModes(),
+      store.listStationSessions(30),
+      store.listEvents(50),
+      store.listReservationBundles(120),
+      store.listTaskEscapes(undefined, 120),
+      store.listOverrides(120),
+    ]);
+
+    const casesById = new Map(persistedCases.map((row) => [row.id, row]));
+    const tasksById = new Map(persistedTasks.map((row) => [row.id, row]));
+    const approvalsById = new Map(persistedApprovals.map((row) => [row.id, row]));
+
+    const derivedCaseIds = new Set<string>();
+    const derivedTaskIds = new Set<string>();
+    const derivedApprovalIds = new Set<string>();
+    const mergedCases = new Map<string, OpsCaseRecord>();
+    const mergedTasks = new Map<string, HumanTaskRecord>();
+    const mergedApprovals = new Map<string, ApprovalItem>();
+    const conversations: OpsPortalSnapshot["conversations"] = [];
+
+    const stageCase = (seed: OpsCaseRecord) => {
+      derivedCaseIds.add(seed.id);
+      const merged = mergeCase(casesById.get(seed.id) ?? null, seed, currentIso);
+      mergedCases.set(seed.id, merged);
+    };
+    const stageTask = (seed: HumanTaskRecord) => {
+      derivedTaskIds.add(seed.id);
+      const merged = mergeTask(tasksById.get(seed.id) ?? null, seed, currentIso);
+      mergedTasks.set(seed.id, merged);
+    };
+    const stageApproval = (seed: ApprovalItem) => {
+      derivedApprovalIds.add(seed.id);
+      const merged = mergeApproval(approvalsById.get(seed.id) ?? null, seed, currentIso);
+      mergedApprovals.set(seed.id, merged);
+    };
+
+    const reservationsOpen = dependencies.studioState?.counts.reservationsOpen ?? 0;
+    const supportOpen = dependencies.supportQueue?.totalOpen ?? dependencies.supportCases.filter((row) => row.queueBucket !== "resolved").length;
+    const supportAwaitingApproval = dependencies.supportQueue?.awaitingApproval ?? 0;
+    const supportSecurityHold = dependencies.supportQueue?.securityHold ?? 0;
+    const kilnAttention = dependencies.kilnOverview?.fleet.attentionCount ?? 0;
+    const kilnActiveRuns = dependencies.kilnOverview?.fleet.activeRuns ?? 0;
+
+    if (dependencies.kilnOverview) {
+      for (const kiln of dependencies.kilnOverview.kilns) {
+        const warnings = [...(kiln.healthWarnings ?? []), ...(kiln.maintenanceFlags ?? [])];
+        const verificationClass: VerificationClass = kiln.connectivityState === "online" ? "observed" : "inferred";
+        const sources = [
+          buildSourceRef("kilnaid", kiln.kilnName, kiln.lastImportTime ?? null, currentIso, { kind: "kiln" }),
+        ];
+        const caseId = `case_kiln_${kiln.kilnId}`;
+        stageCase({
+          id: caseId,
+          kind: "kiln_run",
+          title: `${kiln.kilnName} operating picture`,
+          summary:
+            warnings.length > 0
+              ? `${kiln.kilnName} has ${warnings.length} warning${warnings.length === 1 ? "" : "s"} and needs human attention.`
+              : kiln.currentRunId
+                ? `${kiln.kilnName} is ${kiln.inferredPhase.toLowerCase()} with ${kiln.currentProgram ?? "an active program"}.`
+                : `${kiln.kilnName} is idle and ready for the next commitment.`,
+          status: warnings.length > 0 ? "blocked" : kiln.currentRunId ? "active" : "open",
+          priority: warnings.length > 0 ? "p1" : kiln.currentRunId ? "p2" : "p3",
+          lane: "hands",
+          ownerRole: "kiln_lead",
+          verificationClass,
+          freshestAt: kiln.lastImportTime ?? null,
+          sources,
+          confidence: kiln.connectivityState === "online" ? 0.92 : 0.58,
+          degradeReason: kiln.connectivityState === "stale" ? "Kiln telemetry is stale." : null,
+          dueAt: null,
+          linkedEntityKind: "kiln",
+          linkedEntityId: kiln.kilnId,
+          memoryScope: `ops:kilm:${kiln.kilnId}`,
+          createdAt: currentIso,
+          updatedAt: currentIso,
+          metadata: managedMetadata({
+            managedLabel: "kiln_case",
+            sourceOpen: true,
+            kilnName: kiln.kilnName,
+            currentRunId: kiln.currentRunId,
+            warnings,
+          }),
+        });
+      }
+
+      for (const action of dependencies.kilnOverview.requiredOperatorActions) {
+        const kiln = dependencies.kilnOverview.kilns.find((entry) => entry.kilnId === action.kilnId);
+        const taskKind = String(action.notes ?? "").toLowerCase();
+        const title =
+          taskKind.includes("unload")
+            ? `Unload ${kiln?.kilnName ?? action.kilnId}`
+            : taskKind.includes("press start")
+              ? `Start ${kiln?.kilnName ?? action.kilnId}`
+              : `Handle ${kiln?.kilnName ?? action.kilnId} operator action`;
+        const sources = [
+          buildSourceRef("kilnaid", kiln?.kilnName ?? action.kilnId, action.requestedAt ?? kiln?.lastImportTime ?? null, currentIso, {
+            kind: "operator_action",
+          }),
+        ];
+        stageTask(
+          createHumanTaskSeed({
+            id: `task_kiln_${action.id}`,
+            caseId: `case_kiln_${action.kilnId}`,
+            title,
+            priority: taskKind.includes("unload") ? "p0" : "p1",
+            surface: "hands",
+            role: "kiln_lead",
+            zone: kiln?.kilnName ?? action.kilnId,
+            dueAt: action.requestedAt,
+            etaMinutes: taskKind.includes("unload") ? 15 : 10,
+            toolsNeeded: ["heat gloves", "kiln shelf tools"],
+            interruptibility: "now",
+            whyNow: cleanString(action.notes) || "The kiln queue requires a human step before the next firing can proceed.",
+            whyYou: "Kiln leads own physical kiln transitions and safety-sensitive handling.",
+            evidenceSummary: cleanString(action.notes) || "The kiln system emitted a required operator action.",
+            consequenceIfDelayed: "The kiln queue can drift and the next promised work may slip.",
+            instructions:
+              taskKind.includes("press start")
+                ? ["Verify the kiln load is correct.", "Confirm the controller is ready.", "Press start and watch the first transition."]
+                : ["Check the kiln is safe to open.", "Handle ware carefully and clear the chamber.", "Record proof before leaving the zone."],
+            checklist: [
+              { id: `${action.id}:1`, label: "Safety check", detail: "Confirm the kiln is safe for the requested action.", status: "todo" },
+              { id: `${action.id}:2`, label: "Perform the physical action", detail: cleanString(action.notes) || null, status: "todo" },
+              { id: `${action.id}:3`, label: "Attach proof", detail: "Use the preferred proof path or a manual fallback.", status: "todo" },
+            ],
+            doneDefinition: "The kiln action is complete and the new state is externally visible.",
+            proofModes: ["qr_scan", "manual_confirm", "camera_snapshot"],
+            preferredProofMode: "qr_scan",
+            fallbackIfSignalMissing: "Use manual confirmation and leave a reconciliation note for the manager lane.",
+            verificationClass: "observed",
+            freshestAt: action.requestedAt ?? kiln?.lastImportTime ?? null,
+            sources,
+            confidence: kiln?.connectivityState === "online" ? 0.9 : 0.62,
+            degradeReason: kiln?.connectivityState === "stale" ? "Kiln connectivity is stale." : null,
+            metadata: managedMetadata({
+              managedLabel: "kiln_task",
+              sourceActionId: action.id,
+              sourceOpen: true,
+            }),
+          }),
+        );
+      }
+
+      for (const maintenance of dependencies.kilnOverview.maintenanceFlags) {
+        if (!(maintenance.warnings.length || maintenance.confidenceNotes.length)) continue;
+        const kiln = dependencies.kilnOverview.kilns.find((entry) => entry.kilnId === maintenance.kilnId);
+        const id = `task_kiln_maintenance_${maintenance.kilnId}`;
+        stageTask(
+          createHumanTaskSeed({
+            id,
+            caseId: `case_kiln_${maintenance.kilnId}`,
+            title: `Inspect ${kiln?.kilnName ?? maintenance.kilnId} drift`,
+            priority: "p1",
+            surface: "hands",
+            role: "kiln_lead",
+            zone: kiln?.kilnName ?? maintenance.kilnId,
+            dueAt: currentIso,
+            etaMinutes: 20,
+            toolsNeeded: ["multimeter", "maintenance log"],
+            interruptibility: "soon",
+            whyNow: [...maintenance.warnings, ...maintenance.confidenceNotes].join(" ") || "The kiln health snapshot is asking for inspection.",
+            whyYou: "Kiln leads own relay, coil, and health checks when firing behavior drifts.",
+            evidenceSummary: [...maintenance.warnings, ...maintenance.confidenceNotes].join(" "),
+            consequenceIfDelayed: "Equipment degradation can turn into failed firings and surprise delays.",
+            instructions: [
+              "Inspect the kiln and confirm whether the warning reflects real hardware drift.",
+              "Log anything unusual about relays, coils, or the firing pace.",
+              "Escalate immediately if the kiln cannot safely continue service.",
+            ],
+            checklist: [
+              { id: `${id}:1`, label: "Inspect physical condition", status: "todo" },
+              { id: `${id}:2`, label: "Compare warning to reality", status: "todo" },
+              { id: `${id}:3`, label: "Leave a manager note", status: "todo" },
+            ],
+            doneDefinition: "The kiln health warning has been checked and a clear next action is recorded.",
+            proofModes: ["manual_confirm", "camera_snapshot"],
+            preferredProofMode: "manual_confirm",
+            fallbackIfSignalMissing: "Leave a written note with a photo and flag the task as blocked.",
+            verificationClass: "inferred",
+            freshestAt: kiln?.lastImportTime ?? currentIso,
+            sources: [buildSourceRef("kilnaid", kiln?.kilnName ?? maintenance.kilnId, kiln?.lastImportTime ?? null, currentIso, { kind: "health" })],
+            confidence: 0.7,
+            degradeReason: kiln?.connectivityState === "stale" ? "Kiln telemetry is stale." : null,
+            metadata: managedMetadata({
+              managedLabel: "kiln_maintenance",
+              sourceOpen: true,
+            }),
+          }),
+        );
+      }
+    }
+
+    for (const supportCase of dependencies.supportCases) {
+      const sources = [
+        buildSourceRef(supportCase.provider, (supportCase.senderEmail ?? supportCase.subject) || "support thread", supportCase.updatedAt, currentIso, {
+          kind: "conversation",
+        }),
+      ];
+      const caseId = `case_support_${supportCase.supportRequestId}`;
+      const requiresApproval =
+        supportCase.queueBucket === "awaiting_approval"
+        || supportCase.decision === "proposal_required"
+        || Boolean(supportCase.proposalId);
+      const open = supportCase.queueBucket !== "resolved";
+      stageCase({
+        id: caseId,
+        kind: "support_thread",
+        title: supportCase.subject || supportCase.senderEmail || "Support conversation",
+        summary:
+          supportCase.supportSummary
+          || supportCase.nextRecommendedAction
+          || `${supportCase.queueBucket.replaceAll("_", " ")} support thread awaiting response.`,
+        status:
+          !open
+            ? "resolved"
+            : requiresApproval
+              ? "awaiting_approval"
+              : supportCase.humanHandoff || supportCase.queueBucket === "staff_review"
+                ? "active"
+                : "open",
+        priority:
+          supportCase.riskState === "high_risk"
+            ? "p0"
+            : requiresApproval || supportCase.unread
+              ? "p1"
+              : "p2",
+        lane: "internet",
+        ownerRole: requiresApproval ? "owner" : "support",
+        verificationClass: supportCase.senderVerifiedUid ? "confirmed" : "observed",
+        freshestAt: supportCase.updatedAt,
+        sources,
+        confidence: supportCase.senderVerifiedUid ? 0.91 : 0.72,
+        degradeReason: supportCase.threadDriftFlag ? "Conversation drift is suspected." : null,
+        dueAt: supportCase.lastReceivedAt,
+        linkedEntityKind: "support_request",
+        linkedEntityId: supportCase.supportRequestId,
+        memoryScope: supportCase.emberMemoryScope,
+        createdAt: currentIso,
+        updatedAt: currentIso,
+        metadata: managedMetadata({
+          managedLabel: "support_case",
+          queueBucket: supportCase.queueBucket,
+          sourceOpen: open,
+        }, open),
+      });
+
+      conversations.push({
+        id: `conversation_${supportCase.supportRequestId}`,
+        surface: "internet",
+        roleMask: supportCase.senderVerifiedUid ? "verified member" : "internet thread",
+        senderIdentity: supportCase.senderEmail ?? supportCase.provider,
+        latestMessageAt: supportCase.updatedAt,
+        unread: supportCase.unread,
+        summary: (supportCase.supportSummary ?? supportCase.subject) || "Support thread",
+      });
+
+      if (open) {
+        stageTask(
+          createHumanTaskSeed({
+            id: `task_support_${supportCase.supportRequestId}`,
+            caseId,
+            title: requiresApproval ? `Prepare approval for ${supportCase.subject || "support thread"}` : `Respond to ${supportCase.subject || "support thread"}`,
+            priority:
+              supportCase.riskState === "high_risk"
+                ? "p0"
+                : requiresApproval || supportCase.unread
+                  ? "p1"
+                  : "p2",
+            surface: "internet",
+            role: requiresApproval ? "owner" : "support",
+            zone: supportCase.provider,
+            dueAt: supportCase.lastReceivedAt,
+            etaMinutes: requiresApproval ? 8 : 12,
+            toolsNeeded: ["thread memory", "policy context"],
+            interruptibility: supportCase.unread ? "now" : "soon",
+            whyNow:
+              supportCase.nextRecommendedAction
+              || supportCase.replyDraft
+              || "A member-facing thread is open and needs a safe next step.",
+            whyYou:
+              requiresApproval
+                ? "This thread crosses a policy or money boundary and needs approval."
+                : "Support lane owns external commitments, replies, and thread continuity.",
+            evidenceSummary:
+              supportCase.supportSummary
+              || `${supportCase.queueBucket.replaceAll("_", " ")} · ${supportCase.riskState.replaceAll("_", " ")}`,
+            consequenceIfDelayed: "The member may feel ignored and the studio loses operational trust.",
+            instructions: [
+              "Open the thread context and read the latest message carefully.",
+              requiresApproval ? "Resolve the approval or draft the exact exception path." : "Draft or send the next safe reply.",
+              "Record the outcome so the next shift does not restart the context.",
+            ],
+            checklist: [
+              { id: `${supportCase.supportRequestId}:1`, label: "Understand the ask", status: "todo" },
+              { id: `${supportCase.supportRequestId}:2`, label: requiresApproval ? "Resolve approval" : "Advance the thread", status: "todo" },
+              { id: `${supportCase.supportRequestId}:3`, label: "Leave continuity notes", status: "todo" },
+            ],
+            doneDefinition: requiresApproval ? "The approval state is resolved with rationale." : "The thread has a safe next message or an explicit queued owner.",
+            proofModes: ["manual_confirm"],
+            preferredProofMode: "manual_confirm",
+            fallbackIfSignalMissing: "Add a case note with the intended reply and flag the manager lane.",
+            verificationClass: supportCase.senderVerifiedUid ? "confirmed" : "observed",
+            freshestAt: supportCase.updatedAt,
+            sources,
+            confidence: supportCase.senderVerifiedUid ? 0.86 : 0.67,
+            degradeReason: supportCase.threadDriftFlag ? "Thread drift is suspected." : null,
+            metadata: managedMetadata({
+              managedLabel: "support_task",
+              queueBucket: supportCase.queueBucket,
+              sourceOpen: true,
+            }),
+          }),
+        );
+      }
+
+      if (requiresApproval) {
+        stageApproval({
+          id: `approval_support_${supportCase.supportRequestId}`,
+          caseId,
+          title: `Approval needed for ${supportCase.subject || "support thread"}`,
+          summary:
+            supportCase.replyDraft
+            || supportCase.supportSummary
+            || "A support reply or exception path needs an explicit owner decision.",
+          status: "pending",
+          actionClass: supportCase.proposalCapabilityId ? "proposal_required" : "support_reply",
+          requestedBy: "studio-manager",
+          requiredRole: "owner",
+          riskSummary:
+            supportCase.riskReasons.join(", ")
+            || supportCase.confusionReason
+            || "This thread touches a boundary the manager will not cross alone.",
+          reversibility: supportCase.proposalCapabilityId ? "hard_to_reverse" : "reversible",
+          verificationClass: supportCase.senderVerifiedUid ? "confirmed" : "observed",
+          freshestAt: supportCase.updatedAt,
+          sources,
+          confidence: supportCase.senderVerifiedUid ? 0.82 : 0.63,
+          degradeReason: supportCase.threadDriftFlag ? "Thread drift is suspected." : null,
+          recommendation: supportCase.nextRecommendedAction || "Review the draft, approve the safe response, or reject with guidance.",
+          rollbackPlan: "Reject the approval, leave a note, and keep the thread in staff review.",
+          createdAt: currentIso,
+          updatedAt: currentIso,
+          resolvedAt: null,
+          resolvedBy: null,
+          metadata: managedMetadata({
+            managedLabel: "support_approval",
+            proposalId: supportCase.proposalId,
+            sourceOpen: true,
+          }),
+        });
+      }
+    }
+
+    if (supportAwaitingApproval > 0) {
+      stageTask(
+        createHumanTaskSeed({
+          id: "task_owner_approval_queue",
+          caseId: null,
+          title: `Resolve ${supportAwaitingApproval} approval${supportAwaitingApproval === 1 ? "" : "s"}`,
+          priority: supportAwaitingApproval > 2 ? "p0" : "p1",
+          surface: "owner",
+          role: "owner",
+          zone: "Approval queue",
+          dueAt: currentIso,
+          etaMinutes: 10,
+          toolsNeeded: ["approval context"],
+          interruptibility: "now",
+          whyNow: `${supportAwaitingApproval} conversation${supportAwaitingApproval === 1 ? "" : "s"} cannot advance without owner approval.`,
+          whyYou: "Only the owner can approve money, exceptions, or sensitive commitments.",
+          evidenceSummary: `${supportAwaitingApproval} approvals are pending in the internet lane.`,
+          consequenceIfDelayed: "Replies stall and the studio loses responsiveness.",
+          instructions: [
+            "Review each approval item and its recommendation.",
+            "Approve or reject with a clear note.",
+            "Let the manager lane continue execution with the new boundary.",
+          ],
+          checklist: [
+            { id: "owner-approvals:1", label: "Review recommendations", status: "todo" },
+            { id: "owner-approvals:2", label: "Decide each approval", status: "todo" },
+          ],
+          doneDefinition: "Every pending approval has an explicit owner outcome.",
+          proofModes: ["manual_confirm"],
+          preferredProofMode: "manual_confirm",
+          fallbackIfSignalMissing: "Leave a manual note naming which approval needs deeper context.",
+          verificationClass: "observed",
+          freshestAt: currentIso,
+          sources: [buildSourceRef("ops", "Approval queue", currentIso, currentIso, { kind: "approval_queue" })],
+          confidence: 0.96,
+          metadata: managedMetadata({
+            managedLabel: "owner_approval_queue",
+            sourceOpen: true,
+          }),
+        }),
+      );
+    }
+
+    const reservationBundles = dependencies.reservations.length > 0 ? dependencies.reservations : persistedBundles;
+    for (const bundle of reservationBundles) {
+      const caseId = `case_reservation_${bundle.reservationId}`;
+      const countdown = minutesUntil(bundle.dueAt);
+      const priority: OpsPriority =
+        bundle.arrival.status === "arrived" || (countdown !== null && countdown <= 30)
+          ? "p1"
+          : bundle.notes
+            ? "p1"
+            : "p2";
+      stageCase({
+        id: caseId,
+        kind: "arrival",
+        title: bundle.title,
+        summary: bundle.arrival.summary,
+        status: bundle.arrival.status === "arrived" ? "active" : "open",
+        priority,
+        lane: "manager",
+        ownerRole: "floor_staff",
+        verificationClass: bundle.verificationClass,
+        freshestAt: bundle.freshestAt,
+        sources: bundle.sources,
+        confidence: bundle.confidence,
+        degradeReason: bundle.degradeReason,
+        dueAt: bundle.dueAt,
+        linkedEntityKind: "reservation",
+        linkedEntityId: bundle.reservationId,
+        memoryScope: `ops:reservation:${bundle.reservationId}`,
+        createdAt: currentIso,
+        updatedAt: currentIso,
+        metadata: managedMetadata({
+          managedLabel: "reservation_bundle",
+          sourceOpen: true,
+          ownerUid: bundle.ownerUid,
+        }),
+      });
+      stageTask(
+        createHumanTaskSeed({
+          id: `task_reservation_prepare_${bundle.reservationId}`,
+          caseId,
+          title: bundle.arrival.status === "arrived" ? `Check in ${bundle.displayName}` : `Prepare for ${bundle.displayName}`,
+          priority,
+          surface: "hands",
+          role: bundle.prep.assignedRole,
+          zone: "Intake / front desk",
+          dueAt: bundle.dueAt,
+          etaMinutes: countdown !== null ? Math.max(5, Math.min(30, countdown)) : 15,
+          toolsNeeded: bundle.prep.toolsNeeded,
+          interruptibility: bundle.arrival.status === "arrived" || (countdown !== null && countdown <= 20) ? "now" : "soon",
+          whyNow: bundle.arrival.summary,
+          whyYou: "This lane owns arrival prep, intake context, and making sure the studio is never surprised by a member.",
+          evidenceSummary: bundle.notes || `Reservation status is ${bundle.status}.`,
+          consequenceIfDelayed: "The studio can get surprised by an arrival or miss the prep context that makes intake smooth.",
+          instructions: bundle.prep.actions,
+          checklist: bundle.prep.actions.map((entry, index) => ({
+            id: `${bundle.reservationId}:prep:${index + 1}`,
+            label: entry,
+            status: "todo" as const,
+          })),
+          doneDefinition: "The arrival prep is ready and the intake lane understands what matters for this reservation.",
+          proofModes: ["manual_confirm", "qr_scan"],
+          preferredProofMode: "manual_confirm",
+          fallbackIfSignalMissing: "Leave a manual note with what you prepared and what still needs confirmation.",
+          verificationClass: bundle.verificationClass,
+          freshestAt: bundle.freshestAt,
+          sources: bundle.sources,
+          confidence: bundle.confidence,
+          degradeReason: bundle.degradeReason,
+          metadata: managedMetadata({
+            managedLabel: "reservation_task",
+            reservationId: bundle.reservationId,
+            sourceOpen: true,
+          }),
+        }),
+      );
+    }
+
+    if (kilnAttention > 0 || reservationsOpen > 0 || supportOpen > 0) {
+      stageTask(
+        createHumanTaskSeed({
+          id: "task_manager_operating_brief",
+          caseId: null,
+          title: "Run the current studio brief",
+          priority: kilnAttention > 0 || supportSecurityHold > 0 ? "p0" : "p1",
+          surface: "manager",
+          role: "studio_manager",
+          zone: "Studio twin",
+          dueAt: currentIso,
+          etaMinutes: 6,
+          toolsNeeded: ["studio twin", "approval queue", "live notes"],
+          interruptibility: "now",
+          whyNow: `The studio currently has ${kilnAttention} kiln attention item${kilnAttention === 1 ? "" : "s"}, ${supportOpen} open internet thread${supportOpen === 1 ? "" : "s"}, and ${reservationsOpen} reservation${reservationsOpen === 1 ? "" : "s"} in flight.`,
+          whyYou: "The studio manager is the coordinating intelligence responsible for reducing surprise and sequencing humans.",
+          evidenceSummary: "This brief combines commitments, kiln state, and member communication pressure.",
+          consequenceIfDelayed: "Humans lose clarity and hidden work debt grows.",
+          instructions: [
+            "Read the current risk rail and the top queued tasks.",
+            "Resolve any blocked approvals or assign hands work cleanly.",
+            "Leave continuity notes so the next interaction starts in context.",
+          ],
+          checklist: [
+            { id: "manager-brief:1", label: "Check current risk", status: "todo" },
+            { id: "manager-brief:2", label: "Sequence the next human actions", status: "todo" },
+            { id: "manager-brief:3", label: "Update continuity notes", status: "todo" },
+          ],
+          doneDefinition: "The studio has a clear next action and no hidden high-priority surprise.",
+          proofModes: ["manual_confirm"],
+          preferredProofMode: "manual_confirm",
+          fallbackIfSignalMissing: "Flag the truth rail and move to manual dispatch until the signal returns.",
+          verificationClass: "observed",
+          freshestAt: currentIso,
+          sources: [buildSourceRef("ops", "Studio brief", currentIso, currentIso, { kind: "brief" })],
+          confidence: 0.95,
+          metadata: managedMetadata({
+            managedLabel: "manager_brief",
+            sourceOpen: true,
+          }),
+        }),
+      );
+    }
+
+    for (const [id, record] of tasksById.entries()) {
+      if (!isManagedByOps(record.metadata) || derivedTaskIds.has(id)) continue;
+      const closed = closeMissingManagedTask(record, currentIso);
+      mergedTasks.set(id, closed);
+    }
+    for (const [id, record] of casesById.entries()) {
+      if (!isManagedByOps(record.metadata) || derivedCaseIds.has(id)) continue;
+      const closed = closeMissingManagedCase(record, currentIso);
+      mergedCases.set(id, closed);
+    }
+    for (const [id, record] of approvalsById.entries()) {
+      if (!isManagedByOps(record.metadata) || derivedApprovalIds.has(id)) continue;
+      const closed = expireMissingManagedApproval(record, currentIso);
+      mergedApprovals.set(id, closed);
+    }
+
+    await Promise.all([
+      ...[...mergedCases.values()].map((row) => store.upsertCase(row)),
+      ...[...mergedTasks.values()].map((row) => store.upsertTask(row)),
+      ...[...mergedApprovals.values()].map((row) => store.upsertApproval(row)),
+      ...reservationBundles.map((row) => store.upsertReservationBundle(row)),
+    ]);
+
+    const latestOpsEventAt = recentEvents[0]?.occurredAt ?? null;
+    const latestKilnAt = dependencies.kilnOverview?.kilns.reduce<string | null>((best, row) => latest(best, row.lastImportTime ?? null), null) ?? null;
+    const latestSupportAt = dependencies.supportCases.reduce<string | null>((best, row) => latest(best, row.updatedAt), null);
+    const latestStateAt = dependencies.studioState?.generatedAt ?? null;
+    const latestStationAt = stations.reduce<string | null>((best, row) => latest(best, row.lastSeenAt), null);
+    const latestReservationAt = reservationBundles.reduce<string | null>((best, row) => latest(best, row.freshestAt), null);
+    const latestEventAt = dependencies.events.reduce<string | null>((best, row) => latest(best, row.lastStatusChangedAt ?? row.startAt), null);
+    const latestReportAt = dependencies.reports.reduce<string | null>((best, row) => latest(best, row.createdAt), null);
+    const latestLendingAt = dependencies.lending?.loans.reduce<string | null>((best, row) => latest(best, row.createdAt ?? row.dueAt), null)
+      ?? dependencies.lending?.requests.reduce<string | null>((best, row) => latest(best, row.createdAt), null)
+      ?? null;
+
+    const sourceRows: OpsSourceFreshness[] = [
+      sourceFreshnessRow(currentIso, "ops_ledger", "Ops ledger", latestOpsEventAt, 600, latestOpsEventAt ? null : "No ops events have been ingested yet."),
+      sourceFreshnessRow(currentIso, "studio_state", "Studio state", latestStateAt, 3600, latestStateAt ? null : "No studio state snapshot is available."),
+      sourceFreshnessRow(
+        currentIso,
+        "kilnaid",
+        "Kiln telemetry",
+        latestKilnAt,
+        900,
+        dependencies.kilnOverview ? null : "Kiln telemetry is unavailable.",
+      ),
+      sourceFreshnessRow(
+        currentIso,
+        "support",
+        "Inbox and internet threads",
+        latestSupportAt,
+        900,
+        supportOpsStore ? null : "Support lane is not configured.",
+      ),
+      sourceFreshnessRow(currentIso, "stations", "Station heartbeats", latestStationAt, 900, latestStationAt ? null : "No station heartbeats have been seen yet."),
+      sourceFreshnessRow(currentIso, "reservations", "Reservations", latestReservationAt, 1800, reservationBundles.length > 0 ? null : "No reservation bundles are available yet."),
+      sourceFreshnessRow(currentIso, "events", "Events", latestEventAt, 3600, dependencies.events.length > 0 ? null : "No event records are available yet."),
+      sourceFreshnessRow(currentIso, "reports", "Community reports", latestReportAt, 1800, dependencies.reports.length > 0 ? null : "No community reports are visible."),
+      sourceFreshnessRow(currentIso, "lending", "Lending", latestLendingAt, 1800, dependencies.lending ? null : "Lending data is unavailable."),
+    ];
+
+    const derivedModes = new Set<OpsDegradeMode>(manualModes);
+    if (sourceRows.some((row) => row.source === "ops_ledger" && row.status === "critical")) derivedModes.add("observe_only");
+    if (sourceRows.some((row) => row.source === "kilnaid" && row.status === "critical")) derivedModes.add("manual_dispatch_only");
+    if (sourceRows.some((row) => row.source === "support" && row.status === "critical")) derivedModes.add("internet_pause");
+    if (sourceRows.some((row) => row.status === "critical")) {
+      derivedModes.add("growth_pause");
+      derivedModes.add("forge_pause");
+    }
+    if (sourceRows.some((row) => row.status === "critical" && (row.source === "kilnaid" || row.source === "support"))) {
+      derivedModes.add("no_human_tasking");
+    }
+
+    await store.saveSourceFreshness(sourceRows);
+
+    const truthReadiness = deriveReadiness([...derivedModes], sourceRows);
+    const pendingApprovals = [...mergedApprovals.values()].filter((row) => row.status === "pending").length;
+    const topTask = sortTasks([...mergedTasks.values()]).find((row) => !terminalTaskStatus(row.status)) ?? null;
+    const currentRisk =
+      supportSecurityHold > 0
+        ? `${supportSecurityHold} support thread${supportSecurityHold === 1 ? "" : "s"} are on security hold.`
+        : kilnAttention > 0
+          ? `${kilnAttention} kiln signal${kilnAttention === 1 ? "" : "s"} need attention.`
+          : pendingApprovals > 0
+            ? `${pendingApprovals} approval${pendingApprovals === 1 ? "" : "s"} are blocking forward motion.`
+            : truthReadiness === "blocked"
+              ? "Truth readiness is degraded enough that human trust would be misplaced."
+              : null;
+
+    const watchdogs: OpsWatchdog[] = [
+      {
+        id: "watchdog_truth_readiness",
+        label: "Truth readiness",
+        status: truthReadiness === "ready" ? "healthy" : truthReadiness === "degraded" ? "warning" : "critical",
+        summary:
+          truthReadiness === "ready"
+            ? "Signals are fresh enough to support autonomous coordination."
+            : truthReadiness === "degraded"
+              ? "Some signals are stale or manual degrade modes are active."
+              : "Critical freshness or trust gaps require slower, more explicit operations.",
+        recommendation:
+          truthReadiness === "ready"
+            ? "Keep the manager lane focused on sequencing and approvals."
+            : "Use the truth rail to recover stale sources before widening autonomy.",
+      },
+      {
+        id: "watchdog_arrival_surprise",
+        label: "Arrival surprise risk",
+        status: !dependencies.studioState ? "critical" : reservationsOpen > 0 ? "warning" : "healthy",
+        summary:
+          !dependencies.studioState
+            ? "There is no recent studio state snapshot to ground commitments and arrivals."
+            : reservationsOpen > 0
+              ? `${reservationsOpen} reservation${reservationsOpen === 1 ? "" : "s"} are open and should be prepared explicitly.`
+              : "No open reservation pressure is visible in the current studio snapshot.",
+        recommendation:
+          reservationsOpen > 0
+            ? "Use the manager lane to turn commitments into prep bundles and arrival expectations."
+            : "Continue watching the calendar and occupancy integrations for surprise reduction.",
+      },
+      {
+        id: "watchdog_kiln_health",
+        label: "Kiln and power posture",
+        status: kilnAttention > 0 ? "warning" : dependencies.kilnOverview ? "healthy" : "critical",
+        summary:
+          dependencies.kilnOverview
+            ? `${kilnActiveRuns} active run${kilnActiveRuns === 1 ? "" : "s"} and ${kilnAttention} attention item${kilnAttention === 1 ? "" : "s"} are visible in kiln telemetry.`
+            : "Kiln telemetry is unavailable, so the studio cannot trust the firing picture.",
+        recommendation:
+          kilnAttention > 0
+            ? "Prioritize the kiln lead tasks before promising new firing capacity."
+            : "Keep telemetry fresh and continue watching for long-cycle anomalies.",
+      },
+      {
+        id: "watchdog_approval_pressure",
+        label: "Approval pressure",
+        status: pendingApprovals > 0 ? "warning" : "healthy",
+        summary:
+          pendingApprovals > 0
+            ? `${pendingApprovals} owner approval${pendingApprovals === 1 ? "" : "s"} are currently gating studio motion.`
+            : "No approvals are currently blocking the studio.",
+        recommendation:
+          pendingApprovals > 0
+            ? "Resolve approvals quickly so the manager can continue without impersonating ownership."
+            : "Keep approvals narrow, explicit, and well-rationalized.",
+      },
+    ];
+
+    await store.saveWatchdogs(watchdogs);
+
+    const truthSummary =
+      truthReadiness === "ready"
+        ? "Studio truth is fresh enough for autonomous coordination."
+        : truthReadiness === "degraded"
+          ? "Studio truth is partially stale; autonomous actions should stay inside tighter boundaries."
+          : "Studio truth is blocked by stale or missing signals; prefer manual confirmation and explicit approvals.";
+
+    const truth: OpsPortalSnapshot["truth"] = {
+      generatedAt: currentIso,
+      readiness: truthReadiness,
+      summary: truthSummary,
+      degradeModes: [...derivedModes],
+      sources: sourceRows,
+      watchdogs,
+      metrics: {
+        open_cases: [...mergedCases.values()].filter((row) => !terminalCaseStatus(row.status)).length,
+        open_tasks: [...mergedTasks.values()].filter((row) => !terminalTaskStatus(row.status)).length,
+        pending_approvals: pendingApprovals,
+        reservations_open: reservationsOpen,
+        support_open: supportOpen,
+        kiln_attention: kilnAttention,
+      },
+    };
+
+    const arrivalsEvidence = buildEvidenceSummary(
+      reservationsOpen > 0
+        ? `${reservationsOpen} reservation${reservationsOpen === 1 ? "" : "s"} are open in the current studio snapshot.`
+        : "No open reservations are visible in the latest studio snapshot.",
+      dependencies.studioState ? "observed" : "inferred",
+      [buildSourceRef("studio_state", "Studio commitments", latestStateAt, currentIso, { kind: "commitment" })],
+      dependencies.studioState ? 0.8 : 0.35,
+      dependencies.studioState ? null : "The studio state snapshot is unavailable.",
+    );
+    const kilnEvidence = buildEvidenceSummary(
+      dependencies.kilnOverview
+        ? `${kilnActiveRuns} active run${kilnActiveRuns === 1 ? "" : "s"} and ${kilnAttention} attention item${kilnAttention === 1 ? "" : "s"} are visible.`
+        : "Kiln telemetry is unavailable.",
+      dependencies.kilnOverview ? "observed" : "inferred",
+      [buildSourceRef("kilnaid", "Kiln telemetry", latestKilnAt, currentIso, { kind: "kiln" })],
+      dependencies.kilnOverview ? 0.87 : 0.28,
+      dependencies.kilnOverview ? null : "No kiln telemetry was available.",
+    );
+    const internetEvidence = buildEvidenceSummary(
+      supportOpen > 0
+        ? `${supportOpen} open thread${supportOpen === 1 ? "" : "s"} are still active in the internet lane.`
+        : "No open support or event threads are visible right now.",
+      supportOpsStore ? "observed" : "inferred",
+      [buildSourceRef("support", "Internet lane", latestSupportAt, currentIso, { kind: "conversation" })],
+      supportOpsStore ? 0.84 : 0.3,
+      supportOpsStore ? null : "Support connectors are not configured.",
+    );
+    const truthEvidence = buildEvidenceSummary(
+      truthSummary,
+      truthReadiness === "ready" ? "confirmed" : truthReadiness === "degraded" ? "inferred" : "planned",
+      sourceRows.map((row) => buildSourceRef(row.source, row.label, row.freshestAt, currentIso, { kind: "source" })),
+      sourceRows.length
+        ? sourceRows.reduce<number>((sum, row) => sum + (row.status === "healthy" ? 1 : row.status === "warning" ? 0.6 : 0.2), 0) / sourceRows.length
+        : 0.2,
+      truthReadiness === "ready" ? null : truthSummary,
+    );
+
+    const twinZones: OpsTwinZone[] = [
+      {
+        id: "zone_arrivals",
+        label: "Arrivals and commitments",
+        status: deriveZoneStatus(reservationsOpen > 0 ? "warning" : "healthy", arrivalsEvidence, [...derivedModes]),
+        summary:
+          reservationsOpen > 0
+            ? `${reservationsOpen} reservation${reservationsOpen === 1 ? "" : "s"} are open, so prep and arrival visibility matter right now.`
+            : "No immediate arrival pressure is visible in the current commitments.",
+        nextAction: reservationsOpen > 0 ? "Turn open reservations into prep and arrival bundles." : "Continue monitoring the calendar and occupancy signals.",
+        evidence: arrivalsEvidence,
+      },
+      {
+        id: "zone_kilns",
+        label: "Kilns and physical flow",
+        status: deriveZoneStatus(kilnAttention > 0 ? "warning" : dependencies.kilnOverview ? "healthy" : "critical", kilnEvidence, [...derivedModes]),
+        summary:
+          dependencies.kilnOverview
+            ? `${kilnActiveRuns} active run${kilnActiveRuns === 1 ? "" : "s"} and ${kilnAttention} operator attention item${kilnAttention === 1 ? "" : "s"} define the current kiln load.`
+            : "The kiln picture is unavailable, so humans should verify physical reality directly.",
+        nextAction: kilnAttention > 0 ? "Work the top kiln tasks before queueing more promises." : "Keep kiln telemetry fresh and watch for anomalies.",
+        evidence: kilnEvidence,
+      },
+      {
+        id: "zone_internet",
+        label: "Internet, support, and promises",
+        status: deriveZoneStatus(
+          supportSecurityHold > 0 ? "critical" : supportOpen > 0 ? "warning" : supportOpsStore ? "healthy" : "critical",
+          internetEvidence,
+          [...derivedModes],
+          supportSecurityHold > 0,
+        ),
+        summary:
+          supportSecurityHold > 0
+            ? `${supportSecurityHold} thread${supportSecurityHold === 1 ? "" : "s"} are on security hold and need careful handling.`
+            : supportOpen > 0
+              ? `${supportOpen} open thread${supportOpen === 1 ? "" : "s"} need a clear next step in the internet lane.`
+              : "No urgent member conversations are currently visible.",
+        nextAction:
+          supportSecurityHold > 0
+            ? "Resolve risky threads through the approval path."
+            : supportOpen > 0
+              ? "Advance the next safe reply or approval."
+              : "Keep watching for new inquiries, complaints, and event work.",
+        evidence: internetEvidence,
+      },
+      {
+        id: "zone_truth",
+        label: "Truth and watchdog posture",
+        status: deriveZoneStatus(
+          truthReadiness === "ready" ? "healthy" : truthReadiness === "degraded" ? "warning" : "critical",
+          truthEvidence,
+          [...derivedModes],
+          truthReadiness === "blocked",
+        ),
+        summary: truthSummary,
+        nextAction:
+          truthReadiness === "ready"
+            ? "Keep the manager focused on sequencing and explanation."
+            : "Recover freshness gaps before widening automation.",
+        evidence: truthEvidence,
+      },
+    ];
+
+    const allCases = sortCases([
+      ...persistedCases.filter((row) => !mergedCases.has(row.id)),
+      ...mergedCases.values(),
+    ]);
+    const allTasks = sortTasks([
+      ...persistedTasks.filter((row) => !mergedTasks.has(row.id)),
+      ...mergedTasks.values(),
+    ]);
+    const allApprovals = sortApprovals([
+      ...persistedApprovals.filter((row) => !mergedApprovals.has(row.id)),
+      ...mergedApprovals.values(),
+    ]);
+
+    const twin: OpsTwinState = {
+      generatedAt: currentIso,
+      headline:
+        currentRisk
+          ? `Studio is active: ${currentRisk}`
+          : `Studio is steady with ${kilnActiveRuns} active kiln run${kilnActiveRuns === 1 ? "" : "s"} and ${supportOpen} open internet thread${supportOpen === 1 ? "" : "s"}.`,
+      narrative:
+        `The manager should minimize surprise across ${reservationsOpen} open reservation${reservationsOpen === 1 ? "" : "s"}, `
+        + `${kilnAttention} kiln attention item${kilnAttention === 1 ? "" : "s"}, and ${pendingApprovals} pending approval${pendingApprovals === 1 ? "" : "s"}.`,
+      currentRisk,
+      commitmentsDueSoon: reservationsOpen,
+      arrivalsExpectedSoon: reservationsOpen,
+      zones: twinZones,
+      nextActions:
+        (topTask ? [topTask.title] : [])
+        .concat(allTasks.filter((row) => !terminalTaskStatus(row.status)).slice(1, 4).map((row) => row.title))
+        .filter((value, index, array) => array.indexOf(value) === index)
+        .slice(0, 4),
+    };
+
+    return {
+      twin,
+      truth,
+      tasks: allTasks,
+      cases: allCases,
+      approvals: allApprovals,
+      conversations: conversations.sort((left, right) => right.latestMessageAt.localeCompare(left.latestMessageAt)).slice(0, 10),
+      ceo: [...ceo].sort((left, right) => right.updatedAt.localeCompare(left.updatedAt)),
+      forge: [...forge].sort((left, right) => right.updatedAt.localeCompare(left.updatedAt)),
+      reservations: reservationBundles,
+      events: dependencies.events,
+      reports: dependencies.reports,
+      lending: dependencies.lending,
+      taskEscapes,
+      overrides,
+      dependencies,
+    };
+  }
+
+  async function recordActionReceipt(
+    actionId: string,
+    sourceSystem: string,
+    effectType: string,
+    verificationClass: VerificationClass,
+    summary: string,
+    payload: Record<string, unknown>,
+  ): Promise<ActionEffectReceipt> {
+    const receipt: ActionEffectReceipt = {
+      id: makeId("ops_effect"),
+      actionId,
+      sourceSystem,
+      effectType,
+      verificationClass,
+      observedAt: clock(),
+      summary,
+      payload,
+    };
+    await store.saveActionEffectReceipt(receipt);
+    return receipt;
+  }
+
+  async function ensureCaseRecord(caseId: string): Promise<OpsCaseRecord> {
+    const existing = await store.getCase(caseId);
+    if (existing) return existing;
+    const currentIso = clock();
+    const record: OpsCaseRecord = {
+      id: caseId,
+      kind: "general",
+      title: caseId === "ops:chat" ? "Ops manager chat" : "General ops case",
+      summary: "A durable continuity case created from a direct interaction.",
+      status: "open",
+      priority: "p2",
+      lane: "manager",
+      ownerRole: "studio_manager",
+      verificationClass: "claimed",
+      freshestAt: currentIso,
+      sources: [buildSourceRef("ops", "Direct interaction", currentIso, currentIso, { kind: "manual" })],
+      confidence: 0.72,
+      degradeReason: null,
+      dueAt: null,
+      linkedEntityKind: null,
+      linkedEntityId: null,
+      memoryScope: `ops:case:${caseId}`,
+      createdAt: currentIso,
+      updatedAt: currentIso,
+      metadata: { createdBy: MANAGED_BY, sourceOpen: true },
+    };
+    await store.upsertCase(record);
+    return record;
+  }
+
+  const service = {
+    async ingestWorldEvent(input: AppendWorldEventInput): Promise<{
+      accepted: boolean;
+      event: OpsWorldEvent;
+      receipt: OpsIngestReceipt;
+    }> {
+      const sourceSystem = cleanString(input.sourceSystem).toLowerCase();
+      const sourceEventId = cleanString(input.sourceEventId);
+      const existingReceipt = await store.getIngestReceipt(sourceSystem, sourceEventId);
+      const payloadHash = stableOpsHash(input.payload);
+      const currentIso = clock();
+      const receipt: OpsIngestReceipt = existingReceipt ?? {
+        id: makeId("ops_ingest"),
+        sourceSystem,
+        sourceEventId,
+        payloadHash,
+        authPrincipal: cleanString(input.authPrincipal) || `machine:${sourceSystem}`,
+        receivedAt: currentIso,
+        timestampSkewSeconds: Math.max(0, Math.trunc(input.timestampSkewSeconds)),
+      };
+      const event: OpsWorldEvent = {
+        id: existingReceipt?.id ? `ops_event_${existingReceipt.id}` : makeId("ops_event"),
+        eventType: cleanString(input.eventType) || "ops.event",
+        eventVersion: 1,
+        entityKind: cleanString(input.entityKind) || "unknown",
+        entityId: cleanString(input.entityId) || "unknown",
+        caseId: cleanNullableString(input.caseId) ?? null,
+        sourceSystem,
+        sourceEventId,
+        dedupeKey: stableOpsHash([sourceSystem, sourceEventId, payloadHash]),
+        roomId: cleanNullableString(input.roomId),
+        actorKind: cleanString(input.actorKind) || "machine",
+        actorId: cleanString(input.actorId) || `machine:${sourceSystem}`,
+        confidence: clampConfidence(input.confidence, 0.8),
+        occurredAt: currentIso,
+        ingestedAt: currentIso,
+        verificationClass: input.verificationClass ?? "observed",
+        payload: toRecord(input.payload),
+        artifactRefs: toStringArray(input.artifactRefs, 32),
+      };
+      if (existingReceipt) {
+        return { accepted: false, event, receipt: existingReceipt };
+      }
+      await store.appendEvent(event, receipt);
+      if (event.caseId) {
+        await ensureCaseRecord(event.caseId);
+      }
+      logger?.info("ops-service: ingested world event", {
+        eventType: event.eventType,
+        entityKind: event.entityKind,
+        entityId: event.entityId,
+        sourceSystem: event.sourceSystem,
+      });
+      return { accepted: true, event, receipt };
+    },
+
+    async upsertTask(task: HumanTaskRecord): Promise<void> {
+      await store.upsertTask(task);
+    },
+
+    async getTwin(): Promise<OpsTwinState> {
+      const derived = await ensureDerivedState();
+      return derived.twin;
+    },
+
+    async getTruth(): Promise<OpsPortalSnapshot["truth"]> {
+      const derived = await ensureDerivedState();
+      return derived.truth;
+    },
+
+    async getPortalSnapshot(actor?: Partial<OpsActorContext> | null): Promise<OpsPortalSnapshot> {
+      const derived = await ensureDerivedState();
+      const context = actor ? defaultActorContext(actor) : null;
+      const members = context && staffDataSource && hasOpsCapability(context.opsCapabilities, "members:view")
+        ? await staffDataSource.listMembers(240).catch(() => [])
+        : [];
+      return {
+        generatedAt: clock(),
+        session: buildSession(context),
+        twin: derived.twin,
+        truth: derived.truth,
+        tasks: (context ? derived.tasks.filter((row) => canActorSeeTask(context, row)) : derived.tasks).filter((row) => row.status !== "canceled"),
+        cases: (context ? derived.cases.filter((row) => canActorSeeCase(context, row)) : derived.cases).filter((row) => row.status !== "canceled"),
+        approvals: context ? derived.approvals.filter((row) => canActorSeeApproval(context, row)) : derived.approvals,
+        ceo: derived.ceo,
+        forge: derived.forge,
+        conversations: context
+          ? derived.conversations.filter((row) => canAccessOpsSurface(context.opsCapabilities, row.surface))
+          : derived.conversations,
+        members,
+        reservations: derived.reservations,
+        events: derived.events,
+        reports: derived.reports,
+        lending: derived.lending,
+        taskEscapes: derived.taskEscapes,
+        overrides: context && context.opsRoles.includes("owner") ? derived.overrides : [],
+      };
+    },
+
+    async listTasks(actor?: Partial<OpsActorContext> | null): Promise<HumanTaskRecord[]> {
+      const derived = await ensureDerivedState();
+      if (!actor) return derived.tasks;
+      const context = defaultActorContext(actor);
+      return derived.tasks.filter((row) => canActorSeeTask(context, row));
+    },
+
+    async claimTask(
+      taskId: string,
+      actor: Partial<OpsActorContext>,
+      options?: { actorType?: ActorType; assignee?: string | null; metadata?: Record<string, unknown> },
+    ): Promise<HumanTaskRecord | null> {
+      const task = await store.getTask(taskId);
+      if (!task) return null;
+      const context = defaultActorContext(actor);
+      assertActorCanClaimTask(context, task);
+      if (task.claimedBy && task.claimedBy !== context.actorId && !terminalTaskStatus(task.status)) {
+        return task;
+      }
+      const currentIso = clock();
+      const updated: HumanTaskRecord = {
+        ...task,
+        status: task.status === "queued" || task.status === "proposed" || task.status === "reopened" ? "claimed" : task.status,
+        claimedBy: cleanString(options?.assignee) || context.actorId,
+        claimedAt: task.claimedAt ?? currentIso,
+        updatedAt: currentIso,
+        metadata: {
+          ...task.metadata,
+          actorType: options?.actorType ?? "staff",
+          claimMetadata: options?.metadata ?? {},
+        },
+      };
+      await store.upsertTask(updated);
+      await recordActionReceipt(`claim:${taskId}:${currentIso}`, "ops", "task_claimed", "claimed", `Task ${taskId} was claimed by ${context.actorId}.`, {
+        taskId,
+        actorId: context.actorId,
+      });
+      return updated;
+    },
+
+    async addTaskProof(
+      taskId: string,
+      actor: Partial<OpsActorContext>,
+      mode: ProofMode,
+      note: string | null,
+      artifactRefs: string[],
+    ): Promise<TaskProofRecord | null> {
+      const task = await store.getTask(taskId);
+      if (!task) return null;
+      const context = defaultActorContext(actor);
+      assertActorCanClaimTask(context, task);
+      assertActorCapability(context, "proof:submit", "This actor is not allowed to submit proof.");
+      const currentIso = clock();
+      const proof: TaskProofRecord = {
+        id: makeId("ops_proof"),
+        taskId,
+        mode,
+        actorId: context.actorId,
+        verificationStatus: "submitted",
+        note: cleanNullableString(note),
+        artifactRefs: toStringArray(artifactRefs, 24),
+        createdAt: currentIso,
+      };
+      await store.upsertTaskProof(proof);
+      await store.upsertTask({
+        ...task,
+        status: "proof_pending",
+        claimedBy: task.claimedBy ?? context.actorId,
+        claimedAt: task.claimedAt ?? currentIso,
+        updatedAt: currentIso,
+      });
+      await recordActionReceipt(`proof:${taskId}:${currentIso}`, "ops", "task_proof_submitted", "claimed", `Proof was submitted for task ${taskId}.`, {
+        taskId,
+        actorId: context.actorId,
+        mode,
+      });
+      return proof;
+    },
+
+    async acceptTaskProof(input: AcceptTaskProofInput, actor: Partial<OpsActorContext>): Promise<TaskProofRecord | null> {
+      const task = await store.getTask(input.taskId);
+      if (!task) return null;
+      const context = defaultActorContext(actor);
+      assertActorCapability(context, "proof:accept", "This actor is not allowed to review task proof.");
+      const proofs = await store.listTaskProofs(input.taskId);
+      const target = proofs.find((row) => row.id === input.proofId);
+      if (!target) return null;
+      const updated: TaskProofRecord = {
+        ...target,
+        verificationStatus: input.status,
+        note: cleanNullableString(input.note) ?? target.note,
+        verifiedAt: clock(),
+        verifiedBy: context.actorId,
+      };
+      await store.upsertTaskProof(updated);
+      if (input.status === "accepted") {
+        await store.upsertTask({
+          ...task,
+          status: "verified",
+          completedAt: task.completedAt ?? clock(),
+          updatedAt: clock(),
+        });
+      }
+      return updated;
+    },
+
+    async completeTask(taskId: string, actor: Partial<OpsActorContext>): Promise<HumanTaskRecord | null> {
+      const task = await store.getTask(taskId);
+      if (!task) return null;
+      const context = defaultActorContext(actor);
+      assertActorCanClaimTask(context, task);
+      const currentIso = clock();
+      const proofs = await store.listTaskProofs(taskId);
+      const hasAcceptedProof = proofs.some((row) => row.verificationStatus === "accepted");
+      const updated: HumanTaskRecord = {
+        ...task,
+        status: hasAcceptedProof ? "verified" : "proof_pending",
+        claimedBy: task.claimedBy ?? context.actorId,
+        claimedAt: task.claimedAt ?? currentIso,
+        completedAt: currentIso,
+        updatedAt: currentIso,
+        degradeReason: hasAcceptedProof ? null : "Completion was requested before proof was accepted.",
+      };
+      await store.upsertTask(updated);
+      await recordActionReceipt(`complete:${taskId}:${currentIso}`, "ops", "task_completed", hasAcceptedProof ? "confirmed" : "claimed", `Task ${taskId} was marked complete by ${context.actorId}.`, {
+        taskId,
+        actorId: context.actorId,
+        hasAcceptedProof,
+      });
+      return updated;
+    },
+
+    async escapeTask(input: EscapeTaskInput, actor: Partial<OpsActorContext>): Promise<TaskEscapeRecord | null> {
+      const task = await store.getTask(input.taskId);
+      if (!task) return null;
+      const context = defaultActorContext(actor);
+      assertActorCanClaimTask(context, task);
+      const currentIso = clock();
+      const escape: TaskEscapeRecord = {
+        id: makeId("ops_escape"),
+        taskId: task.id,
+        caseId: task.caseId,
+        actorId: context.actorId,
+        escapeHatch: input.escapeHatch,
+        reason: cleanNullableString(input.reason),
+        status: "open",
+        createdAt: currentIso,
+        resolvedAt: null,
+        resolvedBy: null,
+        metadata: {},
+      };
+      await store.appendTaskEscape(escape);
+      await store.upsertTask({
+        ...task,
+        status: "blocked",
+        blockerReason: cleanNullableString(input.reason) || input.escapeHatch,
+        updatedAt: currentIso,
+      });
+      if (task.caseId) {
+        await service.addCaseNote({
+          caseId: task.caseId,
+          actorId: context.actorId,
+          body: `Task escape: ${input.escapeHatch}${input.reason ? ` · ${input.reason}` : ""}`,
+          metadata: { taskId: task.id, escapeHatch: input.escapeHatch },
+        });
+      }
+      return escape;
+    },
+
+    async listCases(actor?: Partial<OpsActorContext> | null): Promise<OpsCaseRecord[]> {
+      const derived = await ensureDerivedState();
+      if (!actor) return derived.cases;
+      const context = defaultActorContext(actor);
+      return derived.cases.filter((row) => canActorSeeCase(context, row));
+    },
+
+    async getCase(caseId: string, actor?: Partial<OpsActorContext> | null): Promise<CaseDetail> {
+      await ensureDerivedState();
+      const context = actor ? defaultActorContext(actor) : null;
+      const [record, notes, tasks, approvals] = await Promise.all([
+        store.getCase(caseId),
+        store.listCaseNotes(caseId, 100),
+        store.listTasks(200),
+        store.listApprovals(200),
+      ]);
+      return {
+        record: record && context && !canActorSeeCase(context, record) ? null : record,
+        notes,
+        tasks: sortTasks(tasks.filter((row) => row.caseId === caseId && (!context || canActorSeeTask(context, row)))),
+        approvals: sortApprovals(approvals.filter((row) => row.caseId === caseId && (!context || canActorSeeApproval(context, row)))),
+      };
+    },
+
+    async addCaseNote(input: AddCaseNoteInput): Promise<OpsCaseNote> {
+      const record = await ensureCaseRecord(cleanString(input.caseId) || "ops:chat");
+      const note: OpsCaseNote = {
+        id: makeId("ops_note"),
+        caseId: record.id,
+        actorId: cleanString(input.actorId) || "unknown-actor",
+        actorKind: cleanString(input.actorKind) || "staff",
+        body: cleanString(input.body) || "No note body supplied.",
+        createdAt: clock(),
+        metadata: input.metadata ?? {},
+      };
+      await store.appendCaseNote(note);
+      await store.upsertCase({
+        ...record,
+        freshestAt: note.createdAt,
+        updatedAt: note.createdAt,
+        metadata: {
+          ...record.metadata,
+          lastNoteId: note.id,
+        },
+      });
+      return note;
+    },
+
+    async listApprovals(actor?: Partial<OpsActorContext> | null): Promise<ApprovalItem[]> {
+      const derived = await ensureDerivedState();
+      if (!actor) return derived.approvals;
+      const context = defaultActorContext(actor);
+      return derived.approvals.filter((row) => canActorSeeApproval(context, row));
+    },
+
+    async resolveApproval(input: ResolveApprovalInput, actor: Partial<OpsActorContext>): Promise<ApprovalItem | null> {
+      const approval = await store.getApproval(input.approvalId);
+      if (!approval) return null;
+      const context = defaultActorContext(actor);
+      assertActorCanResolveApproval(context, approval);
+      const currentIso = clock();
+      const updated: ApprovalItem = {
+        ...approval,
+        status: input.status,
+        resolvedAt: currentIso,
+        resolvedBy: context.actorId,
+        updatedAt: currentIso,
+        metadata: {
+          ...approval.metadata,
+          resolutionNote: cleanNullableString(input.note),
+        },
+      };
+      await store.upsertApproval(updated);
+      await recordActionReceipt(`approval:${approval.id}:${currentIso}`, "ops", "approval_resolved", "confirmed", `Approval ${approval.id} was ${input.status}.`, {
+        approvalId: approval.id,
+        actorId: context.actorId,
+        status: input.status,
+      });
+      return updated;
+    },
+
+    async getDisplayState(stationId: string): Promise<StationDisplayState> {
+      const snapshot = await service.getPortalSnapshot();
+      const station = await store.getStationSession(stationId);
+      const tasks = snapshot.tasks.filter((row) => row.surface === "hands" && row.status !== "canceled");
+      const focusTask = station?.currentTaskId ? tasks.find((row) => row.id === station.currentTaskId) ?? null : tasks[0] ?? null;
+      return {
+        generatedAt: clock(),
+        station,
+        truth: snapshot.truth,
+        tasks: tasks.slice(0, 8),
+        focusTask,
+      };
+    },
+
+    async sendChat(surface: string, actor: Partial<OpsActorContext>, text: string): Promise<OpsChatResponse> {
+      const normalizedSurface = cleanString(surface) || "manager";
+      const context = defaultActorContext(actor);
+      const snapshot = await service.getPortalSnapshot(context);
+      const activeTasks = snapshot.tasks.filter((row) => !terminalTaskStatus(row.status));
+      const topTask = activeTasks[0] ?? null;
+      const note = await service.addCaseNote({
+        caseId: normalizedSurface === "internet" ? "ops:chat:internet" : "ops:chat",
+        actorId: context.actorId,
+        body: text,
+        metadata: { surface: normalizedSurface },
+      });
+      const reply =
+        normalizedSurface === "internet"
+          ? snapshot.approvals.filter((row) => row.status === "pending").length > 0
+            ? `The internet lane sees ${snapshot.approvals.filter((row) => row.status === "pending").length} approval gate${snapshot.approvals.filter((row) => row.status === "pending").length === 1 ? "" : "s"}. The safest next move is to resolve those before pretending the thread can advance itself.`
+            : topTask && topTask.surface === "internet"
+              ? `The clearest next internet action is "${topTask.title}" because ${topTask.whyNow}`
+              : `The internet lane is currently steady. ${snapshot.truth.summary}`
+          : /why/i.test(text) && topTask
+            ? `The manager assigned "${topTask.title}" because ${topTask.whyNow} It matters because ${topTask.consequenceIfDelayed}`
+            : `Current studio risk: ${snapshot.twin.currentRisk || "none surfaced right now."} Next: ${snapshot.twin.nextActions[0] || "keep the truth rail healthy and continue sequencing work."}`;
+      return {
+        reply,
+        note,
+        caseId: note.caseId,
+      };
+    },
+
+    async getSessionMe(actor: Partial<OpsActorContext>): Promise<OpsSessionMe> {
+      const session = buildSession(defaultActorContext(actor));
+      if (!session) {
+        throw new Error("Unable to derive an ops session.");
+      }
+      return session;
+    },
+
+    async listMembers(actor: Partial<OpsActorContext>): Promise<MemberOpsRecord[]> {
+      const context = defaultActorContext(actor);
+      assertActorCapability(context, "members:view", "This actor is not allowed to view members.");
+      return staffDataSource ? staffDataSource.listMembers(240) : [];
+    },
+
+    async getMember(uid: string, actor: Partial<OpsActorContext>): Promise<MemberOpsRecord | null> {
+      const context = defaultActorContext(actor);
+      assertActorCapability(context, "members:view", "This actor is not allowed to view members.");
+      return staffDataSource ? staffDataSource.getMember(uid) : null;
+    },
+
+    async updateMemberProfile(
+      input: {
+        uid: string;
+        patch: {
+          displayName?: string | null;
+          membershipTier?: string | null;
+          kilnPreferences?: string | null;
+          staffNotes?: string | null;
+        };
+        reason?: string | null;
+      },
+      actor: Partial<OpsActorContext>,
+    ): Promise<{ member: MemberOpsRecord | null; audit: OpsMemberAuditRecord } | null> {
+      if (!staffDataSource) return null;
+      const context = defaultActorContext(actor);
+      assertActorCapability(context, "members:edit_profile", "This actor is not allowed to edit member profiles.");
+      const result = await staffDataSource.updateMemberProfile({
+        uid: input.uid,
+        actorId: context.actorId,
+        patch: input.patch,
+        reason: input.reason,
+      });
+      await store.appendMemberAudit(result.audit);
+      return result;
+    },
+
+    async updateMemberMembership(
+      input: { uid: string; membershipTier: string | null; reason?: string | null },
+      actor: Partial<OpsActorContext>,
+    ): Promise<{ member: MemberOpsRecord | null; audit: MembershipChangeRecord & { summary: string } } | null> {
+      if (!staffDataSource) return null;
+      const context = defaultActorContext(actor);
+      assertActorCapability(context, "members:edit_membership", "This actor is not allowed to edit memberships.");
+      const result = await staffDataSource.updateMemberMembership({
+        uid: input.uid,
+        actorId: context.actorId,
+        membershipTier: input.membershipTier,
+        reason: input.reason,
+      });
+      await store.appendMemberAudit({
+        id: result.audit.id,
+        uid: result.audit.uid,
+        kind: "membership",
+        actorId: context.actorId,
+        summary: result.audit.summary,
+        reason: result.audit.reason,
+        createdAt: result.audit.createdAt,
+        payload: result.audit,
+      });
+      return result;
+    },
+
+    async updateMemberRole(
+      input: { uid: string; portalRole: OpsPortalRole; opsRoles: OpsHumanRole[]; reason?: string | null },
+      actor: Partial<OpsActorContext>,
+    ): Promise<{ member: MemberOpsRecord | null; audit: RoleChangeRecord & { summary: string } } | null> {
+      if (!staffDataSource) return null;
+      const context = defaultActorContext(actor);
+      assertActorCapability(context, "members:edit_role", "This actor is not allowed to change member roles.");
+      if (input.uid === context.actorId) {
+        throw new Error("Use another authorized session to change your own role.");
+      }
+      if (input.opsRoles.includes("owner") && !hasOpsCapability(context.opsCapabilities, "members:edit_owner_role")) {
+        throw new Error("Only the owner can assign or remove owner access.");
+      }
+      const result = await staffDataSource.updateMemberRole({
+        uid: input.uid,
+        actorId: context.actorId,
+        portalRole: input.portalRole,
+        opsRoles: input.opsRoles,
+        reason: input.reason,
+      });
+      await store.appendMemberAudit({
+        id: result.audit.id,
+        uid: result.audit.uid,
+        kind: "role",
+        actorId: context.actorId,
+        summary: result.audit.summary,
+        reason: result.audit.reason,
+        createdAt: result.audit.createdAt,
+        payload: result.audit,
+      });
+      return result;
+    },
+
+    async getMemberActivity(uid: string, actor: Partial<OpsActorContext>): Promise<MemberActivityRecord | null> {
+      if (!staffDataSource) return null;
+      const context = defaultActorContext(actor);
+      assertActorCapability(context, "members:view", "This actor is not allowed to view member activity.");
+      return staffDataSource.getMemberActivity(uid);
+    },
+
+    async listReservations(actor?: Partial<OpsActorContext> | null): Promise<ReservationBundle[]> {
+      const derived = await ensureDerivedState();
+      if (!actor) return derived.reservations;
+      const context = defaultActorContext(actor);
+      assertActorCapability(context, "reservations:view", "This actor is not allowed to view reservation bundles.");
+      return derived.reservations;
+    },
+
+    async getReservationBundle(id: string, actor?: Partial<OpsActorContext> | null): Promise<ReservationBundle | null> {
+      const derived = await ensureDerivedState();
+      if (actor) {
+        const context = defaultActorContext(actor);
+        assertActorCapability(context, "reservations:view", "This actor is not allowed to view reservation bundles.");
+      }
+      return derived.reservations.find((row) => row.reservationId === id || row.id === id) ?? null;
+    },
+
+    async prepareReservation(id: string, actor: Partial<OpsActorContext>): Promise<HumanTaskRecord | null> {
+      const context = defaultActorContext(actor);
+      assertActorCapability(context, "reservations:prepare", "This actor is not allowed to prepare reservations.");
+      const bundle = await service.getReservationBundle(id, context);
+      if (!bundle) return null;
+      return store.getTask(`task_reservation_prepare_${bundle.reservationId}`);
+    },
+
+    async listEvents(actor?: Partial<OpsActorContext> | null): Promise<OpsEventRecord[]> {
+      const derived = await ensureDerivedState();
+      if (actor) {
+        const context = defaultActorContext(actor);
+        assertActorCapability(context, "events:view", "This actor is not allowed to view events.");
+      }
+      return derived.events;
+    },
+
+    async listReports(actor?: Partial<OpsActorContext> | null): Promise<OpsReportRecord[]> {
+      const derived = await ensureDerivedState();
+      if (actor) {
+        const context = defaultActorContext(actor);
+        assertActorCapability(context, "reports:view", "This actor is not allowed to view reports.");
+      }
+      return derived.reports;
+    },
+
+    async getLending(actor?: Partial<OpsActorContext> | null): Promise<OpsLendingSnapshot | null> {
+      const derived = await ensureDerivedState();
+      if (actor) {
+        const context = defaultActorContext(actor);
+        assertActorCapability(context, "lending:view", "This actor is not allowed to view lending.");
+      }
+      return derived.lending;
+    },
+
+    async requestOverride(input: OverrideRequestInput, actor: Partial<OpsActorContext>): Promise<OverrideReceipt> {
+      const context = defaultActorContext(actor);
+      assertActorCapability(context, "overrides:request", "This actor is not allowed to request overrides.");
+      const record: OverrideReceipt = {
+        id: makeId("ops_override"),
+        actorId: context.actorId,
+        scope: cleanString(input.scope) || "manual",
+        reason: cleanString(input.reason) || "Manual override requested.",
+        expiresAt: cleanNullableString(input.expiresAt),
+        requiredRole: input.requiredRole ?? "owner",
+        metadata: input.metadata ?? {},
+        status: "pending",
+        createdAt: clock(),
+        resolvedAt: null,
+        resolvedBy: null,
+      };
+      await store.upsertOverride(record);
+      return record;
+    },
+
+    async listOverrides(actor: Partial<OpsActorContext>): Promise<OverrideReceipt[]> {
+      const context = defaultActorContext(actor);
+      if (!context.opsRoles.includes("owner") && !hasOpsCapability(context.opsCapabilities, "overrides:approve")) {
+        return [];
+      }
+      return store.listOverrides(120);
+    },
+
+    async listGrowthExperiments(): Promise<GrowthExperiment[]> {
+      return store.listGrowthExperiments(40);
+    },
+
+    async createGrowthExperiment(record: GrowthExperiment): Promise<void> {
+      await store.upsertGrowthExperiment(record);
+    },
+
+    async listImprovementCases(): Promise<ImprovementCase[]> {
+      return store.listImprovementCases(40);
+    },
+
+    async createImprovementCase(record: ImprovementCase): Promise<void> {
+      await store.upsertImprovementCase(record);
+    },
+
+    async createStationSession(record: StationSession): Promise<void> {
+      await store.upsertStationSession(record);
+    },
+  };
+
+  return service;
+}
+
+export type OpsService = ReturnType<typeof createOpsService>;

--- a/studio-brain/src/ops/staffData.ts
+++ b/studio-brain/src/ops/staffData.ts
@@ -1,0 +1,633 @@
+import { getApps, initializeApp } from "firebase-admin/app";
+import { getAuth } from "firebase-admin/auth";
+import { getFirestore } from "firebase-admin/firestore";
+import { resolveFirebaseProjectId } from "../cloud/firebaseProject";
+import {
+  deriveOpsCapabilities,
+  makeId,
+  normalizeOpsHumanRole,
+  normalizeOpsHumanRoles,
+  type MemberActivityRecord,
+  type MemberOpsRecord,
+  type OpsCapability,
+  type OpsEventRecord,
+  type OpsHumanRole,
+  type OpsLendingLoanRecord,
+  type OpsLendingRequestRecord,
+  type OpsLendingSnapshot,
+  type OpsMemberAuditRecord,
+  type OpsPortalRole,
+  type OpsReportRecord,
+  type ReservationBundle,
+  type RoleChangeRecord,
+  type MembershipChangeRecord,
+} from "./contracts";
+
+function ensureFirebaseAdmin(): void {
+  if (getApps().length > 0) return;
+  initializeApp({ projectId: resolveFirebaseProjectId() });
+}
+
+function firestore() {
+  ensureFirebaseAdmin();
+  return getFirestore();
+}
+
+function auth() {
+  ensureFirebaseAdmin();
+  return getAuth();
+}
+
+function cleanString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function cleanNullableString(value: unknown): string | null {
+  const normalized = cleanString(value);
+  return normalized.length ? normalized : null;
+}
+
+function toFiniteNumber(value: unknown): number | null {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function toIso(value: unknown): string | null {
+  if (!value) return null;
+  if (typeof value === "string") {
+    const parsed = Date.parse(value);
+    return Number.isFinite(parsed) ? new Date(parsed).toISOString() : value;
+  }
+  if (value instanceof Date && Number.isFinite(value.getTime())) return value.toISOString();
+  if (typeof value === "object" && value !== null && "toDate" in value && typeof (value as { toDate?: unknown }).toDate === "function") {
+    const date = (value as { toDate: () => Date }).toDate();
+    return Number.isFinite(date.getTime()) ? date.toISOString() : null;
+  }
+  return null;
+}
+
+function toPortalRole(value: unknown): OpsPortalRole | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim().toLowerCase();
+  if (normalized === "admin" || normalized === "owner") return "admin";
+  if (normalized === "staff") return "staff";
+  if (normalized === "member" || normalized === "client" || normalized === "user") return "member";
+  return null;
+}
+
+export function derivePortalRoleFromClaims(claims: Record<string, unknown>): OpsPortalRole {
+  if (claims.admin === true) return "admin";
+  if (claims.staff === true) return "staff";
+  const claimsRole = toPortalRole(claims.role);
+  if (claimsRole) return claimsRole;
+  const roles = Array.isArray(claims.roles) ? claims.roles.map((entry) => cleanString(entry).toLowerCase()) : [];
+  if (roles.includes("admin")) return "admin";
+  if (roles.includes("staff")) return "staff";
+  return "member";
+}
+
+export function deriveOpsRolesFromClaims(claims: Record<string, unknown>): OpsHumanRole[] {
+  const direct = normalizeOpsHumanRoles(claims.opsRoles);
+  if (direct.length > 0) return direct;
+  const portalRole = derivePortalRoleFromClaims(claims);
+  if (portalRole === "admin") {
+    return ["owner", "member_ops", "support_ops", "kiln_lead", "floor_staff", "events_ops", "library_ops", "finance_ops"];
+  }
+  if (portalRole === "staff") {
+    return ["member_ops", "support_ops", "kiln_lead", "floor_staff", "events_ops", "library_ops"];
+  }
+  return [];
+}
+
+export function deriveOpsCapabilitiesFromClaims(claims: Record<string, unknown>): OpsCapability[] {
+  const direct = Array.isArray(claims.opsCapabilities)
+    ? claims.opsCapabilities
+        .map((entry) => cleanString(entry))
+        .filter((entry): entry is OpsCapability => entry.length > 0)
+    : [];
+  if (direct.length > 0) return direct;
+  return deriveOpsCapabilities(deriveOpsRolesFromClaims(claims));
+}
+
+export function buildClaimsForOpsRoles(
+  existingClaims: Record<string, unknown>,
+  portalRole: OpsPortalRole,
+  opsRoles: OpsHumanRole[],
+): Record<string, unknown> {
+  const nextOpsRoles = normalizeOpsHumanRoles(opsRoles);
+  const nextPortalRole = portalRole === "admin" && !nextOpsRoles.includes("owner") ? "staff" : portalRole;
+  const staff = nextOpsRoles.length > 0 || nextPortalRole === "staff" || nextPortalRole === "admin";
+  const admin = nextOpsRoles.includes("owner") || nextPortalRole === "admin";
+  const existingRoleEntries = Array.isArray(existingClaims.roles)
+    ? existingClaims.roles.map((entry) => cleanString(entry)).filter(Boolean)
+    : [];
+  const preserved = existingRoleEntries.filter((entry) => entry !== "staff" && entry !== "admin");
+  const roles = [
+    ...preserved,
+    ...(staff ? ["staff"] : []),
+    ...(admin ? ["admin"] : []),
+  ];
+  return {
+    ...existingClaims,
+    role: admin ? "admin" : staff ? "staff" : "member",
+    staff,
+    admin,
+    roles: [...new Set(roles)],
+    opsRoles: nextOpsRoles,
+    opsCapabilities: deriveOpsCapabilities(nextOpsRoles),
+  };
+}
+
+function buildDisplayName(uid: string, row: Record<string, unknown>): string {
+  return (
+    cleanString(row.displayName)
+    || cleanString(row.name)
+    || cleanString(row.fullName)
+    || cleanString(row.ownerName)
+    || `Member ${uid.slice(0, 6)}`
+  );
+}
+
+function readCollectionRole(raw: Record<string, unknown>): OpsPortalRole | null {
+  return [
+    raw.role,
+    raw.userRole,
+    raw.memberRole,
+    raw.staffRole,
+    raw.profileRole,
+    raw.accountRole,
+  ]
+    .map((value) => toPortalRole(value))
+    .find((value): value is OpsPortalRole => value !== null) ?? null;
+}
+
+function memberRecordFromSource(input: {
+  uid: string;
+  userData: Record<string, unknown>;
+  profileData?: Record<string, unknown>;
+  claims?: Record<string, unknown>;
+}): MemberOpsRecord {
+  const merged = {
+    ...(input.profileData ?? {}),
+    ...input.userData,
+  };
+  const claims = input.claims ?? {};
+  const portalRole = derivePortalRoleFromClaims(claims) ?? readCollectionRole(merged) ?? "member";
+  const opsRoles = deriveOpsRolesFromClaims(claims);
+  return {
+    uid: input.uid,
+    email: cleanNullableString(merged.email),
+    displayName: buildDisplayName(input.uid, merged),
+    membershipTier: cleanNullableString(merged.membershipTier),
+    kilnPreferences: cleanNullableString(merged.kilnPreferences),
+    staffNotes: cleanNullableString(merged.staffNotes),
+    portalRole,
+    opsRoles,
+    opsCapabilities: deriveOpsCapabilities(opsRoles),
+    createdAt: toIso(merged.createdAt),
+    updatedAt: toIso(merged.updatedAt),
+    lastSeenAt: toIso(merged.lastSeenAt),
+    metadata: {
+      sourceCollections: ["users", ...(input.profileData ? ["profiles"] : [])],
+    },
+  };
+}
+
+async function countCollection(collectionName: string, field: string, value: string): Promise<number> {
+  const snapshot = await firestore().collection(collectionName).where(field, "==", value).count().get();
+  const data = snapshot.data();
+  return typeof data.count === "number" ? data.count : 0;
+}
+
+async function countArrayContains(collectionName: string, field: string, value: string): Promise<number> {
+  const snapshot = await firestore().collection(collectionName).where(field, "array-contains", value).count().get();
+  const data = snapshot.data();
+  return typeof data.count === "number" ? data.count : 0;
+}
+
+async function latestTimestampForCollection(collectionName: string, field: string, value: string, orderField: string): Promise<string | null> {
+  const snapshot = await firestore()
+    .collection(collectionName)
+    .where(field, "==", value)
+    .orderBy(orderField, "desc")
+    .limit(1)
+    .get();
+  const row = snapshot.docs[0]?.data() as Record<string, unknown> | undefined;
+  return row ? toIso(row[orderField]) : null;
+}
+
+function reservationBundleFromDoc(id: string, raw: Record<string, unknown>): ReservationBundle {
+  const preferredLatest = toIso((raw.preferredWindow as { latestDate?: unknown } | null | undefined)?.latestDate);
+  const createdAt = toIso(raw.createdAt);
+  const updatedAt = toIso(raw.updatedAt);
+  const dueAt = preferredLatest ?? createdAt ?? updatedAt;
+  const notesBlock = raw.notes as { general?: unknown; clayBody?: unknown; glazeNotes?: unknown } | null | undefined;
+  const notes = cleanNullableString(notesBlock?.general) || cleanNullableString(raw.staffNotes) || cleanNullableString(raw.notes);
+  const pieces = Array.isArray(raw.pieces) ? raw.pieces : [];
+  const pieceCount = pieces.reduce((sum, entry) => {
+    if (!entry || typeof entry !== "object") return sum + 1;
+    const next = Math.max(1, Math.round(toFiniteNumber((entry as Record<string, unknown>).pieceCount) ?? 1));
+    return sum + next;
+  }, 0);
+  const shelfEquivalent = Math.max(1, Math.round(toFiniteNumber(raw.estimatedHalfShelves) ?? toFiniteNumber(raw.shelfEquivalent) ?? 1));
+  const itemCount = pieceCount > 0 ? pieceCount : shelfEquivalent;
+  const displayName =
+    cleanString(raw.displayName)
+    || cleanString(raw.ownerName)
+    || cleanString(raw.clientName)
+    || "Studio member";
+  const arrivalStatus = cleanString(raw.arrivalStatus).toLowerCase() || "expected";
+  const arrivedAt = toIso(raw.arrivedAt);
+  const firingType = cleanString(raw.firingType) || "kiln service";
+  const prepActions = [
+    "Confirm shelf space and kiln profile.",
+    "Review member notes and special handling before intake.",
+    notes ? "Read the prep notes before checking the work in." : "If anything looks unusual at intake, route it to the studio manager.",
+  ];
+  return {
+    id: `reservation:${id}`,
+    reservationId: id,
+    title: `${displayName} · ${firingType}`,
+    status: cleanString(raw.status) || "REQUESTED",
+    ownerUid: cleanNullableString(raw.ownerUid),
+    displayName,
+    firingType,
+    dueAt,
+    itemCount,
+    shelfEquivalent,
+    notes,
+    arrival: {
+      status: arrivalStatus || "expected",
+      dueAt,
+      arrivedAt,
+      summary: arrivedAt
+        ? `${displayName} has already arrived for this reservation.`
+        : dueAt
+          ? `${displayName} is expected around ${new Date(dueAt).toLocaleString("en-US", { month: "short", day: "numeric", hour: "numeric", minute: "2-digit" })}.`
+          : `${displayName} has an open reservation without a precise arrival window.`,
+      confidence: arrivedAt ? 1 : 0.66,
+      verificationClass: arrivedAt ? "confirmed" : "planned",
+    },
+    prep: {
+      summary: notes ? "Prep notes and intake context are available." : "Standard intake prep is likely enough.",
+      actions: prepActions,
+      toolsNeeded: ["intake station", "reservation queue", "kiln board"],
+      assignedRole: "floor_staff",
+    },
+    linkedTaskIds: [],
+    verificationClass: dueAt ? "planned" : "inferred",
+    freshestAt: updatedAt ?? createdAt ?? dueAt,
+    sources: [
+      {
+        id: `reservation:${id}`,
+        system: "firestore",
+        label: "Reservation",
+        kind: "reservation",
+        observedAt: updatedAt ?? createdAt,
+        freshnessMs: null,
+      },
+    ],
+    confidence: 0.72,
+    degradeReason: dueAt ? null : "Reservation is missing a preferred arrival window.",
+    metadata: {
+      queuePositionHint: toFiniteNumber(raw.queuePositionHint),
+      loadStatus: cleanNullableString(raw.loadStatus),
+      kilnId: cleanNullableString(raw.kilnId),
+    },
+  };
+}
+
+export type OpsStaffDataSource = {
+  listMembers(limit?: number): Promise<MemberOpsRecord[]>;
+  getMember(uid: string): Promise<MemberOpsRecord | null>;
+  updateMemberProfile(input: {
+    uid: string;
+    actorId: string;
+    patch: {
+      displayName?: string | null;
+      membershipTier?: string | null;
+      kilnPreferences?: string | null;
+      staffNotes?: string | null;
+    };
+    reason?: string | null;
+  }): Promise<{ member: MemberOpsRecord | null; audit: OpsMemberAuditRecord }>;
+  updateMemberMembership(input: {
+    uid: string;
+    actorId: string;
+    membershipTier: string | null;
+    reason?: string | null;
+  }): Promise<{ member: MemberOpsRecord | null; audit: MembershipChangeRecord & { summary: string } }>;
+  updateMemberRole(input: {
+    uid: string;
+    actorId: string;
+    portalRole: OpsPortalRole;
+    opsRoles: OpsHumanRole[];
+    reason?: string | null;
+  }): Promise<{ member: MemberOpsRecord | null; audit: RoleChangeRecord & { summary: string } }>;
+  getMemberActivity(uid: string): Promise<MemberActivityRecord>;
+  listReservations(limit?: number): Promise<ReservationBundle[]>;
+  getReservationBundle(id: string): Promise<ReservationBundle | null>;
+  listEvents(limit?: number): Promise<OpsEventRecord[]>;
+  listReports(limit?: number): Promise<OpsReportRecord[]>;
+  getLendingSnapshot(): Promise<OpsLendingSnapshot>;
+};
+
+export function createOpsStaffDataSource(): OpsStaffDataSource {
+  return {
+    async listMembers(limit = 240): Promise<MemberOpsRecord[]> {
+      const db = firestore();
+      const [usersSnap, profilesSnap] = await Promise.all([
+        db.collection("users").limit(Math.max(1, limit)).get(),
+        db.collection("profiles").limit(Math.max(1, limit)).get().catch(() => null),
+      ]);
+      const profilesByUid = new Map<string, Record<string, unknown>>();
+      for (const doc of profilesSnap?.docs ?? []) {
+        profilesByUid.set(doc.id, (doc.data() ?? {}) as Record<string, unknown>);
+      }
+      const rows = await Promise.all(usersSnap.docs.map(async (doc) => {
+        const userData = (doc.data() ?? {}) as Record<string, unknown>;
+        let claims: Record<string, unknown> = {};
+        try {
+          const user = await auth().getUser(doc.id);
+          claims = (user.customClaims ?? {}) as Record<string, unknown>;
+        } catch {
+          claims = {};
+        }
+        return memberRecordFromSource({
+          uid: doc.id,
+          userData,
+          profileData: profilesByUid.get(doc.id),
+          claims,
+        });
+      }));
+      return rows.sort((a, b) => a.displayName.localeCompare(b.displayName));
+    },
+
+    async getMember(uid: string): Promise<MemberOpsRecord | null> {
+      const db = firestore();
+      const [userSnap, profileSnap] = await Promise.all([
+        db.collection("users").doc(uid).get(),
+        db.collection("profiles").doc(uid).get().catch(() => null),
+      ]);
+      if (!userSnap.exists && !profileSnap?.exists) return null;
+      let claims: Record<string, unknown> = {};
+      try {
+        const user = await auth().getUser(uid);
+        claims = (user.customClaims ?? {}) as Record<string, unknown>;
+      } catch {
+        claims = {};
+      }
+      return memberRecordFromSource({
+        uid,
+        userData: ((userSnap.data() ?? {}) as Record<string, unknown>),
+        profileData: profileSnap?.exists ? (profileSnap.data() ?? {}) as Record<string, unknown> : undefined,
+        claims,
+      });
+    },
+
+    async updateMemberProfile(input) {
+      const db = firestore();
+      const now = new Date();
+      const patch: Record<string, unknown> = {
+        updatedAt: now,
+        staffProfileUpdatedBy: input.actorId,
+      };
+      if ("displayName" in input.patch) patch.displayName = input.patch.displayName ?? null;
+      if ("membershipTier" in input.patch) patch.membershipTier = input.patch.membershipTier ?? null;
+      if ("kilnPreferences" in input.patch) patch.kilnPreferences = input.patch.kilnPreferences ?? null;
+      if ("staffNotes" in input.patch) patch.staffNotes = input.patch.staffNotes ?? null;
+      await db.collection("users").doc(input.uid).set(patch, { merge: true });
+      const audit: OpsMemberAuditRecord = {
+        id: makeId("ops_member_audit"),
+        uid: input.uid,
+        kind: "profile",
+        actorId: input.actorId,
+        summary: "Profile fields were updated from the ops portal.",
+        reason: cleanNullableString(input.reason),
+        createdAt: now.toISOString(),
+        payload: { patch },
+      };
+      await db.collection("staffProfileEdits").doc(audit.id).set({
+        uid: input.uid,
+        editedByUid: input.actorId,
+        reason: audit.reason,
+        patch,
+        at: now,
+        source: "studio-brain-ops",
+      });
+      return {
+        member: await this.getMember(input.uid),
+        audit,
+      };
+    },
+
+    async updateMemberMembership(input) {
+      const db = firestore();
+      const now = new Date();
+      await db.collection("users").doc(input.uid).set(
+        {
+          membershipTier: input.membershipTier ?? null,
+          updatedAt: now,
+          membershipUpdatedByUid: input.actorId,
+        },
+        { merge: true },
+      );
+      const audit: MembershipChangeRecord & { summary: string } = {
+        id: makeId("ops_membership_change"),
+        uid: input.uid,
+        editedByUid: input.actorId,
+        beforeTier: null,
+        afterTier: input.membershipTier ?? null,
+        reason: cleanNullableString(input.reason),
+        createdAt: now.toISOString(),
+        summary: `Membership tier changed to ${input.membershipTier ?? "none"}.`,
+      };
+      await db.collection("staffMembershipEdits").doc(audit.id).set({
+        uid: input.uid,
+        editedByUid: input.actorId,
+        reason: audit.reason,
+        afterTier: audit.afterTier,
+        at: now,
+        source: "studio-brain-ops",
+      });
+      return {
+        member: await this.getMember(input.uid),
+        audit,
+      };
+    },
+
+    async updateMemberRole(input) {
+      const currentUser = await auth().getUser(input.uid);
+      const existingClaims = (currentUser.customClaims ?? {}) as Record<string, unknown>;
+      const beforePortalRole = derivePortalRoleFromClaims(existingClaims);
+      const beforeOpsRoles = deriveOpsRolesFromClaims(existingClaims);
+      const nextClaims = buildClaimsForOpsRoles(existingClaims, input.portalRole, input.opsRoles);
+      await auth().setCustomUserClaims(input.uid, nextClaims);
+      const now = new Date();
+      await firestore().collection("users").doc(input.uid).set(
+        {
+          customClaims: nextClaims,
+          claims: nextClaims,
+          role: nextClaims.role ?? null,
+          staffRole: nextClaims.role ?? null,
+          opsRoles: input.opsRoles,
+          opsCapabilities: deriveOpsCapabilities(input.opsRoles),
+          roleUpdatedByUid: input.actorId,
+          roleUpdatedAt: now,
+          updatedAt: now,
+        },
+        { merge: true },
+      );
+      const audit: RoleChangeRecord & { summary: string } = {
+        id: makeId("ops_role_change"),
+        uid: input.uid,
+        editedByUid: input.actorId,
+        beforePortalRole,
+        afterPortalRole: input.portalRole,
+        beforeOpsRoles,
+        afterOpsRoles: normalizeOpsHumanRoles(input.opsRoles),
+        reason: cleanNullableString(input.reason),
+        createdAt: now.toISOString(),
+        summary: `Role access changed to ${input.portalRole} with ${normalizeOpsHumanRoles(input.opsRoles).join(", ") || "no"} ops roles.`,
+      };
+      await firestore().collection("staffRoleEdits").doc(audit.id).set({
+        uid: input.uid,
+        editedByUid: input.actorId,
+        reason: audit.reason,
+        beforeRole: beforePortalRole,
+        afterRole: input.portalRole,
+        beforeOpsRoles,
+        afterOpsRoles: audit.afterOpsRoles,
+        afterClaims: nextClaims,
+        at: now,
+        source: "studio-brain-ops",
+      });
+      return {
+        member: await this.getMember(input.uid),
+        audit,
+      };
+    },
+
+    async getMemberActivity(uid: string): Promise<MemberActivityRecord> {
+      const [reservations, libraryLoans, supportThreads, events, lastReservationAt, lastLoanAt, lastEventAt] = await Promise.all([
+        countCollection("reservations", "ownerUid", uid),
+        countCollection("libraryLoans", "uid", uid).catch(() => 0),
+        countArrayContains("directMessages", "participants", uid).catch(() => 0),
+        countCollection("eventSignups", "uid", uid).catch(() => 0),
+        latestTimestampForCollection("reservations", "ownerUid", uid, "updatedAt").catch(() => null),
+        latestTimestampForCollection("libraryLoans", "uid", uid, "updatedAt").catch(() => null),
+        latestTimestampForCollection("eventSignups", "uid", uid, "updatedAt").catch(() => null),
+      ]);
+      return {
+        uid,
+        reservations,
+        libraryLoans,
+        supportThreads,
+        events,
+        lastReservationAt,
+        lastLoanAt,
+        lastEventAt,
+      };
+    },
+
+    async listReservations(limit = 60): Promise<ReservationBundle[]> {
+      const snapshot = await firestore().collection("reservations").limit(Math.max(1, limit)).get();
+      const rows = snapshot.docs.map((doc) => reservationBundleFromDoc(doc.id, (doc.data() ?? {}) as Record<string, unknown>));
+      return rows.sort((a, b) => String(a.dueAt ?? "9999").localeCompare(String(b.dueAt ?? "9999")));
+    },
+
+    async getReservationBundle(id: string): Promise<ReservationBundle | null> {
+      const snapshot = await firestore().collection("reservations").doc(id).get();
+      if (!snapshot.exists) return null;
+      return reservationBundleFromDoc(snapshot.id, (snapshot.data() ?? {}) as Record<string, unknown>);
+    },
+
+    async listEvents(limit = 120): Promise<OpsEventRecord[]> {
+      const snapshot = await firestore().collection("events").limit(Math.max(1, limit)).get();
+      return snapshot.docs
+        .map((doc) => {
+          const row = (doc.data() ?? {}) as Record<string, unknown>;
+          return {
+            id: doc.id,
+            title: cleanString(row.title) || "Untitled event",
+            status: cleanString(row.status) || "draft",
+            startAt: toIso(row.startAt),
+            endAt: toIso(row.endAt),
+            remainingCapacity: toFiniteNumber(row.remainingCapacity),
+            capacity: toFiniteNumber(row.capacity),
+            waitlistCount: toFiniteNumber(row.waitlistCount),
+            location: cleanNullableString(row.location),
+            priceCents: toFiniteNumber(row.priceCents),
+            lastStatusReason: cleanNullableString(row.lastStatusReason),
+            lastStatusChangedAt: toIso(row.lastStatusChangedAt),
+          } satisfies OpsEventRecord;
+        })
+        .sort((a, b) => String(a.startAt ?? "9999").localeCompare(String(b.startAt ?? "9999")));
+    },
+
+    async listReports(limit = 120): Promise<OpsReportRecord[]> {
+      const snapshot = await firestore()
+        .collection("communityReports")
+        .orderBy("createdAt", "desc")
+        .limit(Math.max(1, limit))
+        .get();
+      return snapshot.docs.map((doc) => {
+        const row = (doc.data() ?? {}) as Record<string, unknown>;
+        return {
+          id: doc.id,
+          status: cleanString(row.status) || "open",
+          severity: cleanString(row.severity) || "low",
+          summary: cleanString(row.summary) || cleanString(row.notes) || "Community report",
+          createdAt: toIso(row.createdAt),
+          ownerUid: cleanNullableString(row.ownerUid),
+        } satisfies OpsReportRecord;
+      });
+    },
+
+    async getLendingSnapshot(): Promise<OpsLendingSnapshot> {
+      const db = firestore();
+      const [requestsSnap, loansSnap, recommendationsSnap, tagsSnap, itemsSnap] = await Promise.all([
+        db.collection("libraryRequests").limit(60).get(),
+        db.collection("libraryLoans").limit(60).get(),
+        db.collection("libraryRecommendations").limit(120).get(),
+        db.collection("libraryTagSubmissions").limit(160).get(),
+        db.collection("libraryItems").limit(400).get().catch(() => null),
+      ]);
+      const requests: OpsLendingRequestRecord[] = requestsSnap.docs.map((doc) => {
+        const row = (doc.data() ?? {}) as Record<string, unknown>;
+        return {
+          id: doc.id,
+          status: cleanString(row.status) || "open",
+          requesterUid: cleanNullableString(row.requesterUid ?? row.uid ?? row.ownerUid),
+          requesterName: cleanNullableString(row.requesterName ?? row.displayName),
+          title: cleanString(row.title) || "Library request",
+          createdAt: toIso(row.createdAt),
+        };
+      });
+      const loans: OpsLendingLoanRecord[] = loansSnap.docs.map((doc) => {
+        const row = (doc.data() ?? {}) as Record<string, unknown>;
+        return {
+          id: doc.id,
+          status: cleanString(row.status) || "active",
+          borrowerUid: cleanNullableString(row.borrowerUid ?? row.uid ?? row.ownerUid),
+          borrowerName: cleanNullableString(row.borrowerName ?? row.displayName),
+          title: cleanString(row.title) || "Library loan",
+          createdAt: toIso(row.createdAt),
+          dueAt: toIso(row.dueAt),
+        };
+      });
+      const coverReviewCount = (itemsSnap?.docs ?? []).reduce((sum, doc) => {
+        const row = (doc.data() ?? {}) as Record<string, unknown>;
+        const status = cleanString(row.coverQualityStatus).toLowerCase();
+        return sum + (row.needsCoverReview === true || status === "needs_review" || status === "missing" ? 1 : 0);
+      }, 0);
+      return {
+        requests,
+        loans,
+        recommendationCount: recommendationsSnap.size,
+        tagSubmissionCount: tagsSnap.size,
+        coverReviewCount,
+      };
+    },
+  };
+}

--- a/studio-brain/src/ops/store.ts
+++ b/studio-brain/src/ops/store.ts
@@ -1,0 +1,865 @@
+import { getPgPool } from "../db/postgres";
+import type {
+  ActionEffectReceipt,
+  ApprovalItem,
+  GrowthExperiment,
+  HumanTaskRecord,
+  ImprovementCase,
+  MemberActivityRecord,
+  OpsAuthReceipt,
+  OpsMemberAuditRecord,
+  OpsLendingSnapshot,
+  OpsCaseNote,
+  OpsCaseRecord,
+  OpsDegradeMode,
+  OpsEventRecord,
+  OpsIngestReceipt,
+  OverrideReceipt,
+  ReservationBundle,
+  TaskEscapeRecord,
+  OpsSourceFreshness,
+  OpsWatchdog,
+  OpsWorldEvent,
+  StationSession,
+  TaskProofRecord,
+} from "./contracts";
+
+function stringify(value: unknown): string {
+  return JSON.stringify(value);
+}
+
+function asRecord<T>(row: unknown): T {
+  return row as T;
+}
+
+type StoredPayload = {
+  raw_payload: unknown;
+};
+
+export interface OpsStore {
+  appendEvent(event: OpsWorldEvent, receipt: OpsIngestReceipt): Promise<void>;
+  getIngestReceipt(sourceSystem: string, sourceEventId: string): Promise<OpsIngestReceipt | null>;
+  listEvents(limit: number): Promise<OpsWorldEvent[]>;
+  saveAuthReceipt(record: OpsAuthReceipt): Promise<void>;
+  listAuthReceipts(limit: number): Promise<OpsAuthReceipt[]>;
+  upsertCase(record: OpsCaseRecord): Promise<void>;
+  getCase(id: string): Promise<OpsCaseRecord | null>;
+  listCases(limit: number): Promise<OpsCaseRecord[]>;
+  appendCaseNote(note: OpsCaseNote): Promise<void>;
+  listCaseNotes(caseId: string, limit: number): Promise<OpsCaseNote[]>;
+  upsertTask(record: HumanTaskRecord): Promise<void>;
+  getTask(id: string): Promise<HumanTaskRecord | null>;
+  listTasks(limit: number): Promise<HumanTaskRecord[]>;
+  appendTaskProof(record: TaskProofRecord): Promise<void>;
+  upsertTaskProof(record: TaskProofRecord): Promise<void>;
+  listTaskProofs(taskId: string): Promise<TaskProofRecord[]>;
+  appendTaskEscape(record: TaskEscapeRecord): Promise<void>;
+  listTaskEscapes(taskId?: string, limit?: number): Promise<TaskEscapeRecord[]>;
+  upsertApproval(record: ApprovalItem): Promise<void>;
+  getApproval(id: string): Promise<ApprovalItem | null>;
+  listApprovals(limit: number): Promise<ApprovalItem[]>;
+  saveActionEffectReceipt(record: ActionEffectReceipt): Promise<void>;
+  listActionEffectReceipts(actionId: string): Promise<ActionEffectReceipt[]>;
+  upsertGrowthExperiment(record: GrowthExperiment): Promise<void>;
+  listGrowthExperiments(limit: number): Promise<GrowthExperiment[]>;
+  upsertImprovementCase(record: ImprovementCase): Promise<void>;
+  listImprovementCases(limit: number): Promise<ImprovementCase[]>;
+  upsertStationSession(record: StationSession): Promise<void>;
+  getStationSession(stationId: string): Promise<StationSession | null>;
+  listStationSessions(limit: number): Promise<StationSession[]>;
+  setDegradeModes(modes: OpsDegradeMode[]): Promise<void>;
+  getDegradeModes(): Promise<OpsDegradeMode[]>;
+  saveSourceFreshness(rows: OpsSourceFreshness[]): Promise<void>;
+  listSourceFreshness(): Promise<OpsSourceFreshness[]>;
+  saveWatchdogs(rows: OpsWatchdog[]): Promise<void>;
+  listWatchdogs(): Promise<OpsWatchdog[]>;
+  upsertReservationBundle(record: ReservationBundle): Promise<void>;
+  getReservationBundle(id: string): Promise<ReservationBundle | null>;
+  listReservationBundles(limit: number): Promise<ReservationBundle[]>;
+  upsertOverride(record: OverrideReceipt): Promise<void>;
+  listOverrides(limit: number): Promise<OverrideReceipt[]>;
+  appendMemberAudit(record: OpsMemberAuditRecord): Promise<void>;
+  listMemberAudits(uid: string, limit: number): Promise<OpsMemberAuditRecord[]>;
+}
+
+export class MemoryOpsStore implements OpsStore {
+  private readonly events = new Map<string, OpsWorldEvent>();
+  private readonly receipts = new Map<string, OpsIngestReceipt>();
+  private readonly authReceipts = new Map<string, OpsAuthReceipt>();
+  private readonly cases = new Map<string, OpsCaseRecord>();
+  private readonly caseNotes = new Map<string, OpsCaseNote[]>();
+  private readonly tasks = new Map<string, HumanTaskRecord>();
+  private readonly taskProofs = new Map<string, TaskProofRecord[]>();
+  private readonly taskEscapes = new Map<string, TaskEscapeRecord>();
+  private readonly approvals = new Map<string, ApprovalItem>();
+  private readonly actionReceipts = new Map<string, ActionEffectReceipt[]>();
+  private readonly growth = new Map<string, GrowthExperiment>();
+  private readonly improvements = new Map<string, ImprovementCase>();
+  private readonly stations = new Map<string, StationSession>();
+  private readonly sourceFreshness = new Map<string, OpsSourceFreshness>();
+  private readonly watchdogs = new Map<string, OpsWatchdog>();
+  private readonly reservationBundles = new Map<string, ReservationBundle>();
+  private readonly overrides = new Map<string, OverrideReceipt>();
+  private readonly memberAudits = new Map<string, OpsMemberAuditRecord[]>();
+  private degradeModes: OpsDegradeMode[] = [];
+
+  async appendEvent(event: OpsWorldEvent, receipt: OpsIngestReceipt): Promise<void> {
+    this.events.set(event.id, event);
+    this.receipts.set(`${receipt.sourceSystem}:${receipt.sourceEventId}`, receipt);
+  }
+  async getIngestReceipt(sourceSystem: string, sourceEventId: string): Promise<OpsIngestReceipt | null> {
+    return this.receipts.get(`${sourceSystem}:${sourceEventId}`) ?? null;
+  }
+  async listEvents(limit: number): Promise<OpsWorldEvent[]> {
+    return [...this.events.values()].sort((a, b) => b.occurredAt.localeCompare(a.occurredAt)).slice(0, limit);
+  }
+  async saveAuthReceipt(record: OpsAuthReceipt): Promise<void> {
+    this.authReceipts.set(record.id, record);
+  }
+  async listAuthReceipts(limit: number): Promise<OpsAuthReceipt[]> {
+    return [...this.authReceipts.values()].sort((a, b) => b.observedAt.localeCompare(a.observedAt)).slice(0, limit);
+  }
+  async upsertCase(record: OpsCaseRecord): Promise<void> {
+    this.cases.set(record.id, record);
+  }
+  async getCase(id: string): Promise<OpsCaseRecord | null> {
+    return this.cases.get(id) ?? null;
+  }
+  async listCases(limit: number): Promise<OpsCaseRecord[]> {
+    return [...this.cases.values()].sort((a, b) => b.updatedAt.localeCompare(a.updatedAt)).slice(0, limit);
+  }
+  async appendCaseNote(note: OpsCaseNote): Promise<void> {
+    const list = this.caseNotes.get(note.caseId) ?? [];
+    list.unshift(note);
+    this.caseNotes.set(note.caseId, list);
+  }
+  async listCaseNotes(caseId: string, limit: number): Promise<OpsCaseNote[]> {
+    return (this.caseNotes.get(caseId) ?? []).slice(0, limit);
+  }
+  async upsertTask(record: HumanTaskRecord): Promise<void> {
+    this.tasks.set(record.id, record);
+  }
+  async getTask(id: string): Promise<HumanTaskRecord | null> {
+    return this.tasks.get(id) ?? null;
+  }
+  async listTasks(limit: number): Promise<HumanTaskRecord[]> {
+    return [...this.tasks.values()].sort((a, b) => {
+      const dueCompare = (a.dueAt ?? "9999").localeCompare(b.dueAt ?? "9999");
+      if (dueCompare !== 0) return dueCompare;
+      return b.updatedAt.localeCompare(a.updatedAt);
+    }).slice(0, limit);
+  }
+  async appendTaskProof(record: TaskProofRecord): Promise<void> {
+    await this.upsertTaskProof(record);
+  }
+  async upsertTaskProof(record: TaskProofRecord): Promise<void> {
+    const list = this.taskProofs.get(record.taskId) ?? [];
+    const next = list.filter((entry) => entry.id !== record.id);
+    next.unshift(record);
+    this.taskProofs.set(record.taskId, next);
+  }
+  async listTaskProofs(taskId: string): Promise<TaskProofRecord[]> {
+    return this.taskProofs.get(taskId) ?? [];
+  }
+  async appendTaskEscape(record: TaskEscapeRecord): Promise<void> {
+    this.taskEscapes.set(record.id, record);
+  }
+  async listTaskEscapes(taskId?: string, limit = 100): Promise<TaskEscapeRecord[]> {
+    return [...this.taskEscapes.values()]
+      .filter((entry) => !taskId || entry.taskId === taskId)
+      .sort((a, b) => b.createdAt.localeCompare(a.createdAt))
+      .slice(0, limit);
+  }
+  async upsertApproval(record: ApprovalItem): Promise<void> {
+    this.approvals.set(record.id, record);
+  }
+  async getApproval(id: string): Promise<ApprovalItem | null> {
+    return this.approvals.get(id) ?? null;
+  }
+  async listApprovals(limit: number): Promise<ApprovalItem[]> {
+    return [...this.approvals.values()].sort((a, b) => b.updatedAt.localeCompare(a.updatedAt)).slice(0, limit);
+  }
+  async saveActionEffectReceipt(record: ActionEffectReceipt): Promise<void> {
+    const list = this.actionReceipts.get(record.actionId) ?? [];
+    list.unshift(record);
+    this.actionReceipts.set(record.actionId, list);
+  }
+  async listActionEffectReceipts(actionId: string): Promise<ActionEffectReceipt[]> {
+    return this.actionReceipts.get(actionId) ?? [];
+  }
+  async upsertGrowthExperiment(record: GrowthExperiment): Promise<void> {
+    this.growth.set(record.id, record);
+  }
+  async listGrowthExperiments(limit: number): Promise<GrowthExperiment[]> {
+    return [...this.growth.values()].sort((a, b) => b.updatedAt.localeCompare(a.updatedAt)).slice(0, limit);
+  }
+  async upsertImprovementCase(record: ImprovementCase): Promise<void> {
+    this.improvements.set(record.id, record);
+  }
+  async listImprovementCases(limit: number): Promise<ImprovementCase[]> {
+    return [...this.improvements.values()].sort((a, b) => b.updatedAt.localeCompare(a.updatedAt)).slice(0, limit);
+  }
+  async upsertStationSession(record: StationSession): Promise<void> {
+    this.stations.set(record.stationId, record);
+  }
+  async getStationSession(stationId: string): Promise<StationSession | null> {
+    return this.stations.get(stationId) ?? null;
+  }
+  async listStationSessions(limit: number): Promise<StationSession[]> {
+    return [...this.stations.values()].sort((a, b) => b.lastSeenAt.localeCompare(a.lastSeenAt)).slice(0, limit);
+  }
+  async setDegradeModes(modes: OpsDegradeMode[]): Promise<void> {
+    this.degradeModes = [...modes];
+  }
+  async getDegradeModes(): Promise<OpsDegradeMode[]> {
+    return [...this.degradeModes];
+  }
+  async saveSourceFreshness(rows: OpsSourceFreshness[]): Promise<void> {
+    this.sourceFreshness.clear();
+    for (const row of rows) this.sourceFreshness.set(row.source, row);
+  }
+  async listSourceFreshness(): Promise<OpsSourceFreshness[]> {
+    return [...this.sourceFreshness.values()].sort((a, b) => a.label.localeCompare(b.label));
+  }
+  async saveWatchdogs(rows: OpsWatchdog[]): Promise<void> {
+    this.watchdogs.clear();
+    for (const row of rows) this.watchdogs.set(row.id, row);
+  }
+  async listWatchdogs(): Promise<OpsWatchdog[]> {
+    return [...this.watchdogs.values()].sort((a, b) => a.label.localeCompare(b.label));
+  }
+  async upsertReservationBundle(record: ReservationBundle): Promise<void> {
+    this.reservationBundles.set(record.id, record);
+  }
+  async getReservationBundle(id: string): Promise<ReservationBundle | null> {
+    return this.reservationBundles.get(id) ?? null;
+  }
+  async listReservationBundles(limit: number): Promise<ReservationBundle[]> {
+    return [...this.reservationBundles.values()]
+      .sort((a, b) => String(a.dueAt ?? "9999").localeCompare(String(b.dueAt ?? "9999")))
+      .slice(0, limit);
+  }
+  async upsertOverride(record: OverrideReceipt): Promise<void> {
+    this.overrides.set(record.id, record);
+  }
+  async listOverrides(limit: number): Promise<OverrideReceipt[]> {
+    return [...this.overrides.values()].sort((a, b) => b.createdAt.localeCompare(a.createdAt)).slice(0, limit);
+  }
+  async appendMemberAudit(record: OpsMemberAuditRecord): Promise<void> {
+    const list = this.memberAudits.get(record.uid) ?? [];
+    list.unshift(record);
+    this.memberAudits.set(record.uid, list);
+  }
+  async listMemberAudits(uid: string, limit: number): Promise<OpsMemberAuditRecord[]> {
+    return (this.memberAudits.get(uid) ?? []).slice(0, limit);
+  }
+}
+
+export class PostgresOpsStore implements OpsStore {
+  async appendEvent(event: OpsWorldEvent, receipt: OpsIngestReceipt): Promise<void> {
+    const pool = getPgPool();
+    await pool.query("BEGIN");
+    try {
+      await pool.query(
+        `INSERT INTO brain_ops_ingest_receipts
+         (id, source_system, source_event_id, payload_hash, auth_principal, received_at, timestamp_skew_seconds, raw_payload)
+         VALUES ($1,$2,$3,$4,$5,$6::timestamptz,$7,$8::jsonb)
+         ON CONFLICT (source_system, source_event_id) DO NOTHING`,
+        [
+          receipt.id,
+          receipt.sourceSystem,
+          receipt.sourceEventId,
+          receipt.payloadHash,
+          receipt.authPrincipal,
+          receipt.receivedAt,
+          receipt.timestampSkewSeconds,
+          stringify(receipt),
+        ],
+      );
+      await pool.query(
+        `INSERT INTO brain_ops_events
+         (id, event_type, event_version, entity_kind, entity_id, case_id, source_system, source_event_id, dedupe_key, room_id, actor_kind, actor_id, confidence, occurred_at, ingested_at, verification_class, artifact_refs, raw_payload)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14::timestamptz,$15::timestamptz,$16,$17::jsonb,$18::jsonb)
+         ON CONFLICT (id) DO UPDATE SET
+           case_id = EXCLUDED.case_id,
+           confidence = EXCLUDED.confidence,
+           ingested_at = EXCLUDED.ingested_at,
+           verification_class = EXCLUDED.verification_class,
+           artifact_refs = EXCLUDED.artifact_refs,
+           raw_payload = EXCLUDED.raw_payload`,
+        [
+          event.id,
+          event.eventType,
+          event.eventVersion,
+          event.entityKind,
+          event.entityId,
+          event.caseId,
+          event.sourceSystem,
+          event.sourceEventId,
+          event.dedupeKey,
+          event.roomId,
+          event.actorKind,
+          event.actorId,
+          event.confidence,
+          event.occurredAt,
+          event.ingestedAt,
+          event.verificationClass,
+          stringify(event.artifactRefs),
+          stringify(event),
+        ],
+      );
+      await pool.query("COMMIT");
+    } catch (error) {
+      await pool.query("ROLLBACK");
+      throw error;
+    }
+  }
+
+  async getIngestReceipt(sourceSystem: string, sourceEventId: string): Promise<OpsIngestReceipt | null> {
+    const pool = getPgPool();
+    const result = await pool.query(
+      "SELECT raw_payload FROM brain_ops_ingest_receipts WHERE source_system = $1 AND source_event_id = $2 LIMIT 1",
+      [sourceSystem, sourceEventId],
+    );
+    return result.rowCount ? asRecord<OpsIngestReceipt>(result.rows[0].raw_payload) : null;
+  }
+
+  async listEvents(limit: number): Promise<OpsWorldEvent[]> {
+    const pool = getPgPool();
+    const result = await pool.query(
+      "SELECT raw_payload FROM brain_ops_events ORDER BY occurred_at DESC, ingested_at DESC LIMIT $1",
+      [Math.max(1, limit)],
+    );
+    return result.rows.map((row) => asRecord<OpsWorldEvent>((row as StoredPayload).raw_payload));
+  }
+
+  async saveAuthReceipt(record: OpsAuthReceipt): Promise<void> {
+    const pool = getPgPool();
+    await pool.query(
+      `INSERT INTO brain_ops_auth_receipts
+       (id, source_system, actor_id, actor_kind, status, observed_at, expires_at, raw_payload)
+       VALUES ($1,$2,$3,$4,$5,$6::timestamptz,$7::timestamptz,$8::jsonb)
+       ON CONFLICT (id) DO UPDATE SET
+         source_system = EXCLUDED.source_system,
+         actor_id = EXCLUDED.actor_id,
+         actor_kind = EXCLUDED.actor_kind,
+         status = EXCLUDED.status,
+         observed_at = EXCLUDED.observed_at,
+         expires_at = EXCLUDED.expires_at,
+         raw_payload = EXCLUDED.raw_payload`,
+      [record.id, record.sourceSystem, record.actorId, record.actorKind, record.status, record.observedAt, record.expiresAt, stringify(record)],
+    );
+  }
+
+  async listAuthReceipts(limit: number): Promise<OpsAuthReceipt[]> {
+    const pool = getPgPool();
+    const result = await pool.query(
+      "SELECT raw_payload FROM brain_ops_auth_receipts ORDER BY observed_at DESC LIMIT $1",
+      [Math.max(1, limit)],
+    );
+    return result.rows.map((row) => asRecord<OpsAuthReceipt>((row as StoredPayload).raw_payload));
+  }
+
+  async upsertCase(record: OpsCaseRecord): Promise<void> {
+    const pool = getPgPool();
+    await pool.query(
+      `INSERT INTO brain_ops_cases
+       (id, kind, title, status, priority, lane, owner_role, verification_class, freshest_at, confidence, degrade_reason, due_at, linked_entity_kind, linked_entity_id, memory_scope, created_at, updated_at, raw_payload)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9::timestamptz,$10,$11,$12::timestamptz,$13,$14,$15,$16::timestamptz,$17::timestamptz,$18::jsonb)
+       ON CONFLICT (id) DO UPDATE SET
+         kind = EXCLUDED.kind,
+         title = EXCLUDED.title,
+         status = EXCLUDED.status,
+         priority = EXCLUDED.priority,
+         lane = EXCLUDED.lane,
+         owner_role = EXCLUDED.owner_role,
+         verification_class = EXCLUDED.verification_class,
+         freshest_at = EXCLUDED.freshest_at,
+         confidence = EXCLUDED.confidence,
+         degrade_reason = EXCLUDED.degrade_reason,
+         due_at = EXCLUDED.due_at,
+         linked_entity_kind = EXCLUDED.linked_entity_kind,
+         linked_entity_id = EXCLUDED.linked_entity_id,
+         memory_scope = EXCLUDED.memory_scope,
+         updated_at = EXCLUDED.updated_at,
+         raw_payload = EXCLUDED.raw_payload`,
+      [
+        record.id,
+        record.kind,
+        record.title,
+        record.status,
+        record.priority,
+        record.lane,
+        record.ownerRole,
+        record.verificationClass,
+        record.freshestAt,
+        record.confidence,
+        record.degradeReason,
+        record.dueAt,
+        record.linkedEntityKind,
+        record.linkedEntityId,
+        record.memoryScope,
+        record.createdAt,
+        record.updatedAt,
+        stringify(record),
+      ],
+    );
+  }
+
+  async getCase(id: string): Promise<OpsCaseRecord | null> {
+    const pool = getPgPool();
+    const result = await pool.query("SELECT raw_payload FROM brain_ops_cases WHERE id = $1 LIMIT 1", [id]);
+    return result.rowCount ? asRecord<OpsCaseRecord>(result.rows[0].raw_payload) : null;
+  }
+
+  async listCases(limit: number): Promise<OpsCaseRecord[]> {
+    const pool = getPgPool();
+    const result = await pool.query(
+      "SELECT raw_payload FROM brain_ops_cases ORDER BY updated_at DESC LIMIT $1",
+      [Math.max(1, limit)],
+    );
+    return result.rows.map((row) => asRecord<OpsCaseRecord>((row as StoredPayload).raw_payload));
+  }
+
+  async appendCaseNote(note: OpsCaseNote): Promise<void> {
+    const pool = getPgPool();
+    await pool.query(
+      `INSERT INTO brain_ops_case_notes (id, case_id, actor_id, actor_kind, body, created_at, raw_payload)
+       VALUES ($1,$2,$3,$4,$5,$6::timestamptz,$7::jsonb)`,
+      [note.id, note.caseId, note.actorId, note.actorKind, note.body, note.createdAt, stringify(note)],
+    );
+  }
+
+  async listCaseNotes(caseId: string, limit: number): Promise<OpsCaseNote[]> {
+    const pool = getPgPool();
+    const result = await pool.query(
+      "SELECT raw_payload FROM brain_ops_case_notes WHERE case_id = $1 ORDER BY created_at DESC LIMIT $2",
+      [caseId, Math.max(1, limit)],
+    );
+    return result.rows.map((row) => asRecord<OpsCaseNote>((row as StoredPayload).raw_payload));
+  }
+
+  async upsertTask(record: HumanTaskRecord): Promise<void> {
+    const pool = getPgPool();
+    await pool.query(
+      `INSERT INTO brain_ops_tasks
+       (id, case_id, title, status, priority, surface, role, zone, due_at, eta_minutes, interruptibility, verification_class, freshest_at, confidence, degrade_reason, claimed_by, claimed_at, completed_at, blocker_reason, created_at, updated_at, raw_payload)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9::timestamptz,$10,$11,$12,$13::timestamptz,$14,$15,$16,$17::timestamptz,$18::timestamptz,$19,$20::timestamptz,$21::timestamptz,$22::jsonb)
+       ON CONFLICT (id) DO UPDATE SET
+         case_id = EXCLUDED.case_id,
+         title = EXCLUDED.title,
+         status = EXCLUDED.status,
+         priority = EXCLUDED.priority,
+         surface = EXCLUDED.surface,
+         role = EXCLUDED.role,
+         zone = EXCLUDED.zone,
+         due_at = EXCLUDED.due_at,
+         eta_minutes = EXCLUDED.eta_minutes,
+         interruptibility = EXCLUDED.interruptibility,
+         verification_class = EXCLUDED.verification_class,
+         freshest_at = EXCLUDED.freshest_at,
+         confidence = EXCLUDED.confidence,
+         degrade_reason = EXCLUDED.degrade_reason,
+         claimed_by = EXCLUDED.claimed_by,
+         claimed_at = EXCLUDED.claimed_at,
+         completed_at = EXCLUDED.completed_at,
+         blocker_reason = EXCLUDED.blocker_reason,
+         updated_at = EXCLUDED.updated_at,
+         raw_payload = EXCLUDED.raw_payload`,
+      [
+        record.id,
+        record.caseId,
+        record.title,
+        record.status,
+        record.priority,
+        record.surface,
+        record.role,
+        record.zone,
+        record.dueAt,
+        record.etaMinutes,
+        record.interruptibility,
+        record.verificationClass,
+        record.freshestAt,
+        record.confidence,
+        record.degradeReason,
+        record.claimedBy,
+        record.claimedAt,
+        record.completedAt,
+        record.blockerReason,
+        record.createdAt,
+        record.updatedAt,
+        stringify(record),
+      ],
+    );
+  }
+
+  async getTask(id: string): Promise<HumanTaskRecord | null> {
+    const pool = getPgPool();
+    const result = await pool.query("SELECT raw_payload FROM brain_ops_tasks WHERE id = $1 LIMIT 1", [id]);
+    return result.rowCount ? asRecord<HumanTaskRecord>(result.rows[0].raw_payload) : null;
+  }
+
+  async listTasks(limit: number): Promise<HumanTaskRecord[]> {
+    const pool = getPgPool();
+    const result = await pool.query(
+      "SELECT raw_payload FROM brain_ops_tasks ORDER BY COALESCE(due_at, updated_at) ASC, updated_at DESC LIMIT $1",
+      [Math.max(1, limit)],
+    );
+    return result.rows.map((row) => asRecord<HumanTaskRecord>((row as StoredPayload).raw_payload));
+  }
+
+  async appendTaskProof(record: TaskProofRecord): Promise<void> {
+    await this.upsertTaskProof(record);
+  }
+
+  async upsertTaskProof(record: TaskProofRecord): Promise<void> {
+    const pool = getPgPool();
+    await pool.query(
+      `INSERT INTO brain_ops_task_proofs (id, task_id, mode, actor_id, verification_status, note, artifact_refs, created_at, raw_payload)
+       VALUES ($1,$2,$3,$4,$5,$6,$7::jsonb,$8::timestamptz,$9::jsonb)
+       ON CONFLICT (id) DO UPDATE SET
+         verification_status = EXCLUDED.verification_status,
+         note = EXCLUDED.note,
+         artifact_refs = EXCLUDED.artifact_refs,
+         raw_payload = EXCLUDED.raw_payload`,
+      [record.id, record.taskId, record.mode, record.actorId, record.verificationStatus, record.note, stringify(record.artifactRefs), record.createdAt, stringify(record)],
+    );
+  }
+
+  async listTaskProofs(taskId: string): Promise<TaskProofRecord[]> {
+    const pool = getPgPool();
+    const result = await pool.query(
+      "SELECT raw_payload FROM brain_ops_task_proofs WHERE task_id = $1 ORDER BY created_at DESC",
+      [taskId],
+    );
+    return result.rows.map((row) => asRecord<TaskProofRecord>((row as StoredPayload).raw_payload));
+  }
+
+  async appendTaskEscape(record: TaskEscapeRecord): Promise<void> {
+    const pool = getPgPool();
+    await pool.query(
+      `INSERT INTO brain_ops_task_escapes (id, task_id, case_id, actor_id, escape_hatch, status, created_at, resolved_at, resolved_by, raw_payload)
+       VALUES ($1,$2,$3,$4,$5,$6,$7::timestamptz,$8::timestamptz,$9,$10::jsonb)
+       ON CONFLICT (id) DO UPDATE SET raw_payload = EXCLUDED.raw_payload`,
+      [
+        record.id,
+        record.taskId,
+        record.caseId,
+        record.actorId,
+        record.escapeHatch,
+        record.status,
+        record.createdAt,
+        record.resolvedAt,
+        record.resolvedBy,
+        stringify(record),
+      ],
+    );
+  }
+
+  async listTaskEscapes(taskId?: string, limit = 100): Promise<TaskEscapeRecord[]> {
+    const pool = getPgPool();
+    const result = taskId
+      ? await pool.query(
+          "SELECT raw_payload FROM brain_ops_task_escapes WHERE task_id = $1 ORDER BY created_at DESC LIMIT $2",
+          [taskId, Math.max(1, limit)],
+        )
+      : await pool.query(
+          "SELECT raw_payload FROM brain_ops_task_escapes ORDER BY created_at DESC LIMIT $1",
+          [Math.max(1, limit)],
+        );
+    return result.rows.map((row) => asRecord<TaskEscapeRecord>((row as StoredPayload).raw_payload));
+  }
+
+  async upsertApproval(record: ApprovalItem): Promise<void> {
+    const pool = getPgPool();
+    await pool.query(
+      `INSERT INTO brain_ops_approvals
+       (id, case_id, title, status, action_class, requested_by, required_role, verification_class, freshest_at, confidence, degrade_reason, created_at, updated_at, resolved_at, resolved_by, raw_payload)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9::timestamptz,$10,$11,$12::timestamptz,$13::timestamptz,$14::timestamptz,$15,$16::jsonb)
+       ON CONFLICT (id) DO UPDATE SET
+         case_id = EXCLUDED.case_id,
+         title = EXCLUDED.title,
+         status = EXCLUDED.status,
+         action_class = EXCLUDED.action_class,
+         requested_by = EXCLUDED.requested_by,
+         required_role = EXCLUDED.required_role,
+         verification_class = EXCLUDED.verification_class,
+         freshest_at = EXCLUDED.freshest_at,
+         confidence = EXCLUDED.confidence,
+         degrade_reason = EXCLUDED.degrade_reason,
+         updated_at = EXCLUDED.updated_at,
+         resolved_at = EXCLUDED.resolved_at,
+         resolved_by = EXCLUDED.resolved_by,
+         raw_payload = EXCLUDED.raw_payload`,
+      [
+        record.id,
+        record.caseId,
+        record.title,
+        record.status,
+        record.actionClass,
+        record.requestedBy,
+        record.requiredRole,
+        record.verificationClass,
+        record.freshestAt,
+        record.confidence,
+        record.degradeReason,
+        record.createdAt,
+        record.updatedAt,
+        record.resolvedAt,
+        record.resolvedBy,
+        stringify(record),
+      ],
+    );
+  }
+
+  async getApproval(id: string): Promise<ApprovalItem | null> {
+    const pool = getPgPool();
+    const result = await pool.query("SELECT raw_payload FROM brain_ops_approvals WHERE id = $1 LIMIT 1", [id]);
+    return result.rowCount ? asRecord<ApprovalItem>(result.rows[0].raw_payload) : null;
+  }
+
+  async listApprovals(limit: number): Promise<ApprovalItem[]> {
+    const pool = getPgPool();
+    const result = await pool.query(
+      "SELECT raw_payload FROM brain_ops_approvals ORDER BY updated_at DESC LIMIT $1",
+      [Math.max(1, limit)],
+    );
+    return result.rows.map((row) => asRecord<ApprovalItem>((row as StoredPayload).raw_payload));
+  }
+
+  async saveActionEffectReceipt(record: ActionEffectReceipt): Promise<void> {
+    const pool = getPgPool();
+    await pool.query(
+      `INSERT INTO brain_ops_action_effect_receipts
+       (id, action_id, source_system, effect_type, verification_class, observed_at, raw_payload)
+       VALUES ($1,$2,$3,$4,$5,$6::timestamptz,$7::jsonb)
+       ON CONFLICT (id) DO UPDATE SET raw_payload = EXCLUDED.raw_payload`,
+      [record.id, record.actionId, record.sourceSystem, record.effectType, record.verificationClass, record.observedAt, stringify(record)],
+    );
+  }
+
+  async listActionEffectReceipts(actionId: string): Promise<ActionEffectReceipt[]> {
+    const pool = getPgPool();
+    const result = await pool.query(
+      "SELECT raw_payload FROM brain_ops_action_effect_receipts WHERE action_id = $1 ORDER BY observed_at DESC",
+      [actionId],
+    );
+    return result.rows.map((row) => asRecord<ActionEffectReceipt>((row as StoredPayload).raw_payload));
+  }
+
+  async upsertGrowthExperiment(record: GrowthExperiment): Promise<void> {
+    const pool = getPgPool();
+    await pool.query(
+      `INSERT INTO brain_ops_growth_experiments (id, status, owner, updated_at, raw_payload)
+       VALUES ($1,$2,$3,$4::timestamptz,$5::jsonb)
+       ON CONFLICT (id) DO UPDATE SET status = EXCLUDED.status, owner = EXCLUDED.owner, updated_at = EXCLUDED.updated_at, raw_payload = EXCLUDED.raw_payload`,
+      [record.id, record.status, record.owner, record.updatedAt, stringify(record)],
+    );
+  }
+
+  async listGrowthExperiments(limit: number): Promise<GrowthExperiment[]> {
+    const pool = getPgPool();
+    const result = await pool.query(
+      "SELECT raw_payload FROM brain_ops_growth_experiments ORDER BY updated_at DESC LIMIT $1",
+      [Math.max(1, limit)],
+    );
+    return result.rows.map((row) => asRecord<GrowthExperiment>((row as StoredPayload).raw_payload));
+  }
+
+  async upsertImprovementCase(record: ImprovementCase): Promise<void> {
+    const pool = getPgPool();
+    await pool.query(
+      `INSERT INTO brain_ops_improvement_cases (id, status, updated_at, raw_payload)
+       VALUES ($1,$2,$3::timestamptz,$4::jsonb)
+       ON CONFLICT (id) DO UPDATE SET status = EXCLUDED.status, updated_at = EXCLUDED.updated_at, raw_payload = EXCLUDED.raw_payload`,
+      [record.id, record.status, record.updatedAt, stringify(record)],
+    );
+  }
+
+  async listImprovementCases(limit: number): Promise<ImprovementCase[]> {
+    const pool = getPgPool();
+    const result = await pool.query(
+      "SELECT raw_payload FROM brain_ops_improvement_cases ORDER BY updated_at DESC LIMIT $1",
+      [Math.max(1, limit)],
+    );
+    return result.rows.map((row) => asRecord<ImprovementCase>((row as StoredPayload).raw_payload));
+  }
+
+  async upsertStationSession(record: StationSession): Promise<void> {
+    const pool = getPgPool();
+    await pool.query(
+      `INSERT INTO brain_ops_station_sessions (id, station_id, room_id, surface_mode, current_task_id, actor_id, last_seen_at, raw_payload)
+       VALUES ($1,$2,$3,$4,$5,$6,$7::timestamptz,$8::jsonb)
+       ON CONFLICT (station_id) DO UPDATE SET
+         room_id = EXCLUDED.room_id,
+         surface_mode = EXCLUDED.surface_mode,
+         current_task_id = EXCLUDED.current_task_id,
+         actor_id = EXCLUDED.actor_id,
+         last_seen_at = EXCLUDED.last_seen_at,
+         raw_payload = EXCLUDED.raw_payload`,
+      [record.id, record.stationId, record.roomId, record.surfaceMode, record.currentTaskId, record.actorId, record.lastSeenAt, stringify(record)],
+    );
+  }
+
+  async getStationSession(stationId: string): Promise<StationSession | null> {
+    const pool = getPgPool();
+    const result = await pool.query("SELECT raw_payload FROM brain_ops_station_sessions WHERE station_id = $1 LIMIT 1", [stationId]);
+    return result.rowCount ? asRecord<StationSession>(result.rows[0].raw_payload) : null;
+  }
+
+  async listStationSessions(limit: number): Promise<StationSession[]> {
+    const pool = getPgPool();
+    const result = await pool.query(
+      "SELECT raw_payload FROM brain_ops_station_sessions ORDER BY last_seen_at DESC LIMIT $1",
+      [Math.max(1, limit)],
+    );
+    return result.rows.map((row) => asRecord<StationSession>((row as StoredPayload).raw_payload));
+  }
+
+  async setDegradeModes(modes: OpsDegradeMode[]): Promise<void> {
+    const pool = getPgPool();
+    await pool.query("DELETE FROM brain_ops_degraded_modes");
+    if (!modes.length) return;
+    for (const mode of modes) {
+      await pool.query(
+        "INSERT INTO brain_ops_degraded_modes (mode, updated_at) VALUES ($1, now()) ON CONFLICT (mode) DO UPDATE SET updated_at = now()",
+        [mode],
+      );
+    }
+  }
+
+  async getDegradeModes(): Promise<OpsDegradeMode[]> {
+    const pool = getPgPool();
+    const result = await pool.query("SELECT mode FROM brain_ops_degraded_modes ORDER BY mode ASC");
+    return result.rows.map((row) => String(row.mode) as OpsDegradeMode);
+  }
+
+  async saveSourceFreshness(rows: OpsSourceFreshness[]): Promise<void> {
+    const pool = getPgPool();
+    await pool.query("DELETE FROM brain_ops_source_freshness");
+    for (const row of rows) {
+      await pool.query(
+        `INSERT INTO brain_ops_source_freshness (source_key, freshest_at, freshness_seconds, budget_seconds, status, reason, raw_payload)
+         VALUES ($1,$2::timestamptz,$3,$4,$5,$6,$7::jsonb)`,
+        [row.source, row.freshestAt, row.freshnessSeconds, row.budgetSeconds, row.status, row.reason, stringify(row)],
+      );
+    }
+  }
+
+  async listSourceFreshness(): Promise<OpsSourceFreshness[]> {
+    const pool = getPgPool();
+    const result = await pool.query("SELECT raw_payload FROM brain_ops_source_freshness ORDER BY source_key ASC");
+    return result.rows.map((row) => asRecord<OpsSourceFreshness>((row as StoredPayload).raw_payload));
+  }
+
+  async saveWatchdogs(rows: OpsWatchdog[]): Promise<void> {
+    const pool = getPgPool();
+    await pool.query("DELETE FROM brain_ops_watchdogs");
+    for (const row of rows) {
+      await pool.query(
+        `INSERT INTO brain_ops_watchdogs (id, status, raw_payload)
+         VALUES ($1,$2,$3::jsonb)
+         ON CONFLICT (id) DO UPDATE SET status = EXCLUDED.status, raw_payload = EXCLUDED.raw_payload`,
+        [row.id, row.status, stringify(row)],
+      );
+    }
+  }
+
+  async listWatchdogs(): Promise<OpsWatchdog[]> {
+    const pool = getPgPool();
+    const result = await pool.query("SELECT raw_payload FROM brain_ops_watchdogs ORDER BY id ASC");
+    return result.rows.map((row) => asRecord<OpsWatchdog>((row as StoredPayload).raw_payload));
+  }
+
+  async upsertReservationBundle(record: ReservationBundle): Promise<void> {
+    const pool = getPgPool();
+    await pool.query(
+      `INSERT INTO brain_ops_reservation_bundles (id, reservation_id, status, due_at, owner_uid, updated_at, raw_payload)
+       VALUES ($1,$2,$3,$4::timestamptz,$5,$6::timestamptz,$7::jsonb)
+       ON CONFLICT (id) DO UPDATE SET
+         status = EXCLUDED.status,
+         due_at = EXCLUDED.due_at,
+         owner_uid = EXCLUDED.owner_uid,
+         updated_at = EXCLUDED.updated_at,
+         raw_payload = EXCLUDED.raw_payload`,
+      [
+        record.id,
+        record.reservationId,
+        record.status,
+        record.dueAt,
+        record.ownerUid,
+        record.freshestAt ?? record.dueAt ?? record.metadata.updatedAt ?? record.metadata.createdAt ?? new Date().toISOString(),
+        stringify(record),
+      ],
+    );
+  }
+
+  async getReservationBundle(id: string): Promise<ReservationBundle | null> {
+    const pool = getPgPool();
+    const result = await pool.query("SELECT raw_payload FROM brain_ops_reservation_bundles WHERE id = $1 LIMIT 1", [id]);
+    return result.rowCount ? asRecord<ReservationBundle>(result.rows[0].raw_payload) : null;
+  }
+
+  async listReservationBundles(limit: number): Promise<ReservationBundle[]> {
+    const pool = getPgPool();
+    const result = await pool.query(
+      "SELECT raw_payload FROM brain_ops_reservation_bundles ORDER BY COALESCE(due_at, updated_at) ASC LIMIT $1",
+      [Math.max(1, limit)],
+    );
+    return result.rows.map((row) => asRecord<ReservationBundle>((row as StoredPayload).raw_payload));
+  }
+
+  async upsertOverride(record: OverrideReceipt): Promise<void> {
+    const pool = getPgPool();
+    await pool.query(
+      `INSERT INTO brain_ops_overrides (id, actor_id, scope, required_role, status, expires_at, created_at, resolved_at, resolved_by, raw_payload)
+       VALUES ($1,$2,$3,$4,$5,$6::timestamptz,$7::timestamptz,$8::timestamptz,$9,$10::jsonb)
+       ON CONFLICT (id) DO UPDATE SET
+         status = EXCLUDED.status,
+         expires_at = EXCLUDED.expires_at,
+         resolved_at = EXCLUDED.resolved_at,
+         resolved_by = EXCLUDED.resolved_by,
+         raw_payload = EXCLUDED.raw_payload`,
+      [
+        record.id,
+        record.actorId,
+        record.scope,
+        record.requiredRole,
+        record.status,
+        record.expiresAt,
+        record.createdAt,
+        record.resolvedAt,
+        record.resolvedBy,
+        stringify(record),
+      ],
+    );
+  }
+
+  async listOverrides(limit: number): Promise<OverrideReceipt[]> {
+    const pool = getPgPool();
+    const result = await pool.query(
+      "SELECT raw_payload FROM brain_ops_overrides ORDER BY created_at DESC LIMIT $1",
+      [Math.max(1, limit)],
+    );
+    return result.rows.map((row) => asRecord<OverrideReceipt>((row as StoredPayload).raw_payload));
+  }
+
+  async appendMemberAudit(record: OpsMemberAuditRecord): Promise<void> {
+    const pool = getPgPool();
+    await pool.query(
+      `INSERT INTO brain_ops_member_audits (id, uid, kind, actor_id, created_at, raw_payload)
+       VALUES ($1,$2,$3,$4,$5::timestamptz,$6::jsonb)
+       ON CONFLICT (id) DO UPDATE SET raw_payload = EXCLUDED.raw_payload`,
+      [record.id, record.uid, record.kind, record.actorId, record.createdAt, stringify(record)],
+    );
+  }
+
+  async listMemberAudits(uid: string, limit: number): Promise<OpsMemberAuditRecord[]> {
+    const pool = getPgPool();
+    const result = await pool.query(
+      "SELECT raw_payload FROM brain_ops_member_audits WHERE uid = $1 ORDER BY created_at DESC LIMIT $2",
+      [uid, Math.max(1, limit)],
+    );
+    return result.rows.map((row) => asRecord<OpsMemberAuditRecord>((row as StoredPayload).raw_payload));
+  }
+}

--- a/studio-brain/src/ops/ui/contracts.ts
+++ b/studio-brain/src/ops/ui/contracts.ts
@@ -1,0 +1,9 @@
+import type { OpsPortalSnapshot, StationDisplayState } from "../contracts";
+
+export type OpsPortalPageModel = {
+  snapshot: OpsPortalSnapshot;
+  displayState: StationDisplayState | null;
+  surface: string;
+  stationId: string | null;
+  sessionToken?: string | null;
+};

--- a/studio-brain/src/ops/ui/renderOpsPortalPage.ts
+++ b/studio-brain/src/ops/ui/renderOpsPortalPage.ts
@@ -1,0 +1,2976 @@
+import type {
+  ApprovalItem,
+  GrowthExperiment,
+  HumanTaskRecord,
+  ImprovementCase,
+  OpsCaseRecord,
+  OpsConversationThreadRecord,
+  OpsPortalSnapshot,
+  OpsSourceFreshness,
+  OpsTwinZone,
+  OpsWatchdog,
+  StationDisplayState,
+} from "../contracts";
+import type { OpsPortalPageModel } from "./contracts";
+
+function esc(value: unknown): string {
+  return String(value ?? "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+function jsonScript(value: unknown): string {
+  return JSON.stringify(value)
+    .replaceAll("<", "\\u003c")
+    .replaceAll(">", "\\u003e")
+    .replaceAll("&", "\\u0026");
+}
+
+function formatTimestamp(value: string | null): string {
+  if (!value) return "unknown";
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) return value;
+  return new Date(parsed).toLocaleString("en-US", {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+function formatConfidence(value: number): string {
+  return `${Math.round(Math.max(0, Math.min(1, value)) * 100)}%`;
+}
+
+function parseTimestamp(value: string | null): number | null {
+  if (!value) return null;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function minutesUntil(value: string | null): number | null {
+  const parsed = parseTimestamp(value);
+  if (parsed === null) return null;
+  return Math.round((parsed - Date.now()) / 60000);
+}
+
+function formatCountdown(minutes: number | null): string {
+  if (minutes === null) return "live";
+  if (minutes <= 0) return `${Math.abs(minutes)}m late`;
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  const remainder = minutes % 60;
+  return remainder === 0 ? `${hours}h` : `${hours}h ${remainder}m`;
+}
+
+function countdownPercent(minutes: number | null, horizonMinutes: number): number {
+  if (minutes === null) return 52;
+  const bounded = Math.max(0, Math.min(horizonMinutes, minutes));
+  return Math.round((1 - bounded / horizonMinutes) * 100);
+}
+
+function freshnessPercent(freshnessSeconds: number | null, budgetSeconds: number): number {
+  if (freshnessSeconds === null || budgetSeconds <= 0) return 26;
+  const bounded = Math.max(0, Math.min(budgetSeconds, freshnessSeconds));
+  return Math.round((1 - bounded / budgetSeconds) * 100);
+}
+
+function statusTone(status: string): string {
+  if (status === "healthy" || status === "ready" || status === "verified" || status === "approved") return "good";
+  if (status === "warning" || status === "degraded" || status === "proof_pending" || status === "pending") return "warn";
+  if (status === "critical" || status === "blocked" || status === "rejected" || status === "canceled") return "danger";
+  return "neutral";
+}
+
+function renderZone(zone: OpsTwinZone): string {
+  return `
+    <article class="ops-zone ops-tone-${esc(statusTone(zone.status))}">
+      <div class="ops-zone__head">
+        <div>
+          <p class="ops-kicker">Studio twin zone</p>
+          <h3>${esc(zone.label)}</h3>
+        </div>
+        <span class="ops-pill ops-pill-${esc(statusTone(zone.status))}">${esc(zone.status)}</span>
+      </div>
+      <p class="ops-summary">${esc(zone.summary)}</p>
+      <dl class="ops-meta-grid">
+        <div><dt>Why we believe this</dt><dd>${esc(zone.evidence.summary)}</dd></div>
+        <div><dt>Verification</dt><dd>${esc(zone.evidence.verificationClass)}</dd></div>
+        <div><dt>Confidence</dt><dd>${esc(formatConfidence(zone.evidence.confidence))}</dd></div>
+        <div><dt>Freshest signal</dt><dd>${esc(formatTimestamp(zone.evidence.freshestAt))}</dd></div>
+      </dl>
+      <div class="ops-zone__footer">
+        <strong>Next:</strong> ${esc(zone.nextAction || "No explicit next action queued.")}
+      </div>
+    </article>
+  `;
+}
+
+function renderTask(task: HumanTaskRecord): string {
+  const checklist = task.checklist.length
+    ? task.checklist.map((item) => `<li><strong>${esc(item.label)}</strong>${item.detail ? ` · ${esc(item.detail)}` : ""}</li>`).join("")
+    : "<li>No checklist has been generated yet.</li>";
+  return `
+    <article class="ops-task-card ops-tone-${esc(statusTone(task.status))}" data-task-id="${esc(task.id)}">
+      <div class="ops-task-card__head">
+        <div>
+          <p class="ops-kicker">${esc(task.surface)} lane · ${esc(task.role)} · ${esc(task.zone)}</p>
+          <h3>${esc(task.title)}</h3>
+        </div>
+        <div class="ops-task-card__badges">
+          <span class="ops-pill ops-pill-${esc(statusTone(task.status))}">${esc(task.status)}</span>
+          <span class="ops-pill">${esc(task.priority)}</span>
+        </div>
+      </div>
+      <p class="ops-summary">${esc(task.whyNow)}</p>
+      <dl class="ops-task-grid">
+        <div><dt>Why now</dt><dd>${esc(task.whyNow)}</dd></div>
+        <div><dt>Why you</dt><dd>${esc(task.whyYou)}</dd></div>
+        <div><dt>Consequence if delayed</dt><dd>${esc(task.consequenceIfDelayed)}</dd></div>
+        <div><dt>Freshness / confidence</dt><dd>${esc(formatTimestamp(task.freshestAt))} · ${esc(formatConfidence(task.confidence))}</dd></div>
+        <div><dt>Evidence</dt><dd>${esc(task.evidenceSummary)}</dd></div>
+        <div><dt>Tools</dt><dd>${esc(task.toolsNeeded.join(", ") || "Use standard station tools.")}</dd></div>
+        <div><dt>Done definition</dt><dd>${esc(task.doneDefinition)}</dd></div>
+        <div><dt>Proof path</dt><dd>${esc(task.preferredProofMode)}${task.proofModes.length > 1 ? ` (fallbacks: ${esc(task.proofModes.slice(1).join(", "))})` : ""}</dd></div>
+        <div class="ops-span-2"><dt>If the signal path is missing</dt><dd>${esc(task.fallbackIfSignalMissing)}</dd></div>
+      </dl>
+      <div class="ops-subpanel">
+        <h4>How to do it</h4>
+        <ol>${task.instructions.map((line) => `<li>${esc(line)}</li>`).join("")}</ol>
+      </div>
+      <div class="ops-subpanel">
+        <h4>Checklist</h4>
+        <ul>${checklist}</ul>
+      </div>
+      <div class="ops-subpanel">
+        <h4>Need help instead?</h4>
+        <div class="ops-chip-row">
+          ${task.blockerEscapeHatches.map((entry) => `<button type="button" class="ops-chip" data-task-escape="${esc(entry)}" data-task-id="${esc(task.id)}">${esc(entry)}</button>`).join("")}
+        </div>
+      </div>
+      <div class="ops-actions">
+        <button type="button" class="ops-button" data-task-claim="${esc(task.id)}">Claim</button>
+        <button type="button" class="ops-button ops-button-secondary" data-task-proof="${esc(task.id)}" data-task-proof-mode="${esc(task.preferredProofMode)}">Proof</button>
+        <button type="button" class="ops-button ops-button-secondary" data-task-complete="${esc(task.id)}">Complete</button>
+      </div>
+    </article>
+  `;
+}
+
+function renderApproval(row: ApprovalItem): string {
+  return `
+    <article class="ops-approval ops-tone-${esc(statusTone(row.status))}">
+      <div class="ops-zone__head">
+        <div>
+          <p class="ops-kicker">Approval · ${esc(row.actionClass)} · ${esc(row.requiredRole)}</p>
+          <h3>${esc(row.title)}</h3>
+        </div>
+        <span class="ops-pill ops-pill-${esc(statusTone(row.status))}">${esc(row.status)}</span>
+      </div>
+      <p class="ops-summary">${esc(row.summary)}</p>
+      <dl class="ops-meta-grid">
+        <div><dt>Recommendation</dt><dd>${esc(row.recommendation)}</dd></div>
+        <div><dt>Risk</dt><dd>${esc(row.riskSummary)}</dd></div>
+        <div><dt>Reversibility</dt><dd>${esc(row.reversibility)}</dd></div>
+        <div><dt>Freshness / confidence</dt><dd>${esc(formatTimestamp(row.freshestAt))} · ${esc(formatConfidence(row.confidence))}</dd></div>
+      </dl>
+      <p class="ops-meta"><strong>Rollback:</strong> ${esc(row.rollbackPlan || "No rollback plan provided yet.")}</p>
+      <div class="ops-actions">
+        <button type="button" class="ops-button" data-approval-resolve="${esc(row.id)}" data-approval-status="approved">Approve</button>
+        <button type="button" class="ops-button ops-button-secondary" data-approval-resolve="${esc(row.id)}" data-approval-status="rejected">Reject</button>
+      </div>
+    </article>
+  `;
+}
+
+function renderCase(row: OpsCaseRecord): string {
+  return `
+    <article class="ops-case ops-tone-${esc(statusTone(row.status))}">
+      <p class="ops-kicker">${esc(row.kind)} · ${esc(row.lane)} · ${esc(row.priority)}</p>
+      <h3>${esc(row.title)}</h3>
+      <p class="ops-summary">${esc(row.summary)}</p>
+      <dl class="ops-meta-grid">
+        <div><dt>Status</dt><dd>${esc(row.status)}</dd></div>
+        <div><dt>Verification</dt><dd>${esc(row.verificationClass)}</dd></div>
+        <div><dt>Freshest</dt><dd>${esc(formatTimestamp(row.freshestAt))}</dd></div>
+        <div><dt>Confidence</dt><dd>${esc(formatConfidence(row.confidence))}</dd></div>
+      </dl>
+      <div class="ops-actions">
+        <button type="button" class="ops-button ops-button-secondary" data-case-note="${esc(row.id)}">Add note</button>
+      </div>
+    </article>
+  `;
+}
+
+function renderConversation(row: OpsConversationThreadRecord): string {
+  return `
+    <article class="ops-conversation">
+      <p class="ops-kicker">${esc(row.roleMask)} · ${esc(row.senderIdentity)}</p>
+      <h4>${esc(row.summary)}</h4>
+      <p class="ops-meta">${row.unread ? "Unread" : "Read"} · last activity ${esc(formatTimestamp(row.latestMessageAt))}</p>
+    </article>
+  `;
+}
+
+function renderMemberCard(
+  row: OpsPortalSnapshot["members"][number],
+  options: {
+    canEditProfile?: boolean;
+    canEditMembership?: boolean;
+    canEditRole?: boolean;
+    canViewActivity?: boolean;
+  } = {},
+): string {
+  const actions = [
+    options.canViewActivity
+      ? `<button type="button" class="ops-button ops-button-secondary" data-member-activity="${esc(row.uid)}" data-member-name="${esc(row.displayName)}">Activity</button>`
+      : "",
+    options.canEditProfile
+      ? `<button type="button" class="ops-button ops-button-secondary" data-member-profile="${esc(row.uid)}" data-member-display-name="${esc(row.displayName)}" data-member-kiln-preferences="${esc(row.kilnPreferences || "")}" data-member-staff-notes="${esc(row.staffNotes || "")}">Profile</button>`
+      : "",
+    options.canEditMembership
+      ? `<button type="button" class="ops-button ops-button-secondary" data-member-membership="${esc(row.uid)}" data-member-membership-tier="${esc(row.membershipTier || "")}" data-member-name="${esc(row.displayName)}">Membership</button>`
+      : "",
+    options.canEditRole
+      ? `<button type="button" class="ops-button ops-button-secondary" data-member-role="${esc(row.uid)}" data-member-roles="${esc(row.opsRoles.join(", "))}" data-member-name="${esc(row.displayName)}">Roles</button>`
+      : "",
+  ].filter(Boolean);
+  return `
+    <article class="ops-case ops-tone-neutral">
+      <p class="ops-kicker">${esc(row.portalRole)} · ${esc(row.opsRoles.join(", ") || "no ops roles")}</p>
+      <h3>${esc(row.displayName)}</h3>
+      <p class="ops-summary">${esc(row.email || "No email on file.")}</p>
+      <dl class="ops-meta-grid">
+        <div><dt>Membership</dt><dd>${esc(row.membershipTier || "none")}</dd></div>
+        <div><dt>Last seen</dt><dd>${esc(formatTimestamp(row.lastSeenAt))}</dd></div>
+        <div class="ops-span-2"><dt>Capabilities</dt><dd>${esc(row.opsCapabilities.join(", ") || "No explicit ops capabilities.")}</dd></div>
+        <div><dt>Updated</dt><dd>${esc(formatTimestamp(row.updatedAt))}</dd></div>
+      </dl>
+      ${actions.length ? `<div class="ops-actions">${actions.join("")}</div>` : ""}
+    </article>
+  `;
+}
+
+function renderReservationCard(
+  row: OpsPortalSnapshot["reservations"][number],
+  options: {
+    canPrepareReservations?: boolean;
+  } = {},
+): string {
+  return `
+    <article class="ops-case ops-tone-${esc(statusTone(row.arrival.status === "arrived" ? "active" : row.degradeReason ? "warning" : "healthy"))}">
+      <p class="ops-kicker">${esc(row.status)} · ${esc(row.firingType)} · ${esc(row.arrival.status)}</p>
+      <h3>${esc(row.title)}</h3>
+      <p class="ops-summary">${esc(row.arrival.summary)}</p>
+      <dl class="ops-meta-grid">
+        <div><dt>Due</dt><dd>${esc(formatTimestamp(row.dueAt))}</dd></div>
+        <div><dt>Items</dt><dd>${esc(String(row.itemCount))}</dd></div>
+        <div><dt>Verification</dt><dd>${esc(row.verificationClass)}</dd></div>
+        <div class="ops-span-2"><dt>Prep</dt><dd>${esc(row.prep.summary)}</dd></div>
+      </dl>
+      ${options.canPrepareReservations ? `
+        <div class="ops-actions">
+          <button type="button" class="ops-button ops-button-secondary" data-reservation-prepare="${esc(row.reservationId)}" data-reservation-title="${esc(row.title)}">Stage prep task</button>
+        </div>
+      ` : ""}
+    </article>
+  `;
+}
+
+function renderEventCard(row: OpsPortalSnapshot["events"][number]): string {
+  return `
+    <article class="ops-case ops-tone-${esc(statusTone(row.status === "published" ? "healthy" : row.status === "review_required" ? "warning" : "neutral"))}">
+      <p class="ops-kicker">${esc(row.status)} · ${esc(row.location || "Location pending")}</p>
+      <h3>${esc(row.title)}</h3>
+      <p class="ops-summary">${esc(row.lastStatusReason || "Program tracking is stable.")}</p>
+      <dl class="ops-meta-grid">
+        <div><dt>Starts</dt><dd>${esc(formatTimestamp(row.startAt))}</dd></div>
+        <div><dt>Seats</dt><dd>${esc(`${row.remainingCapacity ?? 0}/${row.capacity ?? 0}`)}</dd></div>
+      </dl>
+    </article>
+  `;
+}
+
+function renderReportCard(row: OpsPortalSnapshot["reports"][number]): string {
+  return `
+    <article class="ops-case ops-tone-${esc(statusTone(row.severity === "high" ? "critical" : row.status === "open" ? "warning" : "healthy"))}">
+      <p class="ops-kicker">${esc(row.severity)} severity · ${esc(row.status)}</p>
+      <h3>${esc(row.summary)}</h3>
+      <p class="ops-meta">Opened ${esc(formatTimestamp(row.createdAt))}</p>
+    </article>
+  `;
+}
+
+function renderLendingCard(model: OpsPortalSnapshot["lending"]): string {
+  if (!model) {
+    return '<div class="ops-empty">Lending data is unavailable right now.</div>';
+  }
+  return `
+    <div class="ops-sequence-grid">
+      ${renderSequenceStep(`Open requests: ${model.requests.length}`)}
+      ${renderSequenceStep(`Active loans: ${model.loans.length}`)}
+      ${renderSequenceStep(`Recommendations: ${model.recommendationCount}`)}
+      ${renderSequenceStep(`Tag queue: ${model.tagSubmissionCount}`)}
+      ${renderSequenceStep(`Cover review: ${model.coverReviewCount}`)}
+    </div>
+  `;
+}
+
+function renderExperiment(row: GrowthExperiment | ImprovementCase, lane: "ceo" | "forge"): string {
+  const status = "status" in row ? row.status : "open";
+  const title = "title" in row ? row.title : "Untitled";
+  const summary = "summary" in row ? row.summary : "";
+  const body = lane === "ceo"
+    ? esc((row as GrowthExperiment).hypothesis || summary)
+    : esc((row as ImprovementCase).problem || summary);
+  return `
+    <article class="ops-case ops-tone-${esc(statusTone(status))}">
+      <p class="ops-kicker">${esc(lane)} strategy</p>
+      <h3>${esc(title)}</h3>
+      <p class="ops-summary">${body}</p>
+      <p class="ops-meta">Status: ${esc(status)}</p>
+    </article>
+  `;
+}
+
+function renderWatchdogs(rows: OpsWatchdog[]): string {
+  return rows
+    .map(
+      (row) => `
+      <article class="ops-watchdog ops-tone-${esc(statusTone(row.status))}">
+        <h4>${esc(row.label)}</h4>
+        <p>${esc(row.summary)}</p>
+        <p class="ops-meta"><strong>Next:</strong> ${esc(row.recommendation)}</p>
+      </article>`,
+    )
+    .join("");
+}
+
+function renderModeTabs(surface: string, entries: Array<{ id: string; label: string; meta?: string | number }>): string {
+  return `
+    <nav class="ops-mode-nav" data-mode-nav="${esc(surface)}">
+      ${entries.map((entry) => `
+        <button type="button" class="ops-mode-tab" data-surface-mode-tab="${esc(surface)}" data-mode-tab="${esc(entry.id)}">
+          <span>${esc(entry.label)}</span>
+          ${entry.meta === undefined ? "" : `<strong>${esc(entry.meta)}</strong>`}
+        </button>
+      `).join("")}
+    </nav>
+  `;
+}
+
+function renderModePanel(surface: string, mode: string, body: string): string {
+  return `<div class="ops-mode-panel" data-surface-mode-panel="${esc(surface)}" data-mode="${esc(mode)}">${body}</div>`;
+}
+
+function renderStationContext(displayState: StationDisplayState | null): string {
+  if (!displayState?.station) {
+    return `<div class="ops-empty">No active station heartbeat is visible for this surface right now.</div>`;
+  }
+  const station = displayState.station;
+  return `
+    <article class="ops-station-card">
+      <p class="ops-kicker">Station heartbeat</p>
+      <h3>${esc(station.stationId)}</h3>
+      <dl class="ops-meta-grid">
+        <div><dt>Room</dt><dd>${esc(station.roomId)}</dd></div>
+        <div><dt>Mode</dt><dd>${esc(station.surfaceMode)}</dd></div>
+        <div><dt>Actor</dt><dd>${esc(station.actorId || "unclaimed")}</dd></div>
+        <div><dt>Last seen</dt><dd>${esc(formatTimestamp(station.lastSeenAt))}</dd></div>
+        <div class="ops-span-2"><dt>Capabilities</dt><dd>${esc(station.capabilities.join(", ") || "No capabilities advertised.")}</dd></div>
+      </dl>
+    </article>
+  `;
+}
+
+function renderHandsFocus(displayState: StationDisplayState | null, fallbackTask: HumanTaskRecord | null = null): string {
+  const task = displayState?.focusTask ?? fallbackTask;
+  if (!task) {
+    return `<div class="ops-empty">No focus task is currently pinned to this station.</div>`;
+  }
+  return renderTask(task);
+}
+
+function isActiveTask(task: HumanTaskRecord): boolean {
+  return task.status !== "verified" && task.status !== "canceled";
+}
+
+function renderMeter(value: number, tone: string, label: string): string {
+  const clamped = Math.max(0, Math.min(100, Math.round(value)));
+  return `
+    <div class="ops-meter">
+      <div class="ops-meter__track">
+        <div class="ops-meter__fill ops-meter__fill-${esc(tone)}" style="width:${clamped}%"></div>
+      </div>
+      <span>${esc(label)}</span>
+    </div>
+  `;
+}
+
+function renderPulseZone(zone: OpsTwinZone): string {
+  const tone = statusTone(zone.status);
+  return `
+    <article class="ops-pulse-card ops-tone-${esc(tone)}">
+      <div class="ops-pulse-card__head">
+        <div>
+          <p class="ops-kicker">Studio system</p>
+          <h3>${esc(zone.label)}</h3>
+        </div>
+        <span class="ops-pill ops-pill-${esc(tone)}">${esc(zone.status)}</span>
+      </div>
+      <p class="ops-summary">${esc(zone.summary)}</p>
+      ${renderMeter(zone.evidence.confidence * 100, tone, `${formatConfidence(zone.evidence.confidence)} confidence`)}
+      <dl class="ops-inline-meta">
+        <div><dt>Verification</dt><dd>${esc(zone.evidence.verificationClass)}</dd></div>
+        <div><dt>Freshest</dt><dd>${esc(formatTimestamp(zone.evidence.freshestAt))}</dd></div>
+      </dl>
+      <p class="ops-pulse-card__next"><strong>Next:</strong> ${esc(zone.nextAction || "No explicit next action queued.")}</p>
+    </article>
+  `;
+}
+
+function renderSignalCard(input: { kicker: string; title: string; value: string; summary: string; tone: string; meter: number; meterLabel: string }): string {
+  return `
+    <article class="ops-signal-card ops-tone-${esc(input.tone)}">
+      <div class="ops-signal-card__top">
+        <div>
+          <p class="ops-kicker">${esc(input.kicker)}</p>
+          <strong>${esc(input.value)}</strong>
+        </div>
+        <span class="ops-signal-card__title">${esc(input.title)}</span>
+      </div>
+      ${renderMeter(input.meter, input.tone, input.meterLabel)}
+      <p class="ops-summary">${esc(input.summary)}</p>
+    </article>
+  `;
+}
+
+function renderTaskSpotlight(task: HumanTaskRecord | null, label: string): string {
+  if (!task) {
+    return `
+      <article class="ops-spotlight-card">
+        <p class="ops-kicker">${esc(label)}</p>
+        <h3>No active task</h3>
+        <p class="ops-summary">This lane is currently quiet.</p>
+      </article>
+    `;
+  }
+  const tone = statusTone(task.status);
+  const countdownMinutes = task.dueAt ? minutesUntil(task.dueAt) : (task.etaMinutes ?? null);
+  return `
+    <article class="ops-spotlight-card ops-tone-${esc(tone)}" data-task-id="${esc(task.id)}">
+      <div class="ops-zone__head">
+        <div>
+          <p class="ops-kicker">${esc(label)} · ${esc(task.role)} · ${esc(task.zone)}</p>
+          <h3>${esc(task.title)}</h3>
+        </div>
+        <span class="ops-pill ops-pill-${esc(tone)}">${esc(task.status)}</span>
+      </div>
+      <p class="ops-summary">${esc(task.whyNow)}</p>
+      <div class="ops-spotlight-signal-row">
+        <div class="ops-spotlight-orb" style="--countdown-color:${toneGaugeColor(tone)};--countdown-progress:${Math.round((countdownPercent(countdownMinutes, 180) / 100) * 360)}deg;">
+          <div class="ops-spotlight-orb__ring"></div>
+          <div class="ops-spotlight-orb__core">
+            <strong>${esc(formatCountdown(countdownMinutes))}</strong>
+            <span>${countdownMinutes !== null && countdownMinutes <= 0 ? "late" : "window"}</span>
+          </div>
+        </div>
+        <div class="ops-relay ops-relay-compact">
+          <div class="ops-relay__stage ops-relay__stage-done">
+            <span class="ops-relay__node"></span>
+            <span class="ops-relay__label">manager</span>
+          </div>
+          <div class="ops-relay__stage ${task.status === "claimed" || task.status === "in_progress" ? "ops-relay__stage-active" : task.status === "proof_pending" || task.status === "verified" ? "ops-relay__stage-done" : "ops-relay__stage-queued"}">
+            <span class="ops-relay__node"></span>
+            <span class="ops-relay__label">${esc(task.surface === "internet" ? "reply" : "hands")}</span>
+          </div>
+          <div class="ops-relay__stage ${task.status === "proof_pending" ? "ops-relay__stage-active" : task.status === "verified" ? "ops-relay__stage-done" : "ops-relay__stage-queued"}">
+            <span class="ops-relay__node"></span>
+            <span class="ops-relay__label">verify</span>
+          </div>
+        </div>
+      </div>
+      ${renderMeter(task.confidence * 100, tone, `${formatConfidence(task.confidence)} confidence`)}
+      <dl class="ops-inline-meta">
+        <div><dt>Due</dt><dd>${esc(formatTimestamp(task.dueAt))}</dd></div>
+        <div><dt>ETA</dt><dd>${esc(task.etaMinutes ? `${task.etaMinutes} min` : "unknown")}</dd></div>
+      </dl>
+      <p class="ops-meta"><strong>Why it matters:</strong> ${esc(task.consequenceIfDelayed)}</p>
+      <div class="ops-actions">
+        <button type="button" class="ops-button" data-task-claim="${esc(task.id)}">Claim</button>
+        <button type="button" class="ops-button ops-button-secondary" data-task-proof="${esc(task.id)}" data-task-proof-mode="${esc(task.preferredProofMode)}">Proof</button>
+      </div>
+    </article>
+  `;
+}
+
+function renderApprovalSpotlight(row: ApprovalItem | null): string {
+  if (!row) {
+    return `
+      <article class="ops-spotlight-card">
+        <p class="ops-kicker">Owner gate</p>
+        <h3>No pending approvals</h3>
+        <p class="ops-summary">The manager is not currently blocked on explicit owner agency.</p>
+      </article>
+    `;
+  }
+  const tone = statusTone(row.status);
+  return `
+    <article class="ops-spotlight-card ops-tone-${esc(tone)}">
+      <div class="ops-zone__head">
+        <div>
+          <p class="ops-kicker">Owner gate · ${esc(row.actionClass)}</p>
+          <h3>${esc(row.title)}</h3>
+        </div>
+        <span class="ops-pill ops-pill-${esc(tone)}">${esc(row.status)}</span>
+      </div>
+      <p class="ops-summary">${esc(row.summary)}</p>
+      <div class="ops-spotlight-signal-row">
+        <div class="ops-spotlight-orb" style="--countdown-color:${toneGaugeColor(tone)};--countdown-progress:${Math.round((countdownPercent(minutesUntil(row.freshestAt), 180) / 100) * 360)}deg;">
+          <div class="ops-spotlight-orb__ring"></div>
+          <div class="ops-spotlight-orb__core">
+            <strong>${esc(formatCountdown(minutesUntil(row.freshestAt)))}</strong>
+            <span>aging</span>
+          </div>
+        </div>
+        <div class="ops-relay ops-relay-compact">
+          <div class="ops-relay__stage ops-relay__stage-done">
+            <span class="ops-relay__node"></span>
+            <span class="ops-relay__label">manager</span>
+          </div>
+          <div class="ops-relay__stage ${row.status === "pending" ? "ops-relay__stage-active" : "ops-relay__stage-done"}">
+            <span class="ops-relay__node"></span>
+            <span class="ops-relay__label">owner</span>
+          </div>
+          <div class="ops-relay__stage ${row.status === "approved" || row.status === "executed" ? "ops-relay__stage-done" : "ops-relay__stage-queued"}">
+            <span class="ops-relay__node"></span>
+            <span class="ops-relay__label">release</span>
+          </div>
+        </div>
+      </div>
+      ${renderMeter(row.confidence * 100, tone, `${formatConfidence(row.confidence)} confidence`)}
+      <p class="ops-meta"><strong>Recommendation:</strong> ${esc(row.recommendation)}</p>
+      <div class="ops-actions">
+        <button type="button" class="ops-button" data-approval-resolve="${esc(row.id)}" data-approval-status="approved">Approve</button>
+        <button type="button" class="ops-button ops-button-secondary" data-approval-resolve="${esc(row.id)}" data-approval-status="rejected">Reject</button>
+      </div>
+    </article>
+  `;
+}
+
+function renderSequenceStep(entry: string, index = 0): string {
+  return `
+    <article class="ops-sequence-step">
+      <span class="ops-sequence-step__index">${index + 1}</span>
+      <p>${esc(entry)}</p>
+    </article>
+  `;
+}
+
+function renderIncidentChip(input: { label: string; text: string; tone: string }): string {
+  return `
+    <article class="ops-incident-chip ops-tone-${esc(input.tone)}">
+      <span class="ops-incident-chip__label">${esc(input.label)}</span>
+      <p>${esc(input.text)}</p>
+    </article>
+  `;
+}
+
+function toneGaugeColor(tone: string): string {
+  if (tone === "good") return "var(--good)";
+  if (tone === "warn") return "var(--warn)";
+  if (tone === "danger") return "var(--danger)";
+  return "var(--neutral)";
+}
+
+function renderCountdownOrb(input: { label: string; title: string; summary: string; minutes: number | null; tone: string; horizonMinutes?: number }): string {
+  const percent = countdownPercent(input.minutes, input.horizonMinutes ?? 180);
+  const progressAngle = `${Math.round((percent / 100) * 360)}deg`;
+  return `
+    <article class="ops-countdown-card ops-tone-${esc(input.tone)}" style="--countdown-color:${toneGaugeColor(input.tone)};--countdown-progress:${progressAngle};">
+      <div class="ops-countdown-card__dial" aria-hidden="true">
+        <div class="ops-countdown-card__ring"></div>
+        <div class="ops-countdown-card__core">
+          <strong>${esc(formatCountdown(input.minutes))}</strong>
+          <span>${input.minutes !== null && input.minutes <= 0 ? "late" : "window"}</span>
+        </div>
+      </div>
+      <div class="ops-countdown-card__copy">
+        <p class="ops-kicker">${esc(input.label)}</p>
+        <h3>${esc(input.title)}</h3>
+        <p class="ops-summary">${esc(input.summary)}</p>
+      </div>
+    </article>
+  `;
+}
+
+function renderGaugeCard(input: { label: string; title: string; value: string; summary: string; tone: string; percent: number; meterLabel: string }): string {
+  const clamped = Math.max(0, Math.min(100, Math.round(input.percent)));
+  const progressAngle = `${Math.round((clamped / 100) * 240)}deg`;
+  const needleAngle = `${-120 + (clamped / 100) * 240}deg`;
+  return `
+    <article class="ops-gauge-card ops-tone-${esc(input.tone)}" style="--gauge-color:${toneGaugeColor(input.tone)};--gauge-progress:${progressAngle};--gauge-needle:${needleAngle};">
+      <div class="ops-gauge-card__row">
+        <div class="ops-gauge" aria-hidden="true">
+          <div class="ops-gauge__ring"></div>
+          <div class="ops-gauge__needle"></div>
+          <div class="ops-gauge__hub"></div>
+          <div class="ops-gauge__readout">${esc(input.value)}</div>
+        </div>
+        <div class="ops-gauge-card__copy">
+          <p class="ops-kicker">${esc(input.label)}</p>
+          <h3>${esc(input.title)}</h3>
+          <p class="ops-summary">${esc(input.summary)}</p>
+        </div>
+      </div>
+      ${renderMeter(clamped, input.tone, input.meterLabel)}
+    </article>
+  `;
+}
+
+function renderTickerItem(input: { label: string; text: string; tone: string }): string {
+  return `
+    <article class="ops-ticker-item ops-tone-${esc(input.tone)}">
+      <span class="ops-ticker-item__label">${esc(input.label)}</span>
+      <span class="ops-ticker-item__text">${esc(input.text)}</span>
+    </article>
+  `;
+}
+
+function renderFreshnessRibbon(source: OpsSourceFreshness): string {
+  const tone = statusTone(source.status);
+  const percent = freshnessPercent(source.freshnessSeconds, source.budgetSeconds);
+  const freshnessLabel = source.freshnessSeconds === null
+    ? "freshness unknown"
+    : `${Math.max(0, Math.round((source.budgetSeconds - source.freshnessSeconds) / 60))}m until stale`;
+  return `
+    <article class="ops-source-ribbon ops-tone-${esc(tone)}">
+      <div class="ops-source-ribbon__head">
+        <span>${esc(source.label)}</span>
+        <strong>${esc(freshnessLabel)}</strong>
+      </div>
+      <div class="ops-source-ribbon__track">
+        <div class="ops-source-ribbon__fill ops-source-ribbon__fill-${esc(tone)}" style="width:${Math.max(8, percent)}%"></div>
+      </div>
+      <p class="ops-meta">${esc(source.reason || `Latest signal ${formatTimestamp(source.freshestAt)}`)}</p>
+    </article>
+  `;
+}
+
+function renderRelayCard(input: { label: string; title: string; summary: string; tone: string; stages: Array<{ label: string; state: "done" | "active" | "queued" }> }): string {
+  return `
+    <article class="ops-flow-card ops-tone-${esc(input.tone)}">
+      <p class="ops-kicker">${esc(input.label)}</p>
+      <h3>${esc(input.title)}</h3>
+      <p class="ops-summary">${esc(input.summary)}</p>
+      <div class="ops-relay">
+        ${input.stages.map((stage) => `
+          <div class="ops-relay__stage ops-relay__stage-${esc(stage.state)}">
+            <span class="ops-relay__node"></span>
+            <span class="ops-relay__label">${esc(stage.label)}</span>
+          </div>
+        `).join("")}
+      </div>
+    </article>
+  `;
+}
+
+function renderTaskRelayCard(task: HumanTaskRecord | null, label: string): string {
+  if (!task) {
+    return renderRelayCard({
+      label,
+      title: "No active relay",
+      summary: "This lane is quiet, so no human handoff is flowing right now.",
+      tone: "good",
+      stages: [
+        { label: "manager", state: "done" },
+        { label: "waiting", state: "active" },
+        { label: "verify", state: "queued" },
+      ],
+    });
+  }
+  const tone = statusTone(task.status);
+  const claimState = task.status === "queued" || task.status === "proposed" ? "queued" : "done";
+  const actionState = task.status === "claimed" || task.status === "in_progress" ? "active" : task.status === "proof_pending" || task.status === "verified" ? "done" : "queued";
+  const verifyState = task.status === "proof_pending" ? "active" : task.status === "verified" ? "done" : "queued";
+  return renderRelayCard({
+    label,
+    title: task.title,
+    summary: task.claimedBy ? `Claimed by ${task.claimedBy}.` : task.whyNow,
+    tone,
+    stages: [
+      { label: "manager", state: "done" },
+      { label: task.surface === "internet" ? "reply" : "hands", state: actionState === "active" ? "active" : claimState },
+      { label: "verify", state: verifyState },
+    ],
+  });
+}
+
+function renderApprovalRelayCard(row: ApprovalItem | null): string {
+  if (!row) {
+    return renderRelayCard({
+      label: "Owner gate",
+      title: "Approval lane clear",
+      summary: "Nothing is waiting on explicit owner agency right now.",
+      tone: "good",
+      stages: [
+        { label: "manager", state: "done" },
+        { label: "owner", state: "queued" },
+        { label: "release", state: "queued" },
+      ],
+    });
+  }
+  const tone = statusTone(row.status);
+  const ownerState = row.status === "pending" ? "active" : "done";
+  const releaseState = row.status === "approved" || row.status === "executed" ? "done" : row.status === "rejected" ? "done" : "queued";
+  return renderRelayCard({
+    label: "Owner gate",
+    title: row.title,
+    summary: row.recommendation,
+    tone,
+    stages: [
+      { label: "manager", state: "done" },
+      { label: "owner", state: ownerState },
+      { label: "release", state: releaseState },
+    ],
+  });
+}
+
+function renderMapZone(zone: OpsTwinZone, index: number): string {
+  const tone = statusTone(zone.status);
+  const sourceSignals = zone.evidence.sources.length
+    ? zone.evidence.sources.slice(0, 4).map((source) => {
+        const freshness = source.freshnessMs === null ? null : Math.round(source.freshnessMs / 1000);
+        const freshnessTone = freshness === null ? "neutral" : freshness <= 300 ? "good" : freshness <= 1800 ? "warn" : "danger";
+        return `
+          <span class="ops-zone-ribbon__segment ops-zone-ribbon__segment-${esc(freshnessTone)}" title="${esc(source.label)} · ${esc(source.system)}"></span>
+        `;
+      }).join("")
+    : `<span class="ops-zone-ribbon__segment ops-zone-ribbon__segment-${esc(tone)}"></span>`;
+  return `
+    <article class="ops-map-zone ops-map-zone-${index % 4} ops-tone-${esc(tone)}">
+      <div class="ops-map-zone__head">
+        <div>
+          <p class="ops-kicker">Studio system</p>
+          <h3>${esc(zone.label)}</h3>
+        </div>
+        <span class="ops-map-zone__sentinel ops-map-zone__sentinel-${esc(tone)}" title="${esc(zone.evidence.verificationClass)} · ${esc(formatConfidence(zone.evidence.confidence))}">
+          <span class="ops-map-zone__status ops-map-zone__status-${esc(tone)}"></span>
+        </span>
+      </div>
+      <p class="ops-summary">${esc(zone.summary)}</p>
+      ${renderMeter(zone.evidence.confidence * 100, tone, `${formatConfidence(zone.evidence.confidence)} confidence`)}
+      <div class="ops-zone-ribbon" aria-hidden="true">${sourceSignals}</div>
+      <p class="ops-meta"><strong>${esc(zone.evidence.verificationClass)}</strong> · freshest ${esc(formatTimestamp(zone.evidence.freshestAt))}</p>
+      <p class="ops-map-zone__next"><strong>Next:</strong> ${esc(zone.nextAction || "No explicit next action queued.")}</p>
+    </article>
+  `;
+}
+
+function renderTimelineEntry(input: {
+  time: string | null;
+  lane: string;
+  title: string;
+  summary: string;
+  tone: string;
+}): string {
+  const minutes = minutesUntil(input.time);
+  return `
+    <article class="ops-timeline-entry ops-tone-${esc(input.tone)}">
+      <div class="ops-timeline-entry__time">${esc(formatTimestamp(input.time))}</div>
+      <div class="ops-timeline-entry__body">
+        <div class="ops-timeline-entry__head">
+          <p class="ops-kicker">${esc(input.lane)}</p>
+          <span class="ops-timeline-entry__countdown ops-timeline-entry__countdown-${esc(input.tone)}">${esc(formatCountdown(minutes))}</span>
+        </div>
+        <h4>${esc(input.title)}</h4>
+        <p>${esc(input.summary)}</p>
+        <div class="ops-conveyor ops-conveyor-${esc(input.tone)}" aria-hidden="true">
+          <span></span><span></span><span></span>
+        </div>
+      </div>
+    </article>
+  `;
+}
+
+function renderSurfaceShell(model: OpsPortalSnapshot, displayState: StationDisplayState | null): string {
+  const surfaceTabs = model.session?.allowedSurfaces?.length
+    ? model.session.allowedSurfaces
+    : ["manager", "owner", "hands", "internet", "ceo", "forge"];
+  const sessionCapabilities = model.session?.opsCapabilities ?? [];
+  const canEditMemberProfile = sessionCapabilities.includes("members:edit_profile");
+  const canEditMembership = sessionCapabilities.includes("members:edit_membership");
+  const canEditRole = sessionCapabilities.includes("members:edit_role");
+  const canViewMembers = sessionCapabilities.includes("members:view");
+  const canPrepareReservations = sessionCapabilities.includes("reservations:prepare");
+  const canRequestOverrides = sessionCapabilities.includes("overrides:request");
+  const activeManagerTasks = model.tasks.filter((entry) => (entry.surface === "manager" || entry.surface === "owner") && isActiveTask(entry));
+  const managerTasks = activeManagerTasks.slice(0, 4);
+  const activeHandsTasks = model.tasks.filter((entry) => entry.surface === "hands" && isActiveTask(entry));
+  const handsTasks = model.tasks.filter((entry) => entry.surface === "hands").slice(0, 8);
+  const activeInternetTasks = model.tasks.filter((entry) => entry.surface === "internet" && isActiveTask(entry));
+  const internetTasks = model.tasks.filter((entry) => entry.surface === "internet").slice(0, 8);
+  const handsCases = model.cases.filter((entry) => entry.lane === "hands" || entry.kind === "kiln_run" || entry.kind === "arrival").slice(0, 4);
+  const internetCases = model.cases.filter((entry) => entry.lane === "internet" || entry.kind === "support_thread" || entry.kind === "event" || entry.kind === "complaint").slice(0, 4);
+  const reservationBundles = model.reservations.slice(0, 8);
+  const eventRows = model.events.slice(0, 8);
+  const reportRows = model.reports.slice(0, 8);
+  const memberRows = model.members.slice(0, 12);
+  const memberCards = memberRows.map((row) => renderMemberCard(row, {
+    canEditProfile: canEditMemberProfile,
+    canEditMembership,
+    canEditRole,
+    canViewActivity: canViewMembers,
+  })).join("");
+  const reservationCards = reservationBundles.map((row) => renderReservationCard(row, {
+    canPrepareReservations,
+  })).join("");
+  const overrideCards = model.overrides.map((entry) => renderCase({
+    id: entry.id,
+    kind: "general",
+    title: entry.scope,
+    summary: entry.reason,
+    status: entry.status === "active" ? "active" : entry.status === "pending" ? "awaiting_approval" : "resolved",
+    priority: "p2",
+    lane: "manager",
+    ownerRole: entry.requiredRole,
+    verificationClass: "claimed",
+    freshestAt: entry.createdAt,
+    sources: [],
+    confidence: 0.55,
+    degradeReason: "Manual override in play.",
+    dueAt: entry.expiresAt,
+    linkedEntityKind: null,
+    linkedEntityId: null,
+    memoryScope: null,
+    createdAt: entry.createdAt || model.generatedAt,
+    updatedAt: entry.createdAt || model.generatedAt,
+    metadata: {},
+  })).join("");
+  const ceoCards = model.ceo.map((entry) => renderExperiment(entry, "ceo")).join("");
+  const forgeCards = model.forge.map((entry) => renderExperiment(entry, "forge")).join("");
+  const pendingApprovals = model.approvals.filter((entry) => entry.status === "pending");
+  const unreadConversations = model.conversations.filter((entry) => entry.unread).length;
+  const fastestSource = [...model.truth.sources]
+    .filter((entry) => entry.budgetSeconds > 0)
+    .sort((left, right) => {
+      const leftRemaining = (left.budgetSeconds - (left.freshnessSeconds ?? left.budgetSeconds));
+      const rightRemaining = (right.budgetSeconds - (right.freshnessSeconds ?? right.budgetSeconds));
+      return leftRemaining - rightRemaining;
+    })[0] ?? null;
+  const gaugeCards = [
+    renderGaugeCard({
+      label: "Studio risk",
+      title: "Pressure",
+      value: model.twin.currentRisk ? "82%" : "24%",
+      summary: model.twin.currentRisk || "No issue is dominating the studio right now.",
+      tone: statusTone(model.twin.currentRisk ? "critical" : "healthy"),
+      percent: model.twin.currentRisk ? 82 : 24,
+      meterLabel: model.twin.currentRisk ? "risk elevated" : "risk contained",
+    }),
+    renderGaugeCard({
+      label: "Hands lane",
+      title: "Load",
+      value: `${activeHandsTasks.length}`,
+      summary: activeHandsTasks[0]?.title || "No physical task is currently queued for human hands.",
+      tone: statusTone(activeHandsTasks.length > 0 ? "warning" : "healthy"),
+      percent: Math.min(100, Math.max(12, activeHandsTasks.length * 24)),
+      meterLabel: `${activeHandsTasks.length} active task${activeHandsTasks.length === 1 ? "" : "s"}`,
+    }),
+    renderGaugeCard({
+      label: "Internet lane",
+      title: "Traffic",
+      value: `${Math.max(activeInternetTasks.length, unreadConversations)}`,
+      summary:
+        activeInternetTasks[0]?.title
+        || (unreadConversations > 0 ? `${unreadConversations} unread conversation${unreadConversations === 1 ? "" : "s"} need eyes.` : "No urgent internet thread is visible right now."),
+      tone: statusTone(activeInternetTasks.length > 0 || unreadConversations > 0 ? "warning" : "healthy"),
+      percent: Math.min(100, Math.max(10, Math.max(activeInternetTasks.length, unreadConversations) * 28)),
+      meterLabel: `${activeInternetTasks.length} active thread task${activeInternetTasks.length === 1 ? "" : "s"}`,
+    }),
+    renderGaugeCard({
+      label: "Owner gates",
+      title: "Approval",
+      value: `${pendingApprovals.length}`,
+      summary: pendingApprovals[0]?.title || "No explicit owner approval is currently blocking the manager.",
+      tone: statusTone(pendingApprovals.length > 0 ? "pending" : "approved"),
+      percent: pendingApprovals.length > 0 ? Math.min(100, pendingApprovals.length * 36) : 8,
+      meterLabel: pendingApprovals.length > 0 ? "human decision required" : "clear",
+    }),
+    renderGaugeCard({
+      label: "Truth posture",
+      title: "Readiness",
+      value: model.truth.readiness,
+      summary: model.truth.summary,
+      tone: statusTone(model.truth.readiness),
+      percent: model.truth.readiness === "ready" ? 92 : model.truth.readiness === "degraded" ? 56 : 22,
+      meterLabel: `${model.truth.degradeModes.length} degrade mode${model.truth.degradeModes.length === 1 ? "" : "s"}`,
+    }),
+  ];
+  const incidentItems = [
+    model.twin.currentRisk
+      ? renderIncidentChip({
+          label: "Studio risk",
+          text: model.twin.currentRisk,
+          tone: statusTone("critical"),
+        })
+      : "",
+    activeHandsTasks[0]
+      ? renderIncidentChip({
+          label: "Hands",
+          text: activeHandsTasks[0].title,
+          tone: statusTone(activeHandsTasks[0].status),
+        })
+      : "",
+    activeInternetTasks[0]
+      ? renderIncidentChip({
+          label: "Internet",
+          text: activeInternetTasks[0].title,
+          tone: statusTone(activeInternetTasks[0].status),
+        })
+      : "",
+    pendingApprovals[0]
+      ? renderIncidentChip({
+          label: "Approval",
+          text: pendingApprovals[0].title,
+          tone: statusTone(pendingApprovals[0].status),
+        })
+      : "",
+    model.truth.watchdogs.find((entry) => entry.status !== "healthy")
+      ? renderIncidentChip({
+          label: "Watchdog",
+          text: model.truth.watchdogs.find((entry) => entry.status !== "healthy")?.summary || "",
+          tone: statusTone(model.truth.watchdogs.find((entry) => entry.status !== "healthy")?.status || "warning"),
+        })
+      : "",
+  ].filter(Boolean);
+  const tickerItems = [
+    model.twin.currentRisk
+      ? { label: "risk", text: model.twin.currentRisk, tone: statusTone("critical") }
+      : { label: "studio", text: "No top-level incident is dominating the floor right now.", tone: statusTone("healthy") },
+    activeHandsTasks[0]
+      ? { label: "hands", text: activeHandsTasks[0].title, tone: statusTone(activeHandsTasks[0].status) }
+      : { label: "hands", text: "No physical queue is currently active.", tone: statusTone("healthy") },
+    activeInternetTasks[0]
+      ? { label: "internet", text: activeInternetTasks[0].title, tone: statusTone(activeInternetTasks[0].status) }
+      : { label: "internet", text: "No urgent internet thread is visible right now.", tone: statusTone("healthy") },
+    pendingApprovals[0]
+      ? { label: "approval", text: pendingApprovals[0].title, tone: statusTone(pendingApprovals[0].status) }
+      : { label: "approval", text: "No explicit owner gate is blocking the manager.", tone: statusTone("approved") },
+    model.truth.watchdogs.find((entry) => entry.status !== "healthy")
+      ? {
+          label: "watchdog",
+          text: model.truth.watchdogs.find((entry) => entry.status !== "healthy")?.summary || "",
+          tone: statusTone(model.truth.watchdogs.find((entry) => entry.status !== "healthy")?.status || "warning"),
+        }
+      : { label: "truth", text: model.truth.summary, tone: statusTone(model.truth.readiness) },
+  ];
+  const timelineEntries = [
+    ...activeHandsTasks.slice(0, 3).map((entry) => ({
+      time: entry.dueAt ?? entry.freshestAt,
+      lane: "Hands",
+      title: entry.title,
+      summary: entry.whyNow,
+      tone: statusTone(entry.status),
+    })),
+    ...activeInternetTasks.slice(0, 2).map((entry) => ({
+      time: entry.dueAt ?? entry.freshestAt,
+      lane: "Internet",
+      title: entry.title,
+      summary: entry.whyNow,
+      tone: statusTone(entry.status),
+    })),
+    ...pendingApprovals.slice(0, 2).map((entry) => ({
+      time: entry.freshestAt,
+      lane: "Approval",
+      title: entry.title,
+      summary: entry.recommendation,
+      tone: statusTone(entry.status),
+    })),
+  ]
+    .sort((left, right) => String(left.time ?? "9999").localeCompare(String(right.time ?? "9999")))
+    .slice(0, 6);
+  const countdownItems = [
+    renderCountdownOrb({
+      label: "Hands window",
+      title: activeHandsTasks[0]?.title || "No physical deadline",
+      summary: activeHandsTasks[0]?.whyNow || "The hands lane is not carrying an urgent physical deadline right now.",
+      minutes: activeHandsTasks[0]?.dueAt ? minutesUntil(activeHandsTasks[0].dueAt) : (activeHandsTasks[0]?.etaMinutes ?? null),
+      tone: activeHandsTasks[0] ? statusTone(activeHandsTasks[0].status) : "good",
+      horizonMinutes: 240,
+    }),
+    renderCountdownOrb({
+      label: "Internet window",
+      title: activeInternetTasks[0]?.title || "No reply clock",
+      summary:
+        activeInternetTasks[0]?.whyNow
+        || (unreadConversations > 0 ? `${unreadConversations} unread conversation${unreadConversations === 1 ? "" : "s"} are visible.` : "The internet lane is not under immediate reply pressure."),
+      minutes: activeInternetTasks[0]?.dueAt ? minutesUntil(activeInternetTasks[0].dueAt) : (activeInternetTasks[0]?.etaMinutes ?? null),
+      tone: activeInternetTasks[0] ? statusTone(activeInternetTasks[0].status) : (unreadConversations > 0 ? "warn" : "good"),
+      horizonMinutes: 180,
+    }),
+    renderCountdownOrb({
+      label: "Truth window",
+      title: fastestSource?.label || "No freshness budget",
+      summary: fastestSource?.reason || "No source freshness budget is currently close to expiring.",
+      minutes: fastestSource?.freshnessSeconds === null ? null : Math.round((fastestSource.budgetSeconds - fastestSource.freshnessSeconds) / 60),
+      tone: fastestSource ? statusTone(fastestSource.status) : statusTone(model.truth.readiness),
+      horizonMinutes: Math.max(60, Math.round((fastestSource?.budgetSeconds ?? 3600) / 60)),
+    }),
+  ];
+  const relayItems = [
+    renderTaskRelayCard(activeHandsTasks[0] ?? null, "Hands relay"),
+    renderTaskRelayCard(activeInternetTasks[0] ?? null, "Internet relay"),
+    renderApprovalRelayCard(pendingApprovals[0] ?? null),
+  ];
+  const handsNowCountdowns = [
+    renderCountdownOrb({
+      label: "Current window",
+      title: activeHandsTasks[0]?.title || "No active physical window",
+      summary: activeHandsTasks[0]?.whyNow || "No physical deadline is pressing right now.",
+      minutes: activeHandsTasks[0]?.dueAt ? minutesUntil(activeHandsTasks[0].dueAt) : (activeHandsTasks[0]?.etaMinutes ?? null),
+      tone: activeHandsTasks[0] ? statusTone(activeHandsTasks[0].status) : "good",
+      horizonMinutes: 180,
+    }),
+    renderCountdownOrb({
+      label: "Truth freshness",
+      title: fastestSource?.label || "No live source budget",
+      summary: fastestSource?.reason || "No source budget is near expiry.",
+      minutes: fastestSource?.freshnessSeconds === null ? null : Math.round((fastestSource.budgetSeconds - fastestSource.freshnessSeconds) / 60),
+      tone: fastestSource ? statusTone(fastestSource.status) : statusTone(model.truth.readiness),
+      horizonMinutes: Math.max(60, Math.round((fastestSource?.budgetSeconds ?? 3600) / 60)),
+    }),
+  ];
+  const internetDeskCountdowns = [
+    renderCountdownOrb({
+      label: "Reply window",
+      title: activeInternetTasks[0]?.title || "No urgent reply clock",
+      summary: activeInternetTasks[0]?.whyNow || "No urgent internet task is pressing the queue right now.",
+      minutes: activeInternetTasks[0]?.dueAt ? minutesUntil(activeInternetTasks[0].dueAt) : (activeInternetTasks[0]?.etaMinutes ?? null),
+      tone: activeInternetTasks[0] ? statusTone(activeInternetTasks[0].status) : "good",
+      horizonMinutes: 180,
+    }),
+    renderCountdownOrb({
+      label: "Unread pressure",
+      title: unreadConversations > 0 ? `${unreadConversations} unread thread${unreadConversations === 1 ? "" : "s"}` : "Inbox is calm",
+      summary: unreadConversations > 0 ? "Unread conversations are waiting on clarity or action." : "No unread conversation is currently visible.",
+      minutes: unreadConversations > 0 ? unreadConversations * 12 : 0,
+      tone: unreadConversations > 0 ? "warn" : "good",
+      horizonMinutes: 120,
+    }),
+  ];
+  return `
+    <nav class="ops-surface-nav">
+      ${surfaceTabs.map((surface) => `<button type="button" class="ops-surface-tab" data-surface-tab="${esc(surface)}">${esc(surface)}</button>`).join("")}
+    </nav>
+
+    <section class="ops-surface" data-surface="manager">
+      <div class="ops-manager-canvas">
+        ${renderModeTabs("manager", [
+          { id: "overview", label: "Overview" },
+          { id: "live", label: "Live" },
+          { id: "truth", label: "Truth", meta: model.truth.sources.length },
+          { id: "operations", label: "Operations", meta: managerTasks.length },
+          { id: "commitments", label: "Commitments", meta: reservationBundles.length },
+          { id: "trust", label: "Trust", meta: reportRows.length },
+        ])}
+        ${renderModePanel("manager", "overview", `
+          <div class="ops-manager-canvas">
+            <div class="ops-panel">
+              <div class="ops-panel__head">
+                <div>
+                  <p class="ops-kicker">Studio manager</p>
+                  <h2>${esc(model.twin.headline)}</h2>
+                </div>
+                <span class="ops-pill ops-pill-${esc(statusTone(model.truth.readiness))}">${esc(model.truth.readiness)}</span>
+              </div>
+              <p class="ops-summary">${esc(model.twin.narrative)}</p>
+              <div class="ops-gauge-strip">${gaugeCards.join("")}</div>
+              <div class="ops-ticker-shell">
+                <div class="ops-ticker-track">
+                  ${[...tickerItems, ...tickerItems].map(renderTickerItem).join("")}
+                </div>
+              </div>
+              <div class="ops-incident-strip">${incidentItems.join("") || '<div class="ops-empty">No urgent incidents are firing right now.</div>'}</div>
+            </div>
+            <div class="ops-motion-grid">
+              <div class="ops-panel ops-motion-panel">
+                <div class="ops-panel__head">
+                  <div>
+                    <p class="ops-kicker">Critical windows</p>
+                    <h2>Countdowns and SLA pressure</h2>
+                  </div>
+                </div>
+                <div class="ops-countdown-grid">${countdownItems.join("")}</div>
+              </div>
+              <div class="ops-panel ops-motion-panel">
+                <div class="ops-panel__head">
+                  <div>
+                    <p class="ops-kicker">Flow relays</p>
+                    <h2>Who owns the next handoff</h2>
+                  </div>
+                </div>
+                <div class="ops-relay-stack">${relayItems.join("")}</div>
+              </div>
+              <div class="ops-panel ops-motion-panel">
+                <div class="ops-panel__head">
+                  <div>
+                    <p class="ops-kicker">Freshness field</p>
+                    <h2>Which signals are still live</h2>
+                  </div>
+                </div>
+                <div class="ops-ribbon-stack">
+                  ${model.truth.sources.slice(0, 4).map(renderFreshnessRibbon).join("") || '<div class="ops-empty">No source freshness signals are available.</div>'}
+                </div>
+              </div>
+            </div>
+            <div class="ops-command-grid">
+              ${renderTaskSpotlight(activeHandsTasks[0] ?? null, "Physical priority")}
+              ${renderTaskSpotlight(activeInternetTasks[0] ?? null, "Member priority")}
+              ${renderApprovalSpotlight(pendingApprovals[0] ?? null)}
+            </div>
+          </div>
+        `)}
+        ${renderModePanel("manager", "live", `
+          <div class="ops-manager-canvas">
+            <div class="ops-scan-grid">
+              <div class="ops-panel">
+                <div class="ops-panel__head">
+                  <div>
+                    <p class="ops-kicker">Studio map</p>
+                    <h2>Where the pressure is living</h2>
+                  </div>
+                </div>
+                <div class="ops-studio-map">${model.twin.zones.map(renderMapZone).join("")}</div>
+              </div>
+              <div class="ops-panel">
+                <div class="ops-panel__head">
+                  <div>
+                    <p class="ops-kicker">Time lane</p>
+                    <h2>What lands next</h2>
+                  </div>
+                </div>
+                <div class="ops-timeline">${timelineEntries.map(renderTimelineEntry).join("") || '<div class="ops-empty">No scheduled events are visible right now.</div>'}</div>
+              </div>
+            </div>
+          </div>
+        `)}
+        ${renderModePanel("manager", "operations", `
+          <div class="ops-manager-canvas">
+            <div class="ops-panel">
+              <div class="ops-panel__head">
+                <div>
+                  <p class="ops-kicker">Operating sequence</p>
+                  <h2>What the manager thinks should happen next</h2>
+                </div>
+              </div>
+              <div class="ops-sequence-grid">
+                ${
+                  model.twin.nextActions.length
+                    ? model.twin.nextActions.slice(0, 5).map(renderSequenceStep).join("")
+                    : '<div class="ops-empty">No next action has been surfaced yet.</div>'
+                }
+              </div>
+            </div>
+            <div class="ops-panel">
+              <div class="ops-panel__head">
+                <div>
+                  <p class="ops-kicker">Partner chat</p>
+                  <h2>Studio Manager voice</h2>
+                </div>
+                <span class="ops-pill">memory-backed</span>
+              </div>
+              <p class="ops-meta">The manager voice should reduce surprise, explain its reasoning, and keep continuity across days.</p>
+              <div class="ops-chat-feed" id="ops-chat-feed">
+                <article class="ops-chat-message ops-chat-message-assistant">
+                  <p>${esc(model.twin.headline)}</p>
+                </article>
+              </div>
+              <form class="ops-chat-form" id="ops-chat-form" data-surface-chat="manager">
+                <textarea name="text" rows="4" placeholder="Ask what matters next, why a task was assigned, or what the studio is uncertain about."></textarea>
+                <div class="ops-actions">
+                  <button type="submit" class="ops-button">Send to manager</button>
+                </div>
+              </form>
+            </div>
+            <div class="ops-panel">
+              <div class="ops-panel__head">
+                <div>
+                  <p class="ops-kicker">Manager detail</p>
+                  <h2>Detailed queue</h2>
+                </div>
+              </div>
+              <div class="ops-scroll-stack">${managerTasks.map(renderTask).join("") || '<div class="ops-empty">No manager tasks are queued.</div>'}</div>
+            </div>
+          </div>
+        `)}
+        ${renderModePanel("manager", "truth", `
+          <div class="ops-manager-canvas">
+            <div class="ops-detail-grid">
+              <div class="ops-panel">
+                <div class="ops-panel__head">
+                  <div>
+                    <p class="ops-kicker">Case pulse</p>
+                    <h2>Shared operational ledger</h2>
+                  </div>
+                </div>
+                <div class="ops-scroll-stack">${model.cases.slice(0, 8).map(renderCase).join("") || '<div class="ops-empty">No cases in the ledger yet.</div>'}</div>
+              </div>
+              <div class="ops-panel">
+                <div class="ops-panel__head">
+                  <div>
+                    <p class="ops-kicker">Truth posture</p>
+                    <h2>Watchdogs and degraded paths</h2>
+                  </div>
+                </div>
+                <dl class="ops-meta-grid">
+                  <div><dt>Readiness</dt><dd>${esc(model.truth.readiness)}</dd></div>
+                  <div><dt>Degrade modes</dt><dd>${esc(model.truth.degradeModes.join(", ") || "none")}</dd></div>
+                  <div class="ops-span-2"><dt>Summary</dt><dd>${esc(model.truth.summary)}</dd></div>
+                </dl>
+                <div class="ops-truth-grid">${renderWatchdogs(model.truth.watchdogs)}</div>
+              </div>
+              <div class="ops-panel">
+                <div class="ops-panel__head">
+                  <div>
+                    <p class="ops-kicker">Fresh sources</p>
+                    <h2>Signal provenance</h2>
+                  </div>
+                </div>
+                <div class="ops-ribbon-stack">${model.truth.sources.slice(0, 6).map(renderFreshnessRibbon).join("") || '<div class="ops-empty">No source freshness signals are available.</div>'}</div>
+              </div>
+            </div>
+          </div>
+        `)}
+        ${renderModePanel("manager", "commitments", `
+          <div class="ops-layout">
+            <div class="ops-panel">
+              <div class="ops-panel__head"><div><p class="ops-kicker">Reservation bundles</p><h2>Arrivals, prep, and surprise prevention</h2></div></div>
+              <div class="ops-scroll-stack">${reservationCards || '<div class="ops-empty">No reservation bundles are visible right now.</div>'}</div>
+            </div>
+            <div class="ops-panel">
+              <div class="ops-panel__head"><div><p class="ops-kicker">Program pressure</p><h2>Events landing soon</h2></div></div>
+              <div class="ops-scroll-stack">${eventRows.map(renderEventCard).join("") || '<div class="ops-empty">No event pressure is visible right now.</div>'}</div>
+            </div>
+          </div>
+        `)}
+        ${renderModePanel("manager", "trust", `
+          <div class="ops-layout">
+            <div class="ops-panel">
+              <div class="ops-panel__head"><div><p class="ops-kicker">Trust and reports</p><h2>What could hurt people or confidence</h2></div></div>
+              <div class="ops-scroll-stack">${reportRows.map(renderReportCard).join("") || '<div class="ops-empty">No open community reports are visible.</div>'}</div>
+            </div>
+            <div class="ops-panel">
+              <div class="ops-panel__head"><div><p class="ops-kicker">Override pressure</p><h2>Manual paths degrading autonomy</h2></div></div>
+              <div class="ops-scroll-stack">${overrideCards || '<div class="ops-empty">No override receipts are currently open.</div>'}</div>
+              ${canRequestOverrides ? `
+                <form class="ops-compose-form" id="ops-override-form">
+                  <input name="scope" placeholder="Override scope (for example: kiln-room-manual-verification)" />
+                  <textarea name="reason" rows="3" placeholder="Why does the human need to step outside the normal path?"></textarea>
+                  <input name="expiresAt" placeholder="Optional expiry ISO timestamp" />
+                  <div class="ops-actions"><button type="submit" class="ops-button">Request override</button></div>
+                </form>
+              ` : ""}
+            </div>
+          </div>
+        `)}
+      </div>
+    </section>
+
+    <section class="ops-surface" data-surface="owner">
+      <div class="ops-manager-canvas">
+        ${renderModeTabs("owner", [
+          { id: "brief", label: "Brief" },
+          { id: "approvals", label: "Approvals", meta: pendingApprovals.length },
+          { id: "finance", label: "Finance" },
+          { id: "identity", label: "Identity", meta: memberRows.length },
+        ])}
+        ${renderModePanel("owner", "brief", `
+          <div class="ops-layout">
+            <div class="ops-panel">
+              <div class="ops-panel__head"><div><p class="ops-kicker">Owner briefing</p><h2>Quiet truth, approvals, and strategic risk</h2></div></div>
+              <p class="ops-summary">${esc(model.truth.summary)}</p>
+              <div class="ops-truth-grid">${renderWatchdogs(model.truth.watchdogs)}</div>
+            </div>
+            <div class="ops-panel">
+              <div class="ops-panel__head"><div><p class="ops-kicker">Override posture</p><h2>Where humans had to step outside automation</h2></div></div>
+              <div class="ops-scroll-stack">${overrideCards || '<div class="ops-empty">No overrides are currently recorded.</div>'}</div>
+            </div>
+          </div>
+        `)}
+        ${renderModePanel("owner", "approvals", `
+          <div class="ops-panel">
+            <div class="ops-panel__head"><div><p class="ops-kicker">Approvals</p><h2>Actions that need explicit human agency</h2></div></div>
+            <div class="ops-stack">${model.approvals.map(renderApproval).join("") || '<div class="ops-empty">No approvals are queued.</div>'}</div>
+          </div>
+        `)}
+        ${renderModePanel("owner", "finance", `
+          <div class="ops-panel">
+            <div class="ops-panel__head"><div><p class="ops-kicker">Finance posture</p><h2>Money-moving actions remain owner-gated</h2></div></div>
+            <div class="ops-sequence-grid">
+              ${renderSequenceStep("Finance visibility stays in the owner lane.")}
+              ${renderSequenceStep("No direct money movement is automated here.")}
+              ${renderSequenceStep(`Pending approvals: ${pendingApprovals.length}`)}
+            </div>
+          </div>
+        `)}
+        ${renderModePanel("owner", "identity", `
+          <div class="ops-panel">
+            <div class="ops-panel__head"><div><p class="ops-kicker">Identity and member ops</p><h2>Role changes and protected access</h2></div></div>
+            <div class="ops-scroll-stack">${memberCards || '<div class="ops-empty">No member rows are visible for this owner session.</div>'}</div>
+          </div>
+        `)}
+      </div>
+    </section>
+
+    <section class="ops-surface" data-surface="hands">
+      <div class="ops-manager-canvas">
+        ${renderModeTabs("hands", [
+          { id: "now", label: "Now" },
+          { id: "queue", label: "Queue", meta: handsTasks.length },
+          { id: "checkins", label: "Check-ins", meta: reservationBundles.length },
+          { id: "production", label: "Production", meta: handsCases.length },
+          { id: "firings", label: "Firings", meta: handsCases.filter((entry) => entry.kind === "kiln_run").length },
+          { id: "lending", label: "Lending", meta: model.lending?.loans.length ?? 0 },
+          { id: "lending-intake", label: "Lending intake", meta: model.lending?.requests.length ?? 0 },
+        ])}
+        ${renderModePanel("hands", "now", `
+          <div class="ops-layout ops-layout-hands">
+            <div class="ops-panel">
+              <div class="ops-panel__head"><div><p class="ops-kicker">Hands lane</p><h2>One clear physical next step</h2></div></div>
+              ${renderHandsFocus(displayState, activeHandsTasks[0] ?? null)}
+            </div>
+            <div class="ops-panel">
+              <div class="ops-panel__head"><div><p class="ops-kicker">Live telemetry</p><h2>Window, handoff, and truth</h2></div></div>
+              <div class="ops-countdown-grid ops-countdown-grid-dual">${handsNowCountdowns.join("")}</div>
+              <div class="ops-relay-stack">${renderTaskRelayCard(activeHandsTasks[0] ?? null, "Hands relay")}</div>
+              <div class="ops-ribbon-stack">${model.truth.sources.slice(0, 3).map(renderFreshnessRibbon).join("") || '<div class="ops-empty">No source freshness signals are available.</div>'}</div>
+            </div>
+          </div>
+        `)}
+        ${renderModePanel("hands", "queue", `
+          <div class="ops-panel">
+            <div class="ops-panel__head"><div><p class="ops-kicker">Queued work</p><h2>Task rail</h2></div></div>
+            <div class="ops-scroll-stack">${handsTasks.map(renderTask).join("") || '<div class="ops-empty">No physical tasks are queued.</div>'}</div>
+          </div>
+        `)}
+        ${renderModePanel("hands", "checkins", `
+          <div class="ops-layout">
+            <div class="ops-panel">
+              <div class="ops-panel__head"><div><p class="ops-kicker">Check-ins</p><h2>Reservation prep and day-of arrivals</h2></div></div>
+              <div class="ops-scroll-stack">${reservationCards || '<div class="ops-empty">No reservation bundles are visible right now.</div>'}</div>
+            </div>
+            <div class="ops-panel">
+              <div class="ops-panel__head"><div><p class="ops-kicker">Station context</p><h2>What this station knows</h2></div></div>
+              ${renderStationContext(displayState)}
+              <div class="ops-truth-grid">${renderWatchdogs(model.truth.watchdogs)}</div>
+            </div>
+          </div>
+        `)}
+        ${renderModePanel("hands", "production", `
+          <div class="ops-panel">
+            <div class="ops-panel__head"><div><p class="ops-kicker">Production</p><h2>Kilns, arrivals, and physical commitments</h2></div></div>
+            <div class="ops-scroll-stack">${handsCases.map(renderCase).join("") || '<div class="ops-empty">No hands-related cases are active right now.</div>'}</div>
+          </div>
+        `)}
+        ${renderModePanel("hands", "firings", `
+          <div class="ops-panel">
+            <div class="ops-panel__head"><div><p class="ops-kicker">Firings</p><h2>Kiln runs and maintenance posture</h2></div></div>
+            <div class="ops-scroll-stack">${handsCases.filter((entry) => entry.kind === "kiln_run").map(renderCase).join("") || '<div class="ops-empty">No kiln cases are active right now.</div>'}</div>
+          </div>
+        `)}
+        ${renderModePanel("hands", "lending", `
+          <div class="ops-layout">
+            <div class="ops-panel">
+              <div class="ops-panel__head"><div><p class="ops-kicker">Lending</p><h2>Borrowers, due windows, and returns</h2></div></div>
+              ${renderLendingCard(model.lending)}
+            </div>
+            <div class="ops-panel">
+              <div class="ops-panel__head"><div><p class="ops-kicker">Loans</p><h2>What is actively out</h2></div></div>
+              <div class="ops-scroll-stack">${(model.lending?.loans ?? []).map((row) => renderCase({ id: row.id, kind: "general", title: row.title, summary: row.borrowerName || row.borrowerUid || "Borrower unknown", status: row.status === "overdue" ? "blocked" : "active", priority: row.status === "overdue" ? "p1" : "p2", lane: "hands", ownerRole: "library_ops", verificationClass: "observed", freshestAt: row.createdAt, sources: [], confidence: 0.68, degradeReason: null, dueAt: row.dueAt, linkedEntityKind: null, linkedEntityId: null, memoryScope: null, createdAt: row.createdAt || model.generatedAt, updatedAt: row.createdAt || model.generatedAt, metadata: {} })).join("") || '<div class="ops-empty">No active loans are visible.</div>'}</div>
+            </div>
+          </div>
+        `)}
+        ${renderModePanel("hands", "lending-intake", `
+          <div class="ops-panel">
+            <div class="ops-panel__head"><div><p class="ops-kicker">Lending intake</p><h2>Requests and review queues</h2></div></div>
+            <div class="ops-scroll-stack">${(model.lending?.requests ?? []).map((row) => renderCase({ id: row.id, kind: "general", title: row.title, summary: row.requesterName || row.requesterUid || "Requester unknown", status: row.status === "open" ? "open" : "active", priority: row.status === "open" ? "p2" : "p3", lane: "hands", ownerRole: "library_ops", verificationClass: "observed", freshestAt: row.createdAt, sources: [], confidence: 0.66, degradeReason: null, dueAt: null, linkedEntityKind: null, linkedEntityId: null, memoryScope: null, createdAt: row.createdAt || model.generatedAt, updatedAt: row.createdAt || model.generatedAt, metadata: {} })).join("") || '<div class="ops-empty">No lending intake requests are visible.</div>'}</div>
+          </div>
+        `)}
+      </div>
+    </section>
+
+    <section class="ops-surface" data-surface="internet">
+      <div class="ops-manager-canvas">
+        ${renderModeTabs("internet", [
+          { id: "desk", label: "Desk" },
+          { id: "member-ops", label: "Member ops", meta: memberRows.length },
+          { id: "events", label: "Events", meta: eventRows.length },
+          { id: "support", label: "Support", meta: model.conversations.length },
+          { id: "reputation", label: "Reputation", meta: reportRows.length },
+        ])}
+        ${renderModePanel("internet", "desk", `
+          <div class="ops-layout">
+            <div class="ops-panel">
+              <div class="ops-panel__head"><div><p class="ops-kicker">Internet lane</p><h2>Support, events, reputation, and promises</h2></div></div>
+              <div class="ops-scroll-stack">${internetTasks.map(renderTask).join("") || '<div class="ops-empty">No internet tasks are queued.</div>'}</div>
+            </div>
+            <div class="ops-panel">
+              <div class="ops-panel__head"><div><p class="ops-kicker">Reply pressure</p><h2>What needs eyes next</h2></div></div>
+              <div class="ops-countdown-grid ops-countdown-grid-dual">${internetDeskCountdowns.join("")}</div>
+              <div class="ops-relay-stack">
+                ${renderTaskRelayCard(activeInternetTasks[0] ?? null, "Internet relay")}
+                ${pendingApprovals[0] ? renderApprovalRelayCard(pendingApprovals[0]) : ""}
+              </div>
+            </div>
+          </div>
+        `)}
+        ${renderModePanel("internet", "member-ops", `
+          <div class="ops-layout">
+            <div class="ops-panel">
+              <div class="ops-panel__head"><div><p class="ops-kicker">Member ops</p><h2>Profiles, memberships, and role context</h2></div></div>
+              <div class="ops-scroll-stack">${memberCards || '<div class="ops-empty">No member rows are visible for this session.</div>'}</div>
+            </div>
+            <div class="ops-panel">
+              <div class="ops-panel__head"><div><p class="ops-kicker">Reservation bundles</p><h2>The member promises that need prep context</h2></div></div>
+              <div class="ops-scroll-stack">${reservationCards || '<div class="ops-empty">No member arrival bundles are visible.</div>'}</div>
+            </div>
+          </div>
+        `)}
+        ${renderModePanel("internet", "events", `
+          <div class="ops-layout">
+            <div class="ops-panel">
+              <div class="ops-panel__head"><div><p class="ops-kicker">Events</p><h2>Programs, rosters, and review pressure</h2></div></div>
+              <div class="ops-scroll-stack">${eventRows.map(renderEventCard).join("") || '<div class="ops-empty">No event work is visible right now.</div>'}</div>
+            </div>
+            <div class="ops-panel">
+              <div class="ops-panel__head"><div><p class="ops-kicker">Ask internet lane</p><h2>Draft and policy reasoning</h2></div></div>
+              <form class="ops-chat-form" id="ops-internet-chat-form" data-surface-chat="internet">
+                <textarea name="text" rows="5" placeholder="Ask the internet lane what reply is safe, or what needs approval."></textarea>
+                <div class="ops-actions">
+                  <button type="submit" class="ops-button">Ask internet lane</button>
+                </div>
+              </form>
+            </div>
+          </div>
+        `)}
+        ${renderModePanel("internet", "support", `
+          <div class="ops-layout">
+            <div class="ops-panel">
+              <div class="ops-panel__head"><div><p class="ops-kicker">Related cases</p><h2>Support, events, and reputation ledger</h2></div></div>
+              <div class="ops-scroll-stack">${internetCases.map(renderCase).join("") || '<div class="ops-empty">No internet-related cases are active right now.</div>'}</div>
+            </div>
+            <div class="ops-panel">
+              <div class="ops-panel__head"><div><p class="ops-kicker">Conversations</p><h2>Explicit sender identity and thread memory</h2></div></div>
+              <div class="ops-scroll-stack">${model.conversations.map(renderConversation).join("") || '<div class="ops-empty">No recent conversations.</div>'}</div>
+            </div>
+          </div>
+        `)}
+        ${renderModePanel("internet", "reputation", `
+          <div class="ops-layout">
+            <div class="ops-panel">
+              <div class="ops-panel__head"><div><p class="ops-kicker">Reputation</p><h2>Complaints, reports, and public trust</h2></div></div>
+              <div class="ops-scroll-stack">${reportRows.map(renderReportCard).join("") || '<div class="ops-empty">No open reputation issues are visible.</div>'}</div>
+            </div>
+            <div class="ops-panel">
+              <div class="ops-panel__head"><div><p class="ops-kicker">Approvals and truth</p><h2>Guardrails on public action</h2></div></div>
+              <div class="ops-stack">${pendingApprovals.slice(0, 3).map(renderApproval).join("") || '<div class="ops-empty">No approvals are queued.</div>'}</div>
+            </div>
+          </div>
+        `)}
+      </div>
+    </section>
+
+    <section class="ops-surface" data-surface="ceo">
+      <div class="ops-manager-canvas">
+        ${renderModeTabs("ceo", [
+          { id: "portfolio", label: "Portfolio", meta: model.ceo.length },
+          { id: "community", label: "Community", meta: eventRows.length },
+          { id: "campaigns", label: "Campaigns", meta: reportRows.length },
+        ])}
+        ${renderModePanel("ceo", "portfolio", `
+          <div class="ops-layout">
+            <div class="ops-panel">
+              <div class="ops-panel__head"><div><p class="ops-kicker">CEO mode</p><h2>Growth portfolio and safe experiments</h2></div></div>
+              <p class="ops-summary">CEO mode is research-and-draft only for external impact. It keeps searching for safe ways to grow memberships, workshops, follow-up quality, and community leverage.</p>
+              <div class="ops-stack">${ceoCards || '<div class="ops-empty">No growth experiments are active yet.</div>'}</div>
+            </div>
+            <div class="ops-panel">
+              <div class="ops-panel__head"><div><p class="ops-kicker">Growth telemetry</p><h2>Signals worth compounding</h2></div></div>
+              <div class="ops-sequence-grid">
+                ${renderSequenceStep(`Active experiments: ${model.ceo.length}`)}
+                ${renderSequenceStep(`Upcoming programs: ${eventRows.length}`)}
+                ${renderSequenceStep(`Reputation pressure points: ${reportRows.length}`)}
+                ${renderSequenceStep(`Unread conversations: ${unreadConversations}`)}
+              </div>
+            </div>
+          </div>
+        `)}
+        ${renderModePanel("ceo", "community", `
+          <div class="ops-layout">
+            <div class="ops-panel">
+              <div class="ops-panel__head"><div><p class="ops-kicker">Community presence</p><h2>Events, partnerships, and visible momentum</h2></div></div>
+              <div class="ops-scroll-stack">${eventRows.map(renderEventCard).join("") || '<div class="ops-empty">No live community-facing events are visible right now.</div>'}</div>
+            </div>
+            <div class="ops-panel">
+              <div class="ops-panel__head"><div><p class="ops-kicker">Public trust</p><h2>Reputation and complaint pressure</h2></div></div>
+              <div class="ops-scroll-stack">${reportRows.map(renderReportCard).join("") || '<div class="ops-empty">No trust threats are visible right now.</div>'}</div>
+            </div>
+          </div>
+        `)}
+        ${renderModePanel("ceo", "campaigns", `
+          <div class="ops-layout">
+            <div class="ops-panel">
+              <div class="ops-panel__head"><div><p class="ops-kicker">Campaign drafts</p><h2>Start a safe growth experiment</h2></div></div>
+              <form class="ops-compose-form" id="ops-ceo-form">
+                <input name="title" placeholder="New growth experiment title" />
+                <textarea name="hypothesis" rows="3" placeholder="What should the studio try, and why would it matter?"></textarea>
+                <div class="ops-actions"><button type="submit" class="ops-button">Create CEO experiment</button></div>
+              </form>
+            </div>
+            <div class="ops-panel">
+              <div class="ops-panel__head"><div><p class="ops-kicker">Current thesis</p><h2>Why the studio should grow carefully</h2></div></div>
+              <div class="ops-ribbon-stack">${model.truth.sources.slice(0, 4).map(renderFreshnessRibbon).join("") || '<div class="ops-empty">No source freshness signals are available.</div>'}</div>
+            </div>
+          </div>
+        `)}
+      </div>
+    </section>
+
+    <section class="ops-surface" data-surface="forge">
+      <div class="ops-manager-canvas">
+        ${renderModeTabs("forge", [
+          { id: "lab", label: "Lab", meta: model.forge.length },
+          { id: "policy-agent-ops", label: "Policy / agents", meta: pendingApprovals.length },
+          { id: "telemetry", label: "Telemetry", meta: model.truth.sources.length },
+          { id: "migration", label: "Migration", meta: reservationBundles.length + memberRows.length },
+        ])}
+        ${renderModePanel("forge", "lab", `
+          <div class="ops-layout">
+            <div class="ops-panel">
+              <div class="ops-panel__head"><div><p class="ops-kicker">Forge</p><h2>Internal toolsmithing and eval-backed self-improvement</h2></div></div>
+              <p class="ops-summary">Forge can propose new primitives, adapters, eval bundles, and shadow runs, but nothing should go live without passing truth and rollback gates.</p>
+              <div class="ops-stack">${forgeCards || '<div class="ops-empty">No improvement cases are tracked yet.</div>'}</div>
+            </div>
+            <div class="ops-panel">
+              <div class="ops-panel__head"><div><p class="ops-kicker">Open a lab case</p><h2>Capture a performance or trust gap</h2></div></div>
+              <form class="ops-compose-form" id="ops-forge-form">
+                <input name="title" placeholder="New improvement case title" />
+                <textarea name="problem" rows="3" placeholder="What performance or trust gap should Forge solve?"></textarea>
+                <div class="ops-actions"><button type="submit" class="ops-button">Create Forge case</button></div>
+              </form>
+            </div>
+          </div>
+        `)}
+        ${renderModePanel("forge", "policy-agent-ops", `
+          <div class="ops-layout">
+            <div class="ops-panel">
+              <div class="ops-panel__head"><div><p class="ops-kicker">Approval policy</p><h2>Where agency boundaries are currently binding</h2></div></div>
+              <div class="ops-stack">${pendingApprovals.map(renderApproval).join("") || '<div class="ops-empty">No approval gates are active right now.</div>'}</div>
+            </div>
+            <div class="ops-panel">
+              <div class="ops-panel__head"><div><p class="ops-kicker">Override receipts</p><h2>Manual fallbacks to learn from</h2></div></div>
+              <div class="ops-scroll-stack">${overrideCards || '<div class="ops-empty">No override receipts are currently open.</div>'}</div>
+            </div>
+          </div>
+        `)}
+        ${renderModePanel("forge", "telemetry", `
+          <div class="ops-layout">
+            <div class="ops-panel">
+              <div class="ops-panel__head"><div><p class="ops-kicker">Telemetry ribbons</p><h2>Freshness, drift, and truth posture</h2></div></div>
+              <div class="ops-ribbon-stack">${model.truth.sources.map(renderFreshnessRibbon).join("") || '<div class="ops-empty">No source freshness signals are available.</div>'}</div>
+            </div>
+            <div class="ops-panel">
+              <div class="ops-panel__head"><div><p class="ops-kicker">Watchdogs</p><h2>What would fail a clean autonomy claim</h2></div></div>
+              <div class="ops-truth-grid">${renderWatchdogs(model.truth.watchdogs)}</div>
+            </div>
+          </div>
+        `)}
+        ${renderModePanel("forge", "migration", `
+          <div class="ops-layout">
+            <div class="ops-panel">
+              <div class="ops-panel__head"><div><p class="ops-kicker">Migration posture</p><h2>Legacy parity surfaces now represented in /ops</h2></div></div>
+              <div class="ops-sequence-grid">
+                ${renderSequenceStep(`Member ops cards loaded: ${memberRows.length}`)}
+                ${renderSequenceStep(`Reservation bundles loaded: ${reservationBundles.length}`)}
+                ${renderSequenceStep(`Lending snapshot visible: ${model.lending ? "yes" : "no"}`)}
+                ${renderSequenceStep(`Reports mirrored: ${reportRows.length}`)}
+              </div>
+            </div>
+            <div class="ops-panel">
+              <div class="ops-panel__head"><div><p class="ops-kicker">Cases touching migration</p><h2>Operational ledger that will replace the old board</h2></div></div>
+              <div class="ops-scroll-stack">${model.cases.slice(0, 8).map(renderCase).join("") || '<div class="ops-empty">No migration-relevant cases are visible right now.</div>'}</div>
+            </div>
+          </div>
+        `)}
+      </div>
+    </section>
+
+  `;
+}
+
+export function renderOpsPortalPage(model: OpsPortalPageModel): string {
+  const initialJson = jsonScript(model);
+  return `<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Studio Brain Ops</title>
+    <style>
+      :root {
+        color-scheme: light;
+        --bg: #efe7db;
+        --ink: #1b1714;
+        --muted: #61554b;
+        --panel: rgba(255,255,255,0.78);
+        --line: rgba(49,39,31,0.14);
+        --shadow: 0 16px 46px rgba(62, 42, 22, 0.14);
+        --good: #245c4d;
+        --good-bg: rgba(36,92,77,0.12);
+        --warn: #9a6d12;
+        --warn-bg: rgba(154,109,18,0.12);
+        --danger: #9f3d2d;
+        --danger-bg: rgba(159,61,45,0.12);
+        --neutral: #4f5a67;
+        --neutral-bg: rgba(79,90,103,0.10);
+        --accent: #264d7d;
+        --accent-2: #7b4b28;
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        color: var(--ink);
+        font-family: "Aptos", "Segoe UI", system-ui, sans-serif;
+        background:
+          radial-gradient(circle at top left, rgba(255,255,255,0.75), transparent 34%),
+          radial-gradient(circle at top right, rgba(184,136,72,0.18), transparent 26%),
+          linear-gradient(180deg, #f7f2eb 0%, #ede3d4 46%, #e5d7c2 100%);
+      }
+      main { max-width: 1560px; margin: 0 auto; padding: 28px 24px 44px; }
+      .ops-hero, .ops-panel, .ops-task-card, .ops-case, .ops-zone, .ops-watchdog, .ops-approval, .ops-conversation {
+        background: var(--panel);
+        border: 1px solid var(--line);
+        border-radius: 24px;
+        box-shadow: var(--shadow);
+        backdrop-filter: blur(8px);
+      }
+      .ops-hero {
+        padding: 24px;
+        display: grid;
+        gap: 18px;
+        margin-bottom: 18px;
+      }
+      .ops-hero h1 { margin: 0 0 6px; font-size: clamp(2rem, 2.8vw, 3.3rem); font-family: "Palatino Linotype", Georgia, serif; }
+      .ops-hero p { margin: 0; color: var(--muted); }
+      .ops-kpi-grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 12px; }
+      .ops-kpi { padding: 16px; border-radius: 18px; border: 1px solid var(--line); background: rgba(255,255,255,0.62); }
+      .ops-kpi span { display: block; font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--muted); }
+      .ops-kpi strong { display: block; margin-top: 10px; font-size: 1.55rem; }
+      .ops-surface-nav { display: flex; flex-wrap: wrap; gap: 10px; margin-bottom: 18px; }
+      .ops-surface-tab, .ops-button, .ops-chip {
+        border: 1px solid transparent;
+        border-radius: 999px;
+        padding: 10px 16px;
+        background: rgba(38,77,125,0.10);
+        color: var(--accent);
+        cursor: pointer;
+        font-weight: 700;
+      }
+      .ops-surface-tab.is-active, .ops-button { background: var(--accent); color: #f8f3ed; }
+      .ops-button-secondary { background: rgba(123,75,40,0.12); color: var(--accent-2); border-color: rgba(123,75,40,0.16); }
+      .ops-chip { background: rgba(255,255,255,0.72); color: var(--muted); border-color: var(--line); }
+      .ops-surface { display: none; margin-bottom: 18px; }
+      .ops-surface.is-active { display: block; }
+      .ops-mode-nav {
+        position: sticky;
+        top: 12px;
+        z-index: 6;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 10px;
+        padding: 10px;
+        border-radius: 18px;
+        border: 1px solid var(--line);
+        background: rgba(255,255,255,0.78);
+        box-shadow: 0 12px 28px rgba(62, 42, 22, 0.08);
+        backdrop-filter: blur(10px);
+      }
+      .ops-mode-tab {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        padding: 10px 14px;
+        border-radius: 999px;
+        border: 1px solid rgba(49,39,31,0.12);
+        background: rgba(255,255,255,0.74);
+        color: var(--muted);
+        cursor: pointer;
+        font-weight: 700;
+      }
+      .ops-mode-tab strong {
+        display: inline-flex;
+        min-width: 24px;
+        justify-content: center;
+        padding: 2px 8px;
+        border-radius: 999px;
+        background: rgba(38,77,125,0.10);
+        color: var(--accent);
+        font-size: 0.74rem;
+      }
+      .ops-mode-tab.is-active {
+        background: var(--accent);
+        color: #f8f3ed;
+        border-color: rgba(38,77,125,0.25);
+      }
+      .ops-mode-tab.is-active strong {
+        background: rgba(255,255,255,0.18);
+        color: #f8f3ed;
+      }
+      .ops-mode-panel { display: none; }
+      .ops-mode-panel.is-active { display: block; }
+      .ops-layout { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 18px; }
+      .ops-layout-hands { grid-template-columns: minmax(360px, 0.95fr) minmax(0, 1.05fr); }
+      .ops-manager-canvas { display: grid; gap: 18px; }
+      .ops-gauge-strip { display: grid; grid-template-columns: repeat(5, minmax(0, 1fr)); gap: 12px; margin-top: 16px; }
+      .ops-motion-grid { display: grid; grid-template-columns: 1.1fr 1fr 0.95fr; gap: 18px; }
+      .ops-motion-panel { min-height: 100%; }
+      .ops-countdown-grid,
+      .ops-relay-stack,
+      .ops-ribbon-stack { display: grid; gap: 12px; }
+      .ops-ticker-shell {
+        position: relative;
+        overflow: hidden;
+        margin-top: 12px;
+        border-radius: 18px;
+        border: 1px solid rgba(49,39,31,0.12);
+        background: linear-gradient(90deg, rgba(255,255,255,0.78), rgba(255,255,255,0.52));
+      }
+      .ops-ticker-shell::before,
+      .ops-ticker-shell::after {
+        content: "";
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        width: 54px;
+        pointer-events: none;
+        z-index: 2;
+      }
+      .ops-ticker-shell::before {
+        left: 0;
+        background: linear-gradient(90deg, rgba(247,242,235,1), rgba(247,242,235,0));
+      }
+      .ops-ticker-shell::after {
+        right: 0;
+        background: linear-gradient(270deg, rgba(247,242,235,1), rgba(247,242,235,0));
+      }
+      .ops-ticker-track {
+        display: flex;
+        gap: 12px;
+        width: max-content;
+        padding: 12px;
+        animation: ops-ticker-scroll 34s linear infinite;
+      }
+      .ops-ticker-shell:hover .ops-ticker-track { animation-play-state: paused; }
+      .ops-ticker-item {
+        display: inline-flex;
+        align-items: center;
+        gap: 10px;
+        min-width: 320px;
+        padding: 10px 14px;
+        border-radius: 999px;
+        background: rgba(255,255,255,0.76);
+        border: 1px solid var(--line);
+        box-shadow: inset 0 1px 0 rgba(255,255,255,0.6);
+      }
+      .ops-ticker-item__label {
+        display: inline-flex;
+        padding: 4px 8px;
+        border-radius: 999px;
+        background: rgba(38,77,125,0.08);
+        color: var(--muted);
+        font-size: 0.72rem;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+      }
+      .ops-ticker-item__text {
+        font-size: 0.96rem;
+        color: var(--ink);
+        white-space: nowrap;
+      }
+      .ops-incident-strip { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 12px; margin-top: 12px; }
+      .ops-gauge-card,
+      .ops-incident-chip,
+      .ops-map-zone,
+      .ops-spotlight-card,
+      .ops-sequence-step {
+        padding: 16px;
+        border-radius: 20px;
+        border: 1px solid var(--line);
+        background: rgba(255,255,255,0.6);
+      }
+      .ops-gauge-card__row {
+        display: grid;
+        grid-template-columns: 128px minmax(0, 1fr);
+        gap: 14px;
+        align-items: center;
+      }
+      .ops-gauge-card__copy h3 {
+        margin: 0 0 6px;
+        font-size: 1.05rem;
+      }
+      .ops-gauge {
+        position: relative;
+        width: 128px;
+        height: 128px;
+        display: grid;
+        place-items: center;
+      }
+      .ops-gauge__ring {
+        position: absolute;
+        inset: 0;
+        border-radius: 50%;
+        background:
+          radial-gradient(circle at center, rgba(255,255,255,0.85) 0 50%, transparent 51%),
+          conic-gradient(from -120deg, var(--gauge-color) 0deg var(--gauge-progress), rgba(49,39,31,0.08) var(--gauge-progress) 240deg, transparent 240deg 360deg);
+        animation: ops-gauge-glow 2.8s ease-in-out infinite;
+      }
+      .ops-gauge__needle {
+        position: absolute;
+        bottom: 50%;
+        left: 50%;
+        width: 4px;
+        height: 46px;
+        border-radius: 999px;
+        background: linear-gradient(180deg, rgba(27,23,20,0.25), rgba(27,23,20,0.95));
+        transform-origin: center bottom;
+        transform: translateX(-50%) rotate(var(--gauge-needle));
+        animation: ops-gauge-sweep 1.1s cubic-bezier(.2,.8,.2,1);
+      }
+      .ops-gauge__hub {
+        position: absolute;
+        width: 16px;
+        height: 16px;
+        border-radius: 50%;
+        background: rgba(27,23,20,0.92);
+        box-shadow: 0 0 0 5px rgba(255,255,255,0.82);
+      }
+      .ops-gauge__readout {
+        position: relative;
+        margin-top: 48px;
+        font-size: 1.45rem;
+        font-weight: 700;
+        font-family: "Palatino Linotype", Georgia, serif;
+        text-transform: uppercase;
+        color: var(--ink);
+      }
+      .ops-incident-chip {
+        display: grid;
+        align-content: start;
+        gap: 8px;
+        animation: ops-card-float 5.2s ease-in-out infinite;
+      }
+      .ops-incident-chip__label {
+        display: inline-flex;
+        width: fit-content;
+        padding: 4px 8px;
+        border-radius: 999px;
+        background: rgba(255,255,255,0.75);
+        border: 1px solid var(--line);
+        font-size: 0.72rem;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        color: var(--muted);
+      }
+      .ops-incident-chip p { margin: 0; color: var(--ink); line-height: 1.4; }
+      .ops-countdown-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 12px; }
+      .ops-countdown-grid-dual { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+      .ops-countdown-card {
+        display: grid;
+        grid-template-columns: 104px minmax(0, 1fr);
+        gap: 14px;
+        align-items: center;
+        padding: 14px;
+        border-radius: 20px;
+        border: 1px solid var(--line);
+        background: rgba(255,255,255,0.6);
+      }
+      .ops-countdown-card__dial {
+        position: relative;
+        width: 104px;
+        height: 104px;
+        display: grid;
+        place-items: center;
+      }
+      .ops-countdown-card__ring {
+        position: absolute;
+        inset: 0;
+        border-radius: 50%;
+        background:
+          radial-gradient(circle at center, rgba(255,255,255,0.9) 0 56%, transparent 57%),
+          conic-gradient(from -90deg, var(--countdown-color) 0deg var(--countdown-progress), rgba(49,39,31,0.08) var(--countdown-progress) 360deg);
+        animation: ops-orbit-breathe 3.2s ease-in-out infinite;
+      }
+      .ops-countdown-card__ring::after {
+        content: "";
+        position: absolute;
+        inset: 8px;
+        border-radius: 50%;
+        border: 1px dashed rgba(49,39,31,0.12);
+        animation: ops-countdown-spin 12s linear infinite;
+      }
+      .ops-countdown-card__core {
+        position: relative;
+        display: grid;
+        text-align: center;
+        gap: 2px;
+      }
+      .ops-countdown-card__core strong {
+        font-size: 1.2rem;
+        font-family: "Palatino Linotype", Georgia, serif;
+      }
+      .ops-countdown-card__core span {
+        font-size: 0.72rem;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: var(--muted);
+      }
+      .ops-countdown-card__copy h3 { margin: 0 0 6px; font-size: 1rem; }
+      .ops-flow-card {
+        padding: 16px;
+        border-radius: 20px;
+        border: 1px solid var(--line);
+        background: rgba(255,255,255,0.6);
+      }
+      .ops-flow-card h3 { margin: 0 0 6px; }
+      .ops-relay {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: 12px;
+        margin-top: 14px;
+        position: relative;
+      }
+      .ops-relay::before {
+        content: "";
+        position: absolute;
+        left: calc(16.66% + 12px);
+        right: calc(16.66% + 12px);
+        top: 14px;
+        height: 4px;
+        border-radius: 999px;
+        background: linear-gradient(90deg, rgba(38,77,125,0.2), rgba(123,75,40,0.2));
+      }
+      .ops-relay-compact { margin-top: 0; }
+      .ops-relay__stage {
+        position: relative;
+        display: grid;
+        gap: 8px;
+        justify-items: center;
+        text-align: center;
+        z-index: 1;
+      }
+      .ops-relay__node {
+        width: 28px;
+        height: 28px;
+        border-radius: 50%;
+        background: rgba(255,255,255,0.9);
+        border: 2px solid rgba(49,39,31,0.18);
+        box-shadow: 0 0 0 8px rgba(255,255,255,0.58);
+      }
+      .ops-relay__label {
+        font-size: 0.72rem;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: var(--muted);
+      }
+      .ops-relay__stage-done .ops-relay__node {
+        background: var(--accent);
+        border-color: rgba(38,77,125,0.24);
+      }
+      .ops-relay__stage-active .ops-relay__node {
+        background: var(--accent-2);
+        border-color: rgba(123,75,40,0.28);
+        animation: ops-relay-pulse 1.8s ease-in-out infinite;
+      }
+      .ops-relay__stage-queued .ops-relay__node {
+        background: rgba(255,255,255,0.96);
+      }
+      .ops-source-ribbon {
+        padding: 14px;
+        border-radius: 18px;
+        border: 1px solid var(--line);
+        background: rgba(255,255,255,0.58);
+      }
+      .ops-source-ribbon__head {
+        display: flex;
+        justify-content: space-between;
+        gap: 12px;
+        align-items: baseline;
+        margin-bottom: 8px;
+      }
+      .ops-source-ribbon__head span {
+        font-size: 0.78rem;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: var(--muted);
+      }
+      .ops-source-ribbon__track {
+        position: relative;
+        height: 12px;
+        border-radius: 999px;
+        overflow: hidden;
+        background: rgba(49,39,31,0.08);
+      }
+      .ops-source-ribbon__fill {
+        position: relative;
+        height: 100%;
+        border-radius: 999px;
+        overflow: hidden;
+      }
+      .ops-source-ribbon__fill::after {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background: linear-gradient(90deg, transparent, rgba(255,255,255,0.42), transparent);
+        animation: ops-ribbon-shimmer 2.6s linear infinite;
+      }
+      .ops-source-ribbon__fill-good { background: linear-gradient(90deg, #2e8d73, #245c4d); }
+      .ops-source-ribbon__fill-warn { background: linear-gradient(90deg, #d5a443, #9a6d12); }
+      .ops-source-ribbon__fill-danger { background: linear-gradient(90deg, #cf6a54, #9f3d2d); }
+      .ops-source-ribbon__fill-neutral { background: linear-gradient(90deg, #8fa0b1, #4f5a67); }
+      .ops-scan-grid { display: grid; grid-template-columns: minmax(0, 1.55fr) minmax(360px, 0.9fr); gap: 18px; }
+      .ops-studio-map {
+        display: grid;
+        grid-template-columns: repeat(12, minmax(0, 1fr));
+        gap: 12px;
+      }
+      .ops-map-zone {
+        min-height: 210px;
+        display: grid;
+        align-content: start;
+      }
+      .ops-map-zone-0 { grid-column: span 7; }
+      .ops-map-zone-1 { grid-column: span 5; }
+      .ops-map-zone-2 { grid-column: span 5; }
+      .ops-map-zone-3 { grid-column: span 7; }
+      .ops-map-zone__head {
+        display: flex;
+        justify-content: space-between;
+        gap: 12px;
+        align-items: flex-start;
+      }
+      .ops-map-zone__sentinel {
+        position: relative;
+        display: inline-grid;
+        place-items: center;
+        width: 38px;
+        height: 38px;
+        border-radius: 50%;
+      }
+      .ops-map-zone__sentinel::before {
+        content: "";
+        position: absolute;
+        inset: 4px;
+        border-radius: 50%;
+        border: 1px solid currentColor;
+        opacity: 0.28;
+      }
+      .ops-map-zone__sentinel-good { color: var(--good); }
+      .ops-map-zone__sentinel-warn { color: var(--warn); }
+      .ops-map-zone__sentinel-danger { color: var(--danger); }
+      .ops-map-zone__sentinel-neutral { color: var(--neutral); }
+      .ops-map-zone__sentinel::after {
+        content: "";
+        position: absolute;
+        inset: 0;
+        border-radius: 50%;
+        border: 1px solid currentColor;
+        opacity: 0.18;
+        animation: ops-halo-pulse 2.8s ease-in-out infinite;
+      }
+      .ops-map-zone__status {
+        display: inline-flex;
+        width: 14px;
+        height: 14px;
+        border-radius: 999px;
+        box-shadow: 0 0 0 6px rgba(255,255,255,0.85);
+        animation: ops-pulse-dot 2.4s ease-in-out infinite;
+      }
+      .ops-map-zone__status-good { background: var(--good); }
+      .ops-map-zone__status-warn { background: var(--warn); }
+      .ops-map-zone__status-danger { background: var(--danger); }
+      .ops-map-zone__status-neutral { background: var(--neutral); }
+      .ops-zone-ribbon {
+        display: flex;
+        gap: 6px;
+        margin-top: 12px;
+        min-height: 10px;
+      }
+      .ops-zone-ribbon__segment {
+        flex: 1 1 0;
+        min-width: 16px;
+        height: 10px;
+        border-radius: 999px;
+        opacity: 0.9;
+        animation: ops-ribbon-breathe 2.8s ease-in-out infinite;
+      }
+      .ops-zone-ribbon__segment-good { background: linear-gradient(90deg, #2e8d73, #245c4d); }
+      .ops-zone-ribbon__segment-warn { background: linear-gradient(90deg, #d5a443, #9a6d12); }
+      .ops-zone-ribbon__segment-danger { background: linear-gradient(90deg, #cf6a54, #9f3d2d); }
+      .ops-zone-ribbon__segment-neutral { background: linear-gradient(90deg, #8fa0b1, #4f5a67); }
+      .ops-map-zone__next { margin: 12px 0 0; color: var(--muted); }
+      .ops-timeline {
+        display: grid;
+        gap: 12px;
+        position: relative;
+      }
+      .ops-timeline-entry {
+        display: grid;
+        grid-template-columns: 92px minmax(0, 1fr);
+        gap: 12px;
+        padding: 14px 0 14px 14px;
+        border-left: 3px solid rgba(49,39,31,0.12);
+      }
+      .ops-timeline-entry__time {
+        font-size: 0.8rem;
+        color: var(--muted);
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        padding-top: 2px;
+      }
+      .ops-timeline-entry__head {
+        display: flex;
+        justify-content: space-between;
+        gap: 12px;
+        align-items: center;
+      }
+      .ops-timeline-entry__countdown {
+        display: inline-flex;
+        align-items: center;
+        padding: 5px 10px;
+        border-radius: 999px;
+        font-size: 0.76rem;
+        font-weight: 700;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+        background: rgba(255,255,255,0.8);
+        border: 1px solid currentColor;
+      }
+      .ops-timeline-entry__countdown-good { color: var(--good); }
+      .ops-timeline-entry__countdown-warn { color: var(--warn); }
+      .ops-timeline-entry__countdown-danger { color: var(--danger); }
+      .ops-timeline-entry__countdown-neutral { color: var(--neutral); }
+      .ops-timeline-entry__body h4 {
+        margin: 0 0 4px;
+        font-size: 1rem;
+      }
+      .ops-timeline-entry__body p:last-child { margin: 0; color: var(--muted); }
+      .ops-conveyor {
+        position: relative;
+        display: flex;
+        gap: 8px;
+        margin-top: 10px;
+        overflow: hidden;
+      }
+      .ops-conveyor span {
+        display: inline-flex;
+        width: 28px;
+        height: 6px;
+        border-radius: 999px;
+        opacity: 0.55;
+        transform: translateX(0);
+        animation: ops-conveyor-flow 2.2s linear infinite;
+      }
+      .ops-conveyor span:nth-child(2) { animation-delay: 0.24s; }
+      .ops-conveyor span:nth-child(3) { animation-delay: 0.48s; }
+      .ops-conveyor-good span { background: linear-gradient(90deg, #2e8d73, #245c4d); }
+      .ops-conveyor-warn span { background: linear-gradient(90deg, #d5a443, #9a6d12); }
+      .ops-conveyor-danger span { background: linear-gradient(90deg, #cf6a54, #9f3d2d); }
+      .ops-conveyor-neutral span { background: linear-gradient(90deg, #8fa0b1, #4f5a67); }
+      .ops-command-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 18px; }
+      .ops-detail-grid { display: grid; grid-template-columns: minmax(0, 1.15fr) minmax(0, 1fr) minmax(0, 1fr); gap: 18px; }
+      .ops-sequence-grid { display: grid; grid-template-columns: repeat(5, minmax(0, 1fr)); gap: 12px; }
+      .ops-sequence-step {
+        display: flex;
+        gap: 12px;
+        align-items: flex-start;
+      }
+      .ops-sequence-step__index {
+        flex: 0 0 auto;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 32px;
+        height: 32px;
+        border-radius: 999px;
+        background: rgba(38,77,125,0.12);
+        color: var(--accent);
+        font-weight: 700;
+      }
+      .ops-sequence-step p { margin: 0; color: var(--muted); }
+      .ops-spotlight-signal-row {
+        display: grid;
+        grid-template-columns: 96px minmax(0, 1fr);
+        gap: 14px;
+        align-items: center;
+        margin-top: 12px;
+      }
+      .ops-spotlight-orb {
+        position: relative;
+        width: 96px;
+        height: 96px;
+        display: grid;
+        place-items: center;
+      }
+      .ops-spotlight-orb__ring {
+        position: absolute;
+        inset: 0;
+        border-radius: 50%;
+        background:
+          radial-gradient(circle at center, rgba(255,255,255,0.9) 0 56%, transparent 57%),
+          conic-gradient(from -90deg, var(--countdown-color) 0deg var(--countdown-progress), rgba(49,39,31,0.08) var(--countdown-progress) 360deg);
+        animation: ops-orbit-breathe 3.1s ease-in-out infinite;
+      }
+      .ops-spotlight-orb__core {
+        position: relative;
+        display: grid;
+        text-align: center;
+        gap: 2px;
+      }
+      .ops-spotlight-orb__core strong { font-size: 1rem; }
+      .ops-spotlight-orb__core span {
+        font-size: 0.68rem;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: var(--muted);
+      }
+      .ops-inline-meta {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 10px 14px;
+        margin: 12px 0 0;
+      }
+      .ops-inline-meta dt {
+        font-size: 0.73rem;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        color: var(--muted);
+      }
+      .ops-inline-meta dd { margin: 4px 0 0; }
+      .ops-meter { display: grid; gap: 6px; margin-top: 10px; }
+      .ops-meter span {
+        font-size: 0.75rem;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        color: var(--muted);
+      }
+      .ops-meter__track {
+        height: 9px;
+        border-radius: 999px;
+        background: rgba(49,39,31,0.08);
+        overflow: hidden;
+      }
+      .ops-meter__fill {
+        height: 100%;
+        border-radius: 999px;
+        animation: ops-meter-breathe 2.8s ease-in-out infinite;
+      }
+      .ops-meter__fill-good { background: linear-gradient(90deg, #2e8d73, #245c4d); }
+      .ops-meter__fill-warn { background: linear-gradient(90deg, #d5a443, #9a6d12); }
+      .ops-meter__fill-danger { background: linear-gradient(90deg, #cf6a54, #9f3d2d); }
+      .ops-meter__fill-neutral { background: linear-gradient(90deg, #8fa0b1, #4f5a67); }
+      .ops-bottom-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(340px, 1fr)); gap: 18px; margin-top: 18px; }
+      .ops-scroll-stack {
+        display: grid;
+        gap: 12px;
+        max-height: min(72vh, 1080px);
+        overflow: auto;
+        padding-right: 4px;
+      }
+      .ops-station-card {
+        padding: 16px;
+        border-radius: 20px;
+        border: 1px solid var(--line);
+        background: rgba(255,255,255,0.58);
+      }
+      .ops-station-card h3 { margin: 0; }
+      .ops-panel { padding: 18px; }
+      .ops-panel__head, .ops-zone__head, .ops-task-card__head { display: flex; justify-content: space-between; gap: 12px; align-items: flex-start; }
+      .ops-panel h2, .ops-zone h3, .ops-task-card h3, .ops-case h3, .ops-approval h3 { margin: 0; }
+      .ops-kicker { margin: 0 0 6px; text-transform: uppercase; letter-spacing: 0.08em; font-size: 0.78rem; color: var(--muted); }
+      .ops-summary, .ops-meta { color: var(--muted); }
+      .ops-zone-grid, .ops-stack, .ops-truth-grid { display: grid; gap: 12px; }
+      .ops-zone-grid { grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); margin-top: 14px; }
+      .ops-task-card, .ops-zone, .ops-case, .ops-watchdog, .ops-approval, .ops-conversation { padding: 16px; }
+      .ops-task-grid, .ops-meta-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px 14px; margin: 14px 0 0; }
+      .ops-task-grid dt, .ops-meta-grid dt { font-size: 0.77rem; text-transform: uppercase; letter-spacing: 0.06em; color: var(--muted); }
+      .ops-task-grid dd, .ops-meta-grid dd { margin: 4px 0 0; }
+      .ops-span-2 { grid-column: 1 / -1; }
+      .ops-subpanel { margin-top: 14px; padding-top: 14px; border-top: 1px solid var(--line); }
+      .ops-actions, .ops-chip-row { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 14px; }
+      .ops-pill {
+        display: inline-flex;
+        align-items: center;
+        padding: 5px 10px;
+        border-radius: 999px;
+        background: rgba(79,90,103,0.10);
+        color: var(--neutral);
+        border: 1px solid rgba(79,90,103,0.15);
+        font-size: 0.82rem;
+        font-weight: 700;
+      }
+      .ops-pill-good, .ops-tone-good { border-color: rgba(36,92,77,0.18); }
+      .ops-pill-good { background: var(--good-bg); color: var(--good); }
+      .ops-pill-warn, .ops-tone-warn { border-color: rgba(154,109,18,0.18); }
+      .ops-pill-warn { background: var(--warn-bg); color: var(--warn); }
+      .ops-pill-danger, .ops-tone-danger { border-color: rgba(159,61,45,0.18); }
+      .ops-pill-danger { background: var(--danger-bg); color: var(--danger); }
+      .ops-task-card__badges { display: flex; flex-wrap: wrap; gap: 8px; justify-content: flex-end; }
+      .ops-chat-feed {
+        border-radius: 18px;
+        border: 1px solid var(--line);
+        background: rgba(255,255,255,0.5);
+        padding: 14px;
+        min-height: 120px;
+        max-height: 340px;
+        overflow: auto;
+      }
+      .ops-chat-message { max-width: 92%; padding: 12px 14px; border-radius: 18px; margin-bottom: 10px; }
+      .ops-chat-message-user { margin-left: auto; background: rgba(38,77,125,0.10); }
+      .ops-chat-message-assistant { margin-right: auto; background: rgba(255,255,255,0.8); }
+      .ops-chat-form, .ops-compose-form { display: grid; gap: 10px; margin-top: 14px; }
+      textarea, input {
+        width: 100%;
+        border: 1px solid rgba(49,39,31,0.18);
+        border-radius: 16px;
+        padding: 12px 14px;
+        font: inherit;
+        color: var(--ink);
+        background: rgba(255,255,255,0.84);
+      }
+      .ops-empty {
+        padding: 18px;
+        border: 1px dashed var(--line);
+        border-radius: 18px;
+        color: var(--muted);
+        background: rgba(255,255,255,0.42);
+      }
+      .ops-banner {
+        margin-bottom: 14px;
+        padding: 12px 14px;
+        border-radius: 16px;
+        border: 1px solid var(--line);
+        background: rgba(255,255,255,0.68);
+        display: none;
+      }
+      .ops-banner.is-visible { display: block; }
+      .ops-banner-success { border-color: rgba(36,92,77,0.22); color: var(--good); }
+      .ops-banner-error { border-color: rgba(159,61,45,0.24); color: var(--danger); }
+      .ops-truth-grid { margin-top: 14px; }
+      @keyframes ops-ticker-scroll {
+        from { transform: translateX(0); }
+        to { transform: translateX(-50%); }
+      }
+      @keyframes ops-gauge-sweep {
+        from { transform: translateX(-50%) rotate(-132deg); }
+        to { transform: translateX(-50%) rotate(var(--gauge-needle)); }
+      }
+      @keyframes ops-gauge-glow {
+        0%, 100% { filter: saturate(0.96) brightness(0.98); }
+        50% { filter: saturate(1.12) brightness(1.04); }
+      }
+      @keyframes ops-pulse-dot {
+        0%, 100% { transform: scale(1); opacity: 1; }
+        50% { transform: scale(1.18); opacity: 0.72; }
+      }
+      @keyframes ops-meter-breathe {
+        0%, 100% { filter: saturate(1); }
+        50% { filter: saturate(1.18) brightness(1.02); }
+      }
+      @keyframes ops-card-float {
+        0%, 100% { transform: translateY(0); }
+        50% { transform: translateY(-2px); }
+      }
+      @keyframes ops-countdown-spin {
+        from { transform: rotate(0deg); }
+        to { transform: rotate(360deg); }
+      }
+      @keyframes ops-orbit-breathe {
+        0%, 100% { filter: saturate(1) brightness(1); transform: scale(1); }
+        50% { filter: saturate(1.14) brightness(1.03); transform: scale(1.02); }
+      }
+      @keyframes ops-relay-pulse {
+        0%, 100% { box-shadow: 0 0 0 0 rgba(123,75,40,0.24), 0 0 0 8px rgba(255,255,255,0.58); }
+        50% { box-shadow: 0 0 0 8px rgba(123,75,40,0.06), 0 0 0 10px rgba(255,255,255,0.7); }
+      }
+      @keyframes ops-ribbon-shimmer {
+        0% { transform: translateX(-100%); }
+        100% { transform: translateX(220%); }
+      }
+      @keyframes ops-ribbon-breathe {
+        0%, 100% { opacity: 0.78; transform: translateY(0); }
+        50% { opacity: 1; transform: translateY(-1px); }
+      }
+      @keyframes ops-halo-pulse {
+        0%, 100% { transform: scale(0.92); opacity: 0.14; }
+        50% { transform: scale(1.18); opacity: 0.28; }
+      }
+      @keyframes ops-conveyor-flow {
+        0% { transform: translateX(-4px); opacity: 0.28; }
+        50% { opacity: 0.92; }
+        100% { transform: translateX(16px); opacity: 0.28; }
+      }
+      ul, ol { margin: 0; padding-left: 18px; }
+      li { margin: 6px 0; }
+      @media (max-width: 1280px) {
+        .ops-kpi-grid, .ops-gauge-strip, .ops-incident-strip, .ops-sequence-grid, .ops-countdown-grid, .ops-countdown-grid-dual { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+        .ops-scan-grid, .ops-detail-grid, .ops-command-grid, .ops-motion-grid { grid-template-columns: 1fr; }
+      }
+      @media (max-width: 1100px) {
+        .ops-layout, .ops-layout-hands, .ops-bottom-grid, .ops-scan-grid, .ops-detail-grid, .ops-command-grid, .ops-gauge-strip, .ops-incident-strip, .ops-sequence-grid, .ops-motion-grid, .ops-countdown-grid, .ops-countdown-grid-dual { grid-template-columns: 1fr; }
+        .ops-studio-map { grid-template-columns: 1fr; }
+        .ops-map-zone-0, .ops-map-zone-1, .ops-map-zone-2, .ops-map-zone-3 { grid-column: span 1; }
+        .ops-kpi-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+        .ops-mode-nav { top: 8px; }
+      }
+      @media (max-width: 720px) {
+        .ops-kpi-grid { grid-template-columns: 1fr; }
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <header class="ops-hero">
+        <div>
+          <p class="ops-kicker">Studio Brain Autonomous Studio OS</p>
+          <h1>${esc(model.snapshot.twin.headline)}</h1>
+          <p>${esc(model.snapshot.twin.narrative)}</p>
+          <p class="ops-meta" style="margin-top:10px;">Generated ${esc(formatTimestamp(model.snapshot.generatedAt))} · Truth ${esc(model.snapshot.truth.readiness)} · Current risk ${esc(model.snapshot.twin.currentRisk || "none surfaced")}</p>
+        </div>
+        <div class="ops-kpi-grid">
+          <article class="ops-kpi"><span>Tasks</span><strong>${esc(model.snapshot.tasks.length)}</strong></article>
+          <article class="ops-kpi"><span>Cases</span><strong>${esc(model.snapshot.cases.length)}</strong></article>
+          <article class="ops-kpi"><span>Approvals</span><strong>${esc(model.snapshot.approvals.filter((entry) => entry.status === "pending").length)}</strong></article>
+          <article class="ops-kpi"><span>Growth / Forge</span><strong>${esc(model.snapshot.ceo.length + model.snapshot.forge.length)}</strong></article>
+        </div>
+      </header>
+
+      <div class="ops-banner" id="ops-banner"></div>
+      ${renderSurfaceShell(model.snapshot, model.displayState)}
+    </main>
+    <script id="ops-portal-model" type="application/json">${initialJson}</script>
+    <script>
+      const pageModel = JSON.parse(document.getElementById("ops-portal-model").textContent || "{}");
+      const banner = document.getElementById("ops-banner");
+
+      function showBanner(text, tone) {
+        banner.textContent = text;
+        banner.className = "ops-banner is-visible " + (tone === "error" ? "ops-banner-error" : "ops-banner-success");
+      }
+
+      const defaultModes = {
+        manager: "overview",
+        owner: "brief",
+        hands: "now",
+        internet: "desk",
+        ceo: "portfolio",
+        forge: "lab",
+      };
+      const activeModes = { ...defaultModes };
+
+      function syncOpsUrl(surface) {
+        const params = new URLSearchParams(window.location.search);
+        params.set("surface", surface);
+        const mode = activeModes[surface];
+        if (mode) {
+          params.set("mode", mode);
+        } else {
+          params.delete("mode");
+        }
+        const nextUrl = window.location.pathname + "?" + params.toString();
+        window.history.replaceState({}, "", nextUrl);
+      }
+
+      function setSurfaceMode(surface, mode, shouldSync = true) {
+        activeModes[surface] = mode;
+        document.querySelectorAll("[data-surface-mode-panel]").forEach((panel) => {
+          panel.classList.toggle(
+            "is-active",
+            panel.getAttribute("data-surface-mode-panel") === surface && panel.getAttribute("data-mode") === mode,
+          );
+        });
+        document.querySelectorAll("[data-surface-mode-tab]").forEach((button) => {
+          button.classList.toggle(
+            "is-active",
+            button.getAttribute("data-surface-mode-tab") === surface && button.getAttribute("data-mode-tab") === mode,
+          );
+        });
+        if (shouldSync) {
+          syncOpsUrl(surface);
+        }
+      }
+
+      function setSurface(surface) {
+        document.querySelectorAll("[data-surface]").forEach((section) => {
+          section.classList.toggle("is-active", section.getAttribute("data-surface") === surface);
+        });
+        document.querySelectorAll("[data-surface-tab]").forEach((button) => {
+          button.classList.toggle("is-active", button.getAttribute("data-surface-tab") === surface);
+        });
+        setSurfaceMode(surface, activeModes[surface] || defaultModes[surface] || "overview", false);
+        syncOpsUrl(surface);
+      }
+
+      async function getJson(url) {
+        const headers = {};
+        if (pageModel.sessionToken) {
+          headers["x-studio-brain-ops-session"] = pageModel.sessionToken;
+        }
+        const response = await fetch(url, {
+          method: "GET",
+          credentials: "same-origin",
+          headers,
+        });
+        let payload = null;
+        try {
+          payload = await response.json();
+        } catch {}
+        if (!response.ok || !payload || payload.ok !== true) {
+          throw new Error(payload && payload.message ? payload.message : "Request failed.");
+        }
+        return payload;
+      }
+
+      async function postJson(url, body) {
+        const headers = { "content-type": "application/json" };
+        if (pageModel.sessionToken) {
+          headers["x-studio-brain-ops-session"] = pageModel.sessionToken;
+        }
+        const response = await fetch(url, {
+          method: "POST",
+          credentials: "same-origin",
+          headers,
+          body: JSON.stringify(body),
+        });
+        let payload = null;
+        try {
+          payload = await response.json();
+        } catch {}
+        if (!response.ok || !payload || payload.ok !== true) {
+          throw new Error(payload && payload.message ? payload.message : "Request failed.");
+        }
+        return payload;
+      }
+
+      document.querySelectorAll("[data-surface-tab]").forEach((button) => {
+        button.addEventListener("click", () => setSurface(button.getAttribute("data-surface-tab")));
+      });
+      document.querySelectorAll("[data-surface-mode-tab]").forEach((button) => {
+        button.addEventListener("click", () => {
+          const surface = button.getAttribute("data-surface-mode-tab");
+          const mode = button.getAttribute("data-mode-tab");
+          if (!surface || !mode) return;
+          setSurfaceMode(surface, mode);
+        });
+      });
+      const params = new URLSearchParams(window.location.search);
+      const visibleSurfaces = Array.from(document.querySelectorAll("[data-surface]"))
+        .map((section) => section.getAttribute("data-surface"))
+        .filter(Boolean);
+      const requestedSurface = params.get("surface") || pageModel.surface || visibleSurfaces[0] || "manager";
+      const requestedMode = params.get("mode");
+      if (requestedMode) {
+        activeModes[requestedSurface] = requestedMode;
+      }
+      setSurface(visibleSurfaces.includes(requestedSurface) ? requestedSurface : (visibleSurfaces[0] || "manager"));
+
+      document.querySelectorAll("[data-task-claim]").forEach((button) => {
+        button.addEventListener("click", async () => {
+          try {
+            await postJson("/api/ops/tasks/" + encodeURIComponent(button.getAttribute("data-task-claim")) + "/claim", { actorId: "staff:local-portal" });
+            showBanner("Task claimed. Refresh to see the updated assignment state.", "success");
+          } catch (error) {
+            showBanner(error instanceof Error ? error.message : String(error), "error");
+          }
+        });
+      });
+      document.querySelectorAll("[data-task-proof]").forEach((button) => {
+        button.addEventListener("click", async () => {
+          try {
+            await postJson("/api/ops/tasks/" + encodeURIComponent(button.getAttribute("data-task-proof")) + "/proof", {
+              actorId: "staff:local-portal",
+              mode: button.getAttribute("data-task-proof-mode"),
+              note: "Proof submitted from the Studio Brain portal.",
+              artifactRefs: [],
+            });
+            showBanner("Proof submitted. Refresh to verify the updated task state.", "success");
+          } catch (error) {
+            showBanner(error instanceof Error ? error.message : String(error), "error");
+          }
+        });
+      });
+      document.querySelectorAll("[data-task-complete]").forEach((button) => {
+        button.addEventListener("click", async () => {
+          try {
+            await postJson("/api/ops/tasks/" + encodeURIComponent(button.getAttribute("data-task-complete")) + "/complete", { actorId: "staff:local-portal" });
+            showBanner("Task completion recorded. If proof is still pending, the truth rail will keep it visibly unverified.", "success");
+          } catch (error) {
+            showBanner(error instanceof Error ? error.message : String(error), "error");
+          }
+        });
+      });
+      document.querySelectorAll("[data-task-escape]").forEach((button) => {
+        button.addEventListener("click", async () => {
+          const taskId = button.getAttribute("data-task-id");
+          const hatch = button.getAttribute("data-task-escape");
+          const reason = window.prompt("Tell the manager why this task needs a different path.", "");
+          if (reason === null) return;
+          try {
+            await postJson("/api/ops/tasks/" + encodeURIComponent(taskId) + "/escape", {
+              actorId: "staff:local-portal",
+              escapeHatch: hatch,
+              reason,
+            });
+            showBanner("The manager now sees this task as blocked and routed for reconciliation.", "success");
+          } catch (error) {
+            showBanner(error instanceof Error ? error.message : String(error), "error");
+          }
+        });
+      });
+      document.querySelectorAll("[data-reservation-prepare]").forEach((button) => {
+        button.addEventListener("click", async () => {
+          try {
+            await postJson("/api/ops/reservations/" + encodeURIComponent(button.getAttribute("data-reservation-prepare")) + "/prepare", {
+              actorId: "staff:local-portal",
+            });
+            showBanner("Prep task is staged for that reservation bundle. Refresh to see it in the queue.", "success");
+          } catch (error) {
+            showBanner(error instanceof Error ? error.message : String(error), "error");
+          }
+        });
+      });
+      document.querySelectorAll("[data-member-activity]").forEach((button) => {
+        button.addEventListener("click", async () => {
+          try {
+            const payload = await getJson("/api/ops/members/" + encodeURIComponent(button.getAttribute("data-member-activity")) + "/activity");
+            const activity = payload.activity || {};
+            showBanner(
+              (button.getAttribute("data-member-name") || "Member")
+                + ": "
+                + (activity.reservations || 0)
+                + " reservations, "
+                + (activity.events || 0)
+                + " upcoming events, "
+                + (activity.supportThreads || 0)
+                + " support threads, "
+                + (activity.libraryLoans || 0)
+                + " library loans.",
+              "success",
+            );
+          } catch (error) {
+            showBanner(error instanceof Error ? error.message : String(error), "error");
+          }
+        });
+      });
+      document.querySelectorAll("[data-member-profile]").forEach((button) => {
+        button.addEventListener("click", async () => {
+          const uid = button.getAttribute("data-member-profile");
+          const displayName = window.prompt("Display name", button.getAttribute("data-member-display-name") || "");
+          if (displayName === null) return;
+          const kilnPreferences = window.prompt("Kiln preferences", button.getAttribute("data-member-kiln-preferences") || "");
+          if (kilnPreferences === null) return;
+          const staffNotes = window.prompt("Staff notes", button.getAttribute("data-member-staff-notes") || "");
+          if (staffNotes === null) return;
+          try {
+            await postJson("/api/ops/members/" + encodeURIComponent(uid) + "/profile", {
+              reason: "Edited from the autonomous ops portal.",
+              patch: {
+                displayName,
+                kilnPreferences,
+                staffNotes,
+              },
+            });
+            showBanner("Member profile updated. Refresh to see the new values.", "success");
+          } catch (error) {
+            showBanner(error instanceof Error ? error.message : String(error), "error");
+          }
+        });
+      });
+      document.querySelectorAll("[data-member-membership]").forEach((button) => {
+        button.addEventListener("click", async () => {
+          const uid = button.getAttribute("data-member-membership");
+          const membershipTier = window.prompt("Membership tier", button.getAttribute("data-member-membership-tier") || "");
+          if (membershipTier === null) return;
+          try {
+            await postJson("/api/ops/members/" + encodeURIComponent(uid) + "/membership", {
+              membershipTier,
+              reason: "Updated from the autonomous ops portal.",
+            });
+            showBanner("Membership updated. Refresh to see the new tier.", "success");
+          } catch (error) {
+            showBanner(error instanceof Error ? error.message : String(error), "error");
+          }
+        });
+      });
+      document.querySelectorAll("[data-member-role]").forEach((button) => {
+        button.addEventListener("click", async () => {
+          const uid = button.getAttribute("data-member-role");
+          const rolesInput = window.prompt("Comma-separated ops roles", button.getAttribute("data-member-roles") || "");
+          if (rolesInput === null) return;
+          const opsRoles = rolesInput
+            .split(",")
+            .map((entry) => entry.trim())
+            .filter(Boolean);
+          try {
+            await postJson("/api/ops/members/" + encodeURIComponent(uid) + "/role", {
+              opsRoles,
+              reason: "Updated from the autonomous ops portal.",
+            });
+            showBanner("Role assignment updated. Refresh to see the new capability mask.", "success");
+          } catch (error) {
+            showBanner(error instanceof Error ? error.message : String(error), "error");
+          }
+        });
+      });
+      document.querySelectorAll("[data-approval-resolve]").forEach((button) => {
+        button.addEventListener("click", async () => {
+          try {
+            await postJson("/api/ops/approvals/" + encodeURIComponent(button.getAttribute("data-approval-resolve")) + "/resolve", {
+              actorId: "staff:local-portal",
+              status: button.getAttribute("data-approval-status"),
+            });
+            showBanner("Approval decision recorded. Refresh to see the new state.", "success");
+          } catch (error) {
+            showBanner(error instanceof Error ? error.message : String(error), "error");
+          }
+        });
+      });
+      document.querySelectorAll("[data-case-note]").forEach((button) => {
+        button.addEventListener("click", async () => {
+          const body = window.prompt("Add a case note");
+          if (!body) return;
+          try {
+            await postJson("/api/ops/cases/" + encodeURIComponent(button.getAttribute("data-case-note")) + "/note", {
+              actorId: "staff:local-portal",
+              body,
+            });
+            showBanner("Case note recorded. Refresh to see it in the ledger.", "success");
+          } catch (error) {
+            showBanner(error instanceof Error ? error.message : String(error), "error");
+          }
+        });
+      });
+      document.querySelectorAll("[data-surface-chat]").forEach((form) => {
+        form.addEventListener("submit", async (event) => {
+          event.preventDefault();
+          const surface = form.getAttribute("data-surface-chat");
+          const field = form.querySelector("textarea");
+          const text = field && field.value ? field.value.trim() : "";
+          if (!text) return;
+          try {
+            const payload = await postJson("/api/ops/chat/" + encodeURIComponent(surface) + "/send", { actorId: "staff:local-portal", text });
+            const feed = surface === "manager" ? document.getElementById("ops-chat-feed") : null;
+            if (feed) {
+              const user = document.createElement("article");
+              user.className = "ops-chat-message ops-chat-message-user";
+              user.innerHTML = "<p>" + text.replace(/[&<>]/g, (ch) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;' }[ch])) + "</p>";
+              const assistant = document.createElement("article");
+              assistant.className = "ops-chat-message ops-chat-message-assistant";
+              assistant.innerHTML = "<p>" + String(payload.reply || "").replace(/[&<>]/g, (ch) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;' }[ch])) + "</p>";
+              feed.appendChild(user);
+              feed.appendChild(assistant);
+              feed.scrollTop = feed.scrollHeight;
+            }
+            field.value = "";
+            showBanner("Manager reply received.", "success");
+          } catch (error) {
+            showBanner(error instanceof Error ? error.message : String(error), "error");
+          }
+        });
+      });
+      const ceoForm = document.getElementById("ops-ceo-form");
+      if (ceoForm) {
+        ceoForm.addEventListener("submit", async (event) => {
+          event.preventDefault();
+          const title = ceoForm.querySelector("input[name='title']").value.trim();
+          const hypothesis = ceoForm.querySelector("textarea[name='hypothesis']").value.trim();
+          if (!title || !hypothesis) return;
+          try {
+            await postJson("/api/ops/ceo/experiments", { title, hypothesis });
+            showBanner("CEO experiment added. Refresh to review it in strategy mode.", "success");
+          } catch (error) {
+            showBanner(error instanceof Error ? error.message : String(error), "error");
+          }
+        });
+      }
+      const forgeForm = document.getElementById("ops-forge-form");
+      if (forgeForm) {
+        forgeForm.addEventListener("submit", async (event) => {
+          event.preventDefault();
+          const title = forgeForm.querySelector("input[name='title']").value.trim();
+          const problem = forgeForm.querySelector("textarea[name='problem']").value.trim();
+          if (!title || !problem) return;
+          try {
+            await postJson("/api/ops/forge/improvement-cases", { title, problem });
+            showBanner("Forge case added. Refresh to track the improvement work.", "success");
+          } catch (error) {
+            showBanner(error instanceof Error ? error.message : String(error), "error");
+          }
+        });
+      }
+      const overrideForm = document.getElementById("ops-override-form");
+      if (overrideForm) {
+        overrideForm.addEventListener("submit", async (event) => {
+          event.preventDefault();
+          const scope = overrideForm.querySelector("input[name='scope']").value.trim();
+          const reason = overrideForm.querySelector("textarea[name='reason']").value.trim();
+          const expiresAt = overrideForm.querySelector("input[name='expiresAt']").value.trim();
+          if (!scope || !reason) return;
+          try {
+            await postJson("/api/ops/overrides", {
+              scope,
+              reason,
+              expiresAt: expiresAt || null,
+            });
+            showBanner("Override request recorded. The truth rail will keep it visible until resolved.", "success");
+          } catch (error) {
+            showBanner(error instanceof Error ? error.message : String(error), "error");
+          }
+        });
+      }
+    </script>
+  </body>
+</html>`;
+}
+
+export function renderOpsPortalChoicePage(input: {
+  headline: string;
+  narrative: string;
+  generatedAt: string;
+  opsUrl: string;
+  legacyUrl: string | null;
+}): string {
+  const legacyCard = input.legacyUrl
+    ? `
+      <a class="ops-choice-card ops-choice-card-legacy" href="${esc(input.legacyUrl)}">
+        <p class="ops-kicker">A · Original portal</p>
+        <h2>Legacy staff experience</h2>
+        <p>Use the current portal flow as the control during the trial.</p>
+        <span>Open original</span>
+      </a>
+    `
+    : `
+      <article class="ops-choice-card ops-choice-card-disabled">
+        <p class="ops-kicker">A · Original portal</p>
+        <h2>Legacy staff experience</h2>
+        <p>No legacy comparison URL is configured yet.</p>
+        <span>Unavailable</span>
+      </article>
+    `;
+  return `<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Studio Brain Ops Choice</title>
+    <style>
+      :root {
+        color-scheme: light;
+        --bg: #efe7db;
+        --ink: #1b1714;
+        --muted: #61554b;
+        --panel: rgba(255,255,255,0.82);
+        --line: rgba(49,39,31,0.14);
+        --shadow: 0 16px 46px rgba(62, 42, 22, 0.14);
+        --accent: #264d7d;
+        --accent-2: #7b4b28;
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        color: var(--ink);
+        font-family: "Aptos", "Segoe UI", system-ui, sans-serif;
+        background:
+          radial-gradient(circle at top left, rgba(255,255,255,0.75), transparent 34%),
+          radial-gradient(circle at top right, rgba(184,136,72,0.18), transparent 26%),
+          linear-gradient(180deg, #f7f2eb 0%, #ede3d4 46%, #e5d7c2 100%);
+      }
+      main { max-width: 1240px; margin: 0 auto; padding: 36px 24px 48px; display: grid; gap: 20px; }
+      .ops-choice-hero,
+      .ops-choice-card {
+        background: var(--panel);
+        border: 1px solid var(--line);
+        border-radius: 28px;
+        box-shadow: var(--shadow);
+        backdrop-filter: blur(8px);
+      }
+      .ops-choice-hero { padding: 28px; display: grid; gap: 14px; }
+      .ops-choice-hero h1 { margin: 0; font-size: clamp(2.2rem, 4vw, 4rem); font-family: "Palatino Linotype", Georgia, serif; }
+      .ops-choice-hero p { margin: 0; color: var(--muted); }
+      .ops-kicker {
+        margin: 0;
+        font-size: 0.8rem;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--muted);
+      }
+      .ops-choice-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 18px; }
+      .ops-choice-card {
+        display: grid;
+        gap: 14px;
+        padding: 24px;
+        color: inherit;
+        text-decoration: none;
+      }
+      .ops-choice-card h2 { margin: 0; font-size: 1.6rem; }
+      .ops-choice-card p { margin: 0; color: var(--muted); line-height: 1.5; }
+      .ops-choice-card span {
+        display: inline-flex;
+        width: fit-content;
+        margin-top: 8px;
+        padding: 10px 16px;
+        border-radius: 999px;
+        font-weight: 700;
+        background: rgba(38,77,125,0.12);
+        color: var(--accent);
+      }
+      .ops-choice-card-legacy span { background: rgba(123,75,40,0.14); color: var(--accent-2); }
+      .ops-choice-card-disabled { opacity: 0.72; }
+      .ops-choice-notes {
+        padding: 18px 22px;
+        border-radius: 22px;
+        border: 1px solid var(--line);
+        background: rgba(255,255,255,0.66);
+      }
+      .ops-choice-notes p { margin: 0; color: var(--muted); }
+      @media (max-width: 900px) {
+        .ops-choice-grid { grid-template-columns: 1fr; }
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <section class="ops-choice-hero">
+        <p class="ops-kicker">Studio Brain side-by-side trial</p>
+        <h1>${esc(input.headline)}</h1>
+        <p>${esc(input.narrative)}</p>
+        <p>Generated ${esc(formatTimestamp(input.generatedAt))}. Use this page to choose between the original staff portal and the new autonomous ops portal during the production trial.</p>
+      </section>
+      <section class="ops-choice-grid">
+        ${legacyCard}
+        <a class="ops-choice-card" href="${esc(input.opsUrl)}">
+          <p class="ops-kicker">B · Autonomous Studio OS</p>
+          <h2>New ops portal</h2>
+          <p>Open the new motion-heavy, role-based operating system alongside the legacy portal.</p>
+          <span>Open autonomous ops</span>
+        </a>
+      </section>
+      <section class="ops-choice-notes">
+        <p>Recommendation: keep both live during the trial, make the human choice explicit, and tear down the loser only after task completion confidence and operator preference are both clear.</p>
+      </section>
+    </main>
+  </body>
+</html>`;
+}


### PR DESCRIPTION
## Summary
- add the new autonomous /ops portal foundation and standalone UI
- fold legacy staff workflows into /ops with role-aware member, reservation, task, and approval flows
- add the new ops schema, service layer, and host-safe portal toggles

## Verification
- npm --prefix studio-brain run build
- node --test studio-brain/lib/ops/service.test.js studio-brain/lib/http/server.test.js
- deployed to Studio Brain host at 192.168.1.226 and verified /ops mounts beside legacy staff routes