### PR TITLE
Expand wiki idle task queue

### DIFF
--- a/scripts/lib/wiki-postgres-utils.mjs
+++ b/scripts/lib/wiki-postgres-utils.mjs
@@ -1607,6 +1607,13 @@ function idleTask(taskKey, title, options = {}) {
   };
 }
 
+function claimSetKey(claims = []) {
+  return stableHash(
+    JSON.stringify((Array.isArray(claims) ? claims : []).map((claim) => claim.claimId).filter(Boolean).sort()),
+    24,
+  );
+}
+
 export function buildIdleTaskQueueReport(options = {}) {
   const tenantScope = options.tenantScope || "monsoonfire-main";
   const index = options.index || buildSourceIndex(options);
@@ -1614,6 +1621,10 @@ export function buildIdleTaskQueueReport(options = {}) {
   const scan = options.scan || detectContradictions(index, extraction.claims);
   const drift = options.drift || buildExportDriftReport({ ...options, index, extraction, scan });
   const pack = options.contextPack || generateContextPack(extraction.claims, scan.contradictions, options);
+  const dbProbe = options.dbProbe || buildDbProbeReport();
+  const humanApprovalClaims = extraction.claims.filter((claim) => claim.requiresHumanApproval);
+  const operationalTruthClaims = extraction.claims.filter((claim) => claim.status === "OPERATIONAL_TRUTH");
+  const blockedContradictions = scan.contradictions.filter((entry) => entry.status === "blocked");
   const tasks = [
     idleTask("wiki-source-index-refresh", "Refresh wiki source index and chunk inventory", {
       tenantScope,
@@ -1622,6 +1633,27 @@ export function buildIdleTaskQueueReport(options = {}) {
       idempotencyKey: index.snapshotHash,
       metadata: { lane: "source-index", indexedSources: index.sources.length, chunks: index.chunks.length },
     }),
+    idleTask("wiki-claim-extraction-review", "Review wiki claim extraction coverage", {
+      tenantScope,
+      priority: 0.6,
+      outputArtifactPath: "output/wiki/extract-check.json",
+      idempotencyKey: claimSetKey(extraction.claims),
+      metadata: {
+        lane: "claim-extraction",
+        claims: extraction.summary.claims,
+        requiresHumanApproval: extraction.summary.requiresHumanApproval,
+        operationalTruthClaims: operationalTruthClaims.length,
+      },
+    }),
+    ...(humanApprovalClaims.length > 0
+      ? [idleTask("wiki-human-approval-triage", "Triage wiki claims requiring human approval", {
+          tenantScope,
+          priority: 0.7,
+          outputArtifactPath: "output/wiki/extract-check.json",
+          idempotencyKey: claimSetKey(humanApprovalClaims),
+          metadata: { lane: "human-approval", claims: humanApprovalClaims.length },
+        })]
+      : []),
     idleTask("wiki-context-pack-refresh", "Refresh Studio Brain wiki context pack", {
       tenantScope,
       priority: 0.65,
@@ -1635,6 +1667,51 @@ export function buildIdleTaskQueueReport(options = {}) {
         unverifiedClaimExcludedCount: pack.budget.unverifiedClaimExcludedCount,
         activeContradictionCount: pack.budget.activeContradictionCount,
       },
+    }),
+    idleTask("wiki-contradiction-scan-review", "Review wiki contradiction scan", {
+      tenantScope,
+      priority: scan.summary.contradictions > 0 ? 0.8 : 0.52,
+      outputArtifactPath: "output/wiki/contradictions-scan.json",
+      idempotencyKey: stableHash(
+        JSON.stringify(scan.contradictions.map((entry) => [entry.conflictKey, entry.status, entry.conflictFingerprint])),
+        24,
+      ),
+      metadata: {
+        lane: "contradiction-scan",
+        contradictions: scan.summary.contradictions,
+        hard: scan.summary.hard,
+        critical: scan.summary.critical,
+        blocked: blockedContradictions.length,
+      },
+    }),
+    idleTask(
+      drift.status === "pass" ? "wiki-export-drift-verify" : "wiki-export-drift-review",
+      drift.status === "pass" ? "Verify deterministic wiki exports" : "Review deterministic wiki export drift",
+      {
+        tenantScope,
+        priority: drift.status === "pass" ? 0.5 : 0.75,
+        outputArtifactPath: "output/wiki/export-drift.json",
+        idempotencyKey: stableHash(
+          JSON.stringify(drift.exports.map((entry) => [entry.path, entry.status, entry.expectedHash])),
+          24,
+        ),
+        metadata: {
+          lane: "export-drift",
+          drift: drift.summary.drift,
+          missing: drift.summary.missing,
+          match: drift.summary.match,
+        },
+      },
+    ),
+    idleTask("wiki-db-probe-plan-review", "Review wiki DB query probe plan", {
+      tenantScope,
+      priority: 0.42,
+      outputArtifactPath: "output/wiki/db-probe.json",
+      idempotencyKey: stableHash(
+        JSON.stringify(dbProbe.queries.map((query) => [query.name, query.targetMs])),
+        24,
+      ),
+      metadata: { lane: "db-probe", queryCount: dbProbe.summary.queryCount },
     }),
   ];
   for (const contradiction of scan.contradictions) {
@@ -1652,15 +1729,6 @@ export function buildIdleTaskQueueReport(options = {}) {
         status: contradiction.status,
         humanGate: contradiction.metadata?.humanGate || "",
       },
-    }));
-  }
-  if (drift.status !== "pass") {
-    tasks.push(idleTask("wiki-export-drift-review", "Review deterministic wiki export drift", {
-      tenantScope,
-      priority: 0.75,
-      outputArtifactPath: "output/wiki/export-drift.json",
-      idempotencyKey: stableHash(JSON.stringify(drift.exports.map((entry) => [entry.path, entry.status, entry.expectedHash])), 24),
-      metadata: { lane: "export-drift", drift: drift.summary.drift, missing: drift.summary.missing },
     }));
   }
   tasks.sort((a, b) => b.priority - a.priority || a.taskKey.localeCompare(b.taskKey));
@@ -1731,11 +1799,32 @@ function formatIdleTaskSignals(task) {
   if (metadata.lane === "source-index") {
     return `sources=${metadata.indexedSources ?? 0}, chunks=${metadata.chunks ?? 0}`;
   }
+  if (metadata.lane === "claim-extraction") {
+    return [
+      `claims=${metadata.claims ?? 0}`,
+      `human_approval=${metadata.requiresHumanApproval ?? 0}`,
+      `operational_truth=${metadata.operationalTruthClaims ?? 0}`,
+    ].join(", ");
+  }
+  if (metadata.lane === "human-approval") {
+    return `claims=${metadata.claims ?? 0}`;
+  }
+  if (metadata.lane === "contradiction-scan") {
+    return [
+      `contradictions=${metadata.contradictions ?? 0}`,
+      `hard=${metadata.hard ?? 0}`,
+      `critical=${metadata.critical ?? 0}`,
+      `blocked=${metadata.blocked ?? 0}`,
+    ].join(", ");
+  }
   if (metadata.lane === "contradictions") {
     return `severity=${metadata.severity || "unknown"}, status=${metadata.status || task.status}`;
   }
   if (metadata.lane === "export-drift") {
-    return `drift=${metadata.drift ?? 0}, missing=${metadata.missing ?? 0}`;
+    return `drift=${metadata.drift ?? 0}, missing=${metadata.missing ?? 0}, match=${metadata.match ?? 0}`;
+  }
+  if (metadata.lane === "db-probe") {
+    return `queries=${metadata.queryCount ?? 0}`;
   }
   return "";
 }

--- a/scripts/wiki-postgres-idle-tasks.test.mjs
+++ b/scripts/wiki-postgres-idle-tasks.test.mjs
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildIdleTaskQueueReport } from "./lib/wiki-postgres-utils.mjs";
+
+test("wiki idle task queue advertises the read-only idle budget lanes", () => {
+  const report = buildIdleTaskQueueReport();
+  const byKey = new Map(report.tasks.map((task) => [task.taskKey, task]));
+
+  for (const taskKey of [
+    "wiki-source-index-refresh",
+    "wiki-claim-extraction-review",
+    "wiki-context-pack-refresh",
+    "wiki-contradiction-scan-review",
+    "wiki-db-probe-plan-review",
+  ]) {
+    assert.ok(byKey.has(taskKey), `${taskKey} should be visible in the idle task queue`);
+  }
+
+  assert.ok(
+    byKey.has("wiki-export-drift-verify") || byKey.has("wiki-export-drift-review"),
+    "export drift should be visible as either a clean verification task or a review task",
+  );
+
+  assert.ok(report.summary.tasks >= 6);
+  assert.equal(report.summary.readOnly, report.summary.tasks);
+  assert.equal(report.summary.writeCapable, 0);
+  assert.equal(byKey.get("wiki-claim-extraction-review").metadata.lane, "claim-extraction");
+  assert.equal(byKey.get("wiki-db-probe-plan-review").metadata.queryCount, 5);
+});

--- a/wiki/00_source_index/source-map.md
+++ b/wiki/00_source_index/source-map.md
@@ -14,12 +14,12 @@ agent_allowed_use: planning_context
 supersedes: []
 superseded_by: []
 related_pages: []
-export_hash: 9b599d4fa0b218d1c1afed7fee7d98f07b071f565815916e89af736df35ef989
+export_hash: ce81de65b041ee5f27ef95ed479ab7873ac5d6f1265d53d946e3f8f676cf7029
 ---
 
 # Source Map
 
-Snapshot: 9b599d4fa0b218d1c1afed7fee7d98f07b071f565815916e89af736df35ef989
+Snapshot: ce81de65b041ee5f27ef95ed479ab7873ac5d6f1265d53d946e3f8f676cf7029
 
 | Source | Status | Authority | Chunks | Hash |
 |---|---:|---|---:|---|
@@ -609,7 +609,7 @@ Snapshot: 9b599d4fa0b218d1c1afed7fee7d98f07b071f565815916e89af736df35ef989
 | `scripts/lib/studiobrain-posture-policy.mjs` | indexed | repo | 3 | `505f7366c6e1` |
 | `scripts/lib/studiobrain-posture-policy.test.mjs` | indexed | repo | 1 | `ad39dbf12605` |
 | `scripts/lib/website-ga-utils.mjs` | indexed | repo | 2 | `b31a5f9b1a5c` |
-| `scripts/lib/wiki-postgres-utils.mjs` | indexed | repo | 30 | `d8a0fa5ab24c` |
+| `scripts/lib/wiki-postgres-utils.mjs` | indexed | repo | 31 | `5c15ccea27e8` |
 | `scripts/library-rollout-rollback-drill.mjs` | indexed | repo | 7 | `9f8548f535be` |
 | `scripts/libratom-export-jsonl.sh` | indexed | repo | 3 | `c3a4de589100` |
 | `scripts/libratom.sh` | indexed | repo | 1 | `e58affa06efe` |
@@ -791,6 +791,7 @@ Snapshot: 9b599d4fa0b218d1c1afed7fee7d98f07b071f565815916e89af736df35ef989
 | `scripts/validate-well-known.mjs` | indexed | repo | 5 | `3455b0e9fc25` |
 | `scripts/verify-harness-dedupe-safe.mjs` | indexed | repo | 5 | `702adc22d926` |
 | `scripts/website-playwright-smoke.mjs` | indexed | repo | 6 | `cd73819cf645` |
+| `scripts/wiki-postgres-idle-tasks.test.mjs` | indexed | repo | 1 | `7c69dbe21c55` |
 | `scripts/wiki-postgres.mjs` | indexed | repo | 3 | `5f477a33811d` |
 | `scripts/workflow-failure-ticket.mjs` | indexed | repo | 4 | `159adc1e052a` |
 | `storage.rules` | indexed | repo | 1 | `f04626065d5f` |

--- a/wiki/80_idle_tasks/wiki-idle-task-queue.md
+++ b/wiki/80_idle_tasks/wiki-idle-task-queue.md
@@ -14,13 +14,17 @@ agent_allowed_use: planning_context
 supersedes: []
 superseded_by: []
 related_pages: []
-export_hash: 53274a1eaf2c16f0adcfd06ca29e19bb601f810b75bcb24b8c8d702968c558e5
+export_hash: 1e4f82f8989f451888dc5182b51fb818bd1770cb003cfde477d4d53aebd673ad
 ---
 
 # Wiki Idle Task Queue
 
 | Task | Status | Priority | Read Only | Output | Signals |
 |---|---|---:|---:|---|---|
-| Review wiki contradiction: membership-required-vs-decommission | blocked | 0.9 | true | `wiki/50_contradictions/membership-required-vs-decommission.md` | severity=hard, status=blocked |
-| Refresh Studio Brain wiki context pack | ready | 0.65 | true | `output/wiki/context-check.json` | verified=2, warnings=13, total_warning_items=273, unverified=272, active_contradictions=1 |
-| Refresh wiki source index and chunk inventory | ready | 0.55 | true | `output/wiki/source-index-check.json` | sources=1646, chunks=11182 |
+| Triage wiki claims requiring human approval | ready | 0.7 | true | `output/wiki/extract-check.json` | claims=21 |
+| Refresh Studio Brain wiki context pack | ready | 0.65 | true | `output/wiki/context-check.json` | verified=0, warnings=11, total_warning_items=259, unverified=259, active_contradictions=0 |
+| Review wiki claim extraction coverage | ready | 0.6 | true | `output/wiki/extract-check.json` | claims=259, human_approval=21, operational_truth=0 |
+| Refresh wiki source index and chunk inventory | ready | 0.55 | true | `output/wiki/source-index-check.json` | sources=1609, chunks=11040 |
+| Review wiki contradiction scan | ready | 0.52 | true | `output/wiki/contradictions-scan.json` | contradictions=0, hard=0, critical=0, blocked=0 |
+| Verify deterministic wiki exports | ready | 0.5 | true | `output/wiki/export-drift.json` | drift=0, missing=0, match=3 |
+| Review wiki DB query probe plan | ready | 0.42 | true | `output/wiki/db-probe.json` | queries=5 |


### PR DESCRIPTION
## Summary
- Expand the wiki idle task queue from only source/context refreshes to the worker read-only lanes: claim extraction, human-approval triage, contradiction scan, export verification, and DB probe review
- Refresh the tracked wiki source map and idle task queue page
- Add a regression test so the queue keeps advertising the read-only budget lanes

## Verification
- node --test scripts/wiki-postgres-idle-tasks.test.mjs
- npm run wiki:export:drift
- npm run wiki:idle-tasks:check
- git diff --check
- npm run studio:ops:idle-worker:dry:json -- --run-id wiki-idle-task-queue-expansion-dry --history-limit 3