### PR TITLE
Expose Studio Brain idle worker runs in Control Tower

### DIFF
--- a/studio-brain/lib/controlTower/derive.js
+++ b/studio-brain/lib/controlTower/derive.js
@@ -499,17 +499,30 @@ function buildMissionBoard(rows) {
         .slice(0, MAX_BOARD_ROWS);
 }
 function buildMemoryMaintenanceRow(memoryBrief) {
+    const idleWorker = memoryBrief.idleWorker;
+    const idleTask = idleWorker
+        ? `Idle worker ${idleWorker.status || "unknown"}: ${idleWorker.summary.planned} jobs, ${idleWorker.summary.passed} passed, ${idleWorker.summary.warning} warnings, ${idleWorker.summary.failed} failed.`
+        : "";
     const status = memoryBrief.consolidation.status || memoryBrief.consolidation.mode;
+    const hasIdleFailures = (idleWorker?.summary.failed ?? 0) > 0;
+    const hasIdleWarnings = (idleWorker?.summary.warning ?? 0) > 0;
+    const next = hasIdleFailures
+        ? "Inspect the latest idle-worker artifact."
+        : hasIdleWarnings
+            ? "Review idle-worker warnings before promoting write-capable lanes."
+            : memoryBrief.consolidation.mode === "repair" || memoryBrief.consolidation.status === "failed"
+                ? "Repair continuity"
+                : "Review dream-cycle outputs";
     return {
         id: "board:memory-maintenance",
         owner: "Memory maintenance",
-        task: (0, collect_1.clipText)(memoryBrief.consolidation.summary || "Dream-cycle maintenance is waiting for the next quiet window.", 120),
-        state: status || "idle",
-        blocker: memoryBrief.consolidation.lastError || memoryBrief.blockers[0] || "",
-        next: memoryBrief.consolidation.mode === "repair" || memoryBrief.consolidation.status === "failed"
-            ? "Repair continuity"
-            : "Review dream-cycle outputs",
-        last_update: memoryBrief.consolidation.lastRunAt || memoryBrief.generatedAt,
+        task: (0, collect_1.clipText)(idleTask || memoryBrief.consolidation.summary || "Dream-cycle maintenance is waiting for the next quiet window.", 120),
+        state: idleWorker?.status || status || "idle",
+        blocker: hasIdleFailures
+            ? "Idle worker has failed jobs."
+            : memoryBrief.consolidation.lastError || memoryBrief.blockers[0] || "",
+        next,
+        last_update: idleWorker?.completedAt || memoryBrief.consolidation.lastRunAt || memoryBrief.generatedAt,
         roomId: null,
         sessionName: null,
     };
@@ -608,6 +621,7 @@ function buildFallbackMemoryBrief(raw, rooms, needsAttention, actions, events) {
             topActions: recommendedNextActions.slice(0, 3),
             lastError: null,
         },
+        idleWorker: null,
     };
 }
 function deriveControlTowerState(raw, audits = [], options = {}) {

--- a/studio-brain/lib/http/server.js
+++ b/studio-brain/lib/http/server.js
@@ -44,6 +44,7 @@ const files_2 = require("../partner/files");
 const service_3 = require("../partner/service");
 const CONTROL_TOWER_MEMORY_BRIEF_RELATIVE_PATH = ["output", "studio-brain", "memory-brief", "latest.json"];
 const CONTROL_TOWER_MEMORY_CONSOLIDATION_RELATIVE_PATH = ["output", "studio-brain", "memory-consolidation", "latest.json"];
+const CONTROL_TOWER_IDLE_WORKER_RELATIVE_PATH = ["output", "studio-brain", "idle-worker", "latest.json"];
 const CONTROL_TOWER_STARTUP_SCORECARD_RELATIVE_PATH = ["output", "qa", "codex-startup-scorecard.json"];
 const CONTROL_TOWER_EVENT_STREAM_POLL_MS = 5_000;
 const CONTROL_TOWER_EVENT_STREAM_HEARTBEAT_MS = 15_000;
@@ -153,14 +154,59 @@ function deriveArtifactConsolidationMode(artifact, fallback) {
         return "scheduled";
     return fallback;
 }
+function summarizeIdleWorkerJob(job) {
+    const payloadSummary = toObjectRecord(job.payloadSummary);
+    const rawSummary = payloadSummary.summary ?? job.summary;
+    if (typeof rawSummary === "string")
+        return rawSummary.trim();
+    if (rawSummary && typeof rawSummary === "object")
+        return JSON.stringify(rawSummary);
+    return "";
+}
+function readControlTowerIdleWorkerSummary(repoRoot) {
+    const payload = readJsonFile((0, node_path_1.resolve)(repoRoot, ...CONTROL_TOWER_IDLE_WORKER_RELATIVE_PATH));
+    if (!payload)
+        return null;
+    const summary = toObjectRecord(payload.summary);
+    const jobs = (Array.isArray(payload.jobs) ? payload.jobs : [])
+        .map((entry) => {
+        const job = toObjectRecord(entry);
+        return {
+            id: toTrimmedString(job.id),
+            status: toTrimmedString(job.status) || null,
+            durationMs: toNullableNumber(job.durationMs),
+            summary: summarizeIdleWorkerJob(job),
+        };
+    })
+        .filter((job) => job.id)
+        .slice(0, 32);
+    return {
+        runId: toTrimmedString(payload.runId) || null,
+        status: toTrimmedString(payload.status) || null,
+        profile: toTrimmedString(payload.profile) || null,
+        generatedAt: toTrimmedString(payload.generatedAt) || null,
+        completedAt: toTrimmedString(payload.completedAt) || null,
+        artifactPath: CONTROL_TOWER_IDLE_WORKER_RELATIVE_PATH.join("/"),
+        summary: {
+            planned: toBoundedInt(summary.planned, 0, 0, 1_000_000),
+            passed: toBoundedInt(summary.passed, 0, 0, 1_000_000),
+            warning: toBoundedInt(summary.warning, 0, 0, 1_000_000),
+            failed: toBoundedInt(summary.failed, 0, 0, 1_000_000),
+            skipped: toBoundedInt(summary.skipped, 0, 0, 1_000_000),
+        },
+        jobs,
+    };
+}
 function readControlTowerMemoryBrief(repoRoot, fallback) {
     const targetPath = (0, node_path_1.resolve)(repoRoot, ...CONTROL_TOWER_MEMORY_BRIEF_RELATIVE_PATH);
     const payload = readJsonFile(targetPath);
     const consolidationArtifact = readJsonFile((0, node_path_1.resolve)(repoRoot, ...CONTROL_TOWER_MEMORY_CONSOLIDATION_RELATIVE_PATH));
+    const idleWorker = readControlTowerIdleWorkerSummary(repoRoot);
     if (!payload) {
         return {
             ...fallback,
             sourcePath: fallback.sourcePath || CONTROL_TOWER_MEMORY_BRIEF_RELATIVE_PATH.join("/"),
+            idleWorker: idleWorker ?? fallback.idleWorker ?? null,
             consolidation: {
                 ...fallback.consolidation,
                 mode: deriveArtifactConsolidationMode(consolidationArtifact, fallback.consolidation.mode),
@@ -200,6 +246,7 @@ function readControlTowerMemoryBrief(repoRoot, fallback) {
         recommendedNextActions: toStringList(payload.recommendedNextActions, 8),
         fallbackSources: toStringList(payload.fallbackSources, 8),
         sourcePath: CONTROL_TOWER_MEMORY_BRIEF_RELATIVE_PATH.join("/"),
+        idleWorker: idleWorker ?? fallback.idleWorker ?? null,
         layers: {
             coreBlocks: toStringList(layers.coreBlocks, 8),
             workingMemory: toStringList(layers.workingMemory, 8),
@@ -493,6 +540,33 @@ function buildSyntheticControlTowerEvents(memoryBrief, approvals, agentRuntime, 
             lastError: memoryBrief.consolidation.lastError ?? null,
         },
     });
+    if (memoryBrief.idleWorker) {
+        const idleWorker = memoryBrief.idleWorker;
+        const at = idleWorker.completedAt || idleWorker.generatedAt || memoryBrief.generatedAt;
+        output.push({
+            id: `idle-worker:${idleWorker.runId || at}`,
+            at,
+            kind: "operator",
+            type: "task.updated",
+            runId: idleWorker.runId,
+            agentId: null,
+            channel: "memory",
+            occurredAt: at,
+            severity: idleWorker.summary.failed > 0 ? "critical" : idleWorker.summary.warning > 0 ? "warning" : "info",
+            title: idleWorker.summary.failed > 0
+                ? "Idle worker needs attention"
+                : idleWorker.summary.warning > 0
+                    ? "Idle worker completed with warnings"
+                    : "Idle worker completed",
+            summary: (0, collect_1.clipText)(`Ran ${idleWorker.summary.planned} jobs: ${idleWorker.summary.passed} passed, ${idleWorker.summary.warning} warnings, ${idleWorker.summary.failed} failed.`, 220),
+            actor: "studio-brain-idle-worker",
+            roomId: null,
+            serviceId: null,
+            actionLabel: null,
+            sourceAction: "control_tower.idle_worker",
+            payload: idleWorker,
+        });
+    }
     approvals
         .filter((approval) => approval.status === "pending_approval")
         .forEach((approval) => {

--- a/studio-brain/lib/http/server.test.js
+++ b/studio-brain/lib/http/server.test.js
@@ -321,6 +321,7 @@ function createControlTowerFixture() {
     (0, node_fs_1.mkdirSync)((0, node_path_1.join)(root, "output", "overseer", "discord"), { recursive: true });
     (0, node_fs_1.mkdirSync)((0, node_path_1.join)(root, "output", "studio-brain", "memory-brief"), { recursive: true });
     (0, node_fs_1.mkdirSync)((0, node_path_1.join)(root, "output", "studio-brain", "memory-consolidation"), { recursive: true });
+    (0, node_fs_1.mkdirSync)((0, node_path_1.join)(root, "output", "studio-brain", "idle-worker"), { recursive: true });
     (0, node_fs_1.mkdirSync)((0, node_path_1.join)(root, "output", "qa"), { recursive: true });
     (0, node_fs_1.mkdirSync)((0, node_path_1.join)(root, "output", "agent-runs", "run-background-1"), { recursive: true });
     (0, node_fs_1.writeFileSync)((0, node_path_1.join)(root, "output", "ops-cockpit", "agents", "sb-room.json"), `${JSON.stringify({
@@ -407,6 +408,53 @@ function createControlTowerFixture() {
         outputs: [
             "output/studio-brain/memory-brief/latest.json",
             "output/studio-brain/memory-consolidation/latest.json",
+        ],
+    }, null, 2)}\n`, "utf8");
+    (0, node_fs_1.writeFileSync)((0, node_path_1.join)(root, "output", "studio-brain", "idle-worker", "latest.json"), `${JSON.stringify({
+        schema: "studiobrain-idle-worker-v1",
+        runId: "idle-worker-fixture",
+        generatedAt: "2026-03-30T10:06:00.000Z",
+        completedAt: "2026-03-30T10:06:19.000Z",
+        status: "passed_with_warnings",
+        profile: "idle",
+        summary: {
+            planned: 13,
+            passed: 11,
+            warning: 2,
+            failed: 0,
+            skipped: 0,
+        },
+        jobs: [
+            {
+                id: "memory-consolidation",
+                status: "passed",
+                durationMs: 13000,
+                payloadSummary: {
+                    summary: "Processed 95 candidates.",
+                },
+            },
+            {
+                id: "wiki-contradiction-scan",
+                status: "warning",
+                durationMs: 700,
+                payloadSummary: {
+                    summary: {
+                        contradictions: 1,
+                        hard: 1,
+                    },
+                },
+            },
+            {
+                id: "wiki-export-drift-check",
+                status: "warning",
+                durationMs: 700,
+                payloadSummary: {
+                    summary: {
+                        exports: 4,
+                        drift: 4,
+                    },
+                },
+            },
         ],
     }, null, 2)}\n`, "utf8");
     (0, node_fs_1.writeFileSync)((0, node_path_1.join)(root, "output", "qa", "codex-startup-scorecard.json"), `${JSON.stringify({
@@ -3441,6 +3489,11 @@ function createControlTowerRunner() {
                 "Reuse the promoted approval summary memory as the canonical startup thread.",
                 "Review and split the unknown mail-thread cluster before the next dream pass.",
             ]);
+            strict_1.default.equal(payload.state.memoryBrief.idleWorker?.status, "passed_with_warnings");
+            strict_1.default.equal(payload.state.memoryBrief.idleWorker?.summary.planned, 13);
+            strict_1.default.equal(payload.state.memoryBrief.idleWorker?.summary.warning, 2);
+            strict_1.default.equal(payload.state.memoryBrief.idleWorker?.jobs.some((entry) => entry.id === "wiki-contradiction-scan" && /contradictions/.test(entry.summary)), true);
+            strict_1.default.equal(payload.state.board.some((entry) => entry.owner === "Memory maintenance" && /13 jobs/.test(entry.task)), true);
             strict_1.default.equal(payload.state.startupScorecard?.rubric.grade, "A");
             strict_1.default.equal(payload.state.startupScorecard?.rubric.overallScore, 98);
             strict_1.default.equal(payload.state.startupScorecard?.metrics.readyRate, 0.98);
@@ -3474,6 +3527,7 @@ function createControlTowerRunner() {
             strict_1.default.equal(payload.state.overview.needsAttention.some((entry) => /secret-bearing memories need review|shadow mcp memory needs governance review/i.test(entry.title)), true);
             strict_1.default.ok(payload.state.events.some((entry) => entry.type === "memory.promoted"));
             strict_1.default.ok(payload.state.events.some((entry) => entry.sourceAction === "control_tower.memory_consolidation"));
+            strict_1.default.ok(payload.state.events.some((entry) => entry.sourceAction === "control_tower.idle_worker"));
             const roomResponse = await fetch(`${baseUrl}/api/control-tower/rooms/portal`, {
                 headers: { authorization: "Bearer test-staff" },
             });
@@ -3947,6 +4001,9 @@ function createControlTowerRunner() {
             strict_1.default.ok(eventsPayload.events.some((entry) => entry.sourceAction === "control_tower.memory_consolidation" &&
                 entry.type === "memory.promoted" &&
                 entry.payload?.mode === "scheduled"));
+            strict_1.default.ok(eventsPayload.events.some((entry) => entry.sourceAction === "control_tower.idle_worker" &&
+                entry.type === "task.updated" &&
+                entry.payload?.status === "passed_with_warnings"));
             const sseResponse = await fetch(`${baseUrl}/api/control-tower/events?stream=1&once=1`, {
                 headers: {
                     authorization: "Bearer test-staff",
@@ -3957,6 +4014,7 @@ function createControlTowerRunner() {
             const sseText = await sseResponse.text();
             strict_1.default.match(sseText, /event:\s+memory\.promoted/);
             strict_1.default.match(sseText, /control_tower\.memory_consolidation/);
+            strict_1.default.match(sseText, /control_tower\.idle_worker/);
         });
     }
     finally {

--- a/studio-brain/lib/partner/service.js
+++ b/studio-brain/lib/partner/service.js
@@ -260,6 +260,7 @@ function refreshBriefAfterMutation(repoRoot, brief) {
             maintenanceActions: [],
             outputs: [brief.artifacts.latestBriefPath, brief.artifacts.openLoopsPath],
         },
+        idleWorker: null,
     }, [], openLoops, null, brief);
     return writePartnerArtifacts(repoRoot, refreshed);
 }

--- a/studio-brain/src/controlTower/derive.ts
+++ b/studio-brain/src/controlTower/derive.ts
@@ -560,18 +560,31 @@ function buildMissionBoard(rows: ControlTowerRoomSummary[]): ControlTowerBoardRo
 }
 
 function buildMemoryMaintenanceRow(memoryBrief: ControlTowerMemoryBrief): ControlTowerBoardRow {
+  const idleWorker = memoryBrief.idleWorker;
+  const idleTask = idleWorker
+    ? `Idle worker ${idleWorker.status || "unknown"}: ${idleWorker.summary.planned} jobs, ${idleWorker.summary.passed} passed, ${idleWorker.summary.warning} warnings, ${idleWorker.summary.failed} failed.`
+    : "";
   const status = memoryBrief.consolidation.status || memoryBrief.consolidation.mode;
+  const hasIdleFailures = (idleWorker?.summary.failed ?? 0) > 0;
+  const hasIdleWarnings = (idleWorker?.summary.warning ?? 0) > 0;
+  const next = hasIdleFailures
+    ? "Inspect the latest idle-worker artifact."
+    : hasIdleWarnings
+      ? "Review idle-worker warnings before promoting write-capable lanes."
+      : memoryBrief.consolidation.mode === "repair" || memoryBrief.consolidation.status === "failed"
+        ? "Repair continuity"
+        : "Review dream-cycle outputs";
   return {
     id: "board:memory-maintenance",
     owner: "Memory maintenance",
-    task: clipText(memoryBrief.consolidation.summary || "Dream-cycle maintenance is waiting for the next quiet window.", 120),
-    state: status || "idle",
-    blocker: memoryBrief.consolidation.lastError || memoryBrief.blockers[0] || "",
-    next:
-      memoryBrief.consolidation.mode === "repair" || memoryBrief.consolidation.status === "failed"
-        ? "Repair continuity"
-        : "Review dream-cycle outputs",
-    last_update: memoryBrief.consolidation.lastRunAt || memoryBrief.generatedAt,
+    task: clipText(idleTask || memoryBrief.consolidation.summary || "Dream-cycle maintenance is waiting for the next quiet window.", 120),
+    state: idleWorker?.status || status || "idle",
+    blocker:
+      hasIdleFailures
+        ? "Idle worker has failed jobs."
+        : memoryBrief.consolidation.lastError || memoryBrief.blockers[0] || "",
+    next,
+    last_update: idleWorker?.completedAt || memoryBrief.consolidation.lastRunAt || memoryBrief.generatedAt,
     roomId: null,
     sessionName: null,
   };
@@ -679,6 +692,7 @@ function buildFallbackMemoryBrief(
       topActions: recommendedNextActions.slice(0, 3),
       lastError: null,
     },
+    idleWorker: null,
   };
 }
 

--- a/studio-brain/src/controlTower/types.ts
+++ b/studio-brain/src/controlTower/types.ts
@@ -274,6 +274,28 @@ export type ControlTowerMemoryConsolidation = {
   lastError?: string | null;
 };
 
+export type ControlTowerIdleWorkerSummary = {
+  runId: string | null;
+  status: string | null;
+  profile: string | null;
+  generatedAt: string | null;
+  completedAt: string | null;
+  artifactPath: string | null;
+  summary: {
+    planned: number;
+    passed: number;
+    warning: number;
+    failed: number;
+    skipped: number;
+  };
+  jobs: Array<{
+    id: string;
+    status: string | null;
+    durationMs: number | null;
+    summary: string;
+  }>;
+};
+
 export type ControlTowerMemoryBrief = {
   schema: "studio-brain.memory-brief.v1";
   generatedAt: string;
@@ -292,6 +314,7 @@ export type ControlTowerMemoryBrief = {
     canonicalMemory: string[];
   };
   consolidation: ControlTowerMemoryConsolidation;
+  idleWorker: ControlTowerIdleWorkerSummary | null;
 };
 
 export type ControlTowerStartupScorecard = {

--- a/studio-brain/src/http/server.test.ts
+++ b/studio-brain/src/http/server.test.ts
@@ -332,6 +332,7 @@ function createControlTowerFixture() {
   mkdirSync(join(root, "output", "overseer", "discord"), { recursive: true });
   mkdirSync(join(root, "output", "studio-brain", "memory-brief"), { recursive: true });
   mkdirSync(join(root, "output", "studio-brain", "memory-consolidation"), { recursive: true });
+  mkdirSync(join(root, "output", "studio-brain", "idle-worker"), { recursive: true });
   mkdirSync(join(root, "output", "qa"), { recursive: true });
   mkdirSync(join(root, "output", "agent-runs", "run-background-1"), { recursive: true });
 
@@ -454,6 +455,62 @@ function createControlTowerFixture() {
         outputs: [
           "output/studio-brain/memory-brief/latest.json",
           "output/studio-brain/memory-consolidation/latest.json",
+        ],
+      },
+      null,
+      2,
+    )}\n`,
+    "utf8",
+  );
+
+  writeFileSync(
+    join(root, "output", "studio-brain", "idle-worker", "latest.json"),
+    `${JSON.stringify(
+      {
+        schema: "studiobrain-idle-worker-v1",
+        runId: "idle-worker-fixture",
+        generatedAt: "2026-03-30T10:06:00.000Z",
+        completedAt: "2026-03-30T10:06:19.000Z",
+        status: "passed_with_warnings",
+        profile: "idle",
+        summary: {
+          planned: 13,
+          passed: 11,
+          warning: 2,
+          failed: 0,
+          skipped: 0,
+        },
+        jobs: [
+          {
+            id: "memory-consolidation",
+            status: "passed",
+            durationMs: 13000,
+            payloadSummary: {
+              summary: "Processed 95 candidates.",
+            },
+          },
+          {
+            id: "wiki-contradiction-scan",
+            status: "warning",
+            durationMs: 700,
+            payloadSummary: {
+              summary: {
+                contradictions: 1,
+                hard: 1,
+              },
+            },
+          },
+          {
+            id: "wiki-export-drift-check",
+            status: "warning",
+            durationMs: 700,
+            payloadSummary: {
+              summary: {
+                exports: 4,
+                drift: 4,
+              },
+            },
+          },
         ],
       },
       null,
@@ -3995,6 +4052,19 @@ test("control tower state routes derive browser-friendly room and service data",
                 actionableInsightCount?: number | null;
                 topActions?: string[];
               };
+              idleWorker: {
+                runId: string | null;
+                status: string | null;
+                completedAt: string | null;
+                summary: {
+                  planned: number;
+                  passed: number;
+                  warning: number;
+                  failed: number;
+                  skipped: number;
+                };
+                jobs: Array<{ id: string; status: string | null; summary: string }>;
+              } | null;
             };
             startupScorecard: {
               rubric: { overallScore: number | null; grade: string };
@@ -4047,6 +4117,19 @@ test("control tower state routes derive browser-friendly room and service data",
           "Reuse the promoted approval summary memory as the canonical startup thread.",
           "Review and split the unknown mail-thread cluster before the next dream pass.",
         ]);
+        assert.equal(payload.state.memoryBrief.idleWorker?.status, "passed_with_warnings");
+        assert.equal(payload.state.memoryBrief.idleWorker?.summary.planned, 13);
+        assert.equal(payload.state.memoryBrief.idleWorker?.summary.warning, 2);
+        assert.equal(
+          payload.state.memoryBrief.idleWorker?.jobs.some((entry) =>
+            entry.id === "wiki-contradiction-scan" && /contradictions/.test(entry.summary)
+          ),
+          true,
+        );
+        assert.equal(
+          payload.state.board.some((entry) => entry.owner === "Memory maintenance" && /13 jobs/.test(entry.task)),
+          true,
+        );
         assert.equal(payload.state.startupScorecard?.rubric.grade, "A");
         assert.equal(payload.state.startupScorecard?.rubric.overallScore, 98);
         assert.equal(payload.state.startupScorecard?.metrics.readyRate, 0.98);
@@ -4103,6 +4186,7 @@ test("control tower state routes derive browser-friendly room and service data",
         );
         assert.ok(payload.state.events.some((entry) => entry.type === "memory.promoted"));
         assert.ok(payload.state.events.some((entry) => entry.sourceAction === "control_tower.memory_consolidation"));
+        assert.ok(payload.state.events.some((entry) => entry.sourceAction === "control_tower.idle_worker"));
 
         const roomResponse = await fetch(`${baseUrl}/api/control-tower/rooms/portal`, {
           headers: { authorization: "Bearer test-staff" },
@@ -4728,6 +4812,14 @@ test("control tower actions send room instructions, persist room escalation, and
               entry.payload?.mode === "scheduled",
           ),
         );
+        assert.ok(
+          eventsPayload.events.some(
+            (entry) =>
+              entry.sourceAction === "control_tower.idle_worker" &&
+              entry.type === "task.updated" &&
+              entry.payload?.status === "passed_with_warnings",
+          ),
+        );
 
         const sseResponse = await fetch(`${baseUrl}/api/control-tower/events?stream=1&once=1`, {
           headers: {
@@ -4739,6 +4831,7 @@ test("control tower actions send room instructions, persist room escalation, and
         const sseText = await sseResponse.text();
         assert.match(sseText, /event:\s+memory\.promoted/);
         assert.match(sseText, /control_tower\.memory_consolidation/);
+        assert.match(sseText, /control_tower\.idle_worker/);
       },
     );
   } finally {

--- a/studio-brain/src/http/server.ts
+++ b/studio-brain/src/http/server.ts
@@ -76,6 +76,7 @@ import type {
   ControlTowerApprovalItem,
   ControlTowerEvent,
   ControlTowerHostCard,
+  ControlTowerIdleWorkerSummary,
   ControlTowerMemoryHealth,
   ControlTowerMemoryBrief,
   ControlTowerNextAction,
@@ -108,6 +109,7 @@ import {
 
 const CONTROL_TOWER_MEMORY_BRIEF_RELATIVE_PATH = ["output", "studio-brain", "memory-brief", "latest.json"] as const;
 const CONTROL_TOWER_MEMORY_CONSOLIDATION_RELATIVE_PATH = ["output", "studio-brain", "memory-consolidation", "latest.json"] as const;
+const CONTROL_TOWER_IDLE_WORKER_RELATIVE_PATH = ["output", "studio-brain", "idle-worker", "latest.json"] as const;
 const CONTROL_TOWER_STARTUP_SCORECARD_RELATIVE_PATH = ["output", "qa", "codex-startup-scorecard.json"] as const;
 const CONTROL_TOWER_EVENT_STREAM_POLL_MS = 5_000;
 const CONTROL_TOWER_EVENT_STREAM_HEARTBEAT_MS = 15_000;
@@ -226,16 +228,64 @@ function deriveArtifactConsolidationMode(
   return fallback;
 }
 
+function summarizeIdleWorkerJob(job: Record<string, unknown>): string {
+  const payloadSummary = toObjectRecord(job.payloadSummary);
+  const rawSummary = payloadSummary.summary ?? job.summary;
+  if (typeof rawSummary === "string") return rawSummary.trim();
+  if (rawSummary && typeof rawSummary === "object") return JSON.stringify(rawSummary);
+  return "";
+}
+
+function readControlTowerIdleWorkerSummary(repoRoot: string): ControlTowerIdleWorkerSummary | null {
+  const payload = readJsonFile<Record<string, unknown>>(
+    resolve(repoRoot, ...CONTROL_TOWER_IDLE_WORKER_RELATIVE_PATH)
+  );
+  if (!payload) return null;
+
+  const summary = toObjectRecord(payload.summary);
+  const jobs = (Array.isArray(payload.jobs) ? payload.jobs : [])
+    .map((entry) => {
+      const job = toObjectRecord(entry);
+      return {
+        id: toTrimmedString(job.id),
+        status: toTrimmedString(job.status) || null,
+        durationMs: toNullableNumber(job.durationMs),
+        summary: summarizeIdleWorkerJob(job),
+      };
+    })
+    .filter((job) => job.id)
+    .slice(0, 32);
+
+  return {
+    runId: toTrimmedString(payload.runId) || null,
+    status: toTrimmedString(payload.status) || null,
+    profile: toTrimmedString(payload.profile) || null,
+    generatedAt: toTrimmedString(payload.generatedAt) || null,
+    completedAt: toTrimmedString(payload.completedAt) || null,
+    artifactPath: CONTROL_TOWER_IDLE_WORKER_RELATIVE_PATH.join("/"),
+    summary: {
+      planned: toBoundedInt(summary.planned, 0, 0, 1_000_000),
+      passed: toBoundedInt(summary.passed, 0, 0, 1_000_000),
+      warning: toBoundedInt(summary.warning, 0, 0, 1_000_000),
+      failed: toBoundedInt(summary.failed, 0, 0, 1_000_000),
+      skipped: toBoundedInt(summary.skipped, 0, 0, 1_000_000),
+    },
+    jobs,
+  };
+}
+
 function readControlTowerMemoryBrief(repoRoot: string, fallback: ControlTowerMemoryBrief): ControlTowerMemoryBrief {
   const targetPath = resolve(repoRoot, ...CONTROL_TOWER_MEMORY_BRIEF_RELATIVE_PATH);
   const payload = readJsonFile<Record<string, unknown>>(targetPath);
   const consolidationArtifact = readJsonFile<Record<string, unknown>>(
     resolve(repoRoot, ...CONTROL_TOWER_MEMORY_CONSOLIDATION_RELATIVE_PATH)
   );
+  const idleWorker = readControlTowerIdleWorkerSummary(repoRoot);
   if (!payload) {
     return {
       ...fallback,
       sourcePath: fallback.sourcePath || CONTROL_TOWER_MEMORY_BRIEF_RELATIVE_PATH.join("/"),
+      idleWorker: idleWorker ?? fallback.idleWorker ?? null,
       consolidation: {
         ...fallback.consolidation,
         mode: deriveArtifactConsolidationMode(consolidationArtifact, fallback.consolidation.mode),
@@ -278,6 +328,7 @@ function readControlTowerMemoryBrief(repoRoot: string, fallback: ControlTowerMem
     recommendedNextActions: toStringList(payload.recommendedNextActions, 8),
     fallbackSources: toStringList(payload.fallbackSources, 8),
     sourcePath: CONTROL_TOWER_MEMORY_BRIEF_RELATIVE_PATH.join("/"),
+    idleWorker: idleWorker ?? fallback.idleWorker ?? null,
     layers: {
       coreBlocks: toStringList(layers.coreBlocks, 8),
       workingMemory: toStringList(layers.workingMemory, 8),
@@ -613,6 +664,38 @@ function buildSyntheticControlTowerEvents(
       lastError: memoryBrief.consolidation.lastError ?? null,
     },
   });
+
+  if (memoryBrief.idleWorker) {
+    const idleWorker = memoryBrief.idleWorker;
+    const at = idleWorker.completedAt || idleWorker.generatedAt || memoryBrief.generatedAt;
+    output.push({
+      id: `idle-worker:${idleWorker.runId || at}`,
+      at,
+      kind: "operator",
+      type: "task.updated",
+      runId: idleWorker.runId,
+      agentId: null,
+      channel: "memory",
+      occurredAt: at,
+      severity: idleWorker.summary.failed > 0 ? "critical" : idleWorker.summary.warning > 0 ? "warning" : "info",
+      title:
+        idleWorker.summary.failed > 0
+          ? "Idle worker needs attention"
+          : idleWorker.summary.warning > 0
+            ? "Idle worker completed with warnings"
+            : "Idle worker completed",
+      summary: clipText(
+        `Ran ${idleWorker.summary.planned} jobs: ${idleWorker.summary.passed} passed, ${idleWorker.summary.warning} warnings, ${idleWorker.summary.failed} failed.`,
+        220,
+      ),
+      actor: "studio-brain-idle-worker",
+      roomId: null,
+      serviceId: null,
+      actionLabel: null,
+      sourceAction: "control_tower.idle_worker",
+      payload: idleWorker as unknown as Record<string, unknown>,
+    });
+  }
 
   approvals
     .filter((approval) => approval.status === "pending_approval")

--- a/studio-brain/src/partner/service.ts
+++ b/studio-brain/src/partner/service.ts
@@ -377,6 +377,7 @@ function refreshBriefAfterMutation(repoRoot: string, brief: PartnerBrief): Partn
         maintenanceActions: [],
         outputs: [brief.artifacts.latestBriefPath, brief.artifacts.openLoopsPath],
       },
+      idleWorker: null,
     },
     [],
     openLoops,


### PR DESCRIPTION
## Summary
- Read output/studio-brain/idle-worker/latest.json into the Control Tower memory brief
- Surface idle-worker job totals in the Memory maintenance row
- Emit a control_tower.idle_worker synthetic event and cover it in HTTP route tests

## Verification
- npm --prefix studio-brain run build
- node --test studio-brain/lib/http/server.test.js
- Live authenticated Control Tower state shows idle-worker 13 planned / 11 passed / 2 warnings / 0 failed