### PR TITLE
Bridge public /ops into Studio Brain

### DIFF
--- a/scripts/studiobrain-control-tower-proxy.mjs
+++ b/scripts/studiobrain-control-tower-proxy.mjs
@@ -108,7 +108,11 @@ server.listen(listenPort, listenHost, () => {
 
 function isAllowedPath(pathname) {
   if (pathname === "/") return true;
-  return /^\/api\/control-tower(?:\/.*)?$/i.test(pathname);
+  return (
+    /^\/ops(?:\/.*)?$/i.test(pathname) ||
+    /^\/api\/ops(?:\/.*)?$/i.test(pathname) ||
+    /^\/api\/control-tower(?:\/.*)?$/i.test(pathname)
+  );
 }
 
 function normalizePort(value, fallback) {

--- a/web/deploy/namecheap/.htaccess
+++ b/web/deploy/namecheap/.htaccess
@@ -11,6 +11,10 @@
   RewriteRule ^assets/ - [L,E=MF_ASSET_CACHE:1]
   RewriteRule ^[^/]+\.(js|css|map)$ - [E=ROOT_COMPAT_CHUNK:1]
 
+  # Route the Studio Brain browser bridge before the SPA fallback.
+  RewriteRule ^__studio-brain(?:/(?!index\.php$).*)?$ __studio-brain/index.php [QSA,L,NC]
+  RewriteRule ^api/ops(?:/(?!index\.php$).*)?$ __studio-brain/index.php [QSA,L,NC]
+
   # Never rewrite service worker/runtime manifest endpoints.
   RewriteRule ^(registerSW\.js|sw\.js|workbox-.*\.js|manifest\.webmanifest)$ - [L]
 

--- a/web/deploy/namecheap/.htaccess
+++ b/web/deploy/namecheap/.htaccess
@@ -12,8 +12,12 @@
   RewriteRule ^[^/]+\.(js|css|map)$ - [E=ROOT_COMPAT_CHUNK:1]
 
   # Route the Studio Brain browser bridge before the SPA fallback.
-  RewriteRule ^__studio-brain(?:/(?!index\.php$).*)?$ __studio-brain/index.php [QSA,L,NC]
-  RewriteRule ^api/ops(?:/(?!index\.php$).*)?$ __studio-brain/index.php [QSA,L,NC]
+  # Guard the physical bridge entry from re-entering the rewrite loop.
+  RewriteRule ^__studio-brain/index\.php$ - [END,NC]
+  RewriteRule ^__studio-brain$ __studio-brain/index.php [QSA,END,NC]
+  RewriteRule ^__studio-brain/(.+)$ __studio-brain/index.php?bridgePath=/$1 [QSA,END,NC]
+  RewriteRule ^api/ops$ __studio-brain/index.php?bridgePath=/api/ops [QSA,END,NC]
+  RewriteRule ^api/ops/(.+)$ __studio-brain/index.php?bridgePath=/api/ops/$1 [QSA,END,NC]
 
   # Never rewrite service worker/runtime manifest endpoints.
   RewriteRule ^(registerSW\.js|sw\.js|workbox-.*\.js|manifest\.webmanifest)$ - [L]

--- a/web/public/__studio-brain/index.php
+++ b/web/public/__studio-brain/index.php
@@ -1,0 +1,255 @@
+<?php
+declare(strict_types=1);
+
+const STUDIO_BRAIN_BRIDGE_PREFIX = '/__studio-brain';
+const STUDIO_BRAIN_UPSTREAM_BASE = 'http://127.0.0.1:18787';
+const STUDIO_BRAIN_UPSTREAM_TIMEOUT_SECONDS = 25;
+
+$method = strtoupper((string) ($_SERVER['REQUEST_METHOD'] ?? 'GET'));
+
+if ($method === 'OPTIONS') {
+    emitNoStoreHeaders();
+    header('Allow: GET,POST,OPTIONS,HEAD');
+    http_response_code(204);
+    exit;
+}
+
+if (!function_exists('curl_init')) {
+    emitJson(500, [
+        'ok' => false,
+        'message' => 'studio brain bridge missing curl support',
+    ]);
+}
+
+[$upstreamPath, $upstreamQuery] = resolveUpstreamTarget((string) ($_SERVER['REQUEST_URI'] ?? '/'));
+if (!isAllowedBridgePath($upstreamPath)) {
+    emitJson(404, [
+        'ok' => false,
+        'message' => 'path not allowed',
+    ]);
+}
+
+$upstreamUrl = STUDIO_BRAIN_UPSTREAM_BASE . $upstreamPath;
+if ($upstreamQuery !== '') {
+    $upstreamUrl .= '?' . $upstreamQuery;
+}
+
+$acceptHeader = (string) ($_SERVER['HTTP_ACCEPT'] ?? '');
+$isEventStream = stripos($acceptHeader, 'text/event-stream') !== false || $upstreamPath === '/api/control-tower/events';
+$requestHeaders = buildForwardHeaders();
+$requestBody = readRequestBody($method);
+$responseState = [
+    'status' => 200,
+    'headers' => [],
+    'headersEmitted' => false,
+];
+
+if ($isEventStream) {
+    @ini_set('output_buffering', 'off');
+    @ini_set('zlib.output_compression', '0');
+    while (ob_get_level() > 0) {
+        @ob_end_flush();
+    }
+    ob_implicit_flush(true);
+}
+
+$curlHandle = curl_init($upstreamUrl);
+curl_setopt_array($curlHandle, [
+    CURLOPT_CUSTOMREQUEST => $method,
+    CURLOPT_FOLLOWLOCATION => false,
+    CURLOPT_RETURNTRANSFER => false,
+    CURLOPT_HEADER => false,
+    CURLOPT_CONNECTTIMEOUT => 5,
+    CURLOPT_TIMEOUT => $isEventStream ? 0 : STUDIO_BRAIN_UPSTREAM_TIMEOUT_SECONDS,
+    CURLOPT_HTTPHEADER => $requestHeaders,
+    CURLOPT_HEADERFUNCTION => static function ($handle, string $headerLine) use (&$responseState): int {
+        $trimmed = trim($headerLine);
+        if ($trimmed === '') {
+            return strlen($headerLine);
+        }
+
+        if (preg_match('/^HTTP\/\S+\s+(\d{3})\b/i', $trimmed, $matches)) {
+            $responseState['status'] = (int) $matches[1];
+            return strlen($headerLine);
+        }
+
+        $separator = strpos($trimmed, ':');
+        if ($separator === false) {
+            return strlen($headerLine);
+        }
+
+        $name = strtolower(trim(substr($trimmed, 0, $separator)));
+        $value = trim(substr($trimmed, $separator + 1));
+        if ($value === '') {
+            return strlen($headerLine);
+        }
+
+        if (in_array($name, ['content-type', 'x-request-id'], true)) {
+            $responseState['headers'][$name] = $value;
+        }
+
+        return strlen($headerLine);
+    },
+    CURLOPT_WRITEFUNCTION => static function ($handle, string $chunk) use (&$responseState, $isEventStream): int {
+        emitForwardResponseHeaders($responseState, $isEventStream);
+        echo $chunk;
+        if ($isEventStream) {
+            flush();
+        }
+        return strlen($chunk);
+    },
+]);
+
+if ($method === 'HEAD') {
+    curl_setopt($curlHandle, CURLOPT_NOBODY, true);
+} elseif ($requestBody !== null) {
+    curl_setopt($curlHandle, CURLOPT_POSTFIELDS, $requestBody);
+}
+
+$ok = curl_exec($curlHandle);
+if ($ok === false) {
+    $errorMessage = curl_error($curlHandle);
+    $errorCode = curl_errno($curlHandle);
+    curl_close($curlHandle);
+
+    if (connection_aborted()) {
+        exit;
+    }
+
+    emitJson(502, [
+        'ok' => false,
+        'message' => 'studio brain bridge unavailable',
+        'detail' => $errorMessage !== '' ? $errorMessage : sprintf('curl error %d', $errorCode),
+    ]);
+}
+
+curl_close($curlHandle);
+emitForwardResponseHeaders($responseState, $isEventStream);
+
+function resolveUpstreamTarget(string $requestUri): array
+{
+    $path = (string) parse_url($requestUri, PHP_URL_PATH);
+    $query = (string) parse_url($requestUri, PHP_URL_QUERY);
+
+    if (!str_starts_with($path, STUDIO_BRAIN_BRIDGE_PREFIX)) {
+        return [$path !== '' ? $path : '/', $query];
+    }
+
+    $suffix = substr($path, strlen(STUDIO_BRAIN_BRIDGE_PREFIX));
+    if ($suffix === false || $suffix === '') {
+        return ['/', $query];
+    }
+
+    return [$suffix, $query];
+}
+
+function isAllowedBridgePath(string $path): bool
+{
+    if ($path === '/' || $path === '/healthz') {
+        return true;
+    }
+
+    return (bool) preg_match('#^/(?:ops(?:/.*)?|api/ops(?:/.*)?|api/control-tower(?:/.*)?)$#i', $path);
+}
+
+function buildForwardHeaders(): array
+{
+    $allowedNames = [
+        'authorization',
+        'content-type',
+        'accept',
+        'x-request-id',
+        'x-trace-id',
+        'traceparent',
+    ];
+    $allowedLookup = array_fill_keys($allowedNames, true);
+
+    $headers = [];
+    foreach (readIncomingHeaders() as $name => $value) {
+        $normalizedName = strtolower($name);
+        $normalizedValue = trim((string) $value);
+        if ($normalizedValue === '' || !isset($allowedLookup[$normalizedName])) {
+            continue;
+        }
+        $headers[] = sprintf('%s: %s', $name, $normalizedValue);
+    }
+
+    return $headers;
+}
+
+function readIncomingHeaders(): array
+{
+    if (function_exists('getallheaders')) {
+        $headers = getallheaders();
+        if (is_array($headers)) {
+            return $headers;
+        }
+    }
+
+    $headers = [];
+    foreach ($_SERVER as $key => $value) {
+        if (!str_starts_with((string) $key, 'HTTP_')) {
+            continue;
+        }
+
+        $normalized = str_replace(' ', '-', ucwords(strtolower(str_replace('_', ' ', substr((string) $key, 5)))));
+        $headers[$normalized] = (string) $value;
+    }
+
+    if (isset($_SERVER['CONTENT_TYPE'])) {
+        $headers['Content-Type'] = (string) $_SERVER['CONTENT_TYPE'];
+    }
+
+    return $headers;
+}
+
+function readRequestBody(string $method): ?string
+{
+    if (in_array($method, ['GET', 'HEAD'], true)) {
+        return null;
+    }
+
+    $body = file_get_contents('php://input');
+    if ($body === false || $body === '') {
+        return null;
+    }
+
+    return $body;
+}
+
+function emitForwardResponseHeaders(array &$responseState, bool $isEventStream): void
+{
+    if ($responseState['headersEmitted']) {
+        return;
+    }
+
+    http_response_code((int) $responseState['status']);
+    emitNoStoreHeaders();
+    if ($isEventStream) {
+        header('X-Accel-Buffering: no');
+    }
+
+    foreach ($responseState['headers'] as $name => $value) {
+        if ($value === '') {
+            continue;
+        }
+        header($name . ': ' . $value);
+    }
+
+    $responseState['headersEmitted'] = true;
+}
+
+function emitNoStoreHeaders(): void
+{
+    header('Cache-Control: no-store');
+    header('X-Content-Type-Options: nosniff');
+}
+
+function emitJson(int $statusCode, array $payload): void
+{
+    http_response_code($statusCode);
+    emitNoStoreHeaders();
+    header('Content-Type: application/json');
+    echo json_encode($payload, JSON_UNESCAPED_SLASHES);
+    exit;
+}

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -5624,3 +5624,22 @@ html[data-portal-theme="memoria"] .page .card:nth-of-type(8) {
   font: 600 12px/1.2 var(--ui-font);
   cursor: pointer;
 }
+
+.ops-bridge-shell {
+  min-height: calc(100vh - 4rem);
+  display: flex;
+}
+
+.ops-bridge-card {
+  width: min(720px, 100%);
+  margin: auto;
+}
+
+.ops-bridge-frame {
+  width: 100%;
+  min-height: calc(100vh - 4rem);
+  border: 0;
+  border-radius: 24px;
+  background: #0f1419;
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.35);
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -104,6 +104,7 @@ const StudioReservationsView = React.lazy(() => import("./views/StudioReservatio
 const SignedOutView = React.lazy(() => import("./views/SignedOutView"));
 const StudioResourcesView = React.lazy(() => import("./views/StudioResourcesView"));
 const SupportView = React.lazy(() => import("./views/SupportView"));
+const OpsPortalBridgeView = React.lazy(() => import("./views/OpsPortalBridgeView"));
 const StaffView = React.lazy(() => import("./views/StaffView"));
 const WareCheckInView = React.lazy(() => import("./views/WareCheckInView"));
 
@@ -128,6 +129,7 @@ type NavKey =
   | "notifications"
   | "messages"
   | "support"
+  | "opsPortal"
   | "staff";
 
 type NavItem = {
@@ -361,6 +363,7 @@ const NAV_LABELS: Record<NavKey, string> = {
   notifications: "Notifications",
   messages: "Messages",
   support: "Support",
+  opsPortal: "Studio Ops",
   staff: "Staff",
 };
 
@@ -415,6 +418,10 @@ function normalizeAppPath(pathname: string): string {
 
 function normalizeHashPath(hash: string): string {
   return normalizeStaffPath(hash);
+}
+
+function isOpsPortalPath(pathname: string): boolean {
+  return /^\/ops(?:\/|$)/i.test(normalizeAppPath(pathname));
 }
 
 function isLegacyRequestsPath(pathname: string): boolean {
@@ -888,6 +895,7 @@ export default function App() {
   const [nav, setNav] = useState<NavKey>(() => {
     if (typeof window === "undefined") return "dashboard";
     const normalizedPathname = normalizeAppPath(window.location.pathname);
+    if (isOpsPortalPath(normalizedPathname)) return "opsPortal";
     const staffTaskShortcut = resolveStaffTaskShortcut(normalizedPathname, window.location.hash);
     if (staffTaskShortcut) return staffTaskShortcut.targetNav;
     const staffWorkspaceLaunch = resolveStaffWorkspaceLaunch(normalizedPathname, window.location.hash);
@@ -903,7 +911,7 @@ export default function App() {
     if (reservationsTarget === "wareCheckIn") return "wareCheckIn";
     if (normalizedPathname === "/glazes" || normalizedPathname === "/community/glazes") return "glazes";
     const saved = readLocalItem(LOCAL_NAV_KEY);
-    if (saved && isNavKey(saved)) return saved;
+    if (saved && isNavKey(saved) && saved !== "opsPortal") return saved;
     return "dashboard";
   });
   const [staffWorkspaceMode, setStaffWorkspaceMode] = useState<StaffWorkspaceMode>(() => {
@@ -1213,9 +1221,12 @@ export default function App() {
   }, []);
 
   useEffect(() => {
-    writeLocalItem(LOCAL_NAV_KEY, nav);
+    if (nav !== "opsPortal") {
+      writeLocalItem(LOCAL_NAV_KEY, nav);
+    }
     if (typeof window === "undefined") return;
     const pathname = normalizeAppPath(window.location.pathname);
+    const hasOpsPortalPath = isOpsPortalPath(pathname);
     const hashPath = normalizeHashPath(window.location.hash);
     const staffTaskShortcut = resolveStaffTaskShortcut(pathname, window.location.hash);
     const pathnameStaffMatch = resolveStaffWorkspaceMatch(pathname);
@@ -1266,12 +1277,19 @@ export default function App() {
         }
       }
     } else if (
+      hasOpsPortalPath ||
       pathname === "/glazes" ||
       hasLegacyRequestsPath ||
       hasLegacyRequestsHash ||
       resolveReservationsPathTarget(pathname) !== null
     ) {
-      window.history.replaceState({}, "", "/");
+      if (hasOpsPortalPath) {
+        if (nav !== "opsPortal") {
+          setNav("opsPortal");
+        }
+      } else {
+        window.history.replaceState({}, "", "/");
+      }
     }
   }, [nav, staffInitialTaskAction, staffUi, staffWorkspaceMode]);
 
@@ -1280,6 +1298,15 @@ export default function App() {
 
     const syncStateWithBrowserLocation = () => {
       const pathname = normalizeAppPath(window.location.pathname);
+      if (isOpsPortalPath(pathname)) {
+        if (staffWorkspaceMode !== "default") {
+          setStaffWorkspaceMode("default");
+        }
+        if (nav !== "opsPortal") {
+          setNav("opsPortal");
+        }
+        return;
+      }
       const staffTaskShortcut = resolveStaffTaskShortcut(pathname, window.location.hash);
       if (staffTaskShortcut) {
         if (staffTaskShortcut.targetNav === "staff") {
@@ -2471,6 +2498,8 @@ export default function App() {
             isBusy={supportBusy}
           />
         );
+      case "opsPortal":
+        return <OpsPortalBridgeView user={user} authReady={authReady} isStaff={staffUi} />;
       case "staff":
         return (
           <StaffView

--- a/web/src/views/OpsPortalBridgeView.tsx
+++ b/web/src/views/OpsPortalBridgeView.tsx
@@ -17,6 +17,14 @@ function injectBaseHref(html: string): string {
   return html.replace(/<head([^>]*)>/i, `<head$1><base href="${window.location.origin}/">`);
 }
 
+function buildBridgeUrl(locationKey: string): string {
+  if (typeof window === "undefined") {
+    return "/__studio-brain/ops";
+  }
+  const current = new URL(locationKey, window.location.origin);
+  return `/__studio-brain${current.pathname}${current.search}`;
+}
+
 export default function OpsPortalBridgeView({ user, authReady, isStaff }: Props) {
   const [html, setHtml] = useState("");
   const [loading, setLoading] = useState(true);
@@ -54,7 +62,7 @@ export default function OpsPortalBridgeView({ user, authReady, isStaff }: Props)
 
       try {
         const idToken = await user.getIdToken();
-        const response = await fetch(`/__studio-brain${locationKey}`, {
+        const response = await fetch(buildBridgeUrl(locationKey), {
           method: "GET",
           headers: {
             authorization: `Bearer ${idToken}`,

--- a/web/src/views/OpsPortalBridgeView.tsx
+++ b/web/src/views/OpsPortalBridgeView.tsx
@@ -1,0 +1,143 @@
+import { useEffect, useMemo, useState } from "react";
+import type { User } from "firebase/auth";
+
+type Props = {
+  user: User | null;
+  authReady: boolean;
+  isStaff: boolean;
+};
+
+function injectBaseHref(html: string): string {
+  if (typeof window === "undefined" || !html.includes("<head")) {
+    return html;
+  }
+  if (html.includes("<base ")) {
+    return html;
+  }
+  return html.replace(/<head([^>]*)>/i, `<head$1><base href="${window.location.origin}/">`);
+}
+
+export default function OpsPortalBridgeView({ user, authReady, isStaff }: Props) {
+  const [html, setHtml] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [reloadNonce, setReloadNonce] = useState(0);
+  const locationKey = typeof window === "undefined" ? "/ops" : `${window.location.pathname}${window.location.search}`;
+
+  useEffect(() => {
+    let cancelled = false;
+    const controller = new AbortController();
+
+    async function load(): Promise<void> {
+      if (!authReady) {
+        setLoading(true);
+        setError("");
+        return;
+      }
+
+      if (!user) {
+        setLoading(false);
+        setHtml("");
+        setError("Sign in with a staff account to open Studio Ops.");
+        return;
+      }
+
+      if (!isStaff) {
+        setLoading(false);
+        setHtml("");
+        setError("Studio Ops is only available to staff accounts.");
+        return;
+      }
+
+      setLoading(true);
+      setError("");
+
+      try {
+        const idToken = await user.getIdToken();
+        const response = await fetch(`/__studio-brain${locationKey}`, {
+          method: "GET",
+          headers: {
+            authorization: `Bearer ${idToken}`,
+            accept: "text/html",
+            "cache-control": "no-cache",
+            pragma: "no-cache",
+          },
+          cache: "no-store",
+          signal: controller.signal,
+        });
+        const body = await response.text();
+        if (!response.ok) {
+          throw new Error(body || `Studio Ops bridge returned ${response.status}.`);
+        }
+        if (cancelled) return;
+        setHtml(injectBaseHref(body));
+      } catch (caught) {
+        if (controller.signal.aborted || cancelled) return;
+        const message = caught instanceof Error ? caught.message : String(caught);
+        setHtml("");
+        setError(message || "Unable to load Studio Ops.");
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+
+    void load();
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [authReady, isStaff, locationKey, reloadNonce, user]);
+
+  const title = useMemo(() => {
+    if (typeof window === "undefined") return "Studio Ops";
+    const search = new URLSearchParams(window.location.search);
+    const surface = search.get("surface");
+    return surface ? `Studio Ops · ${surface}` : "Studio Ops";
+  }, [locationKey]);
+
+  if (loading) {
+    return (
+      <section className="ops-bridge-shell">
+        <div className="card ops-bridge-card" role="status" aria-live="polite">
+          <div className="card-title">Loading Studio Ops</div>
+          <p className="card-subtitle">Bridging your signed-in portal session into the new Studio Brain surface.</p>
+        </div>
+      </section>
+    );
+  }
+
+  if (error) {
+    return (
+      <section className="ops-bridge-shell">
+        <div className="card ops-bridge-card" role="alert" aria-live="assertive">
+          <div className="card-title">Studio Ops Bridge Unavailable</div>
+          <p className="card-subtitle">{error}</p>
+          <div className="staff-note">
+            The public `/ops` route now bridges into Studio Brain, so it needs a live staff session before the new operating surface can mount.
+          </div>
+          <div className="staff-actions-row">
+            <button
+              type="button"
+              className="btn btn-secondary"
+              onClick={() => {
+                setLoading(true);
+                setError("");
+                setReloadNonce((value) => value + 1);
+              }}
+            >
+              Retry bridge
+            </button>
+          </div>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className="ops-bridge-shell">
+      <iframe className="ops-bridge-frame" title={title} srcDoc={html} />
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- turn the public /ops route into a portal-side authenticated bridge into Studio Brain
- route public /api/ops requests through the existing Namecheap -> Studio Brain bridge
- widen the bridge PHP allowlist for /ops and /api/ops paths

## Verification
- npm --prefix web run build
- deployed portal bundle to https://portal.monsoonfire.com
- verified public /ops now serves the new bundle hash and the bridge files are live on the portal host