### PR TITLE
[codex] Prepare ticket branch and status-board cleanup

### DIFF
--- a/.codex/INSTRUCTIONS.md
+++ b/.codex/INSTRUCTIONS.md
@@ -59,6 +59,8 @@
 - Default execution mode: high autonomy.
   - Continue implementation until a concrete blocker appears.
   - Minimize routine checkpoint prompts; surface only blocking decisions.
+  - Treat in-thread text status boards as deprecated-by-default. Prefer milestone updates, blocker evidence, and concise handoffs.
+  - Keep `dashboard` / `show board` as explicit user commands, but answer them from the current app/control-tower surface when available or with a compact checkpoint when not.
 - Use external memory workspace for cross-session continuity:
   - `C:\Users\micah\.codex\memory`
   - Stable records: `accepted/accepted.jsonl`

--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ exports/
 /.tmp/
 /.codex/toolcalls.ndjson
 /.codex/tools/
+/.codex-backups/
 /.codex/friction-feedback-state.json
 /.codex/interaction-run-lock.json
 /.studiobrain-host-state.json
@@ -66,6 +67,8 @@ scripts/.tmp-*
 .env
 .env.local
 .env.*.local
+/functions/.env.*
+!/functions/.env.*.example
 extensions/*.env
 extensions/*.secret.local
 secrets/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,6 +149,9 @@ Use these defaults unless the user explicitly overrides them in-session.
 - Execution style:
   - Default to high-autonomy delivery: run deep and continue until a concrete blocker appears.
   - Prefer momentum over repeated permission/checkpoint prompts for routine implementation work.
+  - Prefer lightweight milestone updates, blocker notes, and final handoffs over maintaining an in-thread text status board.
+  - Use a text status board only when the user explicitly asks for `dashboard` or `show board`, or when a long multi-agent run has no better app/control-tower surface.
+  - When `show board` is requested, map it to the current app/control-tower state when available; otherwise provide a compact current-state checkpoint instead of rebuilding a standing board by default.
 - On-demand self-improvement loops:
   - The user can request a self-improvement/interrogation loop at any time (not only on schedule).
   - Fast entry points: `npm run codex:improve:daily`, `npm run codex:interaction:daily`, `npm run codex:pr-green:daily`.

--- a/docs/runbooks/STUDIO_BRAIN_HOST_STACK.md
+++ b/docs/runbooks/STUDIO_BRAIN_HOST_STACK.md
@@ -46,6 +46,7 @@ npm run studio:ops:session:list
 npm run studio:ops:bambu:install
 npm run studio:ops:bambu:status
 npm run studio:ops:bambu:smoke
+npm run studio:ops:bambu:run -- -- --help
 ```
 
 Primary daily operator surface:
@@ -65,6 +66,42 @@ bash ./studiobrain-ops.sh status --json
 bash ./studiobrain-ops.sh cockpit-state --json
 bash ./studiobrain-ops.sh session-list --json
 ```
+
+## Bambu headless slicing
+
+Use these commands as the server-primary path:
+
+```powershell
+npm run studio:ops:bambu:install
+npm run studio:ops:bambu:status
+npm run studio:ops:bambu:smoke -- --keep-output
+```
+
+`studio:ops:bambu:status` verifies the pinned install, the extracted `AppRun`, the smoke fixture, the Bambu data root, and whether the wrapper will use `xvfb-run`. `studio:ops:bambu:smoke -- --keep-output` slices Bambu's bundled 3MF fixture and persists the exported 3MF plus stdout/stderr logs under `/home/wuff/studiobrain-data/bambu/smoke/<run-id>/`.
+
+Use `studio:ops:bambu:run` for raw CLI experiments. Pass a second `--` so Bambu options are not consumed by the local wrapper:
+
+```powershell
+npm run studio:ops:bambu:run -- -- --slice 0 --debug 2 --outputdir /home/wuff/studiobrain-data/bambu/labels/variant_B_insert-YYYYMMDD-HHMM --export-3mf variant_B_insert.3mf --load-settings "/opt/studiobrain/bambu-studio/current/squashfs-root/resources/profiles/BBL/process/0.16mm Optimal @BBL X1C.json;/opt/studiobrain/bambu-studio/current/squashfs-root/resources/profiles/BBL/machine/Bambu Lab X1 Carbon 0.4 nozzle.json" --load-filaments "/opt/studiobrain/bambu-studio/current/squashfs-root/resources/profiles/BBL/filament/Bambu PLA Basic @BBL X1C.json" /home/wuff/studiobrain-data/bambu/labels/inputs/variant_B_insert.stl
+```
+
+Current raw-STL limitation, verified on 2026-05-01: the bundled smoke 3MF slices successfully, but the support-free label STL `labels/variant_B/variant_B_insert.stl` does not yet slice reliably through Bambu's raw CLI path. The raw run failed before producing `variant_B_insert.3mf`; the wrapper classifies the failure as `settings_profile_drift` with supporting categories such as `filament_mapping_mismatch` and `upstream_cli_segfault` when the CLI prints profile/filament warnings and then exits 139. This means the Bambu install is healthy enough for project smoke tests, but the label workflow still needs a known-good Bambu 3MF template or refreshed profile pack before Bambu can be the only printability gate.
+
+Until that template exists, use the PrusaSlicer inspection path for label printability checks and keep Bambu raw-slice artifacts for debugging:
+
+- Keep the exact `studio:ops:bambu:run` command, the JSON `failure` object, stdout, stderr, output directory, and any generated 3MF.
+- Keep the input STL under `/home/wuff/studiobrain-data/bambu/labels/inputs/` when reproducing on Studio Brain.
+- Compare against a fresh `studio:ops:bambu:smoke -- --keep-output` run before treating a raw-STL failure as a broken install.
+- Fall back to `labels/slice_with_prusaslicer.ps1` and `labels/slices/prusaslicer_x1c_inspect/slice_summary.json` when Bambu reports raw CLI instability.
+
+Failure categories reported by `studio:ops:bambu:run`:
+
+- `settings_profile_drift`: printer/process/filament profiles are missing keys, incompatible, duplicated, or otherwise not accepted by the CLI.
+- `filament_mapping_mismatch`: filament IDs, color metadata, or imported model count do not line up with the arguments.
+- `display_backend_unavailable`: the CLI cannot connect to a headless display backend; retry with `STUDIO_BRAIN_BAMBU_XVFB_MODE=always`.
+- `output_path_unavailable`: the export directory or file cannot be opened by the host user.
+- `upstream_cli_segfault`: the Bambu CLI crashes after argument/profile handling; verify smoke, keep logs, and fall back.
+- `unknown_cli_failure`: preserve logs and compare against smoke before deciding next action.
 
 ## Optional env knobs
 

--- a/package.json
+++ b/package.json
@@ -166,6 +166,7 @@
     "studio:ops:bambu:install": "python ./scripts/studiobrain-ops.py --json bambu-install",
     "studio:ops:bambu:status": "python ./scripts/studiobrain-ops.py --json bambu-status",
     "studio:ops:bambu:smoke": "python ./scripts/studiobrain-ops.py --json bambu-smoke",
+    "studio:ops:bambu:run": "python ./scripts/studiobrain-ops.py --json bambu-run",
     "studio:ops:host:heartbeat": "node ./scripts/studiobrain-local-host-heartbeat.mjs --watch",
     "studio:ops:host:heartbeat:once": "node ./scripts/studiobrain-local-host-heartbeat.mjs",
     "studio:check": "node ./scripts/studiobrain-status.mjs --gate",

--- a/scripts/codex-shell.mjs
+++ b/scripts/codex-shell.mjs
@@ -429,10 +429,10 @@ function buildShellPrompt({
 }
 
 async function main() {
+  const options = parseArgs(process.argv.slice(2));
   loadShellEnv();
   await hydrateStudioBrainAuthFromPortal({ repoRoot: REPO_ROOT, env: process.env }).catch(() => null);
 
-  const options = parseArgs(process.argv.slice(2));
   const statePath = resolveShellSessionStatePath();
   const reusableState = getReusableShellState(statePath);
   const runId = buildStartupRunId(options, process.env, reusableState);

--- a/scripts/lib/codex-lifecycle-memory.mjs
+++ b/scripts/lib/codex-lifecycle-memory.mjs
@@ -1,0 +1,162 @@
+import { mkdirSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { appendJsonl, stableHash } from "./pst-memory-utils.mjs";
+import { rememberWithStudioBrain } from "./studio-brain-memory-write.mjs";
+
+const DEFAULT_LIFECYCLE_MEMORY_PATH = resolve(".codex", "lifecycle-memory.ndjson");
+
+function clean(value) {
+  return String(value ?? "").trim();
+}
+
+function toRecord(value) {
+  return value && typeof value === "object" && !Array.isArray(value) ? value : {};
+}
+
+function dedupeStrings(values, limit = 64) {
+  const out = [];
+  const seen = new Set();
+  for (const value of values || []) {
+    const normalized = clean(value);
+    if (!normalized || seen.has(normalized)) continue;
+    seen.add(normalized);
+    out.push(normalized);
+    if (out.length >= limit) break;
+  }
+  return out;
+}
+
+function resolveLifecycleMemoryPath(env = process.env, cwd = process.cwd()) {
+  const override = clean(env.CODEX_LIFECYCLE_MEMORY_PATH || env.CODEX_SHELL_LIFECYCLE_MEMORY_PATH);
+  return resolve(cwd, override || DEFAULT_LIFECYCLE_MEMORY_PATH);
+}
+
+function isEnabled(value, defaultValue = false) {
+  const raw = clean(value).toLowerCase();
+  if (!raw) return defaultValue;
+  if (["0", "false", "no", "off"].includes(raw)) return false;
+  if (["1", "true", "yes", "on"].includes(raw)) return true;
+  return defaultValue;
+}
+
+export function normalizeCodexLifecycleEvent(payload = {}, { now = new Date() } = {}) {
+  const record = toRecord(payload);
+  const metadata = toRecord(record.metadata);
+  const metrics = toRecord(record.metrics);
+  const artifactPointers = toRecord(record.artifactPointers);
+  const tsIso = clean(record.tsIso || record.occurredAt) || now.toISOString();
+  const tool = clean(record.tool || "codex");
+  const event = clean(record.event || "event");
+  const runId = clean(record.runId || metadata.runId);
+  const summary = clean(record.summary || metadata.summary);
+  const row = {
+    schema: "codex-lifecycle-memory.v1",
+    tsIso,
+    occurredAt: tsIso,
+    id: stableHash(`${tool}|${event}|${runId}|${tsIso}|${summary}`, 24),
+    tool,
+    event,
+    status: clean(record.status),
+    runId,
+    kind: clean(record.kind || "progress"),
+    summary,
+    nextAction: clean(record.nextAction),
+    blockers: Array.isArray(record.blockers) ? record.blockers : [],
+    metrics,
+    touchedPaths: dedupeStrings(record.touchedPaths, 128),
+    ownershipHints: Array.isArray(record.ownershipHints) ? record.ownershipHints : [],
+    artifactPointers,
+    metadata,
+    cwd: clean(record.cwd || metadata.cwd),
+  };
+
+  return Object.fromEntries(
+    Object.entries(row).filter(([, value]) => {
+      if (Array.isArray(value)) return value.length > 0;
+      if (value && typeof value === "object") return Object.keys(value).length > 0;
+      return clean(value);
+    })
+  );
+}
+
+function buildRemoteMemoryPayload(row) {
+  const status = clean(row.status);
+  const summary = clean(row.summary) || `${row.tool} ${row.event}${status ? ` ${status}` : ""}`.trim();
+  return {
+    kind: clean(row.kind) || "progress",
+    subjectKey: `codex-lifecycle:${row.tool}:${row.event}`,
+    scopeClass: "work",
+    content: summary,
+    tags: dedupeStrings(["codex", "lifecycle", row.tool, row.event], 16),
+    rememberForStartup: false,
+    importance: 0.35,
+    metadata: {
+      ...toRecord(row.metadata),
+      lifecycleMemory: true,
+      startupEligible: false,
+      event: row.event,
+      tool: row.tool,
+      status: row.status,
+      runId: row.runId,
+      metrics: row.metrics,
+      artifactPointers: row.artifactPointers,
+      touchedPaths: row.touchedPaths,
+    },
+  };
+}
+
+export async function rememberCodexLifecycleEvent(payload = {}, {
+  env = process.env,
+  cwd = process.cwd(),
+  requestJson,
+  remote = isEnabled(env.CODEX_LIFECYCLE_MEMORY_REMOTE, false),
+} = {}) {
+  const row = normalizeCodexLifecycleEvent(payload);
+  const lifecycleMemoryPath = resolveLifecycleMemoryPath(env, cwd);
+  mkdirSync(dirname(lifecycleMemoryPath), { recursive: true });
+  appendJsonl(lifecycleMemoryPath, [row]);
+
+  const result = {
+    attempted: true,
+    ok: true,
+    local: {
+      ok: true,
+      path: lifecycleMemoryPath,
+      id: row.id,
+    },
+    remote: {
+      attempted: false,
+      ok: false,
+    },
+  };
+
+  if (!remote) {
+    return result;
+  }
+
+  try {
+    const remoteResult = await rememberWithStudioBrain(buildRemoteMemoryPayload(row), {
+      env,
+      cwd: clean(row.cwd || cwd),
+      capturedFrom: "codex-lifecycle-memory",
+      requestJson,
+    });
+    return {
+      ...result,
+      remote: {
+        attempted: true,
+        ok: remoteResult.verified === true,
+        ...remoteResult,
+      },
+    };
+  } catch (error) {
+    return {
+      ...result,
+      remote: {
+        attempted: true,
+        ok: false,
+        error: error instanceof Error ? error.message : String(error),
+      },
+    };
+  }
+}

--- a/scripts/lib/codex-lifecycle-memory.test.mjs
+++ b/scripts/lib/codex-lifecycle-memory.test.mjs
@@ -1,0 +1,62 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  normalizeCodexLifecycleEvent,
+  rememberCodexLifecycleEvent,
+} from "./codex-lifecycle-memory.mjs";
+
+test("normalizeCodexLifecycleEvent creates compact stable rows", () => {
+  const row = normalizeCodexLifecycleEvent(
+    {
+      tool: "codex-shell",
+      event: "task-start",
+      status: "running",
+      runId: "run-1",
+      summary: "Shell launched.",
+      metrics: { bootstrap: true },
+      touchedPaths: ["a", "a", "b"],
+    },
+    { now: new Date("2026-04-30T12:00:00.000Z") }
+  );
+
+  assert.equal(row.schema, "codex-lifecycle-memory.v1");
+  assert.equal(row.tool, "codex-shell");
+  assert.equal(row.event, "task-start");
+  assert.equal(row.tsIso, "2026-04-30T12:00:00.000Z");
+  assert.deepEqual(row.touchedPaths, ["a", "b"]);
+  assert.equal(typeof row.id, "string");
+});
+
+test("rememberCodexLifecycleEvent appends local lifecycle memory without remote writes by default", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "codex-lifecycle-"));
+  const lifecyclePath = join(dir, "lifecycle.ndjson");
+  const result = await rememberCodexLifecycleEvent(
+    {
+      tool: "codex-shell",
+      event: "task-stop",
+      status: "exit-0",
+      runId: "run-2",
+      summary: "Shell exited.",
+    },
+    {
+      cwd: dir,
+      env: {
+        CODEX_LIFECYCLE_MEMORY_PATH: lifecyclePath,
+      },
+    }
+  );
+
+  assert.equal(result.ok, true);
+  assert.equal(result.remote.attempted, false);
+  const rows = readFileSync(lifecyclePath, "utf8")
+    .trim()
+    .split(/\r?\n/)
+    .map((line) => JSON.parse(line));
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].tool, "codex-shell");
+  assert.equal(rows[0].event, "task-stop");
+});

--- a/scripts/studiobrain-ops.py
+++ b/scripts/studiobrain-ops.py
@@ -149,6 +149,90 @@ def build_remote_bambu_command(env: dict[str, str], *script_args: str) -> str:
     return build_remote_host_user_command(env, inner_command)
 
 
+BAMBU_FAILURE_PRIORITY = (
+    "settings_profile_drift",
+    "filament_mapping_mismatch",
+    "display_backend_unavailable",
+    "output_path_unavailable",
+    "upstream_cli_segfault",
+    "unknown_cli_failure",
+)
+
+BAMBU_FAILURE_NEXT_ACTIONS = {
+    "settings_profile_drift": (
+        "Refresh or replace the tracked printer/process/filament profile pack, "
+        "or slice through a known-good 3MF template with embedded settings."
+    ),
+    "filament_mapping_mismatch": (
+        "Pass explicit filament/color assignments that match the imported model count, "
+        "or use a reusable 3MF template with filament metadata already assigned."
+    ),
+    "display_backend_unavailable": (
+        "Verify xvfb-run is installed and run with STUDIO_BRAIN_BAMBU_XVFB_MODE=always "
+        "before retrying the same command."
+    ),
+    "output_path_unavailable": (
+        "Create a writable output directory under the Bambu data root and retry with "
+        "the same output file name."
+    ),
+    "upstream_cli_segfault": (
+        "Run the smoke fixture to separate install health from raw-slice instability, "
+        "then keep stdout/stderr and fall back to PrusaSlicer inspection if smoke passes."
+    ),
+    "unknown_cli_failure": (
+        "Keep the command, stdout, stderr, and output directory, then compare against "
+        "a fresh smoke run from the same host."
+    ),
+}
+
+
+def classify_bambu_failure(stdout: str, stderr: str, exit_code: int) -> dict[str, object]:
+    combined = f"{stdout}\n{stderr}".lower()
+    categories: list[str] = []
+
+    def add(category: str) -> None:
+        if category not in categories:
+            categories.append(category)
+
+    if (
+        "nozzle_volume_type not found" in combined
+        or "process not compatible with printer" in combined
+        or "duplicate machine config file" in combined
+        or "config file is not compatible" in combined
+    ):
+        add("settings_profile_drift")
+    if (
+        "loaded_filament_ids size" in combined
+        or "no filament colors found" in combined
+        or "filament ids" in combined
+    ):
+        add("filament_mapping_mismatch")
+    if (
+        "wayland: failed to connect to display" in combined
+        or "failed to connect to display" in combined
+        or "cannot open display" in combined
+        or "glfwinit" in combined
+    ):
+        add("display_backend_unavailable")
+    if (
+        "unable to open the file" in combined
+        or "permission denied" in combined
+        or ("project export" in combined and "failed" in combined)
+    ):
+        add("output_path_unavailable")
+    if exit_code == 139 or "segmentation fault" in combined:
+        add("upstream_cli_segfault")
+    if exit_code != 0 and not categories:
+        add("unknown_cli_failure")
+
+    primary = next((category for category in BAMBU_FAILURE_PRIORITY if category in categories), "")
+    return {
+        "primary": primary,
+        "categories": categories,
+        "nextAction": BAMBU_FAILURE_NEXT_ACTIONS.get(primary, ""),
+    }
+
+
 def resolve_namecheap_tunnel_settings() -> dict[str, object]:
     ssh_binary = resolve_windows_openssh_binary("ssh.exe") or "ssh"
     settings = {
@@ -369,6 +453,10 @@ def run_remote_bambu(
                 payload["parsed"] = json.loads(stdout_text)
             except json.JSONDecodeError:
                 pass
+        if code != 0:
+            failure = classify_bambu_failure(str(payload["stdout"]), str(payload["stderr"]), code)
+            payload["failure"] = failure
+            payload["failureCategory"] = str(failure.get("primary", ""))
         if synced is not None:
             payload["synced"] = synced
         return payload

--- a/tickets/P1-bambu-headless-slice-template-and-cli-reliability.md
+++ b/tickets/P1-bambu-headless-slice-template-and-cli-reliability.md
@@ -1,6 +1,6 @@
 # P1 — Bambu headless slice template and CLI reliability
 
-Status: Active
+Status: Blocked
 Date: 2026-04-14
 Priority: P1
 Owner: Studio Ops
@@ -26,6 +26,14 @@ Studio Brain can install and smoke-test the pinned Bambu Studio CLI, but raw STL
 1. At least one label artifact slices headlessly on Studio Brain with a tracked command and persisted output artifacts.
 2. Failures report actionable cause categories instead of only surfacing opaque CLI crashes.
 3. The runbook covers install, status, smoke, and the current raw-slice limitations honestly.
+
+## Progress — 2026-05-01
+
+- `npm run studio:ops:bambu:status` verifies the pinned Bambu Studio install on Studio Brain.
+- `npm run studio:ops:bambu:smoke -- --keep-output` slices the bundled Bambu 3MF fixture headlessly and persisted the latest verified smoke artifact at `/home/wuff/studiobrain-data/bambu/smoke/20260501-002907/smoke-slice.3mf`.
+- Added `studio:ops:bambu:run` as the explicit raw CLI path and added structured Bambu failure classification to `scripts/studiobrain-ops.py`.
+- Documented install, status, smoke, raw-run usage, failure categories, artifact retention, and fallback behavior in `docs/runbooks/STUDIO_BRAIN_HOST_STACK.md`.
+- Blocker: the support-free label STL `labels/variant_B/variant_B_insert.stl` does not yet slice through Bambu's raw CLI profile path. The latest classified raw run used `/home/wuff/studiobrain-data/bambu/labels/variant_B_insert-20260501-classified`; it failed before producing a label 3MF, with profile/filament warnings and exit 139. The current classified cause is `settings_profile_drift`, with supporting `filament_mapping_mismatch` and `upstream_cli_segfault`. Acceptance criterion 1 remains unmet until a known-good Bambu 3MF template or refreshed profile pack exists.
 
 ## Dependencies
 - `scripts/studiobrain-ops.py`

--- a/tickets/P1-codex-clean-worktree-session-launcher.md
+++ b/tickets/P1-codex-clean-worktree-session-launcher.md
@@ -1,6 +1,6 @@
 # P1 — Codex clean-worktree session launcher
 
-Status: Active
+Status: Completed
 Date: 2026-03-21
 Priority: P1
 Owner: Platform
@@ -20,6 +20,21 @@ Dirty main worktrees create repeated branch/status/reconciliation overhead for C
 1. `npm run codex:shell` defaults to a clean dedicated worktree.
 2. `node ./scripts/codex-worktree-launcher.mjs --json` reports launcher state, workspace path, and branch-prefix validity.
 3. Users can opt out with `--current-worktree` when they intentionally want the dirty repo.
+
+## Completion Notes
+Completed on the `codex/tickets` branch.
+
+Verification:
+1. `node --test scripts/lib/codex-lifecycle-memory.test.mjs scripts/lib/codex-worktree-utils.test.mjs`
+2. `node ./scripts/codex-shell.mjs --help`
+3. `node ./scripts/codex-worktree-launcher.mjs --json`
+
+Evidence:
+1. The launcher reused `C:\Users\micah\.codex\worktrees\monsoonfire-portal`.
+2. The clean worktree branch was `codex/session-monsoonfire-portal`.
+3. `branchPrefixValid` was `true`.
+4. `workspaceStatus.dirty` was `false`.
+5. `--current-worktree` remains documented as the opt-out path in the shell help and MCP operations runbook.
 
 ## Dependencies
 - `scripts/codex-shell.mjs`

--- a/tickets/P1-codex-startup-memory-reliability-and-auth-contract.md
+++ b/tickets/P1-codex-startup-memory-reliability-and-auth-contract.md
@@ -1,6 +1,6 @@
 # P1 — Codex startup memory reliability and auth contract
 
-Status: Active
+Status: Completed
 Date: 2026-03-21
 Priority: P1
 Owner: Platform
@@ -25,6 +25,18 @@ Codex startup continuity has been failing with vague messages, which forces broa
 1. Codex shell prints exact startup reason codes when continuity is unavailable.
 2. `npm run codex:doctor` includes startup preflight results.
 3. Startup diagnostics distinguish auth, transport, timeout, and empty-context failures.
+
+## Completion Notes
+- Verified startup reason-code plumbing is present through the startup preflight, doctor, scorecard, shell, MCP launch/server, and Open Memory automation paths.
+- Live `codex-startup-preflight` initially reported `degraded` while local startup context repaired from cross-thread fallback, then passed on retry through the validated-local fast path with `reasonCode: ok`, `continuityState: ready`, `threadScopedItemCount: 8`, and no degradation buckets.
+- `codex-doctor` passed with startup contract `status: pass`, repo lane alignment, clean `codex/tickets` worktree state, and zero warnings/errors.
+- `codex-startup-scorecard` reported grade `A` for the current live sample. Launcher coverage remains provisional at 4/5 live samples, so one more fresh Codex launcher/startup observation should be collected before treating the aggregate scorecard as fully trustworthy.
+
+## Verification
+- `node ./scripts/codex-startup-preflight.mjs --json`
+- `node ./scripts/codex-doctor.mjs --json`
+- `node ./scripts/codex-startup-scorecard.mjs --json`
+- `node --test scripts/lib/codex-startup-reliability.test.mjs scripts/lib/codex-startup-telemetry.test.mjs scripts/codex-startup-scorecard.test.mjs scripts/codex-doctor.test.mjs scripts/codex/open-memory-automation.test.mjs`
 
 ## Dependencies
 - `scripts/codex-shell.mjs`

--- a/tickets/P1-cross-platform-command-runner-and-wrapper-audit.md
+++ b/tickets/P1-cross-platform-command-runner-and-wrapper-audit.md
@@ -1,6 +1,6 @@
 # P1 — Cross-platform command runner and wrapper audit
 
-Status: Active
+Status: Completed
 Date: 2026-03-21
 Priority: P1
 Owner: Platform
@@ -24,6 +24,16 @@ Several high-use scripts still duplicate platform-specific command lookup and PA
 1. The hot-path scripts no longer spawn bare `npx`/`npm` or hard-code PATH delimiters.
 2. The wrapper audit passes locally and runs inside Codex doctor.
 3. Shared helper logic is the canonical command-resolution path for the tracked surfaces.
+
+## Completion Notes
+- Verified `scripts/lib/command-runner.mjs` is the shared command-resolution, PATH-prepend, and Firebase CLI invocation helper used by the tracked hot paths.
+- Verified `scripts/audit-cross-platform-wrappers.mjs` scans the hot-path scripts and reports no unsafe bare `npx`/`npm`, hard-coded PATH separator, or `shell: true` wrapper patterns.
+- Verified `scripts/codex-doctor.mjs` runs the cross-platform wrapper audit and reports it as `codex-cross-platform-wrapper-audit`.
+
+## Verification
+- `node scripts/audit-cross-platform-wrappers.mjs`
+- `node ./scripts/codex-doctor.mjs --json`
+- `node --test scripts/lib/command-runner.test.mjs scripts/audit-cross-platform-wrappers.test.mjs scripts/codex-doctor.test.mjs`
 
 ## Dependencies
 - `scripts/lib/command-runner.mjs`

--- a/tickets/P3-deprecate-codex-status-board-harness.md
+++ b/tickets/P3-deprecate-codex-status-board-harness.md
@@ -1,0 +1,14 @@
+# P3: Deprecate Codex Text Status Board Harness
+
+## Context
+The app now carries more of the live progress and orchestration surface, so the older in-thread text status board adds scroll and cycle cost without much user value.
+
+## Todo
+- Audit `AGENTS.md`, harness docs, and Codex collaboration scripts for required status-board behavior.
+- Replace default board usage with lighter milestone/checkpoint updates.
+- Keep explicit user commands like `show board` only if they still map to a useful current app surface.
+- Remove or soften tests/docs that assume the text board is the primary coordination UI.
+
+## Notes
+- Do not remove useful handoff/checkpoint summaries.
+- This is a harness/protocol cleanup, not an Ember support feature blocker.

--- a/tickets/P3-deprecate-codex-status-board-harness.md
+++ b/tickets/P3-deprecate-codex-status-board-harness.md
@@ -1,5 +1,10 @@
 # P3: Deprecate Codex Text Status Board Harness
 
+Status: Completed
+Priority: P3
+Owner: Codex Harness
+Type: Ticket
+
 ## Context
 The app now carries more of the live progress and orchestration surface, so the older in-thread text status board adds scroll and cycle cost without much user value.
 
@@ -12,3 +17,9 @@ The app now carries more of the live progress and orchestration surface, so the 
 ## Notes
 - Do not remove useful handoff/checkpoint summaries.
 - This is a harness/protocol cleanup, not an Ember support feature blocker.
+
+## Completion Notes — 2026-05-01
+- Audited `AGENTS.md`, `.codex/INSTRUCTIONS.md`, and harness references on the clean `origin/main` branch for required in-thread text-board behavior.
+- Updated collaboration defaults to prefer milestone updates, blocker evidence, and concise handoffs.
+- Kept `dashboard` / `show board` as explicit user commands, but mapped them to app/control-tower state when available or a compact checkpoint when not.
+- Confirmed Studio Brain runtime/control-tower `board` rows are app-facing coordination state, not the deprecated chat text-board harness, so they were left intact.

--- a/tickets/v3/P0-v3-cloud-truth-guardrails-and-drift-detection.md
+++ b/tickets/v3/P0-v3-cloud-truth-guardrails-and-drift-detection.md
@@ -1,5 +1,11 @@
 # P0: Cloud-Truth Guardrails + Drift Detection
 
+Status: done-in-code
+Priority: P0
+Owner: Studio Brain / Platform
+Type: Ticket
+Parent Epic: tickets/v3/EPICS.md
+
 ## Goal
 Prevent local StudioState from being mistaken as authoritative by enforcing provenance labels, staleness checks, and drift alerts.
 

--- a/tickets/v3/P0-v3-config-and-secrets-contract.md
+++ b/tickets/v3/P0-v3-config-and-secrets-contract.md
@@ -1,5 +1,11 @@
 # P0: Studio Brain Config + Secrets Contract
 
+Status: done-in-code
+Priority: P0
+Owner: Studio Brain / Platform
+Type: Ticket
+Parent Epic: tickets/v3/EPICS.md
+
 ## Goal
 Define and enforce a strict runtime config contract so local orchestration is deterministic, secure, and environment-portable.
 

--- a/tickets/v3/P0-v3-dashboard-studio-state-diffs.md
+++ b/tickets/v3/P0-v3-dashboard-studio-state-diffs.md
@@ -1,5 +1,11 @@
 # P0: Local Dashboard for StudioState + Diffs
 
+Status: done-in-code
+Priority: P0
+Owner: Studio Brain / Platform
+Type: Ticket
+Parent Epic: tickets/v3/EPICS.md
+
 ## Goal
 Expose a local dashboard surface for latest StudioState and recent audit events/diffs.
 

--- a/tickets/v3/P0-v3-observability-baseline.md
+++ b/tickets/v3/P0-v3-observability-baseline.md
@@ -1,5 +1,11 @@
 # P0: Studio Brain Observability Baseline
 
+Status: done-in-code
+Priority: P0
+Owner: Studio Brain / Platform
+Type: Ticket
+Parent Epic: tickets/v3/EPICS.md
+
 ## Goal
 Ship structured logs, event IDs, and health/readiness observability so v3 is operable from day one.
 

--- a/tickets/v3/P0-v3-studio-brain-scaffold.md
+++ b/tickets/v3/P0-v3-studio-brain-scaffold.md
@@ -1,5 +1,11 @@
 # P0: Studio Brain Scaffold (TypeScript + Postgres + Job Runtime)
 
+Status: done-in-code
+Priority: P0
+Owner: Studio Brain / Platform
+Type: Ticket
+Parent Epic: tickets/v3/EPICS.md
+
 ## Goal
 Create a local `studio-brain` package with config, Postgres stores, migrations, job runner, and append-only event log foundations.
 

--- a/tickets/v3/P0-v3-studio-state-readonly-computation.md
+++ b/tickets/v3/P0-v3-studio-state-readonly-computation.md
@@ -1,5 +1,11 @@
 # P0: Read-only StudioState Computation (Firestore + Stripe Reads)
 
+Status: done-in-code
+Priority: P0
+Owner: Studio Brain / Platform
+Type: Ticket
+Parent Epic: tickets/v3/EPICS.md
+
 ## Goal
 Compute daily StudioState snapshots from cloud-authoritative reads and persist locally in Postgres.
 

--- a/tickets/v3/P1-v3-agent-identity-bridge-and-delegation-enforcement.md
+++ b/tickets/v3/P1-v3-agent-identity-bridge-and-delegation-enforcement.md
@@ -1,5 +1,11 @@
 # P1: Agent Identity Bridge + Delegation Enforcement
 
+Status: done-in-code
+Priority: P1
+Owner: Studio Brain / Platform
+Type: Ticket
+Parent Epic: tickets/v3/EPICS.md
+
 ## Goal
 Bind agent actions to explicit delegated authority from humans/staff and deny execution when delegation is missing, expired, revoked, or scope-incompatible.
 

--- a/tickets/v3/P1-v3-approval-ui-in-staff-console.md
+++ b/tickets/v3/P1-v3-approval-ui-in-staff-console.md
@@ -1,5 +1,11 @@
 # P1: Approval Queue UI in Staff Console
 
+Status: done-in-code
+Priority: P1
+Owner: Studio Brain / Platform
+Type: Ticket
+Parent Epic: tickets/v3/EPICS.md
+
 ## Goal
 Expose proposals, approval decisions, and execution traces in the existing staff console so operators can approve safely without leaving cloud surfaces.
 

--- a/tickets/v3/P1-v3-capability-registry-proposal-approval-audit.md
+++ b/tickets/v3/P1-v3-capability-registry-proposal-approval-audit.md
@@ -1,5 +1,11 @@
 # P1: Capability Registry + Proposal/Approval + Immutable Audit
 
+Status: done-in-code
+Priority: P1
+Owner: Studio Brain / Platform
+Type: Ticket
+Parent Epic: tickets/v3/EPICS.md
+
 ## Goal
 Introduce capability definitions and a proposal/approval workflow that gates all external writes.
 

--- a/tickets/v3/P1-v3-connector-framework-hubitat-readonly.md
+++ b/tickets/v3/P1-v3-connector-framework-hubitat-readonly.md
@@ -1,5 +1,11 @@
 # P1: Connector Framework + Hubitat (Read-only First)
 
+Status: done-in-code
+Priority: P1
+Owner: Studio Brain / Platform
+Type: Ticket
+Parent Epic: tickets/v3/EPICS.md
+
 ## Goal
 Create connector interface framework and implement Hubitat read-only adapter with capability definitions.
 

--- a/tickets/v3/P1-v3-connector-framework-roborock-readonly.md
+++ b/tickets/v3/P1-v3-connector-framework-roborock-readonly.md
@@ -1,5 +1,11 @@
 # P1: Roborock Connector (Read-only First)
 
+Status: done-in-code
+Priority: P1
+Owner: Studio Brain / Platform
+Type: Ticket
+Parent Epic: tickets/v3/EPICS.md
+
 ## Goal
 Add Roborock read-only connector for device status telemetry under capability policy.
 

--- a/tickets/v3/P1-v3-connector-test-harness.md
+++ b/tickets/v3/P1-v3-connector-test-harness.md
@@ -1,5 +1,11 @@
 # P1: Connector Contract Test Harness
 
+Status: done-in-code
+Priority: P1
+Owner: Studio Brain / Platform
+Type: Ticket
+Parent Epic: tickets/v3/EPICS.md
+
 ## Goal
 Create a reusable harness that validates connector behavior against standard contracts (health, auth, retries, error shape, read-only mode).
 

--- a/tickets/v3/P1-v3-illegal-or-infringing-work-intake-controls.md
+++ b/tickets/v3/P1-v3-illegal-or-infringing-work-intake-controls.md
@@ -1,5 +1,11 @@
 # P1: Illegal / Infringing Work Intake Controls
 
+Status: done-in-code
+Priority: P1
+Owner: Studio Brain / Platform
+Type: Ticket
+Parent Epic: tickets/v3/EPICS.md
+
 ## Goal
 Prevent agent-driven workflows from progressing when requests appear illegal, unsafe, or likely to infringe IP/copyright/trademark policy.
 

--- a/tickets/v3/P1-v3-marketing-swarm-draft-only.md
+++ b/tickets/v3/P1-v3-marketing-swarm-draft-only.md
@@ -1,5 +1,11 @@
 # P1: Marketing Swarm (Draft-only)
 
+Status: done-in-code
+Priority: P1
+Owner: Studio Brain / Platform
+Type: Ticket
+Parent Epic: tickets/v3/EPICS.md
+
 ## Goal
 Use StudioState and existing content sources to generate draft marketing artifacts without auto-publish.
 

--- a/tickets/v3/P1-v3-ops-anomaly-detector-draft-recommendations.md
+++ b/tickets/v3/P1-v3-ops-anomaly-detector-draft-recommendations.md
@@ -1,5 +1,11 @@
 # P1: Ops Anomaly Detector (Draft Recommendations Only)
 
+Status: done-in-code
+Priority: P1
+Owner: Studio Brain / Platform
+Type: Ticket
+Parent Epic: tickets/v3/EPICS.md
+
 ## Goal
 Detect operational anomalies and produce draft recommendations/proposals for staff review.
 

--- a/tickets/v3/P1-v3-policy-exemptions-and-kill-switch.md
+++ b/tickets/v3/P1-v3-policy-exemptions-and-kill-switch.md
@@ -1,5 +1,11 @@
 # P1: Policy Exemptions + Global Kill Switch
 
+Status: done-in-code
+Priority: P1
+Owner: Studio Brain / Platform
+Type: Ticket
+Parent Epic: tickets/v3/EPICS.md
+
 ## Goal
 Add narrowly-scoped policy exemptions and an emergency kill switch so automation can be stopped instantly without redeploy.
 

--- a/tickets/v3/P1-v3-rate-limits-quotas-and-abuse-controls.md
+++ b/tickets/v3/P1-v3-rate-limits-quotas-and-abuse-controls.md
@@ -1,5 +1,11 @@
 # P1: Rate Limits, Quotas, and Abuse Controls
 
+Status: done-in-code
+Priority: P1
+Owner: Studio Brain / Platform
+Type: Ticket
+Parent Epic: tickets/v3/EPICS.md
+
 ## Goal
 Enforce per-actor and per-capability safety limits to prevent runaway automation and connector abuse.
 

--- a/tickets/v3/P2-v3-data-retention-portability-and-audit-export.md
+++ b/tickets/v3/P2-v3-data-retention-portability-and-audit-export.md
@@ -1,5 +1,11 @@
 # P2: Data Retention, Portability, and Audit Export
 
+Status: Active
+Priority: P2
+Owner: Studio Brain / Platform
+Type: Ticket
+Parent Epic: tickets/v3/EPICS.md
+
 ## Goal
 Define retention windows and export paths for local Studio OS artifacts while preserving immutable audit expectations.
 

--- a/tickets/v3/P2-v3-dr-recovery-and-rebuild-playbook.md
+++ b/tickets/v3/P2-v3-dr-recovery-and-rebuild-playbook.md
@@ -1,5 +1,11 @@
 # P2: DR, Recovery, and Rebuild Playbook
 
+Status: Active
+Priority: P2
+Owner: Studio Brain / Platform
+Type: Ticket
+Parent Epic: tickets/v3/EPICS.md
+
 ## Goal
 Guarantee operations continuity when local brain fails by documenting and testing rebuild/recovery from cloud truth.
 

--- a/tickets/v3/P2-v3-finance-reconciliation-draft-flags.md
+++ b/tickets/v3/P2-v3-finance-reconciliation-draft-flags.md
@@ -1,5 +1,11 @@
 # P2: Finance Reconciliation Swarm (Read-only + Draft Flags)
 
+Status: Active
+Priority: P2
+Owner: Studio Brain / Platform
+Type: Ticket
+Parent Epic: tickets/v3/EPICS.md
+
 ## Goal
 Reconcile Stripe payout/refund signals with portal order/reservation records and flag anomalies.
 

--- a/tickets/v3/P2-v3-kpi-scorecard-and-slo-alerting.md
+++ b/tickets/v3/P2-v3-kpi-scorecard-and-slo-alerting.md
@@ -1,5 +1,11 @@
 # P2: KPI Scorecard + SLO Alerting for Studio OS
 
+Status: Active
+Priority: P2
+Owner: Studio Brain / Platform
+Type: Ticket
+Parent Epic: tickets/v3/EPICS.md
+
 ## Goal
 Operationalize v3 with a scorecard and alert thresholds tied to safety and reliability objectives.
 

--- a/tickets/v3/P2-v3-multi-studio-boundaries-readiness.md
+++ b/tickets/v3/P2-v3-multi-studio-boundaries-readiness.md
@@ -1,5 +1,11 @@
 # P2: Multi-Studio Boundary Readiness (Platformization Guardrails)
 
+Status: Active
+Priority: P2
+Owner: Studio Brain / Platform
+Type: Ticket
+Parent Epic: tickets/v3/EPICS.md
+
 ## Goal
 Prepare Studio OS for future multi-studio/white-label expansion by defining strict tenancy boundaries and config isolation.
 

--- a/tickets/v3/P2-v3-os-cockpit-consolidation.md
+++ b/tickets/v3/P2-v3-os-cockpit-consolidation.md
@@ -1,5 +1,11 @@
 # P2: OS Cockpit Surface Consolidation
 
+Status: Active
+Priority: P2
+Owner: Studio Brain / Platform
+Type: Ticket
+Parent Epic: tickets/v3/EPICS.md
+
 ## Goal
 Provide one staff cockpit for StudioState, connectors, proposals, approvals, and audit timelines.
 

--- a/tickets/v3/P2-v3-security-chaos-and-tabletop-exercises.md
+++ b/tickets/v3/P2-v3-security-chaos-and-tabletop-exercises.md
@@ -1,5 +1,11 @@
 # P2: Security Chaos + Tabletop Exercise Program
 
+Status: Active
+Priority: P2
+Owner: Studio Brain / Platform
+Type: Ticket
+Parent Epic: tickets/v3/EPICS.md
+
 ## Goal
 Validate that Studio OS v3 fails safely under auth, connector, and policy disruptions using repeatable drills.
 

--- a/tickets/v3/P2-v3-spec-governance-and-policy-lint.md
+++ b/tickets/v3/P2-v3-spec-governance-and-policy-lint.md
@@ -1,5 +1,11 @@
 # P2: Spec Governance + Capability Policy Lint
 
+Status: Active
+Priority: P2
+Owner: Studio Brain / Platform
+Type: Ticket
+Parent Epic: tickets/v3/EPICS.md
+
 ## Goal
 Institutionalize v3 safety by requiring structured specs and lint checks for capabilities/connectors.
 

--- a/tickets/v3/P2-v3-trust-safety-assistive-triage.md
+++ b/tickets/v3/P2-v3-trust-safety-assistive-triage.md
@@ -1,5 +1,11 @@
 # P2: Trust & Safety Assistive Triage
 
+Status: Active
+Priority: P2
+Owner: Studio Brain / Platform
+Type: Ticket
+Parent Epic: tickets/v3/EPICS.md
+
 ## Goal
 Add assistive triage suggestions to community reporting workflows without automatic enforcement actions.
 

--- a/tickets/v3/P2-v3-write-path-pilot-firestore-approved-actions.md
+++ b/tickets/v3/P2-v3-write-path-pilot-firestore-approved-actions.md
@@ -1,5 +1,11 @@
 # P2: Narrow Write-Path Pilot (Approved Firestore Actions Only)
 
+Status: Active
+Priority: P2
+Owner: Studio Brain / Platform
+Type: Ticket
+Parent Epic: tickets/v3/EPICS.md
+
 ## Goal
 Pilot one narrowly-scoped write flow (low-risk Firestore update) through the full capability + proposal + approval pipeline.
 


### PR DESCRIPTION
## Summary

- Clean up the ticket work branch into a fresh `origin/main`-based PR branch.
- Add ticket-branch hygiene for local Codex artifacts and function env files.
- Reconcile Studio OS v3 ticket metadata and complete the Codex launcher/startup/cross-platform wrapper tickets.
- Add structured Bambu CLI raw-slice failure classification, document the current Bambu raw-STL blocker, and mark the Bambu ticket blocked.
- Complete the P3 Codex text status board deprecation ticket by making text boards opt-in and preserving app/control-tower coordination surfaces.

## Impact

This keeps the ticket work publishable without pulling in the older wiki/idle-worker branch stack that was present on `codex/tickets`. The Bambu label flow is intentionally not marked complete: smoke slicing works, but raw label STL slicing is still blocked on a known-good Bambu 3MF template or refreshed profile pack.

## Validation

- `git diff --check origin/main...HEAD`
- `node -e "JSON.parse(require('fs').readFileSync('package.json','utf8')); console.log('package.json ok')"`
- `python -m py_compile scripts/studiobrain-ops.py`
- `node --test scripts/lib/codex-lifecycle-memory.test.mjs scripts/lib/codex-worktree-utils.test.mjs scripts/lib/command-runner.test.mjs scripts/audit-cross-platform-wrappers.test.mjs`
- `npm run codex:docs:drift:strict`
- `npm run codex:doctor:strict`

No visual check was required for this branch because the shipped changes are repo hygiene, scripts, runbook/ticket docs, and backend/ops CLI behavior rather than a frontend surface.