### PR TITLE
Preflight wiki startup-pack audit

### DIFF
--- a/package.json
+++ b/package.json
@@ -510,7 +510,7 @@
     "wiki:human-gates:list": "node ./scripts/wiki-human-gates-list.mjs --json",
     "wiki:human-gates:snapshot": "node ./scripts/wiki-human-gates-list.mjs --json --tracked",
     "wiki:human-gates:packets": "node ./scripts/wiki-human-gates-approval-packets.mjs --json",
-    "wiki:startup-pack:audit": "node ./scripts/wiki-startup-pack-audit.mjs --json",
+    "wiki:startup-pack:audit": "node ./scripts/wiki-startup-pack-audit-preflight.mjs --json",
     "wiki:context:check": "node ./scripts/wiki-postgres.mjs context --fresh-extract --json --artifact output/wiki/context-check.json",
     "wiki:context:refresh": "node ./scripts/wiki-postgres.mjs context --fresh-extract --write-markdown --json --artifact output/wiki/context-refresh.json",
     "wiki:context:apply": "node ./scripts/wiki-postgres.mjs context --fresh-extract --apply-db --write-markdown --json --artifact output/wiki/context-apply.json",

--- a/scripts/wiki-startup-pack-audit-preflight.mjs
+++ b/scripts/wiki-startup-pack-audit-preflight.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { dirname } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const REPO_ROOT = resolve(__dirname, "..");
+const DEFAULT_CONTEXT_CANDIDATES = ["output/wiki/context-refresh.json", "output/wiki/context-check.json"];
+const DEFAULT_REFRESH_ARTIFACT = "output/wiki/context-refresh.json";
+
+function clean(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+export function parseContextArg(argv) {
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = clean(argv[index]);
+    if (arg === "--context" && argv[index + 1]) return clean(argv[index + 1]);
+    if (arg.startsWith("--context=")) return clean(arg.slice("--context=".length));
+  }
+  return "";
+}
+
+export function hasJsonArg(argv) {
+  return argv.some((arg) => clean(arg) === "--json");
+}
+
+export function refreshArtifactForContext(context = "") {
+  return clean(context) || DEFAULT_REFRESH_ARTIFACT;
+}
+
+export function buildRefreshArgs(context = "") {
+  return [
+    "./scripts/wiki-postgres.mjs",
+    "context",
+    "--fresh-extract",
+    "--write-markdown",
+    "--json",
+    "--artifact",
+    refreshArtifactForContext(context),
+  ];
+}
+
+export function contextNeedsRefresh({ repoRoot = REPO_ROOT, context = "" } = {}) {
+  const candidates = context ? [context] : DEFAULT_CONTEXT_CANDIDATES;
+  for (const candidate of candidates) {
+    const path = resolve(repoRoot, candidate);
+    if (!existsSync(path)) continue;
+    try {
+      const artifact = JSON.parse(readFileSync(path, "utf8"));
+      const pack = artifact?.contextPack && typeof artifact.contextPack === "object" ? artifact.contextPack : artifact;
+      if (pack && typeof pack === "object" && Array.isArray(pack.items)) return false;
+    } catch {
+      continue;
+    }
+  }
+  return true;
+}
+
+function forwardCapturedFailure(result) {
+  if (result.stderr) process.stderr.write(result.stderr);
+  if (result.stdout) process.stderr.write(result.stdout);
+}
+
+function runNode(args, { quietStdout = false } = {}) {
+  const result = spawnSync(process.execPath, args, {
+    cwd: REPO_ROOT,
+    encoding: "utf8",
+    stdio: quietStdout ? ["ignore", "pipe", "pipe"] : "inherit",
+    shell: false,
+  });
+  if (result.error) throw result.error;
+  if (quietStdout && result.status !== 0) forwardCapturedFailure(result);
+  if (quietStdout && result.stderr) process.stderr.write(result.stderr);
+  return result.status ?? 1;
+}
+
+function main() {
+  const argv = process.argv.slice(2);
+  const context = parseContextArg(argv);
+  const wantsJson = hasJsonArg(argv);
+  if (contextNeedsRefresh({ context })) {
+    const refreshArtifact = refreshArtifactForContext(context);
+    process.stderr.write(`Wiki startup preflight: refreshing context pack at ${refreshArtifact}\n`);
+    const refreshStatus = runNode(buildRefreshArgs(context), { quietStdout: wantsJson });
+    if (refreshStatus !== 0) process.exit(refreshStatus);
+  }
+  process.exit(runNode(["./scripts/wiki-startup-pack-audit.mjs", ...argv]));
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === __filename) main();

--- a/scripts/wiki-startup-pack-audit-preflight.test.mjs
+++ b/scripts/wiki-startup-pack-audit-preflight.test.mjs
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import test from "node:test";
+
+import {
+  buildRefreshArgs,
+  contextNeedsRefresh,
+  hasJsonArg,
+  parseContextArg,
+  refreshArtifactForContext,
+} from "./wiki-startup-pack-audit-preflight.mjs";
+
+function writeJson(path, value) {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+test("wiki startup preflight refreshes when context artifact is missing or malformed", () => {
+  const root = mkdtempSync(join(tmpdir(), "wiki-startup-preflight-missing-"));
+  try {
+    assert.equal(contextNeedsRefresh({ repoRoot: root }), true);
+    writeFileSync(join(root, "output-wrong.json"), "{not json", "utf8");
+    assert.equal(contextNeedsRefresh({ repoRoot: root, context: "output-wrong.json" }), true);
+    writeJson(join(root, "output/wiki/context-refresh.json"), {
+      schema: "wiki-context-pack-report.v1",
+      contextPack: { items: [] },
+    });
+    assert.equal(contextNeedsRefresh({ repoRoot: root }), false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("wiki startup preflight honors explicit context arguments", () => {
+  const root = mkdtempSync(join(tmpdir(), "wiki-startup-preflight-context-"));
+  try {
+    writeJson(join(root, "custom/context.json"), { schema: "wiki-context-pack.v1", items: [] });
+    assert.equal(parseContextArg(["--strict", "--context", "custom/context.json"]), "custom/context.json");
+    assert.equal(parseContextArg(["--context=custom/context.json"]), "custom/context.json");
+    assert.equal(contextNeedsRefresh({ repoRoot: root, context: "custom/context.json" }), false);
+    assert.equal(contextNeedsRefresh({ repoRoot: root, context: "custom/missing.json" }), true);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("wiki startup preflight keeps JSON audit stdout single-object friendly", () => {
+  assert.equal(hasJsonArg(["--strict", "--json"]), true);
+  assert.equal(hasJsonArg(["--strict"]), false);
+  assert.equal(refreshArtifactForContext("custom/context.json"), "custom/context.json");
+  assert.equal(refreshArtifactForContext(""), "output/wiki/context-refresh.json");
+  assert.deepEqual(buildRefreshArgs("custom/context.json"), [
+    "./scripts/wiki-postgres.mjs",
+    "context",
+    "--fresh-extract",
+    "--write-markdown",
+    "--json",
+    "--artifact",
+    "custom/context.json",
+  ]);
+});


### PR DESCRIPTION
## Summary
- route wiki:startup-pack:audit through a preflight wrapper that refreshes the context pack when missing or malformed
- keep strict audit behavior intact for unsafe included claims
- keep JSON-mode refresh output off stdout so the final audit report remains machine-readable

## Tests
- node --test scripts/wiki-startup-pack-audit-preflight.test.mjs scripts/wiki-startup-pack-audit.test.mjs
- npm run wiki:startup-pack:audit -- --strict