### PR TITLE
Align redacted curl output with actual headers in functions client

### DIFF
--- a/web/src/api/functionsClient.test.ts
+++ b/web/src/api/functionsClient.test.ts
@@ -125,6 +125,29 @@ describe("functionsClient", () => {
     expect(redacted).not.toContain("x-admin-token: <ADMIN_TOKEN>");
   });
 
+  it("tracks admin headers supplied through request options", async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({ ok: true }));
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    const client = createFunctionsClient({
+      baseUrl: "https://example.test/functions",
+      getIdToken: async () => "id-token-123",
+    });
+
+    await client.postJson(
+      "createBatch",
+      { uid: "user_1" },
+      {
+        headers: {
+          "x-admin-token": "forwarded-admin-token",
+        },
+      }
+    );
+
+    expect(client.getLastRequest()?.includesAdminTokenHeader).toBe(true);
+    expect(client.getLastCurl()).toContain("x-admin-token: <ADMIN_TOKEN>");
+  });
+
   it("deduplicates identical in-flight requests", async () => {
     let resolveFetch: ((value: Response) => void) | null = null;
     const fetchMock = vi.fn(

--- a/web/src/api/functionsClient.test.ts
+++ b/web/src/api/functionsClient.test.ts
@@ -108,6 +108,23 @@ describe("functionsClient", () => {
     expect(real).toContain("x-admin-token: admin-token-456");
   });
 
+  it("keeps redacted curl aligned with headers when admin token is absent", async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({ ok: true }));
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    const client = createFunctionsClient({
+      baseUrl: "https://example.test/functions",
+      getIdToken: async () => "id-token-123",
+      getAdminToken: () => "  ",
+    });
+
+    await client.postJson("createBatch", { uid: "user_1" });
+
+    const redacted = client.getLastCurl();
+    expect(redacted).toContain("Authorization: Bearer <ID_TOKEN>");
+    expect(redacted).not.toContain("x-admin-token: <ADMIN_TOKEN>");
+  });
+
   it("deduplicates identical in-flight requests", async () => {
     let resolveFetch: ((value: Response) => void) | null = null;
     const fetchMock = vi.fn(

--- a/web/src/api/functionsClient.ts
+++ b/web/src/api/functionsClient.ts
@@ -38,6 +38,7 @@ export type LastRequest = {
 
   /** Redacted curl suitable for sharing/logging. */
   curlExample?: string;
+  includesAdminTokenHeader?: boolean;
 };
 
 export type FunctionsClientConfig = {
@@ -100,12 +101,16 @@ function makeInFlightActionKey(path: string, payload: unknown): string {
   return `${path}::${safeJsonStringify(payload)}`;
 }
 
-export function buildCurlRedacted(url: string, payload?: unknown) {
-  const headerArgs = [
-    `-H 'Content-Type: application/json'`,
-    `-H 'Authorization: Bearer <ID_TOKEN>'`,
-    `-H 'x-admin-token: <ADMIN_TOKEN>'`,
-  ].join(" ");
+export function buildCurlRedacted(
+  url: string,
+  payload?: unknown,
+  opts?: { includeAdminToken?: boolean }
+) {
+  const headers = [`-H 'Content-Type: application/json'`, `-H 'Authorization: Bearer <ID_TOKEN>'`];
+  if (opts?.includeAdminToken) {
+    headers.push(`-H 'x-admin-token: <ADMIN_TOKEN>'`);
+  }
+  const headerArgs = headers.join(" ");
 
   const body = payload
     ? `-d '${escapeSingleQuotesForBash(safeJsonStringify(payload))}'`
@@ -196,6 +201,7 @@ export function createFunctionsClient(config: FunctionsClientConfig): FunctionsC
         payload: normalizedPayload,
         payloadRedacted: redactedPayload,
         curlExample: buildCurlRedacted(url, normalizedPayload),
+        includesAdminTokenHeader: false,
       };
       publish(req);
       publishRequestTelemetry({
@@ -252,11 +258,17 @@ export function createFunctionsClient(config: FunctionsClientConfig): FunctionsC
       }
 
       const adminToken = config.getAdminToken?.();
+      const trimmedAdminToken = adminToken?.trim();
+      const hasAdminToken = Boolean(trimmedAdminToken);
+      req.curlExample = buildCurlRedacted(url, normalizedPayload, {
+        includeAdminToken: hasAdminToken,
+      });
+      req.includesAdminTokenHeader = hasAdminToken;
       const headers: Record<string, string> = {
         "Content-Type": "application/json",
         Authorization: `Bearer ${idToken}`,
       };
-      if (adminToken && adminToken.trim()) headers["x-admin-token"] = adminToken.trim();
+      if (trimmedAdminToken) headers["x-admin-token"] = trimmedAdminToken;
       if (options?.headers) {
         for (const [key, value] of Object.entries(options.headers)) {
           const normalizedKey = String(key || "").trim();
@@ -330,7 +342,9 @@ export function createFunctionsClient(config: FunctionsClientConfig): FunctionsC
         ok: resp.ok,
         response: body,
         responseSnippet: stringifyResponseSnippet(body),
-        curlExample: buildCurlRedacted(url, normalizedPayload),
+        curlExample: buildCurlRedacted(url, normalizedPayload, {
+          includeAdminToken: req.includesAdminTokenHeader,
+        }),
       };
 
       if (!resp.ok) {
@@ -417,7 +431,11 @@ export function createFunctionsClient(config: FunctionsClientConfig): FunctionsC
     if (!lastReq) return "";
 
     const redact = opts?.redact ?? redactDefault;
-    if (redact) return buildCurlRedacted(lastReq.url, lastReq.payload);
+    if (redact) {
+      return buildCurlRedacted(lastReq.url, lastReq.payload, {
+        includeAdminToken: lastReq.includesAdminTokenHeader,
+      });
+    }
 
     // real curl requires we have an idToken from THIS session
     if (!lastIdToken) return "";

--- a/web/src/api/functionsClient.ts
+++ b/web/src/api/functionsClient.ts
@@ -259,11 +259,6 @@ export function createFunctionsClient(config: FunctionsClientConfig): FunctionsC
 
       const adminToken = config.getAdminToken?.();
       const trimmedAdminToken = adminToken?.trim();
-      const hasAdminToken = Boolean(trimmedAdminToken);
-      req.curlExample = buildCurlRedacted(url, normalizedPayload, {
-        includeAdminToken: hasAdminToken,
-      });
-      req.includesAdminTokenHeader = hasAdminToken;
       const headers: Record<string, string> = {
         "Content-Type": "application/json",
         Authorization: `Bearer ${idToken}`,
@@ -277,6 +272,13 @@ export function createFunctionsClient(config: FunctionsClientConfig): FunctionsC
           headers[normalizedKey] = normalizedValue;
         }
       }
+      const includesAdminTokenHeader = Object.entries(headers).some(
+        ([key, value]) => key.trim().toLowerCase() === "x-admin-token" && value.trim() !== ""
+      );
+      req.curlExample = buildCurlRedacted(url, normalizedPayload, {
+        includeAdminToken: includesAdminTokenHeader,
+      });
+      req.includesAdminTokenHeader = includesAdminTokenHeader;
 
       let resp: Response;
       let didTimeout = false;


### PR DESCRIPTION
### Motivation
- Diagnostic curl output in the Functions client always showed `x-admin-token` even when the real request omitted it, causing misleading troubleshooting artifacts. 
- Preserve accurate last-request metadata so success/error/retry snapshots and `getLastCurl()` remain consistent with actual request headers.

### Description
- Updated `web/src/api/functionsClient.ts` to make `buildCurlRedacted()` accept an `includeAdminToken` option and only include the `x-admin-token` header when a trimmed admin token is present. 
- Trimmed and normalized admin token handling and persisted an `includesAdminTokenHeader` flag on the `LastRequest` so all snapshots (initial, error, updated) generate consistent redacted curls. 
- Updated `getLastCurl()` to honor the stored `includesAdminTokenHeader` when producing the redacted curl. 
- Added a regression test in `web/src/api/functionsClient.test.ts` to assert the redacted curl omits the admin header when the admin token is blank.

### Testing
- Ran the focused unit tests with `npm --prefix web run test:run -- src/api/functionsClient.test.ts` and they passed (`9 passed`).
- Verified the full web test suite with `npm --prefix web run test:run` (previous run showed `372 passed`) and confirmed no regressions in the build with `npm --prefix web run build` (success). 
- Ran linting with `npm --prefix web run lint` and TypeScript build for functions with `npm --prefix functions run build`, both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea66e459e8832bbb0e53b791f729b4)