### PR TITLE
chore(deps): refresh routine tooling updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
         "firebase-functions": "^7.2.5"
       },
       "devDependencies": {
-        "@axe-core/playwright": "^4.11.1",
+        "@axe-core/playwright": "^4.11.2",
         "@firebase/rules-unit-testing": "^5.0.0",
         "@playwright/test": "^1.59.1",
-        "firebase-tools": "15.14.0",
+        "firebase-tools": "15.15.0",
         "playwright": "^1.58.2"
       },
       "engines": {
@@ -95,13 +95,13 @@
       "license": "Apache-2.0"
     },
     "node_modules/@axe-core/playwright": {
-      "version": "4.11.1",
-      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.1.tgz",
-      "integrity": "sha512-mKEfoUIB1MkVTht0BGZFXtSAEKXMJoDkyV5YZ9jbBmZCcWDz71tegNsdTkIN8zc/yMi5Gm2kx7Z5YQ9PfWNAWw==",
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.2.tgz",
+      "integrity": "sha512-iP6hfNl9G0j/SEUSo8M7D80RbcDo9KRAAfDP4IT5OHB+Wm6zUHIrm8Y51BKI+Oyqduvipf9u1hcRy57zCBKzWQ==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
-        "axe-core": "~4.11.1"
+        "axe-core": "~4.11.3"
       },
       "peerDependencies": {
         "playwright-core": ">= 1.0.0"
@@ -3040,9 +3040,9 @@
       "license": "MIT"
     },
     "node_modules/axe-core": {
-      "version": "4.11.2",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.2.tgz",
-      "integrity": "sha512-byD6KPdvo72y/wj2T/4zGEvvlis+PsZsn/yPS3pEO+sFpcrqRpX/TJCxvVaEsNeMrfQbCr7w163YqoD9IYwHXw==",
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.3.tgz",
+      "integrity": "sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg==",
       "dev": true,
       "license": "MPL-2.0",
       "engines": {
@@ -5265,9 +5265,9 @@
       }
     },
     "node_modules/firebase-tools": {
-      "version": "15.14.0",
-      "resolved": "https://registry.npmjs.org/firebase-tools/-/firebase-tools-15.14.0.tgz",
-      "integrity": "sha512-SdI+vxB5tLAgJxTxbRJ89tIv1am3Bc1RPW/TL1MIpNDhW0/naS3j28JyzjaHIy/8qBBkzGIzDakI9qFNlVcnLA==",
+      "version": "15.15.0",
+      "resolved": "https://registry.npmjs.org/firebase-tools/-/firebase-tools-15.15.0.tgz",
+      "integrity": "sha512-WzIDUSe2PRHhsLA2uf1xe8CKTLm+Bbfum4fCduCmjzj4ei5WBszF24Kh9MVS1D3clQbyuIlQKbYhEZZTW+5DUw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5312,7 +5312,7 @@
         "leven": "^3.1.0",
         "libsodium-wrappers": "^0.7.10",
         "lodash": "^4.18.0",
-        "lsofi": "1.0.0",
+        "lsofi": "^2.0.0",
         "marked": "^13.0.2",
         "marked-terminal": "^7.0.0",
         "mime": "^2.5.2",
@@ -5344,7 +5344,7 @@
         "winston": "^3.0.0",
         "winston-transport": "^4.4.0",
         "ws": "^7.5.10",
-        "yaml": "^2.4.1",
+        "yaml": "^2.8.3",
         "zod": "^3.24.3",
         "zod-to-json-schema": "^3.24.5"
       },
@@ -6456,13 +6456,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/is-ci": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
@@ -6546,19 +6539,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-number": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-      "integrity": "sha512-QUzH43Gfb9+5yckcrSA0VBDwEtDUchrk4F6tfJZQuNzDJbEDB9cZNzSfXGQ1jqmdDY/kl41lUOWM9syA8z8jlg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "kind-of": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/is-obj": {
@@ -6906,19 +6886,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "node_modules/kind-of": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-buffer": "^1.1.5"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/kuler": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
@@ -7191,14 +7158,13 @@
       }
     },
     "node_modules/lsofi": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lsofi/-/lsofi-1.0.0.tgz",
-      "integrity": "sha512-MKr9vM1MSm+TSKfI05IYxpKV1NCxpJaBLnELyIf784zYJ5KV9lGCE1EvpA2DtXDNM3fCuFeCwXUzim/fyQRi+A==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lsofi/-/lsofi-2.0.0.tgz",
+      "integrity": "sha512-XTFlOBHeuXnUGuUQI0kBb4O4oQW7qCV7MRGQja1xNpxgrI/jptlly+/5126RiRold1zgyxY520qOZUZ31V0I2A==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "is-number": "^2.1.0",
-        "through2": "^2.0.1"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/make-dir": {
@@ -9932,50 +9898,6 @@
       },
       "engines": {
         "node": ">=0.8"
-      }
-    },
-    "node_modules/through2": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "readable-stream": "~2.3.6",
-        "xtend": "~4.0.1"
-      }
-    },
-    "node_modules/through2/node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/through2/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/through2/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/tinyglobby": {

--- a/package.json
+++ b/package.json
@@ -492,10 +492,10 @@
     "firebase-functions": "^7.2.5"
   },
   "devDependencies": {
-    "@axe-core/playwright": "^4.11.1",
+    "@axe-core/playwright": "^4.11.2",
     "@firebase/rules-unit-testing": "^5.0.0",
     "@playwright/test": "^1.59.1",
-    "firebase-tools": "15.14.0",
+    "firebase-tools": "15.15.0",
     "playwright": "^1.58.2"
   },
   "overrides": {

--- a/studio-brain/package-lock.json
+++ b/studio-brain/package-lock.json
@@ -11,7 +11,7 @@
         "dotenv": "^16.4.7",
         "firebase-admin": "^13.8.0",
         "googleapis": "^169.0.0",
-        "imapflow": "^1.3.1",
+        "imapflow": "^1.3.2",
         "mailparser": "^3.9.8",
         "minio": "^8.0.7",
         "nodemailer": "^8.0.5",
@@ -1974,12 +1974,12 @@
       }
     },
     "node_modules/imapflow": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/imapflow/-/imapflow-1.3.1.tgz",
-      "integrity": "sha512-DKwpMDR1EWXpV5T7adqQAccN7n684AX3poEZ5F3YoPlm2MyGeKavpRgNr3qptdEQaK+x5SlZ9jigT+cMs4geBA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/imapflow/-/imapflow-1.3.2.tgz",
+      "integrity": "sha512-lIhVpjAf+o/1SELeR34vqeoEjAyBOMd6xq2Vdx2E4XIRwDi5sfqfBqqr5YkTwp7G/Q3f5ACpU7/zuGklJeCj9Q==",
       "license": "MIT",
       "dependencies": {
-        "@zone-eu/mailsplit": "5.4.8",
+        "@zone-eu/mailsplit": "5.4.9",
         "encoding-japanese": "2.2.0",
         "iconv-lite": "0.7.2",
         "libbase64": "1.3.0",
@@ -1988,6 +1988,17 @@
         "nodemailer": "8.0.5",
         "pino": "10.3.1",
         "socks": "2.8.7"
+      }
+    },
+    "node_modules/imapflow/node_modules/@zone-eu/mailsplit": {
+      "version": "5.4.9",
+      "resolved": "https://registry.npmjs.org/@zone-eu/mailsplit/-/mailsplit-5.4.9.tgz",
+      "integrity": "sha512-Qq7k6FzA5SmGf5HFPcr17gE7M+O1gttlmWn7tlGUlhGsbbjUaBL/4cEWIwExeCzqu5+kyZJ91mcBZbQ9zEwwYA==",
+      "license": "(MIT OR EUPL-1.1+)",
+      "dependencies": {
+        "libbase64": "1.3.0",
+        "libmime": "5.3.8",
+        "libqp": "2.1.1"
       }
     },
     "node_modules/inherits": {

--- a/studio-brain/package.json
+++ b/studio-brain/package.json
@@ -27,7 +27,7 @@
     "dotenv": "^16.4.7",
     "firebase-admin": "^13.8.0",
     "googleapis": "^169.0.0",
-    "imapflow": "^1.3.1",
+    "imapflow": "^1.3.2",
     "mailparser": "^3.9.8",
     "minio": "^8.0.7",
     "nodemailer": "^8.0.5",


### PR DESCRIPTION
## Summary
- refresh the remaining routine Dependabot updates from #485 and #484
- bump root @axe-core/playwright to 4.11.2 and firebase-tools to 15.15.0
- bump studio-brain imapflow to 1.3.2
- keep the uuid 14.0.0 security override from the merged alert fix intact

## Verification
- npm audit --audit-level=moderate
- npm --prefix studio-brain audit --audit-level=moderate
- Node require smoke for @axe-core/playwright, uuid, and firebase-tools
- npx firebase-tools --version
- npm --prefix studio-brain run test:ci
