### PR TITLE
Fix ops bridge srcdoc regressions

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,8 @@
     "test:e2e:headed": "npx playwright test -c website/playwright.config.mjs --headed",
     "test:e2e:dev": "BASE_URL=${BASE_URL:?Set BASE_URL to your preview URL} npx playwright test -c website/playwright.config.mjs",
     "portal:smoke:playwright": "node ./scripts/portal-playwright-smoke.mjs --output-dir output/playwright/portal",
+    "ops:portal:bridge:smoke": "npm --prefix studio-brain run build && node ./scripts/ops-portal-bridge-smoke.mjs --json",
+    "ops:portal:public:smoke": "node ./scripts/ops-portal-public-smoke.mjs --json",
     "portal:smoke:native-browser:shadow": "node ./scripts/native-browser-shadow-verifier.mjs --surface portal --base-url https://portal.monsoonfire.com --output-dir output/native-browser/portal/prod --shadow-of verify.portal.smoke --canonical-artifact-root output/playwright/portal/prod",
     "portal:smoke:playwright:local": "node ./scripts/portal-playwright-smoke.mjs --base-url http://127.0.0.1:5173 --output-dir output/playwright/portal/local",
     "portal:smoke:playwright:local:deep": "node ./scripts/portal-playwright-smoke.mjs --base-url http://127.0.0.1:5173 --output-dir output/playwright/portal/local/deep --deep",

--- a/scripts/ops-portal-bridge-smoke.mjs
+++ b/scripts/ops-portal-bridge-smoke.mjs
@@ -1,0 +1,253 @@
+#!/usr/bin/env node
+
+/* eslint-disable no-console */
+
+import assert from "node:assert/strict";
+import { mkdir, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { chromium } from "playwright";
+
+const __filename = fileURLToPath(import.meta.url);
+const repoRoot = resolve(dirname(__filename), "..");
+const defaultOutputDir = resolve(repoRoot, "output", "playwright", "ops-bridge");
+const defaultSummaryPath = resolve(defaultOutputDir, "ops-portal-bridge-smoke.json");
+const defaultScreenshotPath = resolve(defaultOutputDir, "ops-portal-bridge-smoke.png");
+const renderModulePath = resolve(repoRoot, "studio-brain", "lib", "ops", "ui", "renderOpsPortalPage.js");
+
+function parseArgs(argv) {
+  const options = {
+    outputDir: defaultOutputDir,
+    summaryPath: defaultSummaryPath,
+    screenshotPath: defaultScreenshotPath,
+    asJson: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = String(argv[index] || "").trim();
+    if (!arg.startsWith("--")) continue;
+
+    if (arg === "--json") {
+      options.asJson = true;
+      continue;
+    }
+
+    if (arg === "--output-dir" && argv[index + 1]) {
+      options.outputDir = resolve(process.cwd(), String(argv[index + 1]).trim());
+      options.summaryPath = resolve(options.outputDir, "ops-portal-bridge-smoke.json");
+      options.screenshotPath = resolve(options.outputDir, "ops-portal-bridge-smoke.png");
+      index += 1;
+      continue;
+    }
+  }
+
+  return options;
+}
+
+function buildFixtureModel() {
+  const generatedAt = "2026-04-18T21:00:00.000Z";
+  return {
+    snapshot: {
+      generatedAt,
+      session: {
+        actorId: "staff-qa",
+        portalRole: "staff",
+        isStaff: true,
+        opsRoles: ["floor_staff"],
+        opsCapabilities: ["surface:hands", "surface:internet", "surface:manager"],
+        allowedSurfaces: ["manager", "hands", "internet"],
+        allowedModes: {
+          manager: ["overview", "live", "truth"],
+          owner: [],
+          hands: ["now", "queue", "context"],
+          internet: ["desk", "member-ops", "events"],
+          ceo: [],
+          forge: [],
+        },
+      },
+      twin: {
+        generatedAt,
+        headline: "Studio is quiet and ready for handoff.",
+        narrative: "No arrivals, physical tasks, or approvals are queued right now.",
+        currentRisk: null,
+        commitmentsDueSoon: 0,
+        arrivalsExpectedSoon: 0,
+        zones: [
+          {
+            id: "zone_truth",
+            label: "Truth and watchdog posture",
+            status: "healthy",
+            summary: "Studio truth is fresh enough for autonomous coordination.",
+            nextAction: "Keep the manager focused on sequencing and explanation.",
+            evidence: {
+              summary: "Signals are current and quiet.",
+              verificationClass: "confirmed",
+              sources: [],
+              confidence: 0.94,
+              degradeReason: null,
+            },
+          },
+        ],
+        nextActions: [],
+      },
+      truth: {
+        generatedAt,
+        readiness: "ready",
+        summary: "Studio truth is fresh enough for autonomous coordination.",
+        degradeModes: [],
+        sources: [
+          {
+            source: "reservations",
+            label: "Reservations",
+            freshnessSeconds: null,
+            budgetSeconds: 1800,
+            status: "healthy",
+            freshestAt: null,
+            reason: "No reservation bundles are active right now.",
+          },
+        ],
+        watchdogs: [
+          {
+            id: "watchdog_truth",
+            label: "Truth readiness",
+            status: "healthy",
+            summary: "Signals are fresh enough to support autonomous coordination.",
+            recommendation: "Keep the manager lane focused on sequencing and approvals.",
+          },
+        ],
+        metrics: {
+          open_cases: 0,
+          open_tasks: 0,
+          pending_approvals: 0,
+          reservations_open: 0,
+          support_open: 0,
+          kiln_attention: 0,
+        },
+      },
+      tasks: [],
+      cases: [],
+      approvals: [],
+      ceo: [],
+      forge: [],
+      conversations: [],
+      members: [],
+      reservations: [],
+      events: [],
+      reports: [],
+      lending: {
+        requests: [],
+        loans: [],
+        recommendationCount: 0,
+        tagSubmissionCount: 0,
+        coverReviewCount: 0,
+      },
+      taskEscapes: [],
+      overrides: [],
+    },
+    displayState: null,
+    surface: "hands",
+    stationId: null,
+    sessionToken: null,
+  };
+}
+
+async function loadRenderer() {
+  if (!existsSync(renderModulePath)) {
+    throw new Error(`Missing ${renderModulePath}. Run 'npm --prefix studio-brain run build' first.`);
+  }
+  const module = await import(pathToFileURL(renderModulePath).href);
+  const renderOpsPortalPage = module.renderOpsPortalPage;
+  if (typeof renderOpsPortalPage !== "function") {
+    throw new Error("renderOpsPortalPage export was not found in the built Studio Brain UI module.");
+  }
+  return renderOpsPortalPage;
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  await mkdir(options.outputDir, { recursive: true });
+
+  const summary = {
+    startedAt: new Date().toISOString(),
+    status: "passed",
+    failures: [],
+    notes: [],
+    screenshotPath: options.screenshotPath,
+    summaryPath: options.summaryPath,
+    consoleErrors: [],
+    pageErrors: [],
+    theme: {
+      colorScheme: null,
+      bg: null,
+    },
+  };
+
+  const renderOpsPortalPage = await loadRenderer();
+  const html = renderOpsPortalPage(buildFixtureModel());
+  const bridgeHtml = "<!doctype html><html><body style=\"margin:0;background:#020812\"><iframe id=\"ops-bridge\" style=\"width:1440px;height:2000px;border:0\"></iframe></body></html>";
+
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage({ viewport: { width: 1440, height: 1200 } });
+
+  page.on("console", (message) => {
+    if (message.type() === "error") {
+      summary.consoleErrors.push(message.text());
+    }
+  });
+  page.on("pageerror", (error) => {
+    summary.pageErrors.push(String(error));
+  });
+
+  try {
+    await page.setContent(bridgeHtml, { waitUntil: "domcontentloaded" });
+    await page.evaluate((markup) => {
+      const iframe = document.getElementById("ops-bridge");
+      if (!(iframe instanceof HTMLIFrameElement)) {
+        throw new Error("ops bridge iframe missing");
+      }
+      iframe.srcdoc = markup;
+    }, html);
+    const frameHandle = await page.locator("#ops-bridge").elementHandle();
+    const frame = await frameHandle?.contentFrame();
+    assert.ok(frame, "Expected ops bridge iframe to resolve.");
+
+    await frame.waitForSelector("[data-surface-tab='hands']", { timeout: 30000 });
+    await frame.click("[data-surface-tab='hands']");
+    await frame.click("[data-surface-tab='internet']");
+    await frame.click("[data-surface-tab='hands']");
+    await frame.waitForTimeout(150);
+
+    summary.theme = await frame.evaluate(() => ({
+      colorScheme: getComputedStyle(document.documentElement).colorScheme,
+      bg: getComputedStyle(document.documentElement).getPropertyValue("--bg").trim(),
+    }));
+
+    await frame.locator("body").screenshot({ path: options.screenshotPath });
+
+    assert.equal(summary.theme.colorScheme, "dark", "Expected the ops shell to advertise a dark color scheme.");
+    assert.match(String(summary.theme.bg), /^#0/i, "Expected the ops shell to keep a dark background token.");
+    assert.equal(summary.pageErrors.length, 0, `Unexpected page errors: ${summary.pageErrors.join(" | ")}`);
+    assert.equal(
+      summary.consoleErrors.some((entry) => /SecurityError|replaceState/i.test(entry)),
+      false,
+      `Unexpected console bridge errors: ${summary.consoleErrors.join(" | ")}`,
+    );
+  } catch (error) {
+    summary.status = "failed";
+    summary.failures.push(error instanceof Error ? error.message : String(error));
+    throw error;
+  } finally {
+    summary.finishedAt = new Date().toISOString();
+    await writeFile(options.summaryPath, `${JSON.stringify(summary, null, 2)}\n`, "utf8");
+    await browser.close();
+    if (options.asJson) {
+      process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+    }
+  }
+}
+
+main().catch((error) => {
+  console.error(`ops-portal-bridge-smoke failed: ${error instanceof Error ? error.message : String(error)}`);
+  process.exit(1);
+});

--- a/scripts/ops-portal-public-smoke.mjs
+++ b/scripts/ops-portal-public-smoke.mjs
@@ -1,0 +1,285 @@
+#!/usr/bin/env node
+
+/* eslint-disable no-console */
+
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium } from "playwright";
+import { loadPortalAutomationEnv } from "./lib/runtime-secrets.mjs";
+import { mintStaffIdTokenFromPortalEnv } from "./lib/firebase-auth-token.mjs";
+
+const __filename = fileURLToPath(import.meta.url);
+const repoRoot = resolve(dirname(__filename), "..");
+
+const DEFAULT_BASE_URL = "https://portal.monsoonfire.com";
+const DEFAULT_PATH = "/ops?surface=hands&mode=now";
+const DEFAULT_OUTPUT_DIR = resolve(repoRoot, "output", "playwright", "ops-public");
+const DEFAULT_SCREENSHOT_PATH = resolve(DEFAULT_OUTPUT_DIR, "ops-portal-public-smoke.png");
+const DEFAULT_REPORT_PATH = resolve(DEFAULT_OUTPUT_DIR, "ops-portal-public-smoke.json");
+
+function clean(value) {
+  return String(value ?? "").trim();
+}
+
+function parseArgs(argv) {
+  const options = {
+    baseUrl: clean(process.env.PORTAL_CANARY_BASE_URL || DEFAULT_BASE_URL) || DEFAULT_BASE_URL,
+    path: clean(process.env.OPS_PORTAL_PUBLIC_SMOKE_PATH || DEFAULT_PATH) || DEFAULT_PATH,
+    outputDir: DEFAULT_OUTPUT_DIR,
+    screenshotPath: DEFAULT_SCREENSHOT_PATH,
+    reportPath: DEFAULT_REPORT_PATH,
+    asJson: false,
+    headless: true,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = clean(argv[index]);
+    if (!arg) continue;
+
+    if (arg === "--json") {
+      options.asJson = true;
+      continue;
+    }
+    if (arg === "--headed") {
+      options.headless = false;
+      continue;
+    }
+
+    const next = clean(argv[index + 1]);
+    if (!next || next.startsWith("--")) {
+      throw new Error(`Missing value for ${arg}`);
+    }
+
+    if (arg === "--base-url") {
+      options.baseUrl = next.replace(/\/+$/, "");
+      index += 1;
+      continue;
+    }
+    if (arg === "--path") {
+      options.path = next.startsWith("/") ? next : `/${next}`;
+      index += 1;
+      continue;
+    }
+    if (arg === "--output-dir") {
+      options.outputDir = resolve(process.cwd(), next);
+      options.screenshotPath = resolve(options.outputDir, "ops-portal-public-smoke.png");
+      options.reportPath = resolve(options.outputDir, "ops-portal-public-smoke.json");
+      index += 1;
+      continue;
+    }
+    if (arg === "--screenshot") {
+      options.screenshotPath = resolve(process.cwd(), next);
+      index += 1;
+      continue;
+    }
+    if (arg === "--report") {
+      options.reportPath = resolve(process.cwd(), next);
+      index += 1;
+      continue;
+    }
+  }
+
+  return options;
+}
+
+async function waitForOpsFrame(page) {
+  const iframe = page.locator("iframe").first();
+  await iframe.waitFor({ timeout: 30000 });
+  const handle = await iframe.elementHandle();
+  if (!handle) {
+    throw new Error("The smoke wrapper mounted an iframe, but the element handle was unavailable.");
+  }
+  const frame = await handle.contentFrame();
+  if (!frame) {
+    throw new Error("The smoke wrapper mounted an iframe, but the content frame was unavailable.");
+  }
+  await frame.waitForSelector("[data-surface-tab]", { timeout: 30000 });
+  return frame;
+}
+
+async function runSmoke(argv = process.argv.slice(2)) {
+  const options = parseArgs(argv);
+  loadPortalAutomationEnv();
+
+  const minted = await mintStaffIdTokenFromPortalEnv();
+  if (!minted.ok || !minted.token) {
+    throw new Error(`Could not mint staff token for the public ops smoke: ${minted.reason || "missing token"}`);
+  }
+
+  await mkdir(options.outputDir, { recursive: true });
+  const publicShellUrl = `${options.baseUrl}${options.path}`;
+  const deployedOpsUrl = `${options.baseUrl}/__studio-brain${options.path}`;
+
+  const shellResponse = await fetch(publicShellUrl, {
+    headers: {
+      Authorization: `Bearer ${minted.token}`,
+    },
+  });
+  const shellHtml = await shellResponse.text();
+  const deployedResponse = await fetch(deployedOpsUrl, {
+    headers: {
+      Authorization: `Bearer ${minted.token}`,
+    },
+  });
+  const deployedHtml = await deployedResponse.text();
+
+  if (!deployedResponse.ok) {
+    throw new Error(`Deployed ops HTML fetch failed: HTTP ${deployedResponse.status}`);
+  }
+
+  const summary = {
+    ok: false,
+    baseUrl: options.baseUrl,
+    path: options.path,
+    publicShellUrl,
+    deployedOpsUrl,
+    shellStatus: shellResponse.status,
+    deployedStatus: deployedResponse.status,
+    screenshotPath: options.screenshotPath,
+    reportPath: options.reportPath,
+    consoleErrors: [],
+    pageErrors: [],
+    bridgeMessages: [],
+    theme: null,
+    iframeUrl: "",
+    headline: "",
+    narrative: "",
+    protocol: "",
+    generatedAt: new Date().toISOString(),
+  };
+
+  const browser = await chromium.launch({ headless: options.headless });
+  try {
+    const context = await browser.newContext({
+      colorScheme: "dark",
+      viewport: { width: 1600, height: 1200 },
+    });
+    const page = await context.newPage();
+
+    page.on("console", (message) => {
+      const entry = {
+        type: message.type(),
+        text: message.text(),
+        location: message.location(),
+      };
+      if (entry.text.includes("Bridge Unavailable") || entry.text.includes("SecurityError")) {
+        summary.bridgeMessages.push(entry);
+      }
+      if (entry.type === "error") {
+        summary.consoleErrors.push(entry);
+      }
+    });
+    page.on("pageerror", (error) => {
+      summary.pageErrors.push(String(error?.message || error));
+    });
+
+    await page.setContent(`
+      <!doctype html>
+      <html>
+        <head>
+          <meta charset="utf-8" />
+          <title>Ops Portal Public Smoke</title>
+          <style>
+            html, body { margin: 0; padding: 0; background: #02060b; }
+            iframe { width: 100vw; height: 100vh; border: 0; display: block; }
+          </style>
+        </head>
+        <body>
+          <iframe id="ops-frame" title="Studio Ops public smoke"></iframe>
+        </body>
+      </html>
+    `, { waitUntil: "domcontentloaded" });
+
+    await page.evaluate((html) => {
+      const iframe = document.getElementById("ops-frame");
+      if (!iframe) {
+        throw new Error("Smoke wrapper could not find the iframe mount point.");
+      }
+      iframe.setAttribute("srcdoc", html);
+    }, deployedHtml);
+
+    const frame = await waitForOpsFrame(page);
+    await frame.locator('[data-surface-tab="internet"]').click({ timeout: 10000 });
+    await frame.waitForTimeout(200);
+    await frame.locator('[data-surface-tab="hands"]').click({ timeout: 10000 });
+    await frame.waitForTimeout(200);
+
+    const bodyText = clean(await frame.locator("body").innerText());
+    summary.theme = await frame.evaluate(() => {
+      const styles = window.getComputedStyle(document.documentElement);
+      return {
+        colorScheme: styles.colorScheme,
+        bg: styles.getPropertyValue("--bg").trim(),
+      };
+    });
+    summary.iframeUrl = frame.url();
+    summary.protocol = await frame.evaluate(() => window.location.protocol);
+    summary.headline = clean(await frame.locator(".ops-hero h2, .ops-hero h1").first().textContent());
+    summary.narrative = clean(await frame.locator(".ops-summary, .ops-hero p").nth(1).textContent().catch(() => ""));
+
+    await page.screenshot({ path: options.screenshotPath, fullPage: true });
+
+    const hasSecurityError = summary.consoleErrors.some((entry) => /SecurityError|replaceState/i.test(entry.text));
+    const hasBridgeUnavailable = /Bridge Unavailable|path not allowed|Missing Authorization header/i.test(bodyText);
+    const isDark = summary.theme?.colorScheme === "dark" && /^#0/i.test(summary.theme?.bg || "");
+    const isQuiet = /quiet and waiting for fresher live telemetry|quiet and ready for handoff/i.test(bodyText);
+    const publicShellMounted = /Monsoon Fire Portal/i.test(shellHtml);
+
+    summary.ok = Boolean(
+      publicShellMounted
+      && isDark
+      && isQuiet
+      && !hasSecurityError
+      && !hasBridgeUnavailable
+      && summary.pageErrors.length === 0
+    );
+    summary.assertions = {
+      publicShellMounted,
+      isDark,
+      isQuiet,
+      hasSecurityError,
+      hasBridgeUnavailable,
+      pageErrors: summary.pageErrors.length,
+    };
+
+    await writeFile(options.reportPath, `${JSON.stringify(summary, null, 2)}\n`, "utf8");
+
+    if (options.asJson) {
+      process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+    } else {
+      process.stdout.write(`status: ${summary.ok ? "passed" : "failed"}\n`);
+      process.stdout.write(`public shell: ${summary.shellStatus} ${publicShellUrl}\n`);
+      process.stdout.write(`deployed ops: ${summary.deployedStatus} ${deployedOpsUrl}\n`);
+      process.stdout.write(`headline: ${summary.headline}\n`);
+      process.stdout.write(`theme: ${summary.theme?.colorScheme || "<missing>"} ${summary.theme?.bg || ""}\n`);
+      process.stdout.write(`iframe url: ${summary.iframeUrl}\n`);
+      process.stdout.write(`assertions: ${JSON.stringify(summary.assertions)}\n`);
+      process.stdout.write(`screenshot: ${summary.screenshotPath}\n`);
+      process.stdout.write(`report: ${summary.reportPath}\n`);
+    }
+
+    if (!summary.ok) {
+      process.exitCode = 1;
+    }
+  } finally {
+    await browser.close().catch(() => {});
+  }
+
+  return summary;
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === __filename) {
+  runSmoke().catch(async (error) => {
+    const message = error instanceof Error ? error.message : String(error);
+    const fallbackReport = {
+      ok: false,
+      error: message,
+      generatedAt: new Date().toISOString(),
+    };
+    await mkdir(DEFAULT_OUTPUT_DIR, { recursive: true }).catch(() => {});
+    await writeFile(DEFAULT_REPORT_PATH, `${JSON.stringify(fallbackReport, null, 2)}\n`, "utf8").catch(() => {});
+    console.error(`ops-portal-public-smoke failed: ${message}`);
+    process.exit(1);
+  });
+}

--- a/scripts/pr-gate.mjs
+++ b/scripts/pr-gate.mjs
@@ -202,6 +202,14 @@ if (includeSmoke) {
       required: true,
     },
     {
+      name: "ops portal bridge smoke",
+      kind: "command",
+      command: "npm",
+      args: ["run", "ops:portal:bridge:smoke"],
+      remediation: "Fix Studio Brain /ops iframe bridge regressions and rerun `npm run ops:portal:bridge:smoke` locally.",
+      required: true,
+    },
+    {
       name: "website smoke",
       kind: "command",
       command: "npm",

--- a/studio-brain/.env.integrity.json
+++ b/studio-brain/.env.integrity.json
@@ -1,6 +1,6 @@
 {
   "schema": "studiobrain-infra-integrity-v1",
-  "generatedAt": "2026-04-16T18:44:55.383Z",
+  "generatedAt": "2026-04-18T21:10:39.363Z",
   "generatedBy": "scripts/integrity-check.mjs",
   "allowUnknown": false,
   "metadata": {
@@ -157,8 +157,8 @@
     },
     {
       "path": "docs/runbooks/STUDIO_BRAIN_HOST_DEPLOY.md",
-      "sha256": "6260ccab08677c7dd23a07cfe4b52715a72b311f9f3a08089db71121c61afe34",
-      "size": 5517
+      "sha256": "0ff4404b615a5245e4ab54300dcaa193318e7730e382e473416799bf62dfd184",
+      "size": 5948
     },
     {
       "path": "scripts/deploy-studio-brain-host.py",
@@ -252,8 +252,8 @@
     },
     {
       "path": "scripts/pr-gate.mjs",
-      "sha256": "e6ef12698f2e5efaef7f93c369affe624e2c24f6c2f4aebe81e63f4c55aa0c99",
-      "size": 14485
+      "sha256": "1ce36d276f1bf7919cfbb8b349d9cfd165adb81a890ebb3589bb9d488750fbf0",
+      "size": 14775
     },
     {
       "path": "scripts/scan-studiobrain-host-contract.mjs",

--- a/studio-brain/lib/ops/service.js
+++ b/studio-brain/lib/ops/service.js
@@ -76,6 +76,9 @@ function freshnessMsFrom(timestamp, currentIso) {
         return null;
     return Math.max(0, now - then);
 }
+function msSince(timestamp, currentIso) {
+    return freshnessMsFrom(timestamp, currentIso);
+}
 function minutesUntil(timestamp) {
     if (!timestamp)
         return null;
@@ -184,7 +187,7 @@ function sourceHealth(freshnessSeconds, budgetSeconds) {
         return "warning";
     return "critical";
 }
-function sourceFreshnessRow(currentIso, source, label, observedAt, budgetSeconds, reason) {
+function sourceFreshnessRow(currentIso, source, label, observedAt, budgetSeconds, reason, missingStatus = "critical") {
     const freshnessMs = freshnessMsFrom(observedAt, currentIso);
     const freshnessSeconds = freshnessMs === null ? null : Math.round(freshnessMs / 1000);
     return {
@@ -192,10 +195,30 @@ function sourceFreshnessRow(currentIso, source, label, observedAt, budgetSeconds
         label,
         freshnessSeconds,
         budgetSeconds,
-        status: sourceHealth(freshnessSeconds, budgetSeconds),
+        status: freshnessSeconds === null ? missingStatus : sourceHealth(freshnessSeconds, budgetSeconds),
         freshestAt: observedAt,
         reason,
     };
+}
+function reservationBundleIsOperational(bundle, currentIso) {
+    const normalizedStatus = String(bundle.status || "").trim().toUpperCase();
+    if (["CANCELED", "CANCELLED", "COMPLETED", "FULFILLED", "ARCHIVED"].includes(normalizedStatus)) {
+        return false;
+    }
+    const arrivalStatus = String(bundle.arrival?.status || "").trim().toLowerCase();
+    const arrivedAgeMs = msSince(bundle.arrival?.arrivedAt ?? null, currentIso);
+    if (arrivalStatus === "arrived") {
+        return arrivedAgeMs === null || arrivedAgeMs <= 12 * 60 * 60 * 1000;
+    }
+    const dueAgeMs = msSince(bundle.dueAt, currentIso);
+    if (dueAgeMs !== null) {
+        return dueAgeMs <= 6 * 60 * 60 * 1000;
+    }
+    const freshestAgeMs = msSince(bundle.freshestAt, currentIso);
+    if (freshestAgeMs !== null) {
+        return freshestAgeMs <= 12 * 60 * 60 * 1000;
+    }
+    return false;
 }
 function deriveReadiness(modes, sourceRows) {
     const worstSource = sourceRows.reduce((worst, row) => {
@@ -619,7 +642,6 @@ function createOpsService(options = {}) {
             const merged = mergeApproval(approvalsById.get(seed.id) ?? null, seed, currentIso);
             mergedApprovals.set(seed.id, merged);
         };
-        const reservationsOpen = dependencies.studioState?.counts.reservationsOpen ?? 0;
         const supportOpen = dependencies.supportQueue?.totalOpen ?? dependencies.supportCases.filter((row) => row.queueBucket !== "resolved").length;
         const supportAwaitingApproval = dependencies.supportQueue?.awaitingApproval ?? 0;
         const supportSecurityHold = dependencies.supportQueue?.securityHold ?? 0;
@@ -951,7 +973,10 @@ function createOpsService(options = {}) {
                 }),
             }));
         }
-        const reservationBundles = dependencies.reservations.length > 0 ? dependencies.reservations : persistedBundles;
+        const reservationBundleCandidates = dependencies.reservations.length > 0 ? dependencies.reservations : persistedBundles;
+        const reservationBundles = reservationBundleCandidates.filter((bundle) => reservationBundleIsOperational(bundle, currentIso));
+        const suppressedReservationBundles = Math.max(0, reservationBundleCandidates.length - reservationBundles.length);
+        const reservationsOpen = reservationBundles.length;
         for (const bundle of reservationBundles) {
             const caseId = `case_reservation_${bundle.reservationId}`;
             const countdown = minutesUntil(bundle.dueAt);
@@ -1101,15 +1126,19 @@ function createOpsService(options = {}) {
             ?? dependencies.lending?.requests.reduce((best, row) => latest(best, row.createdAt), null)
             ?? null;
         const sourceRows = [
-            sourceFreshnessRow(currentIso, "ops_ledger", "Ops ledger", latestOpsEventAt, 600, latestOpsEventAt ? null : "No ops events have been ingested yet."),
-            sourceFreshnessRow(currentIso, "studio_state", "Studio state", latestStateAt, 3600, latestStateAt ? null : "No studio state snapshot is available."),
-            sourceFreshnessRow(currentIso, "kilnaid", "Kiln telemetry", latestKilnAt, 900, dependencies.kilnOverview ? null : "Kiln telemetry is unavailable."),
-            sourceFreshnessRow(currentIso, "support", "Inbox and internet threads", latestSupportAt, 900, supportOpsStore ? null : "Support lane is not configured."),
-            sourceFreshnessRow(currentIso, "stations", "Station heartbeats", latestStationAt, 900, latestStationAt ? null : "No station heartbeats have been seen yet."),
-            sourceFreshnessRow(currentIso, "reservations", "Reservations", latestReservationAt, 1800, reservationBundles.length > 0 ? null : "No reservation bundles are available yet."),
-            sourceFreshnessRow(currentIso, "events", "Events", latestEventAt, 3600, dependencies.events.length > 0 ? null : "No event records are available yet."),
-            sourceFreshnessRow(currentIso, "reports", "Community reports", latestReportAt, 1800, dependencies.reports.length > 0 ? null : "No community reports are visible."),
-            sourceFreshnessRow(currentIso, "lending", "Lending", latestLendingAt, 1800, dependencies.lending ? null : "Lending data is unavailable."),
+            sourceFreshnessRow(currentIso, "ops_ledger", "Ops ledger", latestOpsEventAt, 600, latestOpsEventAt ? null : "No ops events have been ingested yet.", "warning"),
+            sourceFreshnessRow(currentIso, "studio_state", "Studio state", latestStateAt, 3600, latestStateAt ? null : "No studio state snapshot is available.", "critical"),
+            sourceFreshnessRow(currentIso, "kilnaid", "Kiln telemetry", latestKilnAt, 900, dependencies.kilnOverview ? null : "Kiln telemetry is unavailable.", "warning"),
+            sourceFreshnessRow(currentIso, "support", "Inbox and internet threads", latestSupportAt, 900, supportOpsStore ? null : "Support lane is not configured.", "warning"),
+            sourceFreshnessRow(currentIso, "stations", "Station heartbeats", latestStationAt, 900, latestStationAt ? null : "No station heartbeats have been seen yet.", "warning"),
+            sourceFreshnessRow(currentIso, "reservations", "Reservations", latestReservationAt, 1800, reservationBundles.length > 0
+                ? null
+                : suppressedReservationBundles > 0
+                    ? "Historical reservation bundles were suppressed from the live board."
+                    : "No reservation bundles are active right now.", "healthy"),
+            sourceFreshnessRow(currentIso, "events", "Events", latestEventAt, 3600, dependencies.events.length > 0 ? null : "No event records are active right now.", "healthy"),
+            sourceFreshnessRow(currentIso, "reports", "Community reports", latestReportAt, 1800, dependencies.reports.length > 0 ? null : "No community reports are active right now.", "healthy"),
+            sourceFreshnessRow(currentIso, "lending", "Lending", latestLendingAt, 1800, dependencies.lending ? null : "Lending data is unavailable.", "warning"),
         ];
         const derivedModes = new Set(manualModes);
         if (sourceRows.some((row) => row.source === "ops_ledger" && row.status === "critical"))
@@ -1129,13 +1158,19 @@ function createOpsService(options = {}) {
         const truthReadiness = deriveReadiness([...derivedModes], sourceRows);
         const pendingApprovals = [...mergedApprovals.values()].filter((row) => row.status === "pending").length;
         const topTask = sortTasks([...mergedTasks.values()]).find((row) => !terminalTaskStatus(row.status)) ?? null;
+        const studioIsQuiet = reservationsOpen === 0
+            && kilnAttention === 0
+            && kilnActiveRuns === 0
+            && supportOpen === 0
+            && pendingApprovals === 0
+            && topTask === null;
         const currentRisk = supportSecurityHold > 0
             ? `${supportSecurityHold} support thread${supportSecurityHold === 1 ? "" : "s"} are on security hold.`
             : kilnAttention > 0
                 ? `${kilnAttention} kiln signal${kilnAttention === 1 ? "" : "s"} need attention.`
                 : pendingApprovals > 0
                     ? `${pendingApprovals} approval${pendingApprovals === 1 ? "" : "s"} are blocking forward motion.`
-                    : truthReadiness === "blocked"
+                    : truthReadiness === "blocked" && !studioIsQuiet
                         ? "Truth readiness is degraded enough that human trust would be misplaced."
                         : null;
         const watchdogs = [
@@ -1286,9 +1321,17 @@ function createOpsService(options = {}) {
             generatedAt: currentIso,
             headline: currentRisk
                 ? `Studio is active: ${currentRisk}`
-                : `Studio is steady with ${kilnActiveRuns} active kiln run${kilnActiveRuns === 1 ? "" : "s"} and ${supportOpen} open internet thread${supportOpen === 1 ? "" : "s"}.`,
-            narrative: `The manager should minimize surprise across ${reservationsOpen} open reservation${reservationsOpen === 1 ? "" : "s"}, `
-                + `${kilnAttention} kiln attention item${kilnAttention === 1 ? "" : "s"}, and ${pendingApprovals} pending approval${pendingApprovals === 1 ? "" : "s"}.`,
+                : studioIsQuiet
+                    ? truthReadiness === "ready"
+                        ? "Studio is quiet and ready for handoff."
+                        : "Studio is quiet and waiting for fresher live telemetry."
+                    : `Studio is steady with ${kilnActiveRuns} active kiln run${kilnActiveRuns === 1 ? "" : "s"} and ${supportOpen} open internet thread${supportOpen === 1 ? "" : "s"}.`,
+            narrative: studioIsQuiet
+                ? truthReadiness === "ready"
+                    ? "No arrivals, physical tasks, or approvals are queued right now."
+                    : "No human handoff is queued right now, so this board should read as ambient status until live signals return."
+                : `The manager should minimize surprise across ${reservationsOpen} open reservation${reservationsOpen === 1 ? "" : "s"}, `
+                    + `${kilnAttention} kiln attention item${kilnAttention === 1 ? "" : "s"}, and ${pendingApprovals} pending approval${pendingApprovals === 1 ? "" : "s"}.`,
             currentRisk,
             commitmentsDueSoon: reservationsOpen,
             arrivalsExpectedSoon: reservationsOpen,

--- a/studio-brain/lib/ops/service.test.js
+++ b/studio-brain/lib/ops/service.test.js
@@ -446,3 +446,140 @@ const store_1 = require("./store");
     strict_1.default.equal(audits[1]?.payload.emailMasked, "n***r@example.com");
     strict_1.default.match(audits[1]?.reason ?? "", /^stored securely \(\d+ chars\)$/);
 });
+(0, node_test_1.default)("ops service suppresses stale reservation bundles from the live handoff view", async () => {
+    const store = new store_1.MemoryOpsStore();
+    await store.upsertReservationBundle({
+        id: "reservation:stale-1",
+        reservationId: "stale-1",
+        title: "Fixture Member · bisque firing",
+        status: "REQUESTED",
+        ownerUid: "member-1",
+        displayName: "Fixture Member",
+        firingType: "bisque firing",
+        dueAt: "2026-04-16T08:00:00.000Z",
+        itemCount: 4,
+        shelfEquivalent: 1,
+        notes: "Old QA fixture",
+        arrival: {
+            status: "expected",
+            dueAt: "2026-04-16T08:00:00.000Z",
+            arrivedAt: null,
+            summary: "Fixture Member is expected.",
+            confidence: 0.7,
+            verificationClass: "planned",
+        },
+        prep: {
+            summary: "Fixture prep",
+            actions: ["Prepare shelf"],
+            toolsNeeded: ["clipboard"],
+            assignedRole: "floor_staff",
+        },
+        linkedTaskIds: [],
+        verificationClass: "planned",
+        freshestAt: "2026-04-16T07:45:00.000Z",
+        sources: [],
+        confidence: 0.7,
+        degradeReason: null,
+        metadata: {},
+    });
+    const service = (0, service_1.createOpsService)({
+        store,
+        now: () => "2026-04-18T20:45:00.000Z",
+        stateStore: {
+            async saveStudioState() { },
+            async getLatestStudioState() {
+                return {
+                    schemaVersion: "v3.0",
+                    snapshotDate: "2026-04-18",
+                    generatedAt: "2026-04-18T20:40:00.000Z",
+                    cloudSync: {
+                        firestoreReadAt: "2026-04-18T20:40:00.000Z",
+                        stripeReadAt: null,
+                    },
+                    counts: {
+                        batchesActive: 0,
+                        batchesClosed: 0,
+                        reservationsOpen: 0,
+                        firingsScheduled: 0,
+                        reportsOpen: 0,
+                    },
+                    ops: {
+                        agentRequestsPending: 0,
+                        highSeverityReports: 0,
+                    },
+                    finance: {
+                        pendingOrders: 0,
+                        unsettledPayments: 0,
+                    },
+                    sourceHashes: {
+                        firestore: "fixture",
+                        stripe: null,
+                    },
+                    diagnostics: {
+                        completeness: "partial",
+                        warnings: [],
+                    },
+                };
+            },
+            async getPreviousStudioState() { return null; },
+            async saveStudioStateDiff() { },
+            async saveOverseerRun() { },
+            async getLatestOverseerRun() { return null; },
+            async listRecentOverseerRuns() { return []; },
+            async listRecentJobRuns() { return []; },
+            async startJobRun(jobName) {
+                return {
+                    id: `${jobName}-1`,
+                    jobName,
+                    status: "running",
+                    startedAt: "2026-04-18T20:40:00.000Z",
+                    completedAt: null,
+                    summary: null,
+                    errorMessage: null,
+                };
+            },
+            async completeJobRun() { },
+            async failJobRun() { },
+        },
+        staffDataSource: {
+            async listMembers() { return []; },
+            async getMember() { return null; },
+            async createMember() { throw new Error("not used"); },
+            async updateMemberProfile() { throw new Error("not used"); },
+            async updateMemberMembership() { throw new Error("not used"); },
+            async updateMemberBilling() { throw new Error("not used"); },
+            async updateMemberRole() { throw new Error("not used"); },
+            async getMemberActivity(uid) {
+                return {
+                    uid,
+                    reservations: 0,
+                    libraryLoans: 0,
+                    supportThreads: 0,
+                    events: 0,
+                    lastReservationAt: null,
+                    lastLoanAt: null,
+                    lastEventAt: null,
+                };
+            },
+            async listReservations() { return []; },
+            async getReservationBundle() { return null; },
+            async listEvents() { return []; },
+            async listReports() { return []; },
+            async getLendingSnapshot() {
+                return {
+                    requests: [],
+                    loans: [],
+                    recommendationCount: 0,
+                    tagSubmissionCount: 0,
+                    coverReviewCount: 0,
+                    generatedAt: "2026-04-18T20:40:00.000Z",
+                };
+            },
+        },
+    });
+    const snapshot = await service.getPortalSnapshot();
+    strict_1.default.equal(snapshot.reservations.length, 0);
+    strict_1.default.equal(snapshot.twin.currentRisk, null);
+    strict_1.default.match(snapshot.twin.headline, /quiet/i);
+    strict_1.default.ok(snapshot.truth.sources.some((row) => row.source === "reservations" && /suppressed|active right now/i.test(String(row.reason || ""))));
+});

--- a/studio-brain/lib/ops/ui/renderOpsPortalPage.js
+++ b/studio-brain/lib/ops/ui/renderOpsPortalPage.js
@@ -1,91 +1,82 @@
-import type {
-  ApprovalItem,
-  GrowthExperiment,
-  HumanTaskRecord,
-  ImprovementCase,
-  OpsCaseRecord,
-  OpsConversationThreadRecord,
-  OpsPortalSnapshot,
-  OpsSourceFreshness,
-  OpsTwinZone,
-  OpsWatchdog,
-  StationDisplayState,
-} from "../contracts";
-import type { OpsPortalPageModel } from "./contracts";
-
-function esc(value: unknown): string {
-  return String(value ?? "")
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-    .replaceAll('"', "&quot;");
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.renderOpsPortalPage = renderOpsPortalPage;
+exports.renderOpsPortalChoicePage = renderOpsPortalChoicePage;
+function esc(value) {
+    return String(value ?? "")
+        .replaceAll("&", "&amp;")
+        .replaceAll("<", "&lt;")
+        .replaceAll(">", "&gt;")
+        .replaceAll('"', "&quot;");
 }
-
-function jsonScript(value: unknown): string {
-  return JSON.stringify(value)
-    .replaceAll("<", "\\u003c")
-    .replaceAll(">", "\\u003e")
-    .replaceAll("&", "\\u0026");
+function jsonScript(value) {
+    return JSON.stringify(value)
+        .replaceAll("<", "\\u003c")
+        .replaceAll(">", "\\u003e")
+        .replaceAll("&", "\\u0026");
 }
-
-function formatTimestamp(value: string | null): string {
-  if (!value) return "unknown";
-  const parsed = Date.parse(value);
-  if (!Number.isFinite(parsed)) return value;
-  return new Date(parsed).toLocaleString("en-US", {
-    month: "short",
-    day: "numeric",
-    hour: "numeric",
-    minute: "2-digit",
-  });
+function formatTimestamp(value) {
+    if (!value)
+        return "unknown";
+    const parsed = Date.parse(value);
+    if (!Number.isFinite(parsed))
+        return value;
+    return new Date(parsed).toLocaleString("en-US", {
+        month: "short",
+        day: "numeric",
+        hour: "numeric",
+        minute: "2-digit",
+    });
 }
-
-function formatConfidence(value: number): string {
-  return `${Math.round(Math.max(0, Math.min(1, value)) * 100)}%`;
+function formatConfidence(value) {
+    return `${Math.round(Math.max(0, Math.min(1, value)) * 100)}%`;
 }
-
-function parseTimestamp(value: string | null): number | null {
-  if (!value) return null;
-  const parsed = Date.parse(value);
-  return Number.isFinite(parsed) ? parsed : null;
+function parseTimestamp(value) {
+    if (!value)
+        return null;
+    const parsed = Date.parse(value);
+    return Number.isFinite(parsed) ? parsed : null;
 }
-
-function minutesUntil(value: string | null): number | null {
-  const parsed = parseTimestamp(value);
-  if (parsed === null) return null;
-  return Math.round((parsed - Date.now()) / 60000);
+function minutesUntil(value) {
+    const parsed = parseTimestamp(value);
+    if (parsed === null)
+        return null;
+    return Math.round((parsed - Date.now()) / 60000);
 }
-
-function formatCountdown(minutes: number | null): string {
-  if (minutes === null) return "live";
-  if (minutes <= 0) return `${Math.abs(minutes)}m late`;
-  if (minutes < 60) return `${minutes}m`;
-  const hours = Math.floor(minutes / 60);
-  const remainder = minutes % 60;
-  return remainder === 0 ? `${hours}h` : `${hours}h ${remainder}m`;
+function formatCountdown(minutes) {
+    if (minutes === null)
+        return "live";
+    if (minutes <= 0)
+        return `${Math.abs(minutes)}m late`;
+    if (minutes < 60)
+        return `${minutes}m`;
+    const hours = Math.floor(minutes / 60);
+    const remainder = minutes % 60;
+    return remainder === 0 ? `${hours}h` : `${hours}h ${remainder}m`;
 }
-
-function countdownPercent(minutes: number | null, horizonMinutes: number): number {
-  if (minutes === null) return 52;
-  const bounded = Math.max(0, Math.min(horizonMinutes, minutes));
-  return Math.round((1 - bounded / horizonMinutes) * 100);
+function countdownPercent(minutes, horizonMinutes) {
+    if (minutes === null)
+        return 52;
+    const bounded = Math.max(0, Math.min(horizonMinutes, minutes));
+    return Math.round((1 - bounded / horizonMinutes) * 100);
 }
-
-function freshnessPercent(freshnessSeconds: number | null, budgetSeconds: number): number {
-  if (freshnessSeconds === null || budgetSeconds <= 0) return 26;
-  const bounded = Math.max(0, Math.min(budgetSeconds, freshnessSeconds));
-  return Math.round((1 - bounded / budgetSeconds) * 100);
+function freshnessPercent(freshnessSeconds, budgetSeconds) {
+    if (freshnessSeconds === null || budgetSeconds <= 0)
+        return 26;
+    const bounded = Math.max(0, Math.min(budgetSeconds, freshnessSeconds));
+    return Math.round((1 - bounded / budgetSeconds) * 100);
 }
-
-function statusTone(status: string): string {
-  if (status === "healthy" || status === "ready" || status === "verified" || status === "approved") return "good";
-  if (status === "warning" || status === "degraded" || status === "proof_pending" || status === "pending") return "warn";
-  if (status === "critical" || status === "blocked" || status === "rejected" || status === "canceled") return "danger";
-  return "neutral";
+function statusTone(status) {
+    if (status === "healthy" || status === "ready" || status === "verified" || status === "approved")
+        return "good";
+    if (status === "warning" || status === "degraded" || status === "proof_pending" || status === "pending")
+        return "warn";
+    if (status === "critical" || status === "blocked" || status === "rejected" || status === "canceled")
+        return "danger";
+    return "neutral";
 }
-
-function renderZone(zone: OpsTwinZone): string {
-  return `
+function renderZone(zone) {
+    return `
     <article class="ops-zone ops-tone-${esc(statusTone(zone.status))}">
       <div class="ops-zone__head">
         <div>
@@ -107,12 +98,11 @@ function renderZone(zone: OpsTwinZone): string {
     </article>
   `;
 }
-
-function renderTask(task: HumanTaskRecord): string {
-  const checklist = task.checklist.length
-    ? task.checklist.map((item) => `<li><strong>${esc(item.label)}</strong>${item.detail ? ` · ${esc(item.detail)}` : ""}</li>`).join("")
-    : "<li>No checklist has been generated yet.</li>";
-  return `
+function renderTask(task) {
+    const checklist = task.checklist.length
+        ? task.checklist.map((item) => `<li><strong>${esc(item.label)}</strong>${item.detail ? ` · ${esc(item.detail)}` : ""}</li>`).join("")
+        : "<li>No checklist has been generated yet.</li>";
+    return `
     <article class="ops-task-card ops-tone-${esc(statusTone(task.status))}" data-task-id="${esc(task.id)}">
       <div class="ops-task-card__head">
         <div>
@@ -158,9 +148,8 @@ function renderTask(task: HumanTaskRecord): string {
     </article>
   `;
 }
-
-function renderApproval(row: ApprovalItem): string {
-  return `
+function renderApproval(row) {
+    return `
     <article class="ops-approval ops-tone-${esc(statusTone(row.status))}">
       <div class="ops-zone__head">
         <div>
@@ -184,9 +173,8 @@ function renderApproval(row: ApprovalItem): string {
     </article>
   `;
 }
-
-function renderCase(row: OpsCaseRecord): string {
-  return `
+function renderCase(row) {
+    return `
     <article class="ops-case ops-tone-${esc(statusTone(row.status))}">
       <p class="ops-kicker">${esc(row.kind)} · ${esc(row.lane)} · ${esc(row.priority)}</p>
       <h3>${esc(row.title)}</h3>
@@ -203,9 +191,8 @@ function renderCase(row: OpsCaseRecord): string {
     </article>
   `;
 }
-
-function renderConversation(row: OpsConversationThreadRecord): string {
-  return `
+function renderConversation(row) {
+    return `
     <article class="ops-conversation">
       <p class="ops-kicker">${esc(row.roleMask)} · ${esc(row.senderIdentity)}</p>
       <h4>${esc(row.summary)}</h4>
@@ -213,31 +200,22 @@ function renderConversation(row: OpsConversationThreadRecord): string {
     </article>
   `;
 }
-
-function renderMemberCard(
-  row: OpsPortalSnapshot["members"][number],
-  options: {
-    canEditProfile?: boolean;
-    canEditMembership?: boolean;
-    canEditRole?: boolean;
-    canViewActivity?: boolean;
-  } = {},
-): string {
-  const actions = [
-    options.canViewActivity
-      ? `<button type="button" class="ops-button ops-button-secondary" data-member-activity="${esc(row.uid)}" data-member-name="${esc(row.displayName)}">Activity</button>`
-      : "",
-    options.canEditProfile
-      ? `<button type="button" class="ops-button ops-button-secondary" data-member-profile="${esc(row.uid)}" data-member-display-name="${esc(row.displayName)}" data-member-kiln-preferences="${esc(row.kilnPreferences || "")}" data-member-staff-notes="${esc(row.staffNotes || "")}">Profile</button>`
-      : "",
-    options.canEditMembership
-      ? `<button type="button" class="ops-button ops-button-secondary" data-member-membership="${esc(row.uid)}" data-member-membership-tier="${esc(row.membershipTier || "")}" data-member-name="${esc(row.displayName)}">Membership</button>`
-      : "",
-    options.canEditRole
-      ? `<button type="button" class="ops-button ops-button-secondary" data-member-role="${esc(row.uid)}" data-member-roles="${esc(row.opsRoles.join(", "))}" data-member-name="${esc(row.displayName)}">Roles</button>`
-      : "",
-  ].filter(Boolean);
-  return `
+function renderMemberCard(row, options = {}) {
+    const actions = [
+        options.canViewActivity
+            ? `<button type="button" class="ops-button ops-button-secondary" data-member-activity="${esc(row.uid)}" data-member-name="${esc(row.displayName)}">Activity</button>`
+            : "",
+        options.canEditProfile
+            ? `<button type="button" class="ops-button ops-button-secondary" data-member-profile="${esc(row.uid)}" data-member-display-name="${esc(row.displayName)}" data-member-kiln-preferences="${esc(row.kilnPreferences || "")}" data-member-staff-notes="${esc(row.staffNotes || "")}">Profile</button>`
+            : "",
+        options.canEditMembership
+            ? `<button type="button" class="ops-button ops-button-secondary" data-member-membership="${esc(row.uid)}" data-member-membership-tier="${esc(row.membershipTier || "")}" data-member-name="${esc(row.displayName)}">Membership</button>`
+            : "",
+        options.canEditRole
+            ? `<button type="button" class="ops-button ops-button-secondary" data-member-role="${esc(row.uid)}" data-member-roles="${esc(row.opsRoles.join(", "))}" data-member-name="${esc(row.displayName)}">Roles</button>`
+            : "",
+    ].filter(Boolean);
+    return `
     <article class="ops-case ops-tone-neutral">
       <p class="ops-kicker">${esc(row.portalRole)} · ${esc(row.opsRoles.join(", ") || "no ops roles")}</p>
       <h3>${esc(row.displayName)}</h3>
@@ -252,14 +230,8 @@ function renderMemberCard(
     </article>
   `;
 }
-
-function renderReservationCard(
-  row: OpsPortalSnapshot["reservations"][number],
-  options: {
-    canPrepareReservations?: boolean;
-  } = {},
-): string {
-  return `
+function renderReservationCard(row, options = {}) {
+    return `
     <article class="ops-case ops-tone-${esc(statusTone(row.arrival.status === "arrived" ? "active" : row.degradeReason ? "warning" : "healthy"))}">
       <p class="ops-kicker">${esc(row.status)} · ${esc(row.firingType)} · ${esc(row.arrival.status)}</p>
       <h3>${esc(row.title)}</h3>
@@ -278,9 +250,8 @@ function renderReservationCard(
     </article>
   `;
 }
-
-function renderEventCard(row: OpsPortalSnapshot["events"][number]): string {
-  return `
+function renderEventCard(row) {
+    return `
     <article class="ops-case ops-tone-${esc(statusTone(row.status === "published" ? "healthy" : row.status === "review_required" ? "warning" : "neutral"))}">
       <p class="ops-kicker">${esc(row.status)} · ${esc(row.location || "Location pending")}</p>
       <h3>${esc(row.title)}</h3>
@@ -292,9 +263,8 @@ function renderEventCard(row: OpsPortalSnapshot["events"][number]): string {
     </article>
   `;
 }
-
-function renderReportCard(row: OpsPortalSnapshot["reports"][number]): string {
-  return `
+function renderReportCard(row) {
+    return `
     <article class="ops-case ops-tone-${esc(statusTone(row.severity === "high" ? "critical" : row.status === "open" ? "warning" : "healthy"))}">
       <p class="ops-kicker">${esc(row.severity)} severity · ${esc(row.status)}</p>
       <h3>${esc(row.summary)}</h3>
@@ -302,12 +272,11 @@ function renderReportCard(row: OpsPortalSnapshot["reports"][number]): string {
     </article>
   `;
 }
-
-function renderLendingCard(model: OpsPortalSnapshot["lending"]): string {
-  if (!model) {
-    return '<div class="ops-empty">Lending data is unavailable right now.</div>';
-  }
-  return `
+function renderLendingCard(model) {
+    if (!model) {
+        return '<div class="ops-empty">Lending data is unavailable right now.</div>';
+    }
+    return `
     <div class="ops-sequence-grid">
       ${renderSequenceStep(`Open requests: ${model.requests.length}`)}
       ${renderSequenceStep(`Active loans: ${model.loans.length}`)}
@@ -317,15 +286,14 @@ function renderLendingCard(model: OpsPortalSnapshot["lending"]): string {
     </div>
   `;
 }
-
-function renderExperiment(row: GrowthExperiment | ImprovementCase, lane: "ceo" | "forge"): string {
-  const status = "status" in row ? row.status : "open";
-  const title = "title" in row ? row.title : "Untitled";
-  const summary = "summary" in row ? row.summary : "";
-  const body = lane === "ceo"
-    ? esc((row as GrowthExperiment).hypothesis || summary)
-    : esc((row as ImprovementCase).problem || summary);
-  return `
+function renderExperiment(row, lane) {
+    const status = "status" in row ? row.status : "open";
+    const title = "title" in row ? row.title : "Untitled";
+    const summary = "summary" in row ? row.summary : "";
+    const body = lane === "ceo"
+        ? esc(row.hypothesis || summary)
+        : esc(row.problem || summary);
+    return `
     <article class="ops-case ops-tone-${esc(statusTone(status))}">
       <p class="ops-kicker">${esc(lane)} strategy</p>
       <h3>${esc(title)}</h3>
@@ -334,22 +302,18 @@ function renderExperiment(row: GrowthExperiment | ImprovementCase, lane: "ceo" |
     </article>
   `;
 }
-
-function renderWatchdogs(rows: OpsWatchdog[]): string {
-  return rows
-    .map(
-      (row) => `
+function renderWatchdogs(rows) {
+    return rows
+        .map((row) => `
       <article class="ops-watchdog ops-tone-${esc(statusTone(row.status))}">
         <h4>${esc(row.label)}</h4>
         <p>${esc(row.summary)}</p>
         <p class="ops-meta"><strong>Next:</strong> ${esc(row.recommendation)}</p>
-      </article>`,
-    )
-    .join("");
+      </article>`)
+        .join("");
 }
-
-function renderModeTabs(surface: string, entries: Array<{ id: string; label: string; meta?: string | number }>): string {
-  return `
+function renderModeTabs(surface, entries) {
+    return `
     <nav class="ops-mode-nav" data-mode-nav="${esc(surface)}">
       ${entries.map((entry) => `
         <button type="button" class="ops-mode-tab" data-surface-mode-tab="${esc(surface)}" data-mode-tab="${esc(entry.id)}">
@@ -360,17 +324,15 @@ function renderModeTabs(surface: string, entries: Array<{ id: string; label: str
     </nav>
   `;
 }
-
-function renderModePanel(surface: string, mode: string, body: string): string {
-  return `<div class="ops-mode-panel" data-surface-mode-panel="${esc(surface)}" data-mode="${esc(mode)}">${body}</div>`;
+function renderModePanel(surface, mode, body) {
+    return `<div class="ops-mode-panel" data-surface-mode-panel="${esc(surface)}" data-mode="${esc(mode)}">${body}</div>`;
 }
-
-function renderStationContext(displayState: StationDisplayState | null): string {
-  if (!displayState?.station) {
-    return `<div class="ops-empty">No active station heartbeat is visible for this surface right now.</div>`;
-  }
-  const station = displayState.station;
-  return `
+function renderStationContext(displayState) {
+    if (!displayState?.station) {
+        return `<div class="ops-empty">No active station heartbeat is visible for this surface right now.</div>`;
+    }
+    const station = displayState.station;
+    return `
     <article class="ops-station-card">
       <p class="ops-kicker">Station heartbeat</p>
       <h3>${esc(station.stationId)}</h3>
@@ -384,22 +346,19 @@ function renderStationContext(displayState: StationDisplayState | null): string 
     </article>
   `;
 }
-
-function renderHandsFocus(displayState: StationDisplayState | null, fallbackTask: HumanTaskRecord | null = null): string {
-  const task = displayState?.focusTask ?? fallbackTask;
-  if (!task) {
-    return `<div class="ops-empty">No focus task is currently pinned to this station.</div>`;
-  }
-  return renderTask(task);
+function renderHandsFocus(displayState, fallbackTask = null) {
+    const task = displayState?.focusTask ?? fallbackTask;
+    if (!task) {
+        return `<div class="ops-empty">No focus task is currently pinned to this station.</div>`;
+    }
+    return renderTask(task);
 }
-
-function isActiveTask(task: HumanTaskRecord): boolean {
-  return task.status !== "verified" && task.status !== "canceled";
+function isActiveTask(task) {
+    return task.status !== "verified" && task.status !== "canceled";
 }
-
-function renderMeter(value: number, tone: string, label: string): string {
-  const clamped = Math.max(0, Math.min(100, Math.round(value)));
-  return `
+function renderMeter(value, tone, label) {
+    const clamped = Math.max(0, Math.min(100, Math.round(value)));
+    return `
     <div class="ops-meter">
       <div class="ops-meter__track">
         <div class="ops-meter__fill ops-meter__fill-${esc(tone)}" style="width:${clamped}%"></div>
@@ -408,10 +367,9 @@ function renderMeter(value: number, tone: string, label: string): string {
     </div>
   `;
 }
-
-function renderPulseZone(zone: OpsTwinZone): string {
-  const tone = statusTone(zone.status);
-  return `
+function renderPulseZone(zone) {
+    const tone = statusTone(zone.status);
+    return `
     <article class="ops-pulse-card ops-tone-${esc(tone)}">
       <div class="ops-pulse-card__head">
         <div>
@@ -430,9 +388,8 @@ function renderPulseZone(zone: OpsTwinZone): string {
     </article>
   `;
 }
-
-function renderSignalCard(input: { kicker: string; title: string; value: string; summary: string; tone: string; meter: number; meterLabel: string }): string {
-  return `
+function renderSignalCard(input) {
+    return `
     <article class="ops-signal-card ops-tone-${esc(input.tone)}">
       <div class="ops-signal-card__top">
         <div>
@@ -446,20 +403,19 @@ function renderSignalCard(input: { kicker: string; title: string; value: string;
     </article>
   `;
 }
-
-function renderTaskSpotlight(task: HumanTaskRecord | null, label: string): string {
-  if (!task) {
-    return `
+function renderTaskSpotlight(task, label) {
+    if (!task) {
+        return `
       <article class="ops-spotlight-card">
         <p class="ops-kicker">${esc(label)}</p>
         <h3>No active task</h3>
         <p class="ops-summary">This lane is currently quiet.</p>
       </article>
     `;
-  }
-  const tone = statusTone(task.status);
-  const countdownMinutes = task.dueAt ? minutesUntil(task.dueAt) : (task.etaMinutes ?? null);
-  return `
+    }
+    const tone = statusTone(task.status);
+    const countdownMinutes = task.dueAt ? minutesUntil(task.dueAt) : (task.etaMinutes ?? null);
+    return `
     <article class="ops-spotlight-card ops-tone-${esc(tone)}" data-task-id="${esc(task.id)}">
       <div class="ops-zone__head">
         <div>
@@ -505,19 +461,18 @@ function renderTaskSpotlight(task: HumanTaskRecord | null, label: string): strin
     </article>
   `;
 }
-
-function renderApprovalSpotlight(row: ApprovalItem | null): string {
-  if (!row) {
-    return `
+function renderApprovalSpotlight(row) {
+    if (!row) {
+        return `
       <article class="ops-spotlight-card">
         <p class="ops-kicker">Owner gate</p>
         <h3>No pending approvals</h3>
         <p class="ops-summary">The manager is not currently blocked on explicit owner agency.</p>
       </article>
     `;
-  }
-  const tone = statusTone(row.status);
-  return `
+    }
+    const tone = statusTone(row.status);
+    return `
     <article class="ops-spotlight-card ops-tone-${esc(tone)}">
       <div class="ops-zone__head">
         <div>
@@ -559,36 +514,35 @@ function renderApprovalSpotlight(row: ApprovalItem | null): string {
     </article>
   `;
 }
-
-function renderSequenceStep(entry: string, index = 0): string {
-  return `
+function renderSequenceStep(entry, index = 0) {
+    return `
     <article class="ops-sequence-step">
       <span class="ops-sequence-step__index">${index + 1}</span>
       <p>${esc(entry)}</p>
     </article>
   `;
 }
-
-function renderIncidentChip(input: { label: string; text: string; tone: string }): string {
-  return `
+function renderIncidentChip(input) {
+    return `
     <article class="ops-incident-chip ops-tone-${esc(input.tone)}">
       <span class="ops-incident-chip__label">${esc(input.label)}</span>
       <p>${esc(input.text)}</p>
     </article>
   `;
 }
-
-function toneGaugeColor(tone: string): string {
-  if (tone === "good") return "var(--good)";
-  if (tone === "warn") return "var(--warn)";
-  if (tone === "danger") return "var(--danger)";
-  return "var(--neutral)";
+function toneGaugeColor(tone) {
+    if (tone === "good")
+        return "var(--good)";
+    if (tone === "warn")
+        return "var(--warn)";
+    if (tone === "danger")
+        return "var(--danger)";
+    return "var(--neutral)";
 }
-
-function renderCountdownOrb(input: { label: string; title: string; summary: string; minutes: number | null; tone: string; horizonMinutes?: number }): string {
-  const percent = countdownPercent(input.minutes, input.horizonMinutes ?? 180);
-  const progressAngle = `${Math.round((percent / 100) * 360)}deg`;
-  return `
+function renderCountdownOrb(input) {
+    const percent = countdownPercent(input.minutes, input.horizonMinutes ?? 180);
+    const progressAngle = `${Math.round((percent / 100) * 360)}deg`;
+    return `
     <article class="ops-countdown-card ops-tone-${esc(input.tone)}" style="--countdown-color:${toneGaugeColor(input.tone)};--countdown-progress:${progressAngle};">
       <div class="ops-countdown-card__dial" aria-hidden="true">
         <div class="ops-countdown-card__ring"></div>
@@ -605,12 +559,11 @@ function renderCountdownOrb(input: { label: string; title: string; summary: stri
     </article>
   `;
 }
-
-function renderGaugeCard(input: { label: string; title: string; value: string; summary: string; tone: string; percent: number; meterLabel: string }): string {
-  const clamped = Math.max(0, Math.min(100, Math.round(input.percent)));
-  const progressAngle = `${Math.round((clamped / 100) * 240)}deg`;
-  const needleAngle = `${-120 + (clamped / 100) * 240}deg`;
-  return `
+function renderGaugeCard(input) {
+    const clamped = Math.max(0, Math.min(100, Math.round(input.percent)));
+    const progressAngle = `${Math.round((clamped / 100) * 240)}deg`;
+    const needleAngle = `${-120 + (clamped / 100) * 240}deg`;
+    return `
     <article class="ops-gauge-card ops-tone-${esc(input.tone)}" style="--gauge-color:${toneGaugeColor(input.tone)};--gauge-progress:${progressAngle};--gauge-needle:${needleAngle};">
       <div class="ops-gauge-card__row">
         <div class="ops-gauge" aria-hidden="true">
@@ -629,23 +582,21 @@ function renderGaugeCard(input: { label: string; title: string; value: string; s
     </article>
   `;
 }
-
-function renderTickerItem(input: { label: string; text: string; tone: string }): string {
-  return `
+function renderTickerItem(input) {
+    return `
     <article class="ops-ticker-item ops-tone-${esc(input.tone)}">
       <span class="ops-ticker-item__label">${esc(input.label)}</span>
       <span class="ops-ticker-item__text">${esc(input.text)}</span>
     </article>
   `;
 }
-
-function renderFreshnessRibbon(source: OpsSourceFreshness): string {
-  const tone = statusTone(source.status);
-  const percent = freshnessPercent(source.freshnessSeconds, source.budgetSeconds);
-  const freshnessLabel = source.freshnessSeconds === null
-    ? "freshness unknown"
-    : `${Math.max(0, Math.round((source.budgetSeconds - source.freshnessSeconds) / 60))}m until stale`;
-  return `
+function renderFreshnessRibbon(source) {
+    const tone = statusTone(source.status);
+    const percent = freshnessPercent(source.freshnessSeconds, source.budgetSeconds);
+    const freshnessLabel = source.freshnessSeconds === null
+        ? "freshness unknown"
+        : `${Math.max(0, Math.round((source.budgetSeconds - source.freshnessSeconds) / 60))}m until stale`;
+    return `
     <article class="ops-source-ribbon ops-tone-${esc(tone)}">
       <div class="ops-source-ribbon__head">
         <span>${esc(source.label)}</span>
@@ -658,9 +609,8 @@ function renderFreshnessRibbon(source: OpsSourceFreshness): string {
     </article>
   `;
 }
-
-function renderRelayCard(input: { label: string; title: string; summary: string; tone: string; stages: Array<{ label: string; state: "done" | "active" | "queued" }> }): string {
-  return `
+function renderRelayCard(input) {
+    return `
     <article class="ops-flow-card ops-tone-${esc(input.tone)}">
       <p class="ops-kicker">${esc(input.label)}</p>
       <h3>${esc(input.title)}</h3>
@@ -676,80 +626,77 @@ function renderRelayCard(input: { label: string; title: string; summary: string;
     </article>
   `;
 }
-
-function renderTaskRelayCard(task: HumanTaskRecord | null, label: string): string {
-  if (!task) {
+function renderTaskRelayCard(task, label) {
+    if (!task) {
+        return renderRelayCard({
+            label,
+            title: "No active relay",
+            summary: "This lane is quiet, so no human handoff is flowing right now.",
+            tone: "good",
+            stages: [
+                { label: "manager", state: "done" },
+                { label: "waiting", state: "active" },
+                { label: "verify", state: "queued" },
+            ],
+        });
+    }
+    const tone = statusTone(task.status);
+    const claimState = task.status === "queued" || task.status === "proposed" ? "queued" : "done";
+    const actionState = task.status === "claimed" || task.status === "in_progress" ? "active" : task.status === "proof_pending" || task.status === "verified" ? "done" : "queued";
+    const verifyState = task.status === "proof_pending" ? "active" : task.status === "verified" ? "done" : "queued";
     return renderRelayCard({
-      label,
-      title: "No active relay",
-      summary: "This lane is quiet, so no human handoff is flowing right now.",
-      tone: "good",
-      stages: [
-        { label: "manager", state: "done" },
-        { label: "waiting", state: "active" },
-        { label: "verify", state: "queued" },
-      ],
+        label,
+        title: task.title,
+        summary: task.claimedBy ? `Claimed by ${task.claimedBy}.` : task.whyNow,
+        tone,
+        stages: [
+            { label: "manager", state: "done" },
+            { label: task.surface === "internet" ? "reply" : "hands", state: actionState === "active" ? "active" : claimState },
+            { label: "verify", state: verifyState },
+        ],
     });
-  }
-  const tone = statusTone(task.status);
-  const claimState = task.status === "queued" || task.status === "proposed" ? "queued" : "done";
-  const actionState = task.status === "claimed" || task.status === "in_progress" ? "active" : task.status === "proof_pending" || task.status === "verified" ? "done" : "queued";
-  const verifyState = task.status === "proof_pending" ? "active" : task.status === "verified" ? "done" : "queued";
-  return renderRelayCard({
-    label,
-    title: task.title,
-    summary: task.claimedBy ? `Claimed by ${task.claimedBy}.` : task.whyNow,
-    tone,
-    stages: [
-      { label: "manager", state: "done" },
-      { label: task.surface === "internet" ? "reply" : "hands", state: actionState === "active" ? "active" : claimState },
-      { label: "verify", state: verifyState },
-    ],
-  });
 }
-
-function renderApprovalRelayCard(row: ApprovalItem | null): string {
-  if (!row) {
+function renderApprovalRelayCard(row) {
+    if (!row) {
+        return renderRelayCard({
+            label: "Owner gate",
+            title: "Approval lane clear",
+            summary: "Nothing is waiting on explicit owner agency right now.",
+            tone: "good",
+            stages: [
+                { label: "manager", state: "done" },
+                { label: "owner", state: "queued" },
+                { label: "release", state: "queued" },
+            ],
+        });
+    }
+    const tone = statusTone(row.status);
+    const ownerState = row.status === "pending" ? "active" : "done";
+    const releaseState = row.status === "approved" || row.status === "executed" ? "done" : row.status === "rejected" ? "done" : "queued";
     return renderRelayCard({
-      label: "Owner gate",
-      title: "Approval lane clear",
-      summary: "Nothing is waiting on explicit owner agency right now.",
-      tone: "good",
-      stages: [
-        { label: "manager", state: "done" },
-        { label: "owner", state: "queued" },
-        { label: "release", state: "queued" },
-      ],
+        label: "Owner gate",
+        title: row.title,
+        summary: row.recommendation,
+        tone,
+        stages: [
+            { label: "manager", state: "done" },
+            { label: "owner", state: ownerState },
+            { label: "release", state: releaseState },
+        ],
     });
-  }
-  const tone = statusTone(row.status);
-  const ownerState = row.status === "pending" ? "active" : "done";
-  const releaseState = row.status === "approved" || row.status === "executed" ? "done" : row.status === "rejected" ? "done" : "queued";
-  return renderRelayCard({
-    label: "Owner gate",
-    title: row.title,
-    summary: row.recommendation,
-    tone,
-    stages: [
-      { label: "manager", state: "done" },
-      { label: "owner", state: ownerState },
-      { label: "release", state: releaseState },
-    ],
-  });
 }
-
-function renderMapZone(zone: OpsTwinZone, index: number): string {
-  const tone = statusTone(zone.status);
-  const sourceSignals = zone.evidence.sources.length
-    ? zone.evidence.sources.slice(0, 4).map((source) => {
-        const freshness = source.freshnessMs === null ? null : Math.round(source.freshnessMs / 1000);
-        const freshnessTone = freshness === null ? "neutral" : freshness <= 300 ? "good" : freshness <= 1800 ? "warn" : "danger";
-        return `
+function renderMapZone(zone, index) {
+    const tone = statusTone(zone.status);
+    const sourceSignals = zone.evidence.sources.length
+        ? zone.evidence.sources.slice(0, 4).map((source) => {
+            const freshness = source.freshnessMs === null ? null : Math.round(source.freshnessMs / 1000);
+            const freshnessTone = freshness === null ? "neutral" : freshness <= 300 ? "good" : freshness <= 1800 ? "warn" : "danger";
+            return `
           <span class="ops-zone-ribbon__segment ops-zone-ribbon__segment-${esc(freshnessTone)}" title="${esc(source.label)} · ${esc(source.system)}"></span>
         `;
-      }).join("")
-    : `<span class="ops-zone-ribbon__segment ops-zone-ribbon__segment-${esc(tone)}"></span>`;
-  return `
+        }).join("")
+        : `<span class="ops-zone-ribbon__segment ops-zone-ribbon__segment-${esc(tone)}"></span>`;
+    return `
     <article class="ops-map-zone ops-map-zone-${index % 4} ops-tone-${esc(tone)}">
       <div class="ops-map-zone__head">
         <div>
@@ -768,16 +715,9 @@ function renderMapZone(zone: OpsTwinZone, index: number): string {
     </article>
   `;
 }
-
-function renderTimelineEntry(input: {
-  time: string | null;
-  lane: string;
-  title: string;
-  summary: string;
-  tone: string;
-}): string {
-  const minutes = minutesUntil(input.time);
-  return `
+function renderTimelineEntry(input) {
+    const minutes = minutesUntil(input.time);
+    return `
     <article class="ops-timeline-entry ops-tone-${esc(input.tone)}">
       <div class="ops-timeline-entry__time">${esc(formatTimestamp(input.time))}</div>
       <div class="ops-timeline-entry__body">
@@ -794,274 +734,271 @@ function renderTimelineEntry(input: {
     </article>
   `;
 }
-
-function renderSurfaceShell(model: OpsPortalSnapshot, displayState: StationDisplayState | null): string {
-  const surfaceTabs = model.session?.allowedSurfaces?.length
-    ? model.session.allowedSurfaces
-    : ["manager", "owner", "hands", "internet", "ceo", "forge"];
-  const sessionCapabilities = model.session?.opsCapabilities ?? [];
-  const canEditMemberProfile = sessionCapabilities.includes("members:edit_profile");
-  const canEditMembership = sessionCapabilities.includes("members:edit_membership");
-  const canEditRole = sessionCapabilities.includes("members:edit_role");
-  const canViewMembers = sessionCapabilities.includes("members:view");
-  const canPrepareReservations = sessionCapabilities.includes("reservations:prepare");
-  const canRequestOverrides = sessionCapabilities.includes("overrides:request");
-  const activeManagerTasks = model.tasks.filter((entry) => (entry.surface === "manager" || entry.surface === "owner") && isActiveTask(entry));
-  const managerTasks = activeManagerTasks.slice(0, 4);
-  const activeHandsTasks = model.tasks.filter((entry) => entry.surface === "hands" && isActiveTask(entry));
-  const handsTasks = model.tasks.filter((entry) => entry.surface === "hands").slice(0, 8);
-  const activeInternetTasks = model.tasks.filter((entry) => entry.surface === "internet" && isActiveTask(entry));
-  const internetTasks = model.tasks.filter((entry) => entry.surface === "internet").slice(0, 8);
-  const handsCases = model.cases.filter((entry) => entry.lane === "hands" || entry.kind === "kiln_run" || entry.kind === "arrival").slice(0, 4);
-  const internetCases = model.cases.filter((entry) => entry.lane === "internet" || entry.kind === "support_thread" || entry.kind === "event" || entry.kind === "complaint").slice(0, 4);
-  const reservationBundles = model.reservations.slice(0, 8);
-  const eventRows = model.events.slice(0, 8);
-  const reportRows = model.reports.slice(0, 8);
-  const memberRows = model.members.slice(0, 12);
-  const memberCards = memberRows.map((row) => renderMemberCard(row, {
-    canEditProfile: canEditMemberProfile,
-    canEditMembership,
-    canEditRole,
-    canViewActivity: canViewMembers,
-  })).join("");
-  const reservationCards = reservationBundles.map((row) => renderReservationCard(row, {
-    canPrepareReservations,
-  })).join("");
-  const overrideCards = model.overrides.map((entry) => renderCase({
-    id: entry.id,
-    kind: "general",
-    title: entry.scope,
-    summary: entry.reason,
-    status: entry.status === "active" ? "active" : entry.status === "pending" ? "awaiting_approval" : "resolved",
-    priority: "p2",
-    lane: "manager",
-    ownerRole: entry.requiredRole,
-    verificationClass: "claimed",
-    freshestAt: entry.createdAt,
-    sources: [],
-    confidence: 0.55,
-    degradeReason: "Manual override in play.",
-    dueAt: entry.expiresAt,
-    linkedEntityKind: null,
-    linkedEntityId: null,
-    memoryScope: null,
-    createdAt: entry.createdAt || model.generatedAt,
-    updatedAt: entry.createdAt || model.generatedAt,
-    metadata: {},
-  })).join("");
-  const ceoCards = model.ceo.map((entry) => renderExperiment(entry, "ceo")).join("");
-  const forgeCards = model.forge.map((entry) => renderExperiment(entry, "forge")).join("");
-  const pendingApprovals = model.approvals.filter((entry) => entry.status === "pending");
-  const unreadConversations = model.conversations.filter((entry) => entry.unread).length;
-  const fastestSource = [...model.truth.sources]
-    .filter((entry) => entry.budgetSeconds > 0)
-    .sort((left, right) => {
-      const leftRemaining = (left.budgetSeconds - (left.freshnessSeconds ?? left.budgetSeconds));
-      const rightRemaining = (right.budgetSeconds - (right.freshnessSeconds ?? right.budgetSeconds));
-      return leftRemaining - rightRemaining;
+function renderSurfaceShell(model, displayState) {
+    const surfaceTabs = model.session?.allowedSurfaces?.length
+        ? model.session.allowedSurfaces
+        : ["manager", "owner", "hands", "internet", "ceo", "forge"];
+    const sessionCapabilities = model.session?.opsCapabilities ?? [];
+    const canEditMemberProfile = sessionCapabilities.includes("members:edit_profile");
+    const canEditMembership = sessionCapabilities.includes("members:edit_membership");
+    const canEditRole = sessionCapabilities.includes("members:edit_role");
+    const canViewMembers = sessionCapabilities.includes("members:view");
+    const canPrepareReservations = sessionCapabilities.includes("reservations:prepare");
+    const canRequestOverrides = sessionCapabilities.includes("overrides:request");
+    const activeManagerTasks = model.tasks.filter((entry) => (entry.surface === "manager" || entry.surface === "owner") && isActiveTask(entry));
+    const managerTasks = activeManagerTasks.slice(0, 4);
+    const activeHandsTasks = model.tasks.filter((entry) => entry.surface === "hands" && isActiveTask(entry));
+    const handsTasks = model.tasks.filter((entry) => entry.surface === "hands").slice(0, 8);
+    const activeInternetTasks = model.tasks.filter((entry) => entry.surface === "internet" && isActiveTask(entry));
+    const internetTasks = model.tasks.filter((entry) => entry.surface === "internet").slice(0, 8);
+    const handsCases = model.cases.filter((entry) => entry.lane === "hands" || entry.kind === "kiln_run" || entry.kind === "arrival").slice(0, 4);
+    const internetCases = model.cases.filter((entry) => entry.lane === "internet" || entry.kind === "support_thread" || entry.kind === "event" || entry.kind === "complaint").slice(0, 4);
+    const reservationBundles = model.reservations.slice(0, 8);
+    const eventRows = model.events.slice(0, 8);
+    const reportRows = model.reports.slice(0, 8);
+    const memberRows = model.members.slice(0, 12);
+    const memberCards = memberRows.map((row) => renderMemberCard(row, {
+        canEditProfile: canEditMemberProfile,
+        canEditMembership,
+        canEditRole,
+        canViewActivity: canViewMembers,
+    })).join("");
+    const reservationCards = reservationBundles.map((row) => renderReservationCard(row, {
+        canPrepareReservations,
+    })).join("");
+    const overrideCards = model.overrides.map((entry) => renderCase({
+        id: entry.id,
+        kind: "general",
+        title: entry.scope,
+        summary: entry.reason,
+        status: entry.status === "active" ? "active" : entry.status === "pending" ? "awaiting_approval" : "resolved",
+        priority: "p2",
+        lane: "manager",
+        ownerRole: entry.requiredRole,
+        verificationClass: "claimed",
+        freshestAt: entry.createdAt,
+        sources: [],
+        confidence: 0.55,
+        degradeReason: "Manual override in play.",
+        dueAt: entry.expiresAt,
+        linkedEntityKind: null,
+        linkedEntityId: null,
+        memoryScope: null,
+        createdAt: entry.createdAt || model.generatedAt,
+        updatedAt: entry.createdAt || model.generatedAt,
+        metadata: {},
+    })).join("");
+    const ceoCards = model.ceo.map((entry) => renderExperiment(entry, "ceo")).join("");
+    const forgeCards = model.forge.map((entry) => renderExperiment(entry, "forge")).join("");
+    const pendingApprovals = model.approvals.filter((entry) => entry.status === "pending");
+    const unreadConversations = model.conversations.filter((entry) => entry.unread).length;
+    const fastestSource = [...model.truth.sources]
+        .filter((entry) => entry.budgetSeconds > 0)
+        .sort((left, right) => {
+        const leftRemaining = (left.budgetSeconds - (left.freshnessSeconds ?? left.budgetSeconds));
+        const rightRemaining = (right.budgetSeconds - (right.freshnessSeconds ?? right.budgetSeconds));
+        return leftRemaining - rightRemaining;
     })[0] ?? null;
-  const gaugeCards = [
-    renderGaugeCard({
-      label: "Studio risk",
-      title: "Pressure",
-      value: model.twin.currentRisk ? "82%" : "24%",
-      summary: model.twin.currentRisk || "No issue is dominating the studio right now.",
-      tone: statusTone(model.twin.currentRisk ? "critical" : "healthy"),
-      percent: model.twin.currentRisk ? 82 : 24,
-      meterLabel: model.twin.currentRisk ? "risk elevated" : "risk contained",
-    }),
-    renderGaugeCard({
-      label: "Hands lane",
-      title: "Load",
-      value: `${activeHandsTasks.length}`,
-      summary: activeHandsTasks[0]?.title || "No physical task is currently queued for human hands.",
-      tone: statusTone(activeHandsTasks.length > 0 ? "warning" : "healthy"),
-      percent: Math.min(100, Math.max(12, activeHandsTasks.length * 24)),
-      meterLabel: `${activeHandsTasks.length} active task${activeHandsTasks.length === 1 ? "" : "s"}`,
-    }),
-    renderGaugeCard({
-      label: "Internet lane",
-      title: "Traffic",
-      value: `${Math.max(activeInternetTasks.length, unreadConversations)}`,
-      summary:
-        activeInternetTasks[0]?.title
-        || (unreadConversations > 0 ? `${unreadConversations} unread conversation${unreadConversations === 1 ? "" : "s"} need eyes.` : "No urgent internet thread is visible right now."),
-      tone: statusTone(activeInternetTasks.length > 0 || unreadConversations > 0 ? "warning" : "healthy"),
-      percent: Math.min(100, Math.max(10, Math.max(activeInternetTasks.length, unreadConversations) * 28)),
-      meterLabel: `${activeInternetTasks.length} active thread task${activeInternetTasks.length === 1 ? "" : "s"}`,
-    }),
-    renderGaugeCard({
-      label: "Owner gates",
-      title: "Approval",
-      value: `${pendingApprovals.length}`,
-      summary: pendingApprovals[0]?.title || "No explicit owner approval is currently blocking the manager.",
-      tone: statusTone(pendingApprovals.length > 0 ? "pending" : "approved"),
-      percent: pendingApprovals.length > 0 ? Math.min(100, pendingApprovals.length * 36) : 8,
-      meterLabel: pendingApprovals.length > 0 ? "human decision required" : "clear",
-    }),
-    renderGaugeCard({
-      label: "Truth posture",
-      title: "Readiness",
-      value: model.truth.readiness,
-      summary: model.truth.summary,
-      tone: statusTone(model.truth.readiness),
-      percent: model.truth.readiness === "ready" ? 92 : model.truth.readiness === "degraded" ? 56 : 22,
-      meterLabel: `${model.truth.degradeModes.length} degrade mode${model.truth.degradeModes.length === 1 ? "" : "s"}`,
-    }),
-  ];
-  const incidentItems = [
-    model.twin.currentRisk
-      ? renderIncidentChip({
-          label: "Studio risk",
-          text: model.twin.currentRisk,
-          tone: statusTone("critical"),
-        })
-      : "",
-    activeHandsTasks[0]
-      ? renderIncidentChip({
-          label: "Hands",
-          text: activeHandsTasks[0].title,
-          tone: statusTone(activeHandsTasks[0].status),
-        })
-      : "",
-    activeInternetTasks[0]
-      ? renderIncidentChip({
-          label: "Internet",
-          text: activeInternetTasks[0].title,
-          tone: statusTone(activeInternetTasks[0].status),
-        })
-      : "",
-    pendingApprovals[0]
-      ? renderIncidentChip({
-          label: "Approval",
-          text: pendingApprovals[0].title,
-          tone: statusTone(pendingApprovals[0].status),
-        })
-      : "",
-    model.truth.watchdogs.find((entry) => entry.status !== "healthy")
-      ? renderIncidentChip({
-          label: "Watchdog",
-          text: model.truth.watchdogs.find((entry) => entry.status !== "healthy")?.summary || "",
-          tone: statusTone(model.truth.watchdogs.find((entry) => entry.status !== "healthy")?.status || "warning"),
-        })
-      : "",
-  ].filter(Boolean);
-  const tickerItems = [
-    model.twin.currentRisk
-      ? { label: "risk", text: model.twin.currentRisk, tone: statusTone("critical") }
-      : { label: "studio", text: "No top-level incident is dominating the floor right now.", tone: statusTone("healthy") },
-    activeHandsTasks[0]
-      ? { label: "hands", text: activeHandsTasks[0].title, tone: statusTone(activeHandsTasks[0].status) }
-      : { label: "hands", text: "No physical queue is currently active.", tone: statusTone("healthy") },
-    activeInternetTasks[0]
-      ? { label: "internet", text: activeInternetTasks[0].title, tone: statusTone(activeInternetTasks[0].status) }
-      : { label: "internet", text: "No urgent internet thread is visible right now.", tone: statusTone("healthy") },
-    pendingApprovals[0]
-      ? { label: "approval", text: pendingApprovals[0].title, tone: statusTone(pendingApprovals[0].status) }
-      : { label: "approval", text: "No explicit owner gate is blocking the manager.", tone: statusTone("approved") },
-    model.truth.watchdogs.find((entry) => entry.status !== "healthy")
-      ? {
-          label: "watchdog",
-          text: model.truth.watchdogs.find((entry) => entry.status !== "healthy")?.summary || "",
-          tone: statusTone(model.truth.watchdogs.find((entry) => entry.status !== "healthy")?.status || "warning"),
-        }
-      : { label: "truth", text: model.truth.summary, tone: statusTone(model.truth.readiness) },
-  ];
-  const timelineEntries = [
-    ...activeHandsTasks.slice(0, 3).map((entry) => ({
-      time: entry.dueAt ?? entry.freshestAt,
-      lane: "Hands",
-      title: entry.title,
-      summary: entry.whyNow,
-      tone: statusTone(entry.status),
-    })),
-    ...activeInternetTasks.slice(0, 2).map((entry) => ({
-      time: entry.dueAt ?? entry.freshestAt,
-      lane: "Internet",
-      title: entry.title,
-      summary: entry.whyNow,
-      tone: statusTone(entry.status),
-    })),
-    ...pendingApprovals.slice(0, 2).map((entry) => ({
-      time: entry.freshestAt,
-      lane: "Approval",
-      title: entry.title,
-      summary: entry.recommendation,
-      tone: statusTone(entry.status),
-    })),
-  ]
-    .sort((left, right) => String(left.time ?? "9999").localeCompare(String(right.time ?? "9999")))
-    .slice(0, 6);
-  const countdownItems = [
-    renderCountdownOrb({
-      label: "Hands window",
-      title: activeHandsTasks[0]?.title || "No physical deadline",
-      summary: activeHandsTasks[0]?.whyNow || "The hands lane is not carrying an urgent physical deadline right now.",
-      minutes: activeHandsTasks[0]?.dueAt ? minutesUntil(activeHandsTasks[0].dueAt) : (activeHandsTasks[0]?.etaMinutes ?? null),
-      tone: activeHandsTasks[0] ? statusTone(activeHandsTasks[0].status) : "good",
-      horizonMinutes: 240,
-    }),
-    renderCountdownOrb({
-      label: "Internet window",
-      title: activeInternetTasks[0]?.title || "No reply clock",
-      summary:
-        activeInternetTasks[0]?.whyNow
-        || (unreadConversations > 0 ? `${unreadConversations} unread conversation${unreadConversations === 1 ? "" : "s"} are visible.` : "The internet lane is not under immediate reply pressure."),
-      minutes: activeInternetTasks[0]?.dueAt ? minutesUntil(activeInternetTasks[0].dueAt) : (activeInternetTasks[0]?.etaMinutes ?? null),
-      tone: activeInternetTasks[0] ? statusTone(activeInternetTasks[0].status) : (unreadConversations > 0 ? "warn" : "good"),
-      horizonMinutes: 180,
-    }),
-    renderCountdownOrb({
-      label: "Truth window",
-      title: fastestSource?.label || "No freshness budget",
-      summary: fastestSource?.reason || "No source freshness budget is currently close to expiring.",
-      minutes: fastestSource?.freshnessSeconds === null ? null : Math.round((fastestSource.budgetSeconds - fastestSource.freshnessSeconds) / 60),
-      tone: fastestSource ? statusTone(fastestSource.status) : statusTone(model.truth.readiness),
-      horizonMinutes: Math.max(60, Math.round((fastestSource?.budgetSeconds ?? 3600) / 60)),
-    }),
-  ];
-  const relayItems = [
-    renderTaskRelayCard(activeHandsTasks[0] ?? null, "Hands relay"),
-    renderTaskRelayCard(activeInternetTasks[0] ?? null, "Internet relay"),
-    renderApprovalRelayCard(pendingApprovals[0] ?? null),
-  ];
-  const handsNowCountdowns = [
-    renderCountdownOrb({
-      label: "Current window",
-      title: activeHandsTasks[0]?.title || "No active physical window",
-      summary: activeHandsTasks[0]?.whyNow || "No physical deadline is pressing right now.",
-      minutes: activeHandsTasks[0]?.dueAt ? minutesUntil(activeHandsTasks[0].dueAt) : (activeHandsTasks[0]?.etaMinutes ?? null),
-      tone: activeHandsTasks[0] ? statusTone(activeHandsTasks[0].status) : "good",
-      horizonMinutes: 180,
-    }),
-    renderCountdownOrb({
-      label: "Truth freshness",
-      title: fastestSource?.label || "No live source budget",
-      summary: fastestSource?.reason || "No source budget is near expiry.",
-      minutes: fastestSource?.freshnessSeconds === null ? null : Math.round((fastestSource.budgetSeconds - fastestSource.freshnessSeconds) / 60),
-      tone: fastestSource ? statusTone(fastestSource.status) : statusTone(model.truth.readiness),
-      horizonMinutes: Math.max(60, Math.round((fastestSource?.budgetSeconds ?? 3600) / 60)),
-    }),
-  ];
-  const internetDeskCountdowns = [
-    renderCountdownOrb({
-      label: "Reply window",
-      title: activeInternetTasks[0]?.title || "No urgent reply clock",
-      summary: activeInternetTasks[0]?.whyNow || "No urgent internet task is pressing the queue right now.",
-      minutes: activeInternetTasks[0]?.dueAt ? minutesUntil(activeInternetTasks[0].dueAt) : (activeInternetTasks[0]?.etaMinutes ?? null),
-      tone: activeInternetTasks[0] ? statusTone(activeInternetTasks[0].status) : "good",
-      horizonMinutes: 180,
-    }),
-    renderCountdownOrb({
-      label: "Unread pressure",
-      title: unreadConversations > 0 ? `${unreadConversations} unread thread${unreadConversations === 1 ? "" : "s"}` : "Inbox is calm",
-      summary: unreadConversations > 0 ? "Unread conversations are waiting on clarity or action." : "No unread conversation is currently visible.",
-      minutes: unreadConversations > 0 ? unreadConversations * 12 : 0,
-      tone: unreadConversations > 0 ? "warn" : "good",
-      horizonMinutes: 120,
-    }),
-  ];
-  return `
+    const gaugeCards = [
+        renderGaugeCard({
+            label: "Studio risk",
+            title: "Pressure",
+            value: model.twin.currentRisk ? "82%" : "24%",
+            summary: model.twin.currentRisk || "No issue is dominating the studio right now.",
+            tone: statusTone(model.twin.currentRisk ? "critical" : "healthy"),
+            percent: model.twin.currentRisk ? 82 : 24,
+            meterLabel: model.twin.currentRisk ? "risk elevated" : "risk contained",
+        }),
+        renderGaugeCard({
+            label: "Hands lane",
+            title: "Load",
+            value: `${activeHandsTasks.length}`,
+            summary: activeHandsTasks[0]?.title || "No physical task is currently queued for human hands.",
+            tone: statusTone(activeHandsTasks.length > 0 ? "warning" : "healthy"),
+            percent: Math.min(100, Math.max(12, activeHandsTasks.length * 24)),
+            meterLabel: `${activeHandsTasks.length} active task${activeHandsTasks.length === 1 ? "" : "s"}`,
+        }),
+        renderGaugeCard({
+            label: "Internet lane",
+            title: "Traffic",
+            value: `${Math.max(activeInternetTasks.length, unreadConversations)}`,
+            summary: activeInternetTasks[0]?.title
+                || (unreadConversations > 0 ? `${unreadConversations} unread conversation${unreadConversations === 1 ? "" : "s"} need eyes.` : "No urgent internet thread is visible right now."),
+            tone: statusTone(activeInternetTasks.length > 0 || unreadConversations > 0 ? "warning" : "healthy"),
+            percent: Math.min(100, Math.max(10, Math.max(activeInternetTasks.length, unreadConversations) * 28)),
+            meterLabel: `${activeInternetTasks.length} active thread task${activeInternetTasks.length === 1 ? "" : "s"}`,
+        }),
+        renderGaugeCard({
+            label: "Owner gates",
+            title: "Approval",
+            value: `${pendingApprovals.length}`,
+            summary: pendingApprovals[0]?.title || "No explicit owner approval is currently blocking the manager.",
+            tone: statusTone(pendingApprovals.length > 0 ? "pending" : "approved"),
+            percent: pendingApprovals.length > 0 ? Math.min(100, pendingApprovals.length * 36) : 8,
+            meterLabel: pendingApprovals.length > 0 ? "human decision required" : "clear",
+        }),
+        renderGaugeCard({
+            label: "Truth posture",
+            title: "Readiness",
+            value: model.truth.readiness,
+            summary: model.truth.summary,
+            tone: statusTone(model.truth.readiness),
+            percent: model.truth.readiness === "ready" ? 92 : model.truth.readiness === "degraded" ? 56 : 22,
+            meterLabel: `${model.truth.degradeModes.length} degrade mode${model.truth.degradeModes.length === 1 ? "" : "s"}`,
+        }),
+    ];
+    const incidentItems = [
+        model.twin.currentRisk
+            ? renderIncidentChip({
+                label: "Studio risk",
+                text: model.twin.currentRisk,
+                tone: statusTone("critical"),
+            })
+            : "",
+        activeHandsTasks[0]
+            ? renderIncidentChip({
+                label: "Hands",
+                text: activeHandsTasks[0].title,
+                tone: statusTone(activeHandsTasks[0].status),
+            })
+            : "",
+        activeInternetTasks[0]
+            ? renderIncidentChip({
+                label: "Internet",
+                text: activeInternetTasks[0].title,
+                tone: statusTone(activeInternetTasks[0].status),
+            })
+            : "",
+        pendingApprovals[0]
+            ? renderIncidentChip({
+                label: "Approval",
+                text: pendingApprovals[0].title,
+                tone: statusTone(pendingApprovals[0].status),
+            })
+            : "",
+        model.truth.watchdogs.find((entry) => entry.status !== "healthy")
+            ? renderIncidentChip({
+                label: "Watchdog",
+                text: model.truth.watchdogs.find((entry) => entry.status !== "healthy")?.summary || "",
+                tone: statusTone(model.truth.watchdogs.find((entry) => entry.status !== "healthy")?.status || "warning"),
+            })
+            : "",
+    ].filter(Boolean);
+    const tickerItems = [
+        model.twin.currentRisk
+            ? { label: "risk", text: model.twin.currentRisk, tone: statusTone("critical") }
+            : { label: "studio", text: "No top-level incident is dominating the floor right now.", tone: statusTone("healthy") },
+        activeHandsTasks[0]
+            ? { label: "hands", text: activeHandsTasks[0].title, tone: statusTone(activeHandsTasks[0].status) }
+            : { label: "hands", text: "No physical queue is currently active.", tone: statusTone("healthy") },
+        activeInternetTasks[0]
+            ? { label: "internet", text: activeInternetTasks[0].title, tone: statusTone(activeInternetTasks[0].status) }
+            : { label: "internet", text: "No urgent internet thread is visible right now.", tone: statusTone("healthy") },
+        pendingApprovals[0]
+            ? { label: "approval", text: pendingApprovals[0].title, tone: statusTone(pendingApprovals[0].status) }
+            : { label: "approval", text: "No explicit owner gate is blocking the manager.", tone: statusTone("approved") },
+        model.truth.watchdogs.find((entry) => entry.status !== "healthy")
+            ? {
+                label: "watchdog",
+                text: model.truth.watchdogs.find((entry) => entry.status !== "healthy")?.summary || "",
+                tone: statusTone(model.truth.watchdogs.find((entry) => entry.status !== "healthy")?.status || "warning"),
+            }
+            : { label: "truth", text: model.truth.summary, tone: statusTone(model.truth.readiness) },
+    ];
+    const timelineEntries = [
+        ...activeHandsTasks.slice(0, 3).map((entry) => ({
+            time: entry.dueAt ?? entry.freshestAt,
+            lane: "Hands",
+            title: entry.title,
+            summary: entry.whyNow,
+            tone: statusTone(entry.status),
+        })),
+        ...activeInternetTasks.slice(0, 2).map((entry) => ({
+            time: entry.dueAt ?? entry.freshestAt,
+            lane: "Internet",
+            title: entry.title,
+            summary: entry.whyNow,
+            tone: statusTone(entry.status),
+        })),
+        ...pendingApprovals.slice(0, 2).map((entry) => ({
+            time: entry.freshestAt,
+            lane: "Approval",
+            title: entry.title,
+            summary: entry.recommendation,
+            tone: statusTone(entry.status),
+        })),
+    ]
+        .sort((left, right) => String(left.time ?? "9999").localeCompare(String(right.time ?? "9999")))
+        .slice(0, 6);
+    const countdownItems = [
+        renderCountdownOrb({
+            label: "Hands window",
+            title: activeHandsTasks[0]?.title || "No physical deadline",
+            summary: activeHandsTasks[0]?.whyNow || "The hands lane is not carrying an urgent physical deadline right now.",
+            minutes: activeHandsTasks[0]?.dueAt ? minutesUntil(activeHandsTasks[0].dueAt) : (activeHandsTasks[0]?.etaMinutes ?? null),
+            tone: activeHandsTasks[0] ? statusTone(activeHandsTasks[0].status) : "good",
+            horizonMinutes: 240,
+        }),
+        renderCountdownOrb({
+            label: "Internet window",
+            title: activeInternetTasks[0]?.title || "No reply clock",
+            summary: activeInternetTasks[0]?.whyNow
+                || (unreadConversations > 0 ? `${unreadConversations} unread conversation${unreadConversations === 1 ? "" : "s"} are visible.` : "The internet lane is not under immediate reply pressure."),
+            minutes: activeInternetTasks[0]?.dueAt ? minutesUntil(activeInternetTasks[0].dueAt) : (activeInternetTasks[0]?.etaMinutes ?? null),
+            tone: activeInternetTasks[0] ? statusTone(activeInternetTasks[0].status) : (unreadConversations > 0 ? "warn" : "good"),
+            horizonMinutes: 180,
+        }),
+        renderCountdownOrb({
+            label: "Truth window",
+            title: fastestSource?.label || "No freshness budget",
+            summary: fastestSource?.reason || "No source freshness budget is currently close to expiring.",
+            minutes: fastestSource?.freshnessSeconds === null ? null : Math.round((fastestSource.budgetSeconds - fastestSource.freshnessSeconds) / 60),
+            tone: fastestSource ? statusTone(fastestSource.status) : statusTone(model.truth.readiness),
+            horizonMinutes: Math.max(60, Math.round((fastestSource?.budgetSeconds ?? 3600) / 60)),
+        }),
+    ];
+    const relayItems = [
+        renderTaskRelayCard(activeHandsTasks[0] ?? null, "Hands relay"),
+        renderTaskRelayCard(activeInternetTasks[0] ?? null, "Internet relay"),
+        renderApprovalRelayCard(pendingApprovals[0] ?? null),
+    ];
+    const handsNowCountdowns = [
+        renderCountdownOrb({
+            label: "Current window",
+            title: activeHandsTasks[0]?.title || "No active physical window",
+            summary: activeHandsTasks[0]?.whyNow || "No physical deadline is pressing right now.",
+            minutes: activeHandsTasks[0]?.dueAt ? minutesUntil(activeHandsTasks[0].dueAt) : (activeHandsTasks[0]?.etaMinutes ?? null),
+            tone: activeHandsTasks[0] ? statusTone(activeHandsTasks[0].status) : "good",
+            horizonMinutes: 180,
+        }),
+        renderCountdownOrb({
+            label: "Truth freshness",
+            title: fastestSource?.label || "No live source budget",
+            summary: fastestSource?.reason || "No source budget is near expiry.",
+            minutes: fastestSource?.freshnessSeconds === null ? null : Math.round((fastestSource.budgetSeconds - fastestSource.freshnessSeconds) / 60),
+            tone: fastestSource ? statusTone(fastestSource.status) : statusTone(model.truth.readiness),
+            horizonMinutes: Math.max(60, Math.round((fastestSource?.budgetSeconds ?? 3600) / 60)),
+        }),
+    ];
+    const internetDeskCountdowns = [
+        renderCountdownOrb({
+            label: "Reply window",
+            title: activeInternetTasks[0]?.title || "No urgent reply clock",
+            summary: activeInternetTasks[0]?.whyNow || "No urgent internet task is pressing the queue right now.",
+            minutes: activeInternetTasks[0]?.dueAt ? minutesUntil(activeInternetTasks[0].dueAt) : (activeInternetTasks[0]?.etaMinutes ?? null),
+            tone: activeInternetTasks[0] ? statusTone(activeInternetTasks[0].status) : "good",
+            horizonMinutes: 180,
+        }),
+        renderCountdownOrb({
+            label: "Unread pressure",
+            title: unreadConversations > 0 ? `${unreadConversations} unread thread${unreadConversations === 1 ? "" : "s"}` : "Inbox is calm",
+            summary: unreadConversations > 0 ? "Unread conversations are waiting on clarity or action." : "No unread conversation is currently visible.",
+            minutes: unreadConversations > 0 ? unreadConversations * 12 : 0,
+            tone: unreadConversations > 0 ? "warn" : "good",
+            horizonMinutes: 120,
+        }),
+    ];
+    return `
     <nav class="ops-surface-nav">
       ${surfaceTabs.map((surface) => `<button type="button" class="ops-surface-tab" data-surface-tab="${esc(surface)}">${esc(surface)}</button>`).join("")}
     </nav>
@@ -1069,13 +1006,13 @@ function renderSurfaceShell(model: OpsPortalSnapshot, displayState: StationDispl
     <section class="ops-surface" data-surface="manager">
       <div class="ops-manager-canvas">
         ${renderModeTabs("manager", [
-          { id: "overview", label: "Overview" },
-          { id: "live", label: "Live" },
-          { id: "truth", label: "Truth", meta: model.truth.sources.length },
-          { id: "operations", label: "Operations", meta: managerTasks.length },
-          { id: "commitments", label: "Commitments", meta: reservationBundles.length },
-          { id: "trust", label: "Trust", meta: reportRows.length },
-        ])}
+        { id: "overview", label: "Overview" },
+        { id: "live", label: "Live" },
+        { id: "truth", label: "Truth", meta: model.truth.sources.length },
+        { id: "operations", label: "Operations", meta: managerTasks.length },
+        { id: "commitments", label: "Commitments", meta: reservationBundles.length },
+        { id: "trust", label: "Trust", meta: reportRows.length },
+    ])}
         ${renderModePanel("manager", "overview", `
           <div class="ops-manager-canvas">
             <div class="ops-panel">
@@ -1167,11 +1104,9 @@ function renderSurfaceShell(model: OpsPortalSnapshot, displayState: StationDispl
                 </div>
               </div>
               <div class="ops-sequence-grid">
-                ${
-                  model.twin.nextActions.length
-                    ? model.twin.nextActions.slice(0, 5).map(renderSequenceStep).join("")
-                    : '<div class="ops-empty">No next action has been surfaced yet.</div>'
-                }
+                ${model.twin.nextActions.length
+        ? model.twin.nextActions.slice(0, 5).map(renderSequenceStep).join("")
+        : '<div class="ops-empty">No next action has been surfaced yet.</div>'}
               </div>
             </div>
             <div class="ops-panel">
@@ -1282,11 +1217,11 @@ function renderSurfaceShell(model: OpsPortalSnapshot, displayState: StationDispl
     <section class="ops-surface" data-surface="owner">
       <div class="ops-manager-canvas">
         ${renderModeTabs("owner", [
-          { id: "brief", label: "Brief" },
-          { id: "approvals", label: "Approvals", meta: pendingApprovals.length },
-          { id: "finance", label: "Finance" },
-          { id: "identity", label: "Identity", meta: memberRows.length },
-        ])}
+        { id: "brief", label: "Brief" },
+        { id: "approvals", label: "Approvals", meta: pendingApprovals.length },
+        { id: "finance", label: "Finance" },
+        { id: "identity", label: "Identity", meta: memberRows.length },
+    ])}
         ${renderModePanel("owner", "brief", `
           <div class="ops-layout">
             <div class="ops-panel">
@@ -1328,14 +1263,14 @@ function renderSurfaceShell(model: OpsPortalSnapshot, displayState: StationDispl
     <section class="ops-surface" data-surface="hands">
       <div class="ops-manager-canvas">
         ${renderModeTabs("hands", [
-          { id: "now", label: "Now" },
-          { id: "queue", label: "Queue", meta: handsTasks.length },
-          { id: "checkins", label: "Check-ins", meta: reservationBundles.length },
-          { id: "production", label: "Production", meta: handsCases.length },
-          { id: "firings", label: "Firings", meta: handsCases.filter((entry) => entry.kind === "kiln_run").length },
-          { id: "lending", label: "Lending", meta: model.lending?.loans.length ?? 0 },
-          { id: "lending-intake", label: "Lending intake", meta: model.lending?.requests.length ?? 0 },
-        ])}
+        { id: "now", label: "Now" },
+        { id: "queue", label: "Queue", meta: handsTasks.length },
+        { id: "checkins", label: "Check-ins", meta: reservationBundles.length },
+        { id: "production", label: "Production", meta: handsCases.length },
+        { id: "firings", label: "Firings", meta: handsCases.filter((entry) => entry.kind === "kiln_run").length },
+        { id: "lending", label: "Lending", meta: model.lending?.loans.length ?? 0 },
+        { id: "lending-intake", label: "Lending intake", meta: model.lending?.requests.length ?? 0 },
+    ])}
         ${renderModePanel("hands", "now", `
           <div class="ops-layout ops-layout-hands">
             <div class="ops-panel">
@@ -1405,12 +1340,12 @@ function renderSurfaceShell(model: OpsPortalSnapshot, displayState: StationDispl
     <section class="ops-surface" data-surface="internet">
       <div class="ops-manager-canvas">
         ${renderModeTabs("internet", [
-          { id: "desk", label: "Desk" },
-          { id: "member-ops", label: "Member ops", meta: memberRows.length },
-          { id: "events", label: "Events", meta: eventRows.length },
-          { id: "support", label: "Support", meta: model.conversations.length },
-          { id: "reputation", label: "Reputation", meta: reportRows.length },
-        ])}
+        { id: "desk", label: "Desk" },
+        { id: "member-ops", label: "Member ops", meta: memberRows.length },
+        { id: "events", label: "Events", meta: eventRows.length },
+        { id: "support", label: "Support", meta: model.conversations.length },
+        { id: "reputation", label: "Reputation", meta: reportRows.length },
+    ])}
         ${renderModePanel("internet", "desk", `
           <div class="ops-layout">
             <div class="ops-panel">
@@ -1486,10 +1421,10 @@ function renderSurfaceShell(model: OpsPortalSnapshot, displayState: StationDispl
     <section class="ops-surface" data-surface="ceo">
       <div class="ops-manager-canvas">
         ${renderModeTabs("ceo", [
-          { id: "portfolio", label: "Portfolio", meta: model.ceo.length },
-          { id: "community", label: "Community", meta: eventRows.length },
-          { id: "campaigns", label: "Campaigns", meta: reportRows.length },
-        ])}
+        { id: "portfolio", label: "Portfolio", meta: model.ceo.length },
+        { id: "community", label: "Community", meta: eventRows.length },
+        { id: "campaigns", label: "Campaigns", meta: reportRows.length },
+    ])}
         ${renderModePanel("ceo", "portfolio", `
           <div class="ops-layout">
             <div class="ops-panel">
@@ -1542,11 +1477,11 @@ function renderSurfaceShell(model: OpsPortalSnapshot, displayState: StationDispl
     <section class="ops-surface" data-surface="forge">
       <div class="ops-manager-canvas">
         ${renderModeTabs("forge", [
-          { id: "lab", label: "Lab", meta: model.forge.length },
-          { id: "policy-agent-ops", label: "Policy / agents", meta: pendingApprovals.length },
-          { id: "telemetry", label: "Telemetry", meta: model.truth.sources.length },
-          { id: "migration", label: "Migration", meta: reservationBundles.length + memberRows.length },
-        ])}
+        { id: "lab", label: "Lab", meta: model.forge.length },
+        { id: "policy-agent-ops", label: "Policy / agents", meta: pendingApprovals.length },
+        { id: "telemetry", label: "Telemetry", meta: model.truth.sources.length },
+        { id: "migration", label: "Migration", meta: reservationBundles.length + memberRows.length },
+    ])}
         ${renderModePanel("forge", "lab", `
           <div class="ops-layout">
             <div class="ops-panel">
@@ -1610,10 +1545,9 @@ function renderSurfaceShell(model: OpsPortalSnapshot, displayState: StationDispl
 
   `;
 }
-
-export function renderOpsPortalPage(model: OpsPortalPageModel): string {
-  const initialJson = jsonScript(model);
-  return `<!doctype html>
+function renderOpsPortalPage(model) {
+    const initialJson = jsonScript(model);
+    return `<!doctype html>
 <html>
   <head>
     <meta charset="utf-8" />
@@ -2855,16 +2789,9 @@ export function renderOpsPortalPage(model: OpsPortalPageModel): string {
   </body>
 </html>`;
 }
-
-export function renderOpsPortalChoicePage(input: {
-  headline: string;
-  narrative: string;
-  generatedAt: string;
-  opsUrl: string;
-  legacyUrl: string | null;
-}): string {
-  const legacyCard = input.legacyUrl
-    ? `
+function renderOpsPortalChoicePage(input) {
+    const legacyCard = input.legacyUrl
+        ? `
       <a class="ops-choice-card ops-choice-card-legacy" href="${esc(input.legacyUrl)}">
         <p class="ops-kicker">A · Original portal</p>
         <h2>Legacy staff experience</h2>
@@ -2872,7 +2799,7 @@ export function renderOpsPortalChoicePage(input: {
         <span>Open original</span>
       </a>
     `
-    : `
+        : `
       <article class="ops-choice-card ops-choice-card-disabled">
         <p class="ops-kicker">A · Original portal</p>
         <h2>Legacy staff experience</h2>
@@ -2880,7 +2807,7 @@ export function renderOpsPortalChoicePage(input: {
         <span>Unavailable</span>
       </article>
     `;
-  return `<!doctype html>
+    return `<!doctype html>
 <html>
   <head>
     <meta charset="utf-8" />

--- a/studio-brain/src/ops/service.test.ts
+++ b/studio-brain/src/ops/service.test.ts
@@ -475,3 +475,147 @@ test("ops service creates members and stores only billing-safe metadata", async 
   assert.equal(audits[1]?.payload.emailMasked, "n***r@example.com");
   assert.match(audits[1]?.reason ?? "", /^stored securely \(\d+ chars\)$/);
 });
+
+test("ops service suppresses stale reservation bundles from the live handoff view", async () => {
+  const store = new MemoryOpsStore();
+  await store.upsertReservationBundle({
+    id: "reservation:stale-1",
+    reservationId: "stale-1",
+    title: "Fixture Member · bisque firing",
+    status: "REQUESTED",
+    ownerUid: "member-1",
+    displayName: "Fixture Member",
+    firingType: "bisque firing",
+    dueAt: "2026-04-16T08:00:00.000Z",
+    itemCount: 4,
+    shelfEquivalent: 1,
+    notes: "Old QA fixture",
+    arrival: {
+      status: "expected",
+      dueAt: "2026-04-16T08:00:00.000Z",
+      arrivedAt: null,
+      summary: "Fixture Member is expected.",
+      confidence: 0.7,
+      verificationClass: "planned",
+    },
+    prep: {
+      summary: "Fixture prep",
+      actions: ["Prepare shelf"],
+      toolsNeeded: ["clipboard"],
+      assignedRole: "floor_staff",
+    },
+    linkedTaskIds: [],
+    verificationClass: "planned",
+    freshestAt: "2026-04-16T07:45:00.000Z",
+    sources: [],
+    confidence: 0.7,
+    degradeReason: null,
+    metadata: {},
+  });
+
+  const service = createOpsService({
+    store,
+    now: () => "2026-04-18T20:45:00.000Z",
+    stateStore: {
+      async saveStudioState() {},
+      async getLatestStudioState() {
+        return {
+          schemaVersion: "v3.0",
+          snapshotDate: "2026-04-18",
+          generatedAt: "2026-04-18T20:40:00.000Z",
+          cloudSync: {
+            firestoreReadAt: "2026-04-18T20:40:00.000Z",
+            stripeReadAt: null,
+          },
+          counts: {
+            batchesActive: 0,
+            batchesClosed: 0,
+            reservationsOpen: 0,
+            firingsScheduled: 0,
+            reportsOpen: 0,
+          },
+          ops: {
+            agentRequestsPending: 0,
+            highSeverityReports: 0,
+          },
+          finance: {
+            pendingOrders: 0,
+            unsettledPayments: 0,
+          },
+          sourceHashes: {
+            firestore: "fixture",
+            stripe: null,
+          },
+          diagnostics: {
+            completeness: "partial",
+            warnings: [],
+          },
+        };
+      },
+      async getPreviousStudioState() { return null; },
+      async saveStudioStateDiff() {},
+      async saveOverseerRun() {},
+      async getLatestOverseerRun() { return null; },
+      async listRecentOverseerRuns() { return []; },
+      async listRecentJobRuns() { return []; },
+      async startJobRun(jobName) {
+        return {
+          id: `${jobName}-1`,
+          jobName,
+          status: "running" as const,
+          startedAt: "2026-04-18T20:40:00.000Z",
+          completedAt: null,
+          summary: null,
+          errorMessage: null,
+        };
+      },
+      async completeJobRun() {},
+      async failJobRun() {},
+    },
+    staffDataSource: {
+      async listMembers() { return []; },
+      async getMember() { return null; },
+      async createMember() { throw new Error("not used"); },
+      async updateMemberProfile() { throw new Error("not used"); },
+      async updateMemberMembership() { throw new Error("not used"); },
+      async updateMemberBilling() { throw new Error("not used"); },
+      async updateMemberRole() { throw new Error("not used"); },
+      async getMemberActivity(uid) {
+        return {
+          uid,
+          reservations: 0,
+          libraryLoans: 0,
+          supportThreads: 0,
+          events: 0,
+          lastReservationAt: null,
+          lastLoanAt: null,
+          lastEventAt: null,
+        };
+      },
+      async listReservations() { return []; },
+      async getReservationBundle() { return null; },
+      async listEvents() { return []; },
+      async listReports() { return []; },
+      async getLendingSnapshot() {
+        return {
+          requests: [],
+          loans: [],
+          recommendationCount: 0,
+          tagSubmissionCount: 0,
+          coverReviewCount: 0,
+          generatedAt: "2026-04-18T20:40:00.000Z",
+        };
+      },
+    },
+  });
+
+  const snapshot = await service.getPortalSnapshot();
+  assert.equal(snapshot.reservations.length, 0);
+  assert.equal(snapshot.twin.currentRisk, null);
+  assert.match(snapshot.twin.headline, /quiet/i);
+  assert.ok(
+    snapshot.truth.sources.some((row) =>
+      row.source === "reservations" && /suppressed|active right now/i.test(String(row.reason || ""))
+    ),
+  );
+});

--- a/studio-brain/src/ops/service.ts
+++ b/studio-brain/src/ops/service.ts
@@ -287,6 +287,10 @@ function freshnessMsFrom(timestamp: string | null, currentIso: string): number |
   return Math.max(0, now - then);
 }
 
+function msSince(timestamp: string | null, currentIso: string): number | null {
+  return freshnessMsFrom(timestamp, currentIso);
+}
+
 function minutesUntil(timestamp: string | null): number | null {
   if (!timestamp) return null;
   const then = Date.parse(timestamp);
@@ -415,6 +419,7 @@ function sourceFreshnessRow(
   observedAt: string | null,
   budgetSeconds: number,
   reason: string | null,
+  missingStatus: OpsHealth = "critical",
 ): OpsSourceFreshness {
   const freshnessMs = freshnessMsFrom(observedAt, currentIso);
   const freshnessSeconds = freshnessMs === null ? null : Math.round(freshnessMs / 1000);
@@ -423,10 +428,35 @@ function sourceFreshnessRow(
     label,
     freshnessSeconds,
     budgetSeconds,
-    status: sourceHealth(freshnessSeconds, budgetSeconds),
+    status: freshnessSeconds === null ? missingStatus : sourceHealth(freshnessSeconds, budgetSeconds),
     freshestAt: observedAt,
     reason,
   };
+}
+
+function reservationBundleIsOperational(bundle: ReservationBundle, currentIso: string): boolean {
+  const normalizedStatus = String(bundle.status || "").trim().toUpperCase();
+  if (["CANCELED", "CANCELLED", "COMPLETED", "FULFILLED", "ARCHIVED"].includes(normalizedStatus)) {
+    return false;
+  }
+
+  const arrivalStatus = String(bundle.arrival?.status || "").trim().toLowerCase();
+  const arrivedAgeMs = msSince(bundle.arrival?.arrivedAt ?? null, currentIso);
+  if (arrivalStatus === "arrived") {
+    return arrivedAgeMs === null || arrivedAgeMs <= 12 * 60 * 60 * 1000;
+  }
+
+  const dueAgeMs = msSince(bundle.dueAt, currentIso);
+  if (dueAgeMs !== null) {
+    return dueAgeMs <= 6 * 60 * 60 * 1000;
+  }
+
+  const freshestAgeMs = msSince(bundle.freshestAt, currentIso);
+  if (freshestAgeMs !== null) {
+    return freshestAgeMs <= 12 * 60 * 60 * 1000;
+  }
+
+  return false;
 }
 
 function deriveReadiness(modes: OpsDegradeMode[], sourceRows: OpsSourceFreshness[]): OpsPortalSnapshot["truth"]["readiness"] {
@@ -859,7 +889,6 @@ export function createOpsService(options: OpsServiceOptions = {}) {
       mergedApprovals.set(seed.id, merged);
     };
 
-    const reservationsOpen = dependencies.studioState?.counts.reservationsOpen ?? 0;
     const supportOpen = dependencies.supportQueue?.totalOpen ?? dependencies.supportCases.filter((row) => row.queueBucket !== "resolved").length;
     const supportAwaitingApproval = dependencies.supportQueue?.awaitingApproval ?? 0;
     const supportSecurityHold = dependencies.supportQueue?.securityHold ?? 0;
@@ -1220,7 +1249,10 @@ export function createOpsService(options: OpsServiceOptions = {}) {
       );
     }
 
-    const reservationBundles = dependencies.reservations.length > 0 ? dependencies.reservations : persistedBundles;
+    const reservationBundleCandidates = dependencies.reservations.length > 0 ? dependencies.reservations : persistedBundles;
+    const reservationBundles = reservationBundleCandidates.filter((bundle) => reservationBundleIsOperational(bundle, currentIso));
+    const suppressedReservationBundles = Math.max(0, reservationBundleCandidates.length - reservationBundles.length);
+    const reservationsOpen = reservationBundles.length;
     for (const bundle of reservationBundles) {
       const caseId = `case_reservation_${bundle.reservationId}`;
       const countdown = minutesUntil(bundle.dueAt);
@@ -1377,8 +1409,8 @@ export function createOpsService(options: OpsServiceOptions = {}) {
       ?? null;
 
     const sourceRows: OpsSourceFreshness[] = [
-      sourceFreshnessRow(currentIso, "ops_ledger", "Ops ledger", latestOpsEventAt, 600, latestOpsEventAt ? null : "No ops events have been ingested yet."),
-      sourceFreshnessRow(currentIso, "studio_state", "Studio state", latestStateAt, 3600, latestStateAt ? null : "No studio state snapshot is available."),
+      sourceFreshnessRow(currentIso, "ops_ledger", "Ops ledger", latestOpsEventAt, 600, latestOpsEventAt ? null : "No ops events have been ingested yet.", "warning"),
+      sourceFreshnessRow(currentIso, "studio_state", "Studio state", latestStateAt, 3600, latestStateAt ? null : "No studio state snapshot is available.", "critical"),
       sourceFreshnessRow(
         currentIso,
         "kilnaid",
@@ -1386,6 +1418,7 @@ export function createOpsService(options: OpsServiceOptions = {}) {
         latestKilnAt,
         900,
         dependencies.kilnOverview ? null : "Kiln telemetry is unavailable.",
+        "warning",
       ),
       sourceFreshnessRow(
         currentIso,
@@ -1394,12 +1427,25 @@ export function createOpsService(options: OpsServiceOptions = {}) {
         latestSupportAt,
         900,
         supportOpsStore ? null : "Support lane is not configured.",
+        "warning",
       ),
-      sourceFreshnessRow(currentIso, "stations", "Station heartbeats", latestStationAt, 900, latestStationAt ? null : "No station heartbeats have been seen yet."),
-      sourceFreshnessRow(currentIso, "reservations", "Reservations", latestReservationAt, 1800, reservationBundles.length > 0 ? null : "No reservation bundles are available yet."),
-      sourceFreshnessRow(currentIso, "events", "Events", latestEventAt, 3600, dependencies.events.length > 0 ? null : "No event records are available yet."),
-      sourceFreshnessRow(currentIso, "reports", "Community reports", latestReportAt, 1800, dependencies.reports.length > 0 ? null : "No community reports are visible."),
-      sourceFreshnessRow(currentIso, "lending", "Lending", latestLendingAt, 1800, dependencies.lending ? null : "Lending data is unavailable."),
+      sourceFreshnessRow(currentIso, "stations", "Station heartbeats", latestStationAt, 900, latestStationAt ? null : "No station heartbeats have been seen yet.", "warning"),
+      sourceFreshnessRow(
+        currentIso,
+        "reservations",
+        "Reservations",
+        latestReservationAt,
+        1800,
+        reservationBundles.length > 0
+          ? null
+          : suppressedReservationBundles > 0
+            ? "Historical reservation bundles were suppressed from the live board."
+            : "No reservation bundles are active right now.",
+        "healthy",
+      ),
+      sourceFreshnessRow(currentIso, "events", "Events", latestEventAt, 3600, dependencies.events.length > 0 ? null : "No event records are active right now.", "healthy"),
+      sourceFreshnessRow(currentIso, "reports", "Community reports", latestReportAt, 1800, dependencies.reports.length > 0 ? null : "No community reports are active right now.", "healthy"),
+      sourceFreshnessRow(currentIso, "lending", "Lending", latestLendingAt, 1800, dependencies.lending ? null : "Lending data is unavailable.", "warning"),
     ];
 
     const derivedModes = new Set<OpsDegradeMode>(manualModes);
@@ -1419,6 +1465,13 @@ export function createOpsService(options: OpsServiceOptions = {}) {
     const truthReadiness = deriveReadiness([...derivedModes], sourceRows);
     const pendingApprovals = [...mergedApprovals.values()].filter((row) => row.status === "pending").length;
     const topTask = sortTasks([...mergedTasks.values()]).find((row) => !terminalTaskStatus(row.status)) ?? null;
+    const studioIsQuiet =
+      reservationsOpen === 0
+      && kilnAttention === 0
+      && kilnActiveRuns === 0
+      && supportOpen === 0
+      && pendingApprovals === 0
+      && topTask === null;
     const currentRisk =
       supportSecurityHold > 0
         ? `${supportSecurityHold} support thread${supportSecurityHold === 1 ? "" : "s"} are on security hold.`
@@ -1426,7 +1479,7 @@ export function createOpsService(options: OpsServiceOptions = {}) {
           ? `${kilnAttention} kiln signal${kilnAttention === 1 ? "" : "s"} need attention.`
           : pendingApprovals > 0
             ? `${pendingApprovals} approval${pendingApprovals === 1 ? "" : "s"} are blocking forward motion.`
-            : truthReadiness === "blocked"
+            : truthReadiness === "blocked" && !studioIsQuiet
               ? "Truth readiness is degraded enough that human trust would be misplaced."
               : null;
 
@@ -1634,10 +1687,18 @@ export function createOpsService(options: OpsServiceOptions = {}) {
       headline:
         currentRisk
           ? `Studio is active: ${currentRisk}`
-          : `Studio is steady with ${kilnActiveRuns} active kiln run${kilnActiveRuns === 1 ? "" : "s"} and ${supportOpen} open internet thread${supportOpen === 1 ? "" : "s"}.`,
+          : studioIsQuiet
+            ? truthReadiness === "ready"
+              ? "Studio is quiet and ready for handoff."
+              : "Studio is quiet and waiting for fresher live telemetry."
+            : `Studio is steady with ${kilnActiveRuns} active kiln run${kilnActiveRuns === 1 ? "" : "s"} and ${supportOpen} open internet thread${supportOpen === 1 ? "" : "s"}.`,
       narrative:
-        `The manager should minimize surprise across ${reservationsOpen} open reservation${reservationsOpen === 1 ? "" : "s"}, `
-        + `${kilnAttention} kiln attention item${kilnAttention === 1 ? "" : "s"}, and ${pendingApprovals} pending approval${pendingApprovals === 1 ? "" : "s"}.`,
+        studioIsQuiet
+          ? truthReadiness === "ready"
+            ? "No arrivals, physical tasks, or approvals are queued right now."
+            : "No human handoff is queued right now, so this board should read as ambient status until live signals return."
+          : `The manager should minimize surprise across ${reservationsOpen} open reservation${reservationsOpen === 1 ? "" : "s"}, `
+            + `${kilnAttention} kiln attention item${kilnAttention === 1 ? "" : "s"}, and ${pendingApprovals} pending approval${pendingApprovals === 1 ? "" : "s"}.`,
       currentRisk,
       commitmentsDueSoon: reservationsOpen,
       arrivalsExpectedSoon: reservationsOpen,


### PR DESCRIPTION
## Summary
- restore the dark ops shell and guard syncOpsUrl inside bout:srcdoc bridge frames
- suppress stale reservation bundles so the hands board returns to a quiet handoff state instead of lab residue
- add Playwright smoke coverage for both the local bridge payload and the deployed public bridge payload

## Verification
- npm --prefix studio-brain run build
- node --test studio-brain/lib/ops/service.test.js
- npm run ops:portal:bridge:smoke
- npm run ops:portal:public:smoke