### PR TITLE
Support npm-safe ship workflow aliases

### DIFF
--- a/docs/runbooks/SHIP_WORKFLOW.md
+++ b/docs/runbooks/SHIP_WORKFLOW.md
@@ -38,6 +38,13 @@ Apply the portal lane:
 npm run ship:portal:apply -- 473
 ```
 
+When you want extra toggles through `npm run`, prefer npm-safe positional aliases:
+
+```bash
+npm run ship:apply -- 474 skip-cleanup
+npm run ship:portal:apply -- 474 skip-cleanup skip-sync
+```
+
 Website and Studio Brain presets follow the same pattern:
 - `npm run ship:website`
 - `npm run ship:website:apply`
@@ -60,4 +67,5 @@ When apply mode is enabled, the workflow can:
 ## Notes
 - The workflow writes a JSON report to `output/maintenance/ship-workflow-latest.json` by default.
 - If no clean default-branch worktree is available, deploy is blocked on purpose rather than deploying from a dirty feature branch.
-- Use `--skip-deploy`, `--skip-sync`, or `--skip-cleanup` when you only want part of the tail-end flow.
+- Direct `node ./scripts/ship-workflow.mjs ...` runs accept the full `--flag` syntax.
+- `npm run ship...` shorthands also accept positional aliases like `apply`, `portal`, `474`, `skip-cleanup`, `skip-sync`, `skip-merge`, and `pr=474`.

--- a/scripts/ship-workflow.mjs
+++ b/scripts/ship-workflow.mjs
@@ -91,6 +91,10 @@ function printUsage() {
     "  --artifact <path>       Write the JSON report to a custom repo-relative path.",
     "  --json                  Emit the report as JSON.",
     "  --help                  Show this help text.",
+    "",
+    "NPM-safe positional aliases:",
+    "  apply, portal, website, studio, 474, pr=474, skip-cleanup, skip-sync, skip-merge",
+    "  no-update-branch, no-wait-checks, no-delete-branch, merge-method=squash",
   ];
   process.stdout.write(`${lines.join("\n")}\n`);
 }
@@ -115,45 +119,46 @@ export function parseArgs(argv) {
 
   for (let index = 0; index < argv.length; index += 1) {
     const arg = clean(argv[index]);
+    const lowerArg = arg.toLowerCase();
     if (!arg) continue;
 
-    if (arg === "--apply") {
+    if (arg === "--apply" || lowerArg === "apply") {
       parsed.apply = true;
       continue;
     }
-    if (arg === "--json") {
+    if (arg === "--json" || lowerArg === "json") {
       parsed.json = true;
       continue;
     }
-    if (arg === "--help" || arg === "-h") {
+    if (arg === "--help" || arg === "-h" || lowerArg === "help") {
       parsed.help = true;
       continue;
     }
-    if (arg === "--skip-merge") {
+    if (arg === "--skip-merge" || lowerArg === "skip-merge") {
       parsed.merge = false;
       continue;
     }
-    if (arg === "--skip-deploy") {
+    if (arg === "--skip-deploy" || lowerArg === "skip-deploy") {
       parsed.deploy = false;
       continue;
     }
-    if (arg === "--skip-sync") {
+    if (arg === "--skip-sync" || lowerArg === "skip-sync") {
       parsed.sync = false;
       continue;
     }
-    if (arg === "--skip-cleanup") {
+    if (arg === "--skip-cleanup" || lowerArg === "skip-cleanup") {
       parsed.cleanup = false;
       continue;
     }
-    if (arg === "--no-update-branch") {
+    if (arg === "--no-update-branch" || lowerArg === "no-update-branch") {
       parsed.updateBranch = false;
       continue;
     }
-    if (arg === "--no-wait-checks") {
+    if (arg === "--no-wait-checks" || lowerArg === "no-wait-checks") {
       parsed.waitChecks = false;
       continue;
     }
-    if (arg === "--no-delete-branch") {
+    if (arg === "--no-delete-branch" || lowerArg === "no-delete-branch") {
       parsed.deleteBranch = false;
       continue;
     }
@@ -162,8 +167,8 @@ export function parseArgs(argv) {
       index += 1;
       continue;
     }
-    if (arg.startsWith("--lane=")) {
-      parsed.lane = clean(arg.slice("--lane=".length)).toLowerCase();
+    if (arg.startsWith("--lane=") || lowerArg.startsWith("lane=")) {
+      parsed.lane = clean(arg.slice(arg.indexOf("=") + 1)).toLowerCase();
       continue;
     }
     if (arg === "--pr" && argv[index + 1]) {
@@ -171,8 +176,8 @@ export function parseArgs(argv) {
       index += 1;
       continue;
     }
-    if (arg.startsWith("--pr=")) {
-      parsed.pr = clean(arg.slice("--pr=".length));
+    if (arg.startsWith("--pr=") || lowerArg.startsWith("pr=")) {
+      parsed.pr = clean(arg.slice(arg.indexOf("=") + 1));
       continue;
     }
     if (arg === "--merge-method" && argv[index + 1]) {
@@ -180,8 +185,8 @@ export function parseArgs(argv) {
       index += 1;
       continue;
     }
-    if (arg.startsWith("--merge-method=")) {
-      parsed.mergeMethod = clean(arg.slice("--merge-method=".length)).toLowerCase();
+    if (arg.startsWith("--merge-method=") || lowerArg.startsWith("merge-method=")) {
+      parsed.mergeMethod = clean(arg.slice(arg.indexOf("=") + 1)).toLowerCase();
       continue;
     }
     if (arg === "--artifact" && argv[index + 1]) {
@@ -189,8 +194,8 @@ export function parseArgs(argv) {
       index += 1;
       continue;
     }
-    if (arg.startsWith("--artifact=")) {
-      parsed.artifact = clean(arg.slice("--artifact=".length));
+    if (arg.startsWith("--artifact=") || lowerArg.startsWith("artifact=")) {
+      parsed.artifact = clean(arg.slice(arg.indexOf("=") + 1));
       continue;
     }
     if (!arg.startsWith("--")) {
@@ -198,8 +203,8 @@ export function parseArgs(argv) {
         parsed.pr = arg;
         continue;
       }
-      if (parsed.lane === "none" && Object.hasOwn(LANE_PRESETS, arg.toLowerCase())) {
-        parsed.lane = arg.toLowerCase();
+      if (parsed.lane === "none" && Object.hasOwn(LANE_PRESETS, lowerArg)) {
+        parsed.lane = lowerArg;
         continue;
       }
     }

--- a/scripts/ship-workflow.test.mjs
+++ b/scripts/ship-workflow.test.mjs
@@ -23,6 +23,24 @@ test("parseArgs accepts lane, apply, and skip flags", () => {
   assert.equal(parsed.updateBranch, false);
 });
 
+test("parseArgs accepts npm-safe positional aliases", () => {
+  const parsed = parseArgs(["apply", "portal", "474", "skip-cleanup", "skip-sync", "no-update-branch"]);
+  assert.equal(parsed.apply, true);
+  assert.equal(parsed.lane, "portal");
+  assert.equal(parsed.pr, "474");
+  assert.equal(parsed.deploy, true);
+  assert.equal(parsed.cleanup, false);
+  assert.equal(parsed.sync, false);
+  assert.equal(parsed.updateBranch, false);
+});
+
+test("parseArgs accepts positional key=value aliases", () => {
+  const parsed = parseArgs(["pr=474", "merge-method=merge", "artifact=output/custom-report.json"]);
+  assert.equal(parsed.pr, "474");
+  assert.equal(parsed.mergeMethod, "merge");
+  assert.equal(parsed.artifact, "output/custom-report.json");
+});
+
 test("resolveLanePreset maps studio lane to reconcile script", () => {
   const preset = resolveLanePreset("studio");
   assert.equal(preset.script, "studio:ops:reconcile");


### PR DESCRIPTION
## Summary
- accept npm-safe positional aliases in the ship workflow parser
- document the shorthand for skip toggles in the runbook
- add coverage for positional alias parsing

## Verification
- node --test scripts/ship-workflow.test.mjs
- npm run ship:apply -- 474 skip-cleanup skip-sync skip-merge
