### PR TITLE
Stabilize wiki context outcome exports

### DIFF
--- a/scripts/lib/wiki-postgres-utils.mjs
+++ b/scripts/lib/wiki-postgres-utils.mjs
@@ -145,6 +145,10 @@ const NO_VOLUME_PRICING_PATTERN = /\b(do not bill by kiln volume|do not measure 
 
 const GUARDRAIL_VOLUME_CONTEXT_PATTERN = /\b(assertNoMatches|repo grep|returns no|forbidden|deny|not allowed|should not|must not|without volume pricing|no billing-path matches)\b/i;
 
+const DEFAULT_WIKI_OUTCOMES_PATH = process.env.STUDIO_BRAIN_WIKI_OUTCOMES_PATH
+  ? resolve(REPO_ROOT, process.env.STUDIO_BRAIN_WIKI_OUTCOMES_PATH)
+  : "";
+
 const MEMBERSHIP_ACTIVE_MODEL_PATTERN = /\b(member-only\s+(benefit|benefits|feature|features|logistics|pricing|plan|plans|membership|access|page|pages|content|area|areas)|active studio members|membership tiers include|memberships are tiered|membership(s)?\s+(is|are)\s+required\b|membership(s)?\b.{0,40}\brequired\s+(before|to|for)\b|membership plan|current tier|storage discounts|storage and discounts)\b/i;
 
 const MEMBERSHIP_CURRENT_PLAN_PATTERN = /\b(membership|memberships|member)\b.{0,80}\bcurrent plan\b|\bcurrent plan\b.{0,80}\b(membership|memberships|member)\b/i;
@@ -192,7 +196,7 @@ export function parseArgs(argv) {
     freshExtract: false,
     limit: 0,
     artifact: "",
-    outcomesPath: resolve(REPO_ROOT, "output", "studio-brain", "agent-harness", "outcomes.jsonl"),
+    outcomesPath: DEFAULT_WIKI_OUTCOMES_PATH,
     leaseLimit: 5,
     root: REPO_ROOT,
     strict: false,

--- a/wiki/00_source_index/source-map.md
+++ b/wiki/00_source_index/source-map.md
@@ -14,12 +14,12 @@ agent_allowed_use: planning_context
 supersedes: []
 superseded_by: []
 related_pages: []
-export_hash: 585b068d6c76879a97ad11d884f9a80f9c70f995049a5c26ee576dd1612b8e03
+export_hash: 8ece2e6e5929f37d173c302725dceefa88a379343094d3d9b73a5e69080ef8f9
 ---
 
 # Source Map
 
-Snapshot: 585b068d6c76879a97ad11d884f9a80f9c70f995049a5c26ee576dd1612b8e03
+Snapshot: 8ece2e6e5929f37d173c302725dceefa88a379343094d3d9b73a5e69080ef8f9
 
 | Source | Status | Authority | Chunks | Hash |
 |---|---:|---|---:|---|
@@ -609,7 +609,7 @@ Snapshot: 585b068d6c76879a97ad11d884f9a80f9c70f995049a5c26ee576dd1612b8e03
 | `scripts/lib/studiobrain-posture-policy.mjs` | indexed | repo | 3 | `505f7366c6e1` |
 | `scripts/lib/studiobrain-posture-policy.test.mjs` | indexed | repo | 1 | `ad39dbf12605` |
 | `scripts/lib/website-ga-utils.mjs` | indexed | repo | 2 | `b31a5f9b1a5c` |
-| `scripts/lib/wiki-postgres-utils.mjs` | indexed | repo | 30 | `ac96d8c56499` |
+| `scripts/lib/wiki-postgres-utils.mjs` | indexed | repo | 30 | `d8a0fa5ab24c` |
 | `scripts/library-rollout-rollback-drill.mjs` | indexed | repo | 7 | `9f8548f535be` |
 | `scripts/libratom-export-jsonl.sh` | indexed | repo | 3 | `c3a4de589100` |
 | `scripts/libratom.sh` | indexed | repo | 1 | `e58affa06efe` |

--- a/wiki/70_agent_context_packs/studio-brain-wiki.md
+++ b/wiki/70_agent_context_packs/studio-brain-wiki.md
@@ -14,7 +14,7 @@ agent_allowed_use: planning_context
 supersedes: []
 superseded_by: []
 related_pages: []
-export_hash: d63c724cffbccb97df8ac4ac30ab8f2c3f321ac91fe857e82d62db35a457c747
+export_hash: ead54f43ced5a9e651f807b0e587b00db92faaace1dc7ccb037e351418f8b092
 ---
 # Studio Brain Wiki Context Pack
 
@@ -23,7 +23,7 @@ Snapshot: 7319cf63c5171e42c73ee82029960f048a1ea9bb66adc97ad7406bcd04757f32
 ## Usefulness Signals
 
 - outcome verdict: insufficient_real_usage
-- wiki-relevant outcomes: 1; helpful: 1; stale_or_misleading: 0; minutes_saved: 18
+- wiki-relevant outcomes: 0; helpful: 0; stale_or_misleading: 0; minutes_saved: 0
 
 ## Verified Operational Context
 


### PR DESCRIPTION
## Summary
- make wiki context outcome telemetry opt-in via STUDIO_BRAIN_WIKI_OUTCOMES_PATH or --outcomes
- refresh the tracked Studio Brain wiki context pack without local ignored outcome ledger data
- refresh the source map for the wiki utility change

## Verification
- npm run wiki:context:refresh
- node ./scripts/wiki-postgres.mjs context --fresh-extract --json --outcomes output/studio-brain/agent-harness/outcomes.jsonl --artifact output/wiki/context-explicit-outcomes.json
- npm run wiki:export:drift -- --artifact output/wiki/export-drift-context-outcome-after-index.json
- npm run studio:ops:idle-worker:wiki:json
- git diff --check