### PR TITLE
Tighten ship workflow GitHub check waiting

### DIFF
--- a/docs/runbooks/SHIP_WORKFLOW.md
+++ b/docs/runbooks/SHIP_WORKFLOW.md
@@ -10,6 +10,7 @@ Shorten the common close-out sequence of:
 The workflow is intentionally safe by default:
 - preview is the default mode
 - merge happens remotely through GitHub so local worktree conflicts do not block it
+- apply mode waits on required GitHub checks and fails fast if one of the long lanes turns red
 - deploy only runs from a clean default-branch worktree
 - cleanup runs last
 
@@ -56,7 +57,7 @@ When apply mode is enabled, the workflow can:
 1. verify `gh` auth
 2. mark a draft PR ready
 3. update a behind PR branch
-4. wait for checks
+4. wait for required GitHub checks to settle
 5. merge the PR remotely
 6. delete the remote branch
 7. fetch/prune local refs
@@ -66,6 +67,18 @@ When apply mode is enabled, the workflow can:
 
 ## Notes
 - The workflow writes a JSON report to `output/maintenance/ship-workflow-latest.json` by default.
+- The wait step uses `gh pr checks --required --watch --fail-fast`, so long GitHub lanes such as smoke, lighthouse, and mobile builds stay part of the ship instead of becoming a manual follow-up.
 - If no clean default-branch worktree is available, deploy is blocked on purpose rather than deploying from a dirty feature branch.
 - Direct `node ./scripts/ship-workflow.mjs ...` runs accept the full `--flag` syntax.
 - `npm run ship...` shorthands also accept positional aliases like `apply`, `portal`, `474`, `skip-cleanup`, `skip-sync`, `skip-merge`, and `pr=474`.
+
+## Studio Brain close-out
+
+For Studio Brain deploy PRs, use the ship workflow as the close-out command after the PR exists:
+
+```bash
+npm run ship:studio -- 476
+npm run ship:studio:apply -- 476
+```
+
+That sequence waits on GitHub, merges remotely, syncs a clean `main` worktree, then runs `studio:ops:reconcile` from the clean lane.

--- a/docs/runbooks/STUDIO_BRAIN_HOST_DEPLOY.md
+++ b/docs/runbooks/STUDIO_BRAIN_HOST_DEPLOY.md
@@ -35,6 +35,19 @@ npm run studio:ops:reconcile
 - `studio:ops:deploy` is the wrapper alias for the full runtime deploy.
 - `studio:ops:reconcile` runs the full runtime deploy, then the tracked host-stack install, then captures a fresh status snapshot.
 
+## Ship Close-Out
+
+After the PR for a Studio Brain host change exists, the recommended close-out path is the ship workflow:
+
+```powershell
+npm run ship:studio -- 476
+npm run ship:studio:apply -- 476
+```
+
+- preview first with `ship:studio`
+- apply with `ship:studio:apply` once the PR is ready
+- the ship workflow now waits on required GitHub checks before merge, then syncs a clean `main` worktree and runs `studio:ops:reconcile`
+
 ## Secrets
 
 The script reads remote connection details from the gitignored secret file:

--- a/scripts/ship-workflow.mjs
+++ b/scripts/ship-workflow.mjs
@@ -226,6 +226,19 @@ export function resolveLanePreset(lane) {
   return LANE_PRESETS[clean(lane).toLowerCase()] || null;
 }
 
+export function buildWaitChecksArgs(prNumber, intervalSeconds = DEFAULT_CHECK_INTERVAL_SECONDS) {
+  return [
+    "pr",
+    "checks",
+    String(prNumber),
+    "--required",
+    "--watch",
+    "--fail-fast",
+    "--interval",
+    String(intervalSeconds),
+  ];
+}
+
 export function chooseSyncTarget({ repoRoot, defaultBranch, currentStatus, worktrees, statusByPath }) {
   const root = resolve(repoRoot);
   const preferred = worktrees.find((entry) => {
@@ -521,17 +534,18 @@ function main() {
         }
 
         if (options.waitChecks) {
+          const waitChecksArgs = buildWaitChecksArgs(report.pr.number);
           plannedSteps.push(
             attachExecutable(
               createStep(
                 "wait-checks",
-                "Wait for GitHub checks",
+                "Wait for required GitHub checks",
                 "gh",
-                ["pr", "checks", String(report.pr.number), "--watch", "--interval", DEFAULT_CHECK_INTERVAL_SECONDS],
+                waitChecksArgs,
                 repoRoot,
               ),
               "gh",
-              ["pr", "checks", String(report.pr.number), "--watch", "--interval", DEFAULT_CHECK_INTERVAL_SECONDS],
+              waitChecksArgs,
             ),
           );
         }

--- a/scripts/ship-workflow.test.mjs
+++ b/scripts/ship-workflow.test.mjs
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { resolve } from "node:path";
 import test from "node:test";
 
-import { chooseSyncTarget, parseArgs, resolveLanePreset } from "./ship-workflow.mjs";
+import { buildWaitChecksArgs, chooseSyncTarget, parseArgs, resolveLanePreset } from "./ship-workflow.mjs";
 
 test("parseArgs defaults to preview mode with merge, sync, and cleanup enabled", () => {
   const parsed = parseArgs([]);
@@ -45,6 +45,19 @@ test("resolveLanePreset maps studio lane to reconcile script", () => {
   const preset = resolveLanePreset("studio");
   assert.equal(preset.script, "studio:ops:reconcile");
   assert.match(preset.label, /Studio Brain/i);
+});
+
+test("buildWaitChecksArgs waits on required GitHub checks with fail-fast semantics", () => {
+  assert.deepEqual(buildWaitChecksArgs(476), [
+    "pr",
+    "checks",
+    "476",
+    "--required",
+    "--watch",
+    "--fail-fast",
+    "--interval",
+    "15",
+  ]);
 });
 
 test("chooseSyncTarget prefers a separate clean default-branch worktree", () => {


### PR DESCRIPTION
## Summary
- make the ship workflow wait on required GitHub checks with fail-fast semantics
- document the Studio Brain close-out path through ship:studio
- add a regression test for the required-check wait args

## Testing
- node --test scripts/ship-workflow.test.mjs
- node ./scripts/ship-workflow.mjs --json --pr 476
