### PR TITLE
Surface idle worker utilization history

### DIFF
--- a/scripts/studiobrain-idle-worker.mjs
+++ b/scripts/studiobrain-idle-worker.mjs
@@ -11,6 +11,7 @@ const REPO_ROOT = resolve(dirname(__filename), "..");
 const DEFAULT_RUN_ROOT = resolve(REPO_ROOT, "output", "studio-brain", "idle-worker");
 const DEFAULT_JOBS = ["memory", "repo", "harness", "wiki"];
 const DEFAULT_OUTPUT_TAIL_CHARS = 2_000;
+const DEFAULT_HISTORY_LIMIT = 20;
 const WIKI_MODES = new Set(["check", "refresh", "apply"]);
 const JOB_ALIASES = new Map([
   ["all", DEFAULT_JOBS],
@@ -134,6 +135,7 @@ function printUsage() {
       "  --run-id <id>                          Run identifier",
       "  --run-root <path>                      Artifact directory",
       "  --artifact <path>                      latest report path",
+      "  --history-limit <n>                    Recent run history cap (default: 20)",
       "  --lock-path <path>                     lock file path",
       "  --watch                                Repeat on an interval",
       "  --interval-minutes <n>                 Watch interval (default: 240)",
@@ -171,6 +173,7 @@ export function parseArgs(argv) {
     runId: "",
     runRoot: DEFAULT_RUN_ROOT,
     artifact: "",
+    historyLimit: DEFAULT_HISTORY_LIMIT,
     lockPath: "",
     lockStaleMinutes: 0,
   };
@@ -313,6 +316,11 @@ export function parseArgs(argv) {
     if (arg === "--artifact") {
       if (!next) throw new Error("--artifact requires a path.");
       parsed.artifact = resolve(REPO_ROOT, next);
+      index += 1;
+      continue;
+    }
+    if (arg === "--history-limit") {
+      parsed.historyLimit = parsePositiveInteger(next, "--history-limit");
       index += 1;
       continue;
     }
@@ -841,6 +849,32 @@ function buildBaseReport(options, runId, jobs) {
       maxLoad1m: options.maxLoad1m,
       observed: captureLoad(),
     },
+    budget: {
+      commandTimeoutMs: options.commandTimeoutMs,
+      repoDepth: options.repoDepth,
+      wikiMode: options.wikiMode,
+      maxLoad1m: options.maxLoad1m,
+      lockStaleMinutes: options.lockStaleMinutes,
+      memory: {
+        mode: options.memoryMode,
+        maxCandidates: options.memoryMaxCandidates,
+        maxWrites: options.memoryMaxWrites,
+        timeBudgetMs: options.memoryTimeBudgetMs,
+        timeoutMs: options.memoryTimeoutMs,
+      },
+    },
+    utilization: {
+      attemptedJobs: 0,
+      activeJobDurationMs: 0,
+      runDurationMs: null,
+      averageJobDurationMs: null,
+      longestJob: null,
+      failedJobIds: [],
+      warningJobIds: [],
+      skippedJobIds: [],
+      idleReason: "Idle worker run is still active.",
+      nextRecommendedJob: null,
+    },
     jobs: jobs.map((job) => ({
       id: job.id,
       label: job.label,
@@ -860,6 +894,80 @@ function buildBaseReport(options, runId, jobs) {
   };
 }
 
+function numericDuration(value) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed >= 0 ? Math.round(parsed) : 0;
+}
+
+function jobIdsWithStatus(report, status) {
+  return report.jobs
+    .filter((job) => clean(job.status).toLowerCase() === status)
+    .map((job) => clean(job.id))
+    .filter(Boolean);
+}
+
+function deriveIdleReason(report) {
+  if (report.status === "planned") {
+    return "Dry run planned the idle-worker jobs without spending the execution budget.";
+  }
+  if (report.status === "skipped" && report.loadGate?.skipped) {
+    return `Skipped because load1m ${report.loadGate.observed?.load1m} exceeded max ${report.loadGate.maxLoad1m}.`;
+  }
+  if (report.status === "skipped" && report.lock?.reason) {
+    return clean(report.lock.reason);
+  }
+  if (report.summary.failed > 0) {
+    return "Idle-worker budget was spent, but failed jobs need operator attention.";
+  }
+  if (report.summary.warning > 0) {
+    return "Idle-worker budget was spent and warnings should be reviewed before widening write-capable work.";
+  }
+  if (report.summary.skipped > 0) {
+    return "Idle-worker work was partially skipped; review skipped job reasons before treating the lane as fully used.";
+  }
+  return "All planned idle jobs completed cleanly; no operator intervention is needed.";
+}
+
+function deriveNextRecommendedJob(report) {
+  const failed = jobIdsWithStatus(report, "failed");
+  if (failed.length > 0) return failed[0];
+  const warning = jobIdsWithStatus(report, "warning");
+  if (warning.length > 0) return warning[0];
+  const skipped = jobIdsWithStatus(report, "skipped");
+  if (skipped.length > 0) return skipped[0];
+  const preferred = report.jobs.find((job) => clean(job.id) === "memory-consolidation") || report.jobs[0];
+  return preferred ? clean(preferred.id) : null;
+}
+
+function buildUtilizationSummary(report) {
+  const completedJobs = report.jobs.filter((job) => ["passed", "warning", "failed"].includes(clean(job.status).toLowerCase()));
+  const durations = completedJobs.map((job) => numericDuration(job.durationMs));
+  const activeJobDurationMs = durations.reduce((sum, durationMs) => sum + durationMs, 0);
+  const started = Date.parse(clean(report.startedAt));
+  const completed = Date.parse(clean(report.completedAt));
+  const runDurationMs = Number.isFinite(started) && Number.isFinite(completed) && completed >= started ? completed - started : null;
+  const longestJob = completedJobs
+    .map((job) => ({
+      id: clean(job.id),
+      status: clean(job.status) || null,
+      durationMs: numericDuration(job.durationMs),
+    }))
+    .sort((left, right) => right.durationMs - left.durationMs)[0] || null;
+
+  return {
+    attemptedJobs: completedJobs.length,
+    activeJobDurationMs,
+    runDurationMs,
+    averageJobDurationMs: completedJobs.length > 0 ? Math.round(activeJobDurationMs / completedJobs.length) : null,
+    longestJob,
+    failedJobIds: jobIdsWithStatus(report, "failed"),
+    warningJobIds: jobIdsWithStatus(report, "warning"),
+    skippedJobIds: jobIdsWithStatus(report, "skipped"),
+    idleReason: deriveIdleReason(report),
+    nextRecommendedJob: deriveNextRecommendedJob(report),
+  };
+}
+
 function finishReport(report) {
   const statuses = report.jobs.map((job) => job.status);
   report.summary.passed = statuses.filter((status) => status === "passed").length;
@@ -871,7 +979,50 @@ function finishReport(report) {
       report.summary.failed > 0 ? "degraded" : report.summary.warning > 0 ? "passed_with_warnings" : "passed";
   }
   report.completedAt = nowIso();
+  report.utilization = buildUtilizationSummary(report);
   return report;
+}
+
+function summarizeHistoryRun(report) {
+  return {
+    runId: clean(report.runId) || null,
+    status: clean(report.status) || null,
+    profile: clean(report.profile) || null,
+    generatedAt: clean(report.generatedAt) || null,
+    startedAt: clean(report.startedAt) || null,
+    completedAt: clean(report.completedAt) || null,
+    dryRun: Boolean(report.dryRun),
+    summary: report.summary,
+    utilization: report.utilization,
+  };
+}
+
+function writeHistory(report, options) {
+  const historyPath = resolve(options.runRoot, "history.json");
+  const existing = readJsonIfPresent(historyPath);
+  const existingRuns = Array.isArray(existing?.runs) ? existing.runs : [];
+  const current = summarizeHistoryRun(report);
+  const seen = new Set([current.runId].filter(Boolean));
+  const runs = [
+    current,
+    ...existingRuns.filter((entry) => {
+      const runId = clean(entry?.runId);
+      if (!runId || seen.has(runId)) return false;
+      seen.add(runId);
+      return true;
+    }),
+  ].slice(0, Math.max(1, options.historyLimit || DEFAULT_HISTORY_LIMIT));
+
+  const history = {
+    schema: "studiobrain-idle-worker-history-v1",
+    generatedAt: nowIso(),
+    latestRunId: current.runId,
+    runRoot: options.runRoot,
+    artifact: options.artifact,
+    limit: Math.max(1, options.historyLimit || DEFAULT_HISTORY_LIMIT),
+    runs,
+  };
+  writeFileSync(historyPath, `${JSON.stringify(history, null, 2)}\n`, "utf8");
 }
 
 function writeReport(report, options) {
@@ -879,6 +1030,7 @@ function writeReport(report, options) {
   writeFileSync(options.artifact, `${JSON.stringify(report, null, 2)}\n`, "utf8");
   const runPath = resolve(options.runRoot, `${safeSegment(report.runId)}.json`);
   writeFileSync(runPath, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+  writeHistory(report, options);
 }
 
 export async function runIdleWorker(rawOptions, deps = {}) {

--- a/scripts/studiobrain-idle-worker.test.mjs
+++ b/scripts/studiobrain-idle-worker.test.mjs
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { parseArgs, runIdleWorker } from "./studiobrain-idle-worker.mjs";
+
+test("idle worker writes bounded run history and utilization context", async () => {
+  const runRoot = mkdtempSync(join(tmpdir(), "studiobrain-idle-worker-"));
+  try {
+    const firstOptions = parseArgs([
+      "--dry-run",
+      "--jobs",
+      "memory",
+      "--run-id",
+      "idle-history-one",
+      "--run-root",
+      runRoot,
+      "--history-limit",
+      "2",
+    ]);
+    const secondOptions = parseArgs([
+      "--dry-run",
+      "--jobs",
+      "memory",
+      "--run-id",
+      "idle-history-two",
+      "--run-root",
+      runRoot,
+      "--history-limit",
+      "2",
+    ]);
+
+    const firstReport = await runIdleWorker(firstOptions);
+    const secondReport = await runIdleWorker(secondOptions);
+    const latest = JSON.parse(readFileSync(join(runRoot, "latest.json"), "utf8"));
+    const history = JSON.parse(readFileSync(join(runRoot, "history.json"), "utf8"));
+
+    assert.equal(firstReport.status, "planned");
+    assert.equal(secondReport.status, "planned");
+    assert.equal(latest.runId, "idle-history-two");
+    assert.equal(latest.utilization.idleReason, "Dry run planned the idle-worker jobs without spending the execution budget.");
+    assert.equal(latest.utilization.nextRecommendedJob, "memory-consolidation");
+    assert.equal(latest.budget.memory.maxCandidates, 80);
+    assert.equal(history.schema, "studiobrain-idle-worker-history-v1");
+    assert.deepEqual(history.runs.map((run) => run.runId), ["idle-history-two", "idle-history-one"]);
+    assert.equal(history.runs[0].utilization.attemptedJobs, 0);
+  } finally {
+    rmSync(runRoot, { recursive: true, force: true });
+  }
+});

--- a/studio-brain/lib/controlTower/derive.js
+++ b/studio-brain/lib/controlTower/derive.js
@@ -500,19 +500,32 @@ function buildMissionBoard(rows) {
 }
 function buildMemoryMaintenanceRow(memoryBrief) {
     const idleWorker = memoryBrief.idleWorker;
+    const recentRunCount = idleWorker?.recentRuns?.length ?? 0;
+    const nextRecommendedJob = idleWorker?.utilization.nextRecommendedJob || "";
+    const idleReason = idleWorker?.utilization.idleReason || "";
+    const repeatedProblem = idleWorker?.problemClusters?.[0] ?? null;
     const idleTask = idleWorker
-        ? `Idle worker ${idleWorker.status || "unknown"}: ${idleWorker.summary.planned} jobs, ${idleWorker.summary.passed} passed, ${idleWorker.summary.warning} warnings, ${idleWorker.summary.failed} failed.`
+        ? `Idle worker ${idleWorker.status || "unknown"}: ${idleWorker.summary.planned} jobs, ${idleWorker.summary.passed} passed, ${idleWorker.summary.warning} warnings, ${idleWorker.summary.failed} failed${recentRunCount > 1 ? `; ${recentRunCount} recent runs tracked` : ""}.`
         : "";
     const status = memoryBrief.consolidation.status || memoryBrief.consolidation.mode;
     const hasIdleFailures = (idleWorker?.summary.failed ?? 0) > 0;
     const hasIdleWarnings = (idleWorker?.summary.warning ?? 0) > 0;
+    const hasIdleSkips = (idleWorker?.summary.skipped ?? 0) > 0;
     const next = hasIdleFailures
         ? "Inspect the latest idle-worker artifact."
         : hasIdleWarnings
-            ? "Review idle-worker warnings before promoting write-capable lanes."
-            : memoryBrief.consolidation.mode === "repair" || memoryBrief.consolidation.status === "failed"
-                ? "Repair continuity"
-                : "Review dream-cycle outputs";
+            ? repeatedProblem
+                ? `Review repeated idle-worker job: ${repeatedProblem.jobId}`
+                : "Review idle-worker warnings before promoting write-capable lanes."
+            : hasIdleSkips
+                ? "Review skipped idle-worker reasons."
+                : idleWorker?.stale
+                    ? "Refresh idle-worker loop evidence."
+                    : nextRecommendedJob
+                        ? `Next idle job: ${nextRecommendedJob}`
+                        : memoryBrief.consolidation.mode === "repair" || memoryBrief.consolidation.status === "failed"
+                            ? "Repair continuity"
+                            : "Review dream-cycle outputs";
     return {
         id: "board:memory-maintenance",
         owner: "Memory maintenance",
@@ -520,7 +533,11 @@ function buildMemoryMaintenanceRow(memoryBrief) {
         state: idleWorker?.status || status || "idle",
         blocker: hasIdleFailures
             ? "Idle worker has failed jobs."
-            : memoryBrief.consolidation.lastError || memoryBrief.blockers[0] || "",
+            : idleWorker?.stale
+                ? "Latest idle-worker artifact is stale."
+                : hasIdleSkips && idleReason
+                    ? (0, collect_1.clipText)(idleReason, 140)
+                    : memoryBrief.consolidation.lastError || memoryBrief.blockers[0] || "",
         next,
         last_update: idleWorker?.completedAt || memoryBrief.consolidation.lastRunAt || memoryBrief.generatedAt,
         roomId: null,

--- a/studio-brain/lib/http/server.js
+++ b/studio-brain/lib/http/server.js
@@ -45,7 +45,9 @@ const service_3 = require("../partner/service");
 const CONTROL_TOWER_MEMORY_BRIEF_RELATIVE_PATH = ["output", "studio-brain", "memory-brief", "latest.json"];
 const CONTROL_TOWER_MEMORY_CONSOLIDATION_RELATIVE_PATH = ["output", "studio-brain", "memory-consolidation", "latest.json"];
 const CONTROL_TOWER_IDLE_WORKER_RELATIVE_PATH = ["output", "studio-brain", "idle-worker", "latest.json"];
+const CONTROL_TOWER_IDLE_WORKER_HISTORY_RELATIVE_PATH = ["output", "studio-brain", "idle-worker", "history.json"];
 const CONTROL_TOWER_STARTUP_SCORECARD_RELATIVE_PATH = ["output", "qa", "codex-startup-scorecard.json"];
+const CONTROL_TOWER_IDLE_WORKER_STALE_MINUTES = 180;
 const CONTROL_TOWER_EVENT_STREAM_POLL_MS = 5_000;
 const CONTROL_TOWER_EVENT_STREAM_HEARTBEAT_MS = 15_000;
 function withSecurityHeaders(headers) {
@@ -163,11 +165,107 @@ function summarizeIdleWorkerJob(job) {
         return JSON.stringify(rawSummary);
     return "";
 }
+function idleWorkerJobIdsWithStatus(jobs, status) {
+    return jobs
+        .filter((job) => toTrimmedString(job.status).toLowerCase() === status)
+        .map((job) => job.id)
+        .filter(Boolean)
+        .slice(0, 16);
+}
+function parseIdleWorkerRunDigest(payload, jobs = []) {
+    const summary = toObjectRecord(payload.summary);
+    const utilization = toObjectRecord(payload.utilization);
+    const longestJob = toObjectRecord(utilization.longestJob);
+    const completedJobs = jobs.filter((job) => ["passed", "warning", "failed"].includes(toTrimmedString(job.status).toLowerCase()));
+    const activeJobDurationMs = completedJobs.reduce((sum, job) => sum + (job.durationMs ?? 0), 0);
+    return {
+        runId: toTrimmedString(payload.runId) || null,
+        status: toTrimmedString(payload.status) || null,
+        profile: toTrimmedString(payload.profile) || null,
+        generatedAt: toTrimmedString(payload.generatedAt) || null,
+        startedAt: toTrimmedString(payload.startedAt) || null,
+        completedAt: toTrimmedString(payload.completedAt) || null,
+        dryRun: Boolean(payload.dryRun),
+        summary: {
+            planned: toBoundedInt(summary.planned, 0, 0, 1_000_000),
+            passed: toBoundedInt(summary.passed, 0, 0, 1_000_000),
+            warning: toBoundedInt(summary.warning, 0, 0, 1_000_000),
+            failed: toBoundedInt(summary.failed, 0, 0, 1_000_000),
+            skipped: toBoundedInt(summary.skipped, 0, 0, 1_000_000),
+        },
+        utilization: {
+            attemptedJobs: toBoundedInt(utilization.attemptedJobs, completedJobs.length, 0, 1_000_000),
+            activeJobDurationMs: toNullableNumber(utilization.activeJobDurationMs) ?? activeJobDurationMs,
+            runDurationMs: toNullableNumber(utilization.runDurationMs),
+            averageJobDurationMs: toNullableNumber(utilization.averageJobDurationMs),
+            longestJob: toTrimmedString(longestJob.id)
+                ? {
+                    id: toTrimmedString(longestJob.id),
+                    status: toTrimmedString(longestJob.status) || null,
+                    durationMs: toNullableNumber(longestJob.durationMs),
+                }
+                : null,
+            failedJobIds: toStringList(utilization.failedJobIds, 16).length
+                ? toStringList(utilization.failedJobIds, 16)
+                : idleWorkerJobIdsWithStatus(jobs, "failed"),
+            warningJobIds: toStringList(utilization.warningJobIds, 16).length
+                ? toStringList(utilization.warningJobIds, 16)
+                : idleWorkerJobIdsWithStatus(jobs, "warning"),
+            skippedJobIds: toStringList(utilization.skippedJobIds, 16).length
+                ? toStringList(utilization.skippedJobIds, 16)
+                : idleWorkerJobIdsWithStatus(jobs, "skipped"),
+            idleReason: toTrimmedString(utilization.idleReason) || null,
+            nextRecommendedJob: toTrimmedString(utilization.nextRecommendedJob) || null,
+        },
+    };
+}
+function buildIdleWorkerProblemClusters(recentRuns) {
+    const clusters = new Map();
+    for (const run of recentRuns) {
+        const runKey = run.runId || run.completedAt || run.generatedAt || "";
+        const addJob = (jobId, kind) => {
+            const cleanJobId = toTrimmedString(jobId);
+            if (!cleanJobId)
+                return;
+            const cluster = clusters.get(cleanJobId) ?? {
+                jobId: cleanJobId,
+                affectedRunIds: new Set(),
+                warningRuns: 0,
+                failedRuns: 0,
+            };
+            if (kind === "warning")
+                cluster.warningRuns += 1;
+            if (kind === "failed")
+                cluster.failedRuns += 1;
+            cluster.affectedRunIds.add(runKey || `${cleanJobId}:${cluster.warningRuns}:${cluster.failedRuns}`);
+            clusters.set(cleanJobId, cluster);
+        };
+        for (const jobId of run.utilization.warningJobIds)
+            addJob(jobId, "warning");
+        for (const jobId of run.utilization.failedJobIds)
+            addJob(jobId, "failed");
+    }
+    return Array.from(clusters.values())
+        .map((cluster) => ({
+        jobId: cluster.jobId,
+        affectedRuns: cluster.affectedRunIds.size,
+        warningRuns: cluster.warningRuns,
+        failedRuns: cluster.failedRuns,
+    }))
+        .filter((cluster) => cluster.affectedRuns > 1 || cluster.failedRuns > 0)
+        .sort((left, right) => {
+        if (right.failedRuns !== left.failedRuns)
+            return right.failedRuns - left.failedRuns;
+        if (right.affectedRuns !== left.affectedRuns)
+            return right.affectedRuns - left.affectedRuns;
+        return left.jobId.localeCompare(right.jobId);
+    })
+        .slice(0, 8);
+}
 function readControlTowerIdleWorkerSummary(repoRoot) {
     const payload = readJsonFile((0, node_path_1.resolve)(repoRoot, ...CONTROL_TOWER_IDLE_WORKER_RELATIVE_PATH));
     if (!payload)
         return null;
-    const summary = toObjectRecord(payload.summary);
     const jobs = (Array.isArray(payload.jobs) ? payload.jobs : [])
         .map((entry) => {
         const job = toObjectRecord(entry);
@@ -180,20 +278,27 @@ function readControlTowerIdleWorkerSummary(repoRoot) {
     })
         .filter((job) => job.id)
         .slice(0, 32);
+    const latestRun = parseIdleWorkerRunDigest(payload, jobs);
+    const history = readJsonFile((0, node_path_1.resolve)(repoRoot, ...CONTROL_TOWER_IDLE_WORKER_HISTORY_RELATIVE_PATH));
+    const seenRunIds = new Set();
+    const recentRuns = [latestRun, ...(Array.isArray(history?.runs) ? history.runs : []).map((entry) => parseIdleWorkerRunDigest(toObjectRecord(entry)))]
+        .filter((run) => {
+        const key = run.runId || `${run.completedAt || run.generatedAt || ""}:${run.status || ""}`;
+        if (!key || seenRunIds.has(key))
+            return false;
+        seenRunIds.add(key);
+        return true;
+    })
+        .slice(0, 10);
+    const ageMinutes = ageMinutesSince(latestRun.completedAt || latestRun.generatedAt);
     return {
-        runId: toTrimmedString(payload.runId) || null,
-        status: toTrimmedString(payload.status) || null,
-        profile: toTrimmedString(payload.profile) || null,
-        generatedAt: toTrimmedString(payload.generatedAt) || null,
-        completedAt: toTrimmedString(payload.completedAt) || null,
+        ...latestRun,
         artifactPath: CONTROL_TOWER_IDLE_WORKER_RELATIVE_PATH.join("/"),
-        summary: {
-            planned: toBoundedInt(summary.planned, 0, 0, 1_000_000),
-            passed: toBoundedInt(summary.passed, 0, 0, 1_000_000),
-            warning: toBoundedInt(summary.warning, 0, 0, 1_000_000),
-            failed: toBoundedInt(summary.failed, 0, 0, 1_000_000),
-            skipped: toBoundedInt(summary.skipped, 0, 0, 1_000_000),
-        },
+        historyPath: CONTROL_TOWER_IDLE_WORKER_HISTORY_RELATIVE_PATH.join("/"),
+        ageMinutes,
+        stale: ageMinutes != null && ageMinutes > CONTROL_TOWER_IDLE_WORKER_STALE_MINUTES,
+        problemClusters: buildIdleWorkerProblemClusters(recentRuns),
+        recentRuns,
         jobs,
     };
 }

--- a/studio-brain/lib/http/server.test.js
+++ b/studio-brain/lib/http/server.test.js
@@ -424,6 +424,22 @@ function createControlTowerFixture() {
             failed: 0,
             skipped: 0,
         },
+        utilization: {
+            attemptedJobs: 13,
+            activeJobDurationMs: 14400,
+            runDurationMs: 19000,
+            averageJobDurationMs: 1108,
+            longestJob: {
+                id: "memory-consolidation",
+                status: "passed",
+                durationMs: 13000,
+            },
+            failedJobIds: [],
+            warningJobIds: ["wiki-contradiction-scan", "wiki-export-drift-check"],
+            skippedJobIds: [],
+            idleReason: "Idle-worker budget was spent and warnings should be reviewed before widening write-capable work.",
+            nextRecommendedJob: "wiki-contradiction-scan",
+        },
         jobs: [
             {
                 id: "memory-consolidation",
@@ -453,6 +469,74 @@ function createControlTowerFixture() {
                         exports: 4,
                         drift: 4,
                     },
+                },
+            },
+        ],
+    }, null, 2)}\n`, "utf8");
+    (0, node_fs_1.writeFileSync)((0, node_path_1.join)(root, "output", "studio-brain", "idle-worker", "history.json"), `${JSON.stringify({
+        schema: "studiobrain-idle-worker-history-v1",
+        generatedAt: "2026-03-30T10:06:20.000Z",
+        latestRunId: "idle-worker-fixture",
+        limit: 20,
+        runs: [
+            {
+                runId: "idle-worker-fixture",
+                status: "passed_with_warnings",
+                profile: "idle",
+                generatedAt: "2026-03-30T10:06:00.000Z",
+                completedAt: "2026-03-30T10:06:19.000Z",
+                summary: {
+                    planned: 13,
+                    passed: 11,
+                    warning: 2,
+                    failed: 0,
+                    skipped: 0,
+                },
+                utilization: {
+                    attemptedJobs: 13,
+                    activeJobDurationMs: 14400,
+                    runDurationMs: 19000,
+                    averageJobDurationMs: 1108,
+                    longestJob: {
+                        id: "memory-consolidation",
+                        status: "passed",
+                        durationMs: 13000,
+                    },
+                    failedJobIds: [],
+                    warningJobIds: ["wiki-contradiction-scan", "wiki-export-drift-check"],
+                    skippedJobIds: [],
+                    idleReason: "Idle-worker budget was spent and warnings should be reviewed before widening write-capable work.",
+                    nextRecommendedJob: "wiki-contradiction-scan",
+                },
+            },
+            {
+                runId: "idle-worker-older-warning",
+                status: "passed_with_warnings",
+                profile: "idle",
+                generatedAt: "2026-03-30T08:00:00.000Z",
+                completedAt: "2026-03-30T08:01:40.000Z",
+                summary: {
+                    planned: 13,
+                    passed: 11,
+                    warning: 2,
+                    failed: 0,
+                    skipped: 0,
+                },
+                utilization: {
+                    attemptedJobs: 13,
+                    activeJobDurationMs: 100000,
+                    runDurationMs: 100000,
+                    averageJobDurationMs: 7692,
+                    longestJob: {
+                        id: "memory-consolidation",
+                        status: "passed",
+                        durationMs: 90000,
+                    },
+                    failedJobIds: [],
+                    warningJobIds: ["wiki-contradiction-scan", "wiki-export-drift-check"],
+                    skippedJobIds: [],
+                    idleReason: "Idle-worker budget was spent and warnings should be reviewed before widening write-capable work.",
+                    nextRecommendedJob: "wiki-contradiction-scan",
                 },
             },
         ],
@@ -3492,8 +3576,17 @@ function createControlTowerRunner() {
             strict_1.default.equal(payload.state.memoryBrief.idleWorker?.status, "passed_with_warnings");
             strict_1.default.equal(payload.state.memoryBrief.idleWorker?.summary.planned, 13);
             strict_1.default.equal(payload.state.memoryBrief.idleWorker?.summary.warning, 2);
+            strict_1.default.equal(payload.state.memoryBrief.idleWorker?.recentRuns.length, 2);
+            strict_1.default.equal(payload.state.memoryBrief.idleWorker?.recentRuns[1]?.runId, "idle-worker-older-warning");
+            strict_1.default.equal(payload.state.memoryBrief.idleWorker?.stale, true);
+            strict_1.default.equal(payload.state.memoryBrief.idleWorker?.problemClusters[0]?.jobId, "wiki-contradiction-scan");
+            strict_1.default.equal(payload.state.memoryBrief.idleWorker?.problemClusters[0]?.affectedRuns, 2);
+            strict_1.default.equal(payload.state.memoryBrief.idleWorker?.utilization.attemptedJobs, 13);
+            strict_1.default.equal(payload.state.memoryBrief.idleWorker?.utilization.activeJobDurationMs, 14400);
+            strict_1.default.equal(payload.state.memoryBrief.idleWorker?.utilization.nextRecommendedJob, "wiki-contradiction-scan");
+            strict_1.default.ok(payload.state.memoryBrief.idleWorker?.utilization.warningJobIds.includes("wiki-export-drift-check"));
             strict_1.default.equal(payload.state.memoryBrief.idleWorker?.jobs.some((entry) => entry.id === "wiki-contradiction-scan" && /contradictions/.test(entry.summary)), true);
-            strict_1.default.equal(payload.state.board.some((entry) => entry.owner === "Memory maintenance" && /13 jobs/.test(entry.task)), true);
+            strict_1.default.equal(payload.state.board.some((entry) => entry.owner === "Memory maintenance" && /2 recent runs tracked/.test(entry.task)), true);
             strict_1.default.equal(payload.state.startupScorecard?.rubric.grade, "A");
             strict_1.default.equal(payload.state.startupScorecard?.rubric.overallScore, 98);
             strict_1.default.equal(payload.state.startupScorecard?.metrics.readyRate, 0.98);

--- a/studio-brain/src/controlTower/derive.ts
+++ b/studio-brain/src/controlTower/derive.ts
@@ -561,19 +561,32 @@ function buildMissionBoard(rows: ControlTowerRoomSummary[]): ControlTowerBoardRo
 
 function buildMemoryMaintenanceRow(memoryBrief: ControlTowerMemoryBrief): ControlTowerBoardRow {
   const idleWorker = memoryBrief.idleWorker;
+  const recentRunCount = idleWorker?.recentRuns?.length ?? 0;
+  const nextRecommendedJob = idleWorker?.utilization.nextRecommendedJob || "";
+  const idleReason = idleWorker?.utilization.idleReason || "";
+  const repeatedProblem = idleWorker?.problemClusters?.[0] ?? null;
   const idleTask = idleWorker
-    ? `Idle worker ${idleWorker.status || "unknown"}: ${idleWorker.summary.planned} jobs, ${idleWorker.summary.passed} passed, ${idleWorker.summary.warning} warnings, ${idleWorker.summary.failed} failed.`
+    ? `Idle worker ${idleWorker.status || "unknown"}: ${idleWorker.summary.planned} jobs, ${idleWorker.summary.passed} passed, ${idleWorker.summary.warning} warnings, ${idleWorker.summary.failed} failed${recentRunCount > 1 ? `; ${recentRunCount} recent runs tracked` : ""}.`
     : "";
   const status = memoryBrief.consolidation.status || memoryBrief.consolidation.mode;
   const hasIdleFailures = (idleWorker?.summary.failed ?? 0) > 0;
   const hasIdleWarnings = (idleWorker?.summary.warning ?? 0) > 0;
+  const hasIdleSkips = (idleWorker?.summary.skipped ?? 0) > 0;
   const next = hasIdleFailures
     ? "Inspect the latest idle-worker artifact."
     : hasIdleWarnings
-      ? "Review idle-worker warnings before promoting write-capable lanes."
-      : memoryBrief.consolidation.mode === "repair" || memoryBrief.consolidation.status === "failed"
-        ? "Repair continuity"
-        : "Review dream-cycle outputs";
+      ? repeatedProblem
+        ? `Review repeated idle-worker job: ${repeatedProblem.jobId}`
+        : "Review idle-worker warnings before promoting write-capable lanes."
+      : hasIdleSkips
+        ? "Review skipped idle-worker reasons."
+        : idleWorker?.stale
+          ? "Refresh idle-worker loop evidence."
+        : nextRecommendedJob
+          ? `Next idle job: ${nextRecommendedJob}`
+          : memoryBrief.consolidation.mode === "repair" || memoryBrief.consolidation.status === "failed"
+            ? "Repair continuity"
+            : "Review dream-cycle outputs";
   return {
     id: "board:memory-maintenance",
     owner: "Memory maintenance",
@@ -582,6 +595,10 @@ function buildMemoryMaintenanceRow(memoryBrief: ControlTowerMemoryBrief): Contro
     blocker:
       hasIdleFailures
         ? "Idle worker has failed jobs."
+        : idleWorker?.stale
+          ? "Latest idle-worker artifact is stale."
+        : hasIdleSkips && idleReason
+          ? clipText(idleReason, 140)
         : memoryBrief.consolidation.lastError || memoryBrief.blockers[0] || "",
     next,
     last_update: idleWorker?.completedAt || memoryBrief.consolidation.lastRunAt || memoryBrief.generatedAt,

--- a/studio-brain/src/controlTower/types.ts
+++ b/studio-brain/src/controlTower/types.ts
@@ -274,13 +274,14 @@ export type ControlTowerMemoryConsolidation = {
   lastError?: string | null;
 };
 
-export type ControlTowerIdleWorkerSummary = {
+export type ControlTowerIdleWorkerRunDigest = {
   runId: string | null;
   status: string | null;
   profile: string | null;
   generatedAt: string | null;
+  startedAt?: string | null;
   completedAt: string | null;
-  artifactPath: string | null;
+  dryRun?: boolean;
   summary: {
     planned: number;
     passed: number;
@@ -288,6 +289,36 @@ export type ControlTowerIdleWorkerSummary = {
     failed: number;
     skipped: number;
   };
+  utilization: {
+    attemptedJobs: number;
+    activeJobDurationMs: number | null;
+    runDurationMs: number | null;
+    averageJobDurationMs: number | null;
+    longestJob: {
+      id: string;
+      status: string | null;
+      durationMs: number | null;
+    } | null;
+    failedJobIds: string[];
+    warningJobIds: string[];
+    skippedJobIds: string[];
+    idleReason: string | null;
+    nextRecommendedJob: string | null;
+  };
+};
+
+export type ControlTowerIdleWorkerSummary = ControlTowerIdleWorkerRunDigest & {
+  artifactPath: string | null;
+  historyPath: string | null;
+  ageMinutes: number | null;
+  stale: boolean;
+  problemClusters: Array<{
+    jobId: string;
+    affectedRuns: number;
+    warningRuns: number;
+    failedRuns: number;
+  }>;
+  recentRuns: ControlTowerIdleWorkerRunDigest[];
   jobs: Array<{
     id: string;
     status: string | null;

--- a/studio-brain/src/http/server.test.ts
+++ b/studio-brain/src/http/server.test.ts
@@ -480,6 +480,22 @@ function createControlTowerFixture() {
           failed: 0,
           skipped: 0,
         },
+        utilization: {
+          attemptedJobs: 13,
+          activeJobDurationMs: 14400,
+          runDurationMs: 19000,
+          averageJobDurationMs: 1108,
+          longestJob: {
+            id: "memory-consolidation",
+            status: "passed",
+            durationMs: 13000,
+          },
+          failedJobIds: [],
+          warningJobIds: ["wiki-contradiction-scan", "wiki-export-drift-check"],
+          skippedJobIds: [],
+          idleReason: "Idle-worker budget was spent and warnings should be reviewed before widening write-capable work.",
+          nextRecommendedJob: "wiki-contradiction-scan",
+        },
         jobs: [
           {
             id: "memory-consolidation",
@@ -509,6 +525,83 @@ function createControlTowerFixture() {
                 exports: 4,
                 drift: 4,
               },
+            },
+          },
+        ],
+      },
+      null,
+      2,
+    )}\n`,
+    "utf8",
+  );
+
+  writeFileSync(
+    join(root, "output", "studio-brain", "idle-worker", "history.json"),
+    `${JSON.stringify(
+      {
+        schema: "studiobrain-idle-worker-history-v1",
+        generatedAt: "2026-03-30T10:06:20.000Z",
+        latestRunId: "idle-worker-fixture",
+        limit: 20,
+        runs: [
+          {
+            runId: "idle-worker-fixture",
+            status: "passed_with_warnings",
+            profile: "idle",
+            generatedAt: "2026-03-30T10:06:00.000Z",
+            completedAt: "2026-03-30T10:06:19.000Z",
+            summary: {
+              planned: 13,
+              passed: 11,
+              warning: 2,
+              failed: 0,
+              skipped: 0,
+            },
+            utilization: {
+              attemptedJobs: 13,
+              activeJobDurationMs: 14400,
+              runDurationMs: 19000,
+              averageJobDurationMs: 1108,
+              longestJob: {
+                id: "memory-consolidation",
+                status: "passed",
+                durationMs: 13000,
+              },
+              failedJobIds: [],
+              warningJobIds: ["wiki-contradiction-scan", "wiki-export-drift-check"],
+              skippedJobIds: [],
+              idleReason: "Idle-worker budget was spent and warnings should be reviewed before widening write-capable work.",
+              nextRecommendedJob: "wiki-contradiction-scan",
+            },
+          },
+          {
+            runId: "idle-worker-older-warning",
+            status: "passed_with_warnings",
+            profile: "idle",
+            generatedAt: "2026-03-30T08:00:00.000Z",
+            completedAt: "2026-03-30T08:01:40.000Z",
+            summary: {
+              planned: 13,
+              passed: 11,
+              warning: 2,
+              failed: 0,
+              skipped: 0,
+            },
+            utilization: {
+              attemptedJobs: 13,
+              activeJobDurationMs: 100000,
+              runDurationMs: 100000,
+              averageJobDurationMs: 7692,
+              longestJob: {
+                id: "memory-consolidation",
+                status: "passed",
+                durationMs: 90000,
+              },
+              failedJobIds: [],
+              warningJobIds: ["wiki-contradiction-scan", "wiki-export-drift-check"],
+              skippedJobIds: [],
+              idleReason: "Idle-worker budget was spent and warnings should be reviewed before widening write-capable work.",
+              nextRecommendedJob: "wiki-contradiction-scan",
             },
           },
         ],
@@ -4063,6 +4156,17 @@ test("control tower state routes derive browser-friendly room and service data",
                   failed: number;
                   skipped: number;
                 };
+                utilization: {
+                  attemptedJobs: number;
+                  activeJobDurationMs: number | null;
+                  idleReason: string | null;
+                  nextRecommendedJob: string | null;
+                  warningJobIds: string[];
+                };
+                stale: boolean;
+                ageMinutes: number | null;
+                problemClusters: Array<{ jobId: string; affectedRuns: number; warningRuns: number; failedRuns: number }>;
+                recentRuns: Array<{ runId: string | null; status: string | null }>;
                 jobs: Array<{ id: string; status: string | null; summary: string }>;
               } | null;
             };
@@ -4120,6 +4224,15 @@ test("control tower state routes derive browser-friendly room and service data",
         assert.equal(payload.state.memoryBrief.idleWorker?.status, "passed_with_warnings");
         assert.equal(payload.state.memoryBrief.idleWorker?.summary.planned, 13);
         assert.equal(payload.state.memoryBrief.idleWorker?.summary.warning, 2);
+        assert.equal(payload.state.memoryBrief.idleWorker?.recentRuns.length, 2);
+        assert.equal(payload.state.memoryBrief.idleWorker?.recentRuns[1]?.runId, "idle-worker-older-warning");
+        assert.equal(payload.state.memoryBrief.idleWorker?.stale, true);
+        assert.equal(payload.state.memoryBrief.idleWorker?.problemClusters[0]?.jobId, "wiki-contradiction-scan");
+        assert.equal(payload.state.memoryBrief.idleWorker?.problemClusters[0]?.affectedRuns, 2);
+        assert.equal(payload.state.memoryBrief.idleWorker?.utilization.attemptedJobs, 13);
+        assert.equal(payload.state.memoryBrief.idleWorker?.utilization.activeJobDurationMs, 14400);
+        assert.equal(payload.state.memoryBrief.idleWorker?.utilization.nextRecommendedJob, "wiki-contradiction-scan");
+        assert.ok(payload.state.memoryBrief.idleWorker?.utilization.warningJobIds.includes("wiki-export-drift-check"));
         assert.equal(
           payload.state.memoryBrief.idleWorker?.jobs.some((entry) =>
             entry.id === "wiki-contradiction-scan" && /contradictions/.test(entry.summary)
@@ -4127,7 +4240,7 @@ test("control tower state routes derive browser-friendly room and service data",
           true,
         );
         assert.equal(
-          payload.state.board.some((entry) => entry.owner === "Memory maintenance" && /13 jobs/.test(entry.task)),
+          payload.state.board.some((entry) => entry.owner === "Memory maintenance" && /2 recent runs tracked/.test(entry.task)),
           true,
         );
         assert.equal(payload.state.startupScorecard?.rubric.grade, "A");

--- a/studio-brain/src/http/server.ts
+++ b/studio-brain/src/http/server.ts
@@ -76,6 +76,7 @@ import type {
   ControlTowerApprovalItem,
   ControlTowerEvent,
   ControlTowerHostCard,
+  ControlTowerIdleWorkerRunDigest,
   ControlTowerIdleWorkerSummary,
   ControlTowerMemoryHealth,
   ControlTowerMemoryBrief,
@@ -110,7 +111,9 @@ import {
 const CONTROL_TOWER_MEMORY_BRIEF_RELATIVE_PATH = ["output", "studio-brain", "memory-brief", "latest.json"] as const;
 const CONTROL_TOWER_MEMORY_CONSOLIDATION_RELATIVE_PATH = ["output", "studio-brain", "memory-consolidation", "latest.json"] as const;
 const CONTROL_TOWER_IDLE_WORKER_RELATIVE_PATH = ["output", "studio-brain", "idle-worker", "latest.json"] as const;
+const CONTROL_TOWER_IDLE_WORKER_HISTORY_RELATIVE_PATH = ["output", "studio-brain", "idle-worker", "history.json"] as const;
 const CONTROL_TOWER_STARTUP_SCORECARD_RELATIVE_PATH = ["output", "qa", "codex-startup-scorecard.json"] as const;
+const CONTROL_TOWER_IDLE_WORKER_STALE_MINUTES = 180;
 const CONTROL_TOWER_EVENT_STREAM_POLL_MS = 5_000;
 const CONTROL_TOWER_EVENT_STREAM_HEARTBEAT_MS = 15_000;
 
@@ -236,13 +239,113 @@ function summarizeIdleWorkerJob(job: Record<string, unknown>): string {
   return "";
 }
 
+function idleWorkerJobIdsWithStatus(jobs: Array<{ id: string; status: string | null }>, status: string): string[] {
+  return jobs
+    .filter((job) => toTrimmedString(job.status).toLowerCase() === status)
+    .map((job) => job.id)
+    .filter(Boolean)
+    .slice(0, 16);
+}
+
+function parseIdleWorkerRunDigest(
+  payload: Record<string, unknown>,
+  jobs: Array<{ id: string; status: string | null; durationMs: number | null }> = [],
+): ControlTowerIdleWorkerRunDigest {
+  const summary = toObjectRecord(payload.summary);
+  const utilization = toObjectRecord(payload.utilization);
+  const longestJob = toObjectRecord(utilization.longestJob);
+  const completedJobs = jobs.filter((job) => ["passed", "warning", "failed"].includes(toTrimmedString(job.status).toLowerCase()));
+  const activeJobDurationMs = completedJobs.reduce((sum, job) => sum + (job.durationMs ?? 0), 0);
+
+  return {
+    runId: toTrimmedString(payload.runId) || null,
+    status: toTrimmedString(payload.status) || null,
+    profile: toTrimmedString(payload.profile) || null,
+    generatedAt: toTrimmedString(payload.generatedAt) || null,
+    startedAt: toTrimmedString(payload.startedAt) || null,
+    completedAt: toTrimmedString(payload.completedAt) || null,
+    dryRun: Boolean(payload.dryRun),
+    summary: {
+      planned: toBoundedInt(summary.planned, 0, 0, 1_000_000),
+      passed: toBoundedInt(summary.passed, 0, 0, 1_000_000),
+      warning: toBoundedInt(summary.warning, 0, 0, 1_000_000),
+      failed: toBoundedInt(summary.failed, 0, 0, 1_000_000),
+      skipped: toBoundedInt(summary.skipped, 0, 0, 1_000_000),
+    },
+    utilization: {
+      attemptedJobs: toBoundedInt(utilization.attemptedJobs, completedJobs.length, 0, 1_000_000),
+      activeJobDurationMs: toNullableNumber(utilization.activeJobDurationMs) ?? activeJobDurationMs,
+      runDurationMs: toNullableNumber(utilization.runDurationMs),
+      averageJobDurationMs: toNullableNumber(utilization.averageJobDurationMs),
+      longestJob: toTrimmedString(longestJob.id)
+        ? {
+            id: toTrimmedString(longestJob.id),
+            status: toTrimmedString(longestJob.status) || null,
+            durationMs: toNullableNumber(longestJob.durationMs),
+          }
+        : null,
+      failedJobIds: toStringList(utilization.failedJobIds, 16).length
+        ? toStringList(utilization.failedJobIds, 16)
+        : idleWorkerJobIdsWithStatus(jobs, "failed"),
+      warningJobIds: toStringList(utilization.warningJobIds, 16).length
+        ? toStringList(utilization.warningJobIds, 16)
+        : idleWorkerJobIdsWithStatus(jobs, "warning"),
+      skippedJobIds: toStringList(utilization.skippedJobIds, 16).length
+        ? toStringList(utilization.skippedJobIds, 16)
+        : idleWorkerJobIdsWithStatus(jobs, "skipped"),
+      idleReason: toTrimmedString(utilization.idleReason) || null,
+      nextRecommendedJob: toTrimmedString(utilization.nextRecommendedJob) || null,
+    },
+  };
+}
+
+function buildIdleWorkerProblemClusters(
+  recentRuns: ControlTowerIdleWorkerRunDigest[],
+): ControlTowerIdleWorkerSummary["problemClusters"] {
+  const clusters = new Map<string, { jobId: string; affectedRunIds: Set<string>; warningRuns: number; failedRuns: number }>();
+  for (const run of recentRuns) {
+    const runKey = run.runId || run.completedAt || run.generatedAt || "";
+    const addJob = (jobId: string, kind: "warning" | "failed"): void => {
+      const cleanJobId = toTrimmedString(jobId);
+      if (!cleanJobId) return;
+      const cluster = clusters.get(cleanJobId) ?? {
+        jobId: cleanJobId,
+        affectedRunIds: new Set<string>(),
+        warningRuns: 0,
+        failedRuns: 0,
+      };
+      if (kind === "warning") cluster.warningRuns += 1;
+      if (kind === "failed") cluster.failedRuns += 1;
+      cluster.affectedRunIds.add(runKey || `${cleanJobId}:${cluster.warningRuns}:${cluster.failedRuns}`);
+      clusters.set(cleanJobId, cluster);
+    };
+
+    for (const jobId of run.utilization.warningJobIds) addJob(jobId, "warning");
+    for (const jobId of run.utilization.failedJobIds) addJob(jobId, "failed");
+  }
+
+  return Array.from(clusters.values())
+    .map((cluster) => ({
+      jobId: cluster.jobId,
+      affectedRuns: cluster.affectedRunIds.size,
+      warningRuns: cluster.warningRuns,
+      failedRuns: cluster.failedRuns,
+    }))
+    .filter((cluster) => cluster.affectedRuns > 1 || cluster.failedRuns > 0)
+    .sort((left, right) => {
+      if (right.failedRuns !== left.failedRuns) return right.failedRuns - left.failedRuns;
+      if (right.affectedRuns !== left.affectedRuns) return right.affectedRuns - left.affectedRuns;
+      return left.jobId.localeCompare(right.jobId);
+    })
+    .slice(0, 8);
+}
+
 function readControlTowerIdleWorkerSummary(repoRoot: string): ControlTowerIdleWorkerSummary | null {
   const payload = readJsonFile<Record<string, unknown>>(
     resolve(repoRoot, ...CONTROL_TOWER_IDLE_WORKER_RELATIVE_PATH)
   );
   if (!payload) return null;
 
-  const summary = toObjectRecord(payload.summary);
   const jobs = (Array.isArray(payload.jobs) ? payload.jobs : [])
     .map((entry) => {
       const job = toObjectRecord(entry);
@@ -255,21 +358,29 @@ function readControlTowerIdleWorkerSummary(repoRoot: string): ControlTowerIdleWo
     })
     .filter((job) => job.id)
     .slice(0, 32);
+  const latestRun = parseIdleWorkerRunDigest(payload, jobs);
+  const history = readJsonFile<Record<string, unknown>>(
+    resolve(repoRoot, ...CONTROL_TOWER_IDLE_WORKER_HISTORY_RELATIVE_PATH)
+  );
+  const seenRunIds = new Set<string>();
+  const recentRuns = [latestRun, ...(Array.isArray(history?.runs) ? history.runs : []).map((entry) => parseIdleWorkerRunDigest(toObjectRecord(entry)))]
+    .filter((run) => {
+      const key = run.runId || `${run.completedAt || run.generatedAt || ""}:${run.status || ""}`;
+      if (!key || seenRunIds.has(key)) return false;
+      seenRunIds.add(key);
+      return true;
+    })
+    .slice(0, 10);
+  const ageMinutes = ageMinutesSince(latestRun.completedAt || latestRun.generatedAt);
 
   return {
-    runId: toTrimmedString(payload.runId) || null,
-    status: toTrimmedString(payload.status) || null,
-    profile: toTrimmedString(payload.profile) || null,
-    generatedAt: toTrimmedString(payload.generatedAt) || null,
-    completedAt: toTrimmedString(payload.completedAt) || null,
+    ...latestRun,
     artifactPath: CONTROL_TOWER_IDLE_WORKER_RELATIVE_PATH.join("/"),
-    summary: {
-      planned: toBoundedInt(summary.planned, 0, 0, 1_000_000),
-      passed: toBoundedInt(summary.passed, 0, 0, 1_000_000),
-      warning: toBoundedInt(summary.warning, 0, 0, 1_000_000),
-      failed: toBoundedInt(summary.failed, 0, 0, 1_000_000),
-      skipped: toBoundedInt(summary.skipped, 0, 0, 1_000_000),
-    },
+    historyPath: CONTROL_TOWER_IDLE_WORKER_HISTORY_RELATIVE_PATH.join("/"),
+    ageMinutes,
+    stale: ageMinutes != null && ageMinutes > CONTROL_TOWER_IDLE_WORKER_STALE_MINUTES,
+    problemClusters: buildIdleWorkerProblemClusters(recentRuns),
+    recentRuns,
     jobs,
   };
 }


### PR DESCRIPTION
## Summary
- add idle-worker `budget` and `utilization` fields so each run explains spent budget, skipped/failed/warning jobs, idle reason, and next recommended job
- write bounded `output/studio-brain/idle-worker/history.json` alongside latest/run artifacts
- teach Control Tower to read recent idle runs, stale evidence, and repeated warning/failure job clusters

## Verification
- `npm --prefix studio-brain run build`
- `node --test scripts/studiobrain-idle-worker.test.mjs`
- `node --test studio-brain/lib/http/server.test.js` (74/74)
- `npm run studio:ops:idle-worker:dry:json -- --run-id idle-worker-utilization-dry --history-limit 3`
- `git diff --check`