### PR TITLE
Stabilize Studio Brain wiki export drift

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+wiki/00_source_index/source-map.md text eol=lf
+wiki/00_source_index/extracted-facts.jsonl text eol=lf
+wiki/50_contradictions/*.md text eol=lf
+wiki/70_agent_context_packs/*.md text eol=lf

--- a/scripts/lib/wiki-postgres-utils.mjs
+++ b/scripts/lib/wiki-postgres-utils.mjs
@@ -77,7 +77,6 @@ const APPROVED_SOURCE_ROOTS = [
   "config/studiobrain",
   "docs",
   "functions/src",
-  "memory/accepted",
   "scripts",
   "studio-brain/docs",
   "studio-brain/src",

--- a/wiki/00_source_index/source-map.md
+++ b/wiki/00_source_index/source-map.md
@@ -14,12 +14,12 @@ agent_allowed_use: planning_context
 supersedes: []
 superseded_by: []
 related_pages: []
-export_hash: 49d71e73d899219ae22e6b445393240959ea1bf925bdc308f0711aca5bed8e73
+export_hash: 6009b40aa7d69195db5483f6f7000b4cfcb35c58605bfd9e64b570e34415bf61
 ---
 
 # Source Map
 
-Snapshot: 49d71e73d899219ae22e6b445393240959ea1bf925bdc308f0711aca5bed8e73
+Snapshot: 6009b40aa7d69195db5483f6f7000b4cfcb35c58605bfd9e64b570e34415bf61
 
 | Source | Status | Authority | Chunks | Hash |
 |---|---:|---|---:|---|
@@ -362,7 +362,6 @@ Snapshot: 49d71e73d899219ae22e6b445393240959ea1bf925bdc308f0711aca5bed8e73
 | `functions/src/updateReservation.ts` | indexed | repo | 4 | `d40e1722eb53` |
 | `functions/src/v3Execution/pilotFirestoreAction.ts` | indexed | repo | 3 | `d08fd411c22d` |
 | `functions/src/websiteKilnBoard.ts` | indexed | repo | 5 | `03c60ebe28ae` |
-| `memory/accepted/accepted.jsonl` | indexed | repo | 1 | `9821da585a7b` |
 | `package.json` | indexed | repo | 7 | `fbdf795ca0f8` |
 | `PROJECT_SNAPSHOT.md` | indexed | repo | 12 | `19a864819a3b` |
 | `scripts/agent-file-plan-apply.mjs` | indexed | repo | 3 | `d8a827ad3b76` |
@@ -610,7 +609,7 @@ Snapshot: 49d71e73d899219ae22e6b445393240959ea1bf925bdc308f0711aca5bed8e73
 | `scripts/lib/studiobrain-posture-policy.mjs` | indexed | repo | 3 | `45cc17331aab` |
 | `scripts/lib/studiobrain-posture-policy.test.mjs` | indexed | repo | 1 | `140c9035c2d2` |
 | `scripts/lib/website-ga-utils.mjs` | indexed | repo | 2 | `1bf1773d3d8c` |
-| `scripts/lib/wiki-postgres-utils.mjs` | indexed | repo | 30 | `7bd2b8cb05cb` |
+| `scripts/lib/wiki-postgres-utils.mjs` | indexed | repo | 30 | `c5ba71ab6c92` |
 | `scripts/library-rollout-rollback-drill.mjs` | indexed | repo | 7 | `42c0fee0f773` |
 | `scripts/libratom-export-jsonl.sh` | indexed | repo | 3 | `b370d2593d09` |
 | `scripts/libratom.sh` | indexed | repo | 1 | `c310dbf956d2` |


### PR DESCRIPTION
## Summary
- pin deterministic wiki export artifacts to LF line endings
- exclude the ignored local memory/accepted cache from wiki source indexing
- refresh the wiki source map so Windows, CI, and the Studio Brain host agree on source counts

## Verification
- npm run wiki:export:drift -- --artifact output/wiki/export-drift-determinism.json
- npm run studio:ops:idle-worker:wiki:json
- discoverSourceFiles smoke confirmed memory/accepted is excluded
- git diff --cached --check