### PR TITLE
[ops] Add Studio Brain ops doctor first pass

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,33 @@
+SHELL := /bin/bash
+
+PG_CONTAINER ?= studiobrain_postgres
+PGDATABASE ?= monsoonfire_studio_os
+
+.PHONY: ops-check ops-inventory ops-postgres-review ops-docker-review ops-capacity ops-backlog ops-report
+
+ops-check: ops-inventory ops-docker-review ops-capacity
+
+ops-inventory:
+	bash scripts/ops/system_inventory.sh
+
+ops-postgres-review:
+	@if command -v psql >/dev/null 2>&1; then \
+		psql -X -v ON_ERROR_STOP=1 -f scripts/ops/postgres_readonly_review.sql; \
+	elif command -v docker >/dev/null 2>&1 && docker ps --format '{{.Names}}' | grep -qx '$(PG_CONTAINER)'; then \
+		docker exec -i -u postgres $(PG_CONTAINER) psql -d $(PGDATABASE) -X -v ON_ERROR_STOP=1 < scripts/ops/postgres_readonly_review.sql; \
+	else \
+		echo "No local psql connection or $(PG_CONTAINER) container found. Set PG* env vars or run on the Studio Brain host."; \
+	fi
+
+ops-docker-review:
+	bash scripts/ops/docker_inventory.sh
+
+ops-capacity:
+	bash scripts/ops/disk_pressure.sh
+	bash scripts/ops/log_pressure.sh
+
+ops-backlog:
+	@sed -n '1,260p' docs/ops/02-kanban-backlog.md
+
+ops-report:
+	bash scripts/ops/generate_ops_report.sh

--- a/docs/ops/00-system-inventory.md
+++ b/docs/ops/00-system-inventory.md
@@ -1,0 +1,199 @@
+# Studio Brain System Inventory
+
+Snapshot time: 2026-05-06 00:16-00:20 UTC, from `D:\monsoonfire-portal-ops-doctor` against SSH alias `studiobrain` and LAN API `http://192.168.1.226:8787`.
+
+## Host Assumptions And Known Facts
+
+- Studio Brain LAN API: `http://192.168.1.226:8787`.
+- SSH alias: `studiobrain`, user `wuff`, key path reported by the repo wrapper as `C:\Users\micah\.ssh\studiobrain-codex`.
+- Live repo path: `/home/wuff/monsoonfire-portal`.
+- Windows repo path for reviewable changes: `D:\monsoonfire-portal`.
+- This inventory is read-only. No services were restarted, no packages were upgraded, no Docker objects were pruned, and no database writes were made.
+- The live host checkout is not currently clean: it is on `codex/next-fix-20260312...origin/codex/next-fix-20260312 [gone]` with 211 tracked dirty files.
+
+## OS And Kernel
+
+- OS: Ubuntu 25.10 (`PRETTY_NAME="Ubuntu 25.10"`).
+- Kernel: `6.17.0-22-generic`.
+- Uptime: 19 days, 1 hour at collection time.
+- Hostname: `studiobrain`.
+- Primary operator user: `wuff` (`uid=1000`), member of `sudo`, `docker`, and `adm`.
+
+## Package Manager State
+
+- Reboot required: no `/var/run/reboot-required` file at collection time.
+- `unattended-upgrades.service`: enabled and active.
+- Pending upgrades include kernel packages (`linux-generic` 6.17.0-23), Docker Engine/Compose (`29.4.2`, compose `5.1.3`), `curl`, `systemd`, `nodejs` 25.9.0, `containerd.io`, `rsyslog`, `sed`, and `snapd`.
+- Failed units include `apt-daily-upgrade.service`; systemd reports `Result=oom-kill`, and the kernel log shows `unattended-upgr` was killed by the OOM killer on 2026-05-05 06:56 UTC.
+
+## Mounted Filesystems
+
+| Mount | Type | Size | Used | Available | Use |
+| --- | --- | ---: | ---: | ---: | ---: |
+| `/` | ext4 on LVM | 914G | 124G | 753G | 15% |
+| `/boot` | ext4 | 2.0G | 240M | 1.6G | 14% |
+| `/boot/efi` | vfat | 1.1G | 6.3M | 1.1G | 1% |
+| `/tmp` | tmpfs | 16G | 28M | 16G | 1% |
+
+Inodes are healthy: `/` has about 59M inodes with 2% used.
+
+## Disk Usage Risks
+
+- `/home/wuff`: 89G.
+- `/home/wuff/monsoonfire-portal`: 44G.
+- `/home/wuff/imports`: 23G.
+- `/var/lib/docker`: 12G.
+- `/home/wuff/backups`: 2.4G.
+- `/home/wuff/studio-brain-mission-control`: 2.8G.
+- `/home/wuff/.npm`: 4.2G.
+- `/home/wuff/.cache`: 3.8G.
+- `/var/log`: 84M.
+- `/tmp`: 28M.
+- `/var/backups/studio-brain`: 756K.
+
+Disk pressure is not immediate, but repository/import/cache growth is the largest long-term storage concern.
+
+## Memory And Swap
+
+- RAM: 30Gi total, 4.5Gi used, 19Gi free, 25Gi available.
+- Swap: 8.0Gi total, 448Mi used.
+- Load average at collection: about `1.36, 1.28, 1.11`.
+- One OOM event was observed in the last 14 days: `apt-daily-upgrade.service` caused an OOM kill of `unattended-upgr`.
+
+## Systemd Services Relevant To Studio Brain
+
+User-scoped services under `wuff`:
+
+| Unit | State | Restart | PID | Memory |
+| --- | --- | --- | ---: | ---: |
+| `studio-brain.service` | active/running | always | 525535 | ~286M |
+| `studio-brain-mission-control.service` | active/running | on-failure | 3552280 | ~980M |
+
+System services/timers:
+
+| Unit | State | Notes |
+| --- | --- | --- |
+| `studio-brain-control-tower-proxy.service` | active/running | system service, restart always |
+| `studio-brain-namecheap-tunnel.service` | active/running | system service, restart always |
+| `studio-brain-backup.timer` | active/waiting | daily 03:45 UTC |
+| `studio-brain-healthcheck.timer` | active/waiting | every 5 minutes |
+| `studio-brain-disk-alert.timer` | active/waiting | every 15 minutes |
+| `studio-brain-reboot-watch.timer` | active/waiting | every 15 minutes |
+| `studio-brain-idle-worker.timer` | active/waiting | every 4 hours after inactive, randomized delay |
+| `studio-brain-idle-worker-overnight.timer` | active/waiting | nightly around 02:30 UTC |
+
+The idle-worker timers are present on the host, but the clean `origin/main` checkout used for this PR does not contain corresponding tracked unit files under `config/studiobrain/systemd`.
+
+## Failed Units
+
+- `apt-daily-upgrade.service`: failed, `Result=oom-kill`.
+- `dailyaidecheck.service`: failed, `ExecMainStatus=1`.
+- `snap.canonical-livepatch.canonical-livepatchd.service`: failed, 5 restarts.
+- `systemd-networkd-wait-online.service`: failed, `ExecMainStatus=1`.
+
+## Cron And Timer Inventory
+
+User crontab for `wuff`:
+
+```cron
+*/15 * * * * cd /home/wuff/monsoonfire-portal && /usr/bin/node ./scripts/mail-profile-sync.mjs --json >> /home/wuff/monsoonfire-portal/imports/mail/runs/mail-profile-sync-cron.log 2>&1
+```
+
+Other notable cron entries:
+
+- `/etc/cron.daily/dailyaidecheck`
+- `/etc/cron.weekly/studiobrain-lynis`
+- standard `apt`, `dpkg`, `logrotate`, `man-db`, and `sysstat` entries.
+
+## Open Ports
+
+Observed listeners:
+
+- `0.0.0.0:22` and `[::]:22`: SSH.
+- `0.0.0.0:25` and `[::]:25`: Postfix.
+- `192.168.1.226:8787`: Studio Brain API.
+- `127.0.0.1:4100`: Mission Control.
+- `127.0.0.1:18788`: Control Tower proxy.
+- `0.0.0.0:5433` and `[::]:5433`: PostgreSQL container host port.
+- `127.0.0.1:6379`: Redis.
+- `127.0.0.1:9010` and `127.0.0.1:9011`: MinIO API/console.
+- `127.0.0.1:19999`: Netdata.
+- `127.0.0.1:3001`: Uptime Kuma.
+- `192.168.1.226:18080` and `192.168.1.226:18081`: monitoring proxy.
+- `127.0.0.1:8080`: SearXNG.
+
+`ufw` is inactive. `fail2ban` is active for `sshd` with 0 current bans and 2 total failed attempts.
+
+SSH posture from `sshd -T`:
+
+- `permitrootlogin without-password`
+- `pubkeyauthentication yes`
+- `passwordauthentication yes`
+- `kbdinteractiveauthentication yes`
+- `x11forwarding yes`
+
+## Docker Version And Compose Files
+
+- Docker Engine: 29.4.0.
+- Docker Compose: v5.1.2.
+- Compose projects reported by `docker compose ls`:
+  - `studio-brain`: `/home/wuff/monsoonfire-portal/studio-brain/docker-compose.yml`
+  - `monitoring`: `/home/wuff/monitoring/docker-compose.yml`
+  - `searxng`: `/home/wuff/searxng/docker-compose.yml`
+- Tracked compose files in this repo:
+  - `studio-brain/docker-compose.yml`
+  - `studio-brain/docker-compose.proxy.yml`
+  - `config/studiobrain/monitoring/docker-compose.yml`
+
+## Running Containers And Roles
+
+| Container | Role | Status | Image |
+| --- | --- | --- | --- |
+| `studiobrain_postgres` | primary PostgreSQL and pgvector state | healthy | `pgvector/pgvector:pg16` |
+| `studiobrain_redis` | queue/event primitives, currently app reports Redis disabled | healthy | `redis:7-alpine` |
+| `studiobrain_minio` | artifact/object storage | healthy | `minio/minio:latest` |
+| `studiobrain_otel_collector` | optional OpenTelemetry collector | up, no healthcheck | `otel/opentelemetry-collector-contrib:latest` |
+| `netdata` | host/container metrics | healthy | `netdata/netdata:stable` |
+| `uptime-kuma` | synthetic monitors | healthy | `louislam/uptime-kuma:1` |
+| `monitoring-proxy` | Caddy bridge for monitoring | up, no healthcheck | `caddy:2-alpine` |
+| `searxng-searxng-1` | search service | up, no healthcheck | `searxng/searxng:latest` |
+| `searxng-redis-1` | SearXNG Redis | up, no healthcheck | `redis:7-alpine` |
+
+Docker space summary:
+
+- Images: 9 total, 4.397GB.
+- Containers: 9 total, all active.
+- Local volumes: 8 total, 5 active, 9.303GB.
+- Build cache: 300.3MB, all reclaimable.
+
+## PostgreSQL Version And Connection Method
+
+- PostgreSQL: 16.13 inside `studiobrain_postgres`.
+- Image: `pgvector/pgvector:pg16`.
+- Host port: `5433 -> 5432`, bound to all interfaces by current Compose default.
+- Database: `monsoonfire_studio_os`.
+- Extensions: `pg_stat_statements`, `pg_trgm`, `pgcrypto`, `plpgsql`, `vector`.
+- App health reports PostgreSQL connected with low single-digit millisecond latency.
+
+## Application Components And Dependency Map
+
+```mermaid
+flowchart LR
+  User["Operator / Codex"] --> SSH["SSH alias: studiobrain"]
+  SSH --> Host["Ubuntu host 192.168.1.226"]
+  Host --> SB["studio-brain.service :8787"]
+  Host --> MC["studio-brain-mission-control.service :4100 localhost"]
+  Host --> Proxy["control-tower proxy :18788"]
+  SB --> PG["PostgreSQL/pgvector container :5433"]
+  SB --> MinIO["MinIO container :9010/:9011"]
+  SB -. disabled at app layer .-> Redis["Redis container :6379"]
+  Host --> Timers["systemd timers: health, backup, disk, reboot, idle"]
+  Host --> Monitoring["Netdata + Uptime Kuma + Caddy proxy"]
+```
+
+## Current Live API Health
+
+- `/healthz`: `ok=true`.
+- `/readyz`: `ok=true`, PostgreSQL connected, state snapshot age 13 minutes.
+- `/health/dependencies`: PostgreSQL, artifact store, vector store, skill registry, and skill sandbox OK; Redis/event bus/kilnaid provider disabled.
+- `/api/status`: scheduler healthy, `computeStudioState` has 210 successes and 0 failures since runtime start on 2026-05-03; overseer status remains `critical` with 6 signal gaps and 8 actions.

--- a/docs/ops/01-risk-register.md
+++ b/docs/ops/01-risk-register.md
@@ -1,0 +1,133 @@
+# Studio Brain Risk Register
+
+Snapshot time: 2026-05-06 00:16-00:20 UTC. Findings are separated from fixes. No destructive action was taken.
+
+## Critical
+
+No immediate critical data-loss or outage condition was observed in the read-only pass. The high findings below are still worth treating as near-term operational work because several affect backup confidence, patching, and network exposure.
+
+## High
+
+### Backup Evidence Is Split And Restore Confidence Is Incomplete
+
+- Affected component: backups, restore posture, PostgreSQL/Redis/MinIO data.
+- Evidence: `studio-brain-backup.timer` runs daily and root-owned config archives exist through 2026-05-05 under `/var/backups/studio-brain/daily`, but `/home/wuff/monsoonfire-portal/output/backups/latest.json` still points to 2026-04-28. The tracked system backup script archives host and Studio Brain config, not an obvious PostgreSQL dump, Redis snapshot, or MinIO object backup.
+- Likely impact: operators may believe full service backups are fresh while only config-level archives are demonstrably current; restore time and data-loss exposure are unknown.
+- Recommended action: unify backup evidence into one current manifest that distinguishes config archive, PostgreSQL dump, Redis state, MinIO data, and restore-drill status.
+- Safe next step: add a read-only backup evidence script and run a non-destructive restore-prerequisite drill.
+- Rollback/undo notes: documentation/script additions can be reverted; do not delete existing backups.
+- PR can address it: yes, for documentation and read-only verification scripts. Full backup changes require approval.
+
+### Live Host Checkout Is On A Gone Branch With 211 Dirty Tracked Files
+
+- Affected component: deployment source of truth and drift control.
+- Evidence: `/home/wuff/monsoonfire-portal` reports `codex/next-fix-20260312...origin/codex/next-fix-20260312 [gone]` and 211 dirty tracked files, including package, migrations, Studio Brain runtime, scripts, and docs.
+- Likely impact: deploys and reconciliations may package host-only drift, hide unreviewed runtime changes, or make rollback hard to reason about.
+- Recommended action: inventory dirty host changes, classify them as accepted source changes, generated artifacts, or discardable runtime drift, then reconcile through PRs.
+- Safe next step: generate a redacted diff manifest and compare against `host-drift-allowlist.json`.
+- Rollback/undo notes: do not reset the host checkout until the diff manifest is reviewed and backed up.
+- PR can address it: yes, for the audit/reporting tool. Cleanup requires human approval.
+
+### PostgreSQL Is Bound To All Interfaces While UFW Is Inactive
+
+- Affected component: PostgreSQL network exposure.
+- Evidence: `ss` shows `0.0.0.0:5433` and `[::]:5433` listening via Docker; `ufw` reports inactive. Compose default is `"${PGPORT:-5433}:5432"`.
+- Likely impact: the database is reachable from more than localhost. If credentials or LAN trust assumptions are weak, this increases blast radius.
+- Recommended action: confirm all legitimate clients, then bind Postgres to `127.0.0.1:5433` or add a host firewall rule.
+- Safe next step: add a docs/task item and a Compose validation check that reports non-loopback DB binds.
+- Rollback/undo notes: changing bind address is reversible but can break remote clients; requires service window and approval.
+- PR can address it: yes, detection and documentation. Actual bind/firewall change needs human approval.
+
+### Unattended Upgrade Failed Due OOM While Security Updates Are Pending
+
+- Affected component: Ubuntu patching and package hygiene.
+- Evidence: `apt-daily-upgrade.service` failed with `Result=oom-kill`; kernel log shows `unattended-upgr` killed after about 29GB RSS. Pending upgrades include kernel, Docker, curl, systemd, nodejs, snapd, and containerd.
+- Likely impact: security updates may not apply reliably; unattended upgrade can create memory pressure or fail silently between admin reviews.
+- Recommended action: inspect apt logs, determine why unattended upgrade consumed excessive memory, then run updates in a supervised maintenance window.
+- Safe next step: capture apt/unattended-upgrades logs and create a maintenance checklist.
+- Rollback/undo notes: package upgrades need normal apt rollback planning; do not upgrade automatically from this PR.
+- PR can address it: yes, runbook and diagnostic script. Host update execution needs approval.
+
+## Medium
+
+### SSH Password And Keyboard-Interactive Auth Are Enabled
+
+- Affected component: SSH access posture.
+- Evidence: `sshd -T` reports `passwordauthentication yes`, `kbdinteractiveauthentication yes`, `permitrootlogin without-password`; `fail2ban` is active and currently has no bans.
+- Likely impact: password auth increases remote brute-force exposure, especially with `ssh` listening on all interfaces.
+- Recommended action: confirm any legitimate password-based access, then plan key-only SSH with fail2ban retained.
+- Safe next step: add a key-only SSH migration checklist and current-posture diagnostic.
+- Rollback/undo notes: keep an out-of-band console or verified second key before changing SSH auth.
+- PR can address it: documentation only; host SSH changes require approval.
+
+### Live Idle-Worker Timers Are Host-Only Drift
+
+- Affected component: systemd timer source of truth.
+- Evidence: host has `studio-brain-idle-worker.timer` and `studio-brain-idle-worker-overnight.timer`, but clean `origin/main` lacks matching files under `config/studiobrain/systemd`.
+- Likely impact: reinstall or reconcile paths may drop or fail to recreate important scheduled work.
+- Recommended action: import these unit files into source control after review.
+- Safe next step: add a PR with the timer/service definitions and install script coverage.
+- Rollback/undo notes: source-controlled units can be reverted; do not remove live timers until replacement is verified.
+- PR can address it: yes.
+
+### Several System Units Are Failed
+
+- Affected component: base OS hygiene.
+- Evidence: failed units include `dailyaidecheck.service`, `snap.canonical-livepatch.canonical-livepatchd.service`, and `systemd-networkd-wait-online.service`.
+- Likely impact: integrity scanning, livepatch reporting, and network-online semantics may be unreliable or noisy.
+- Recommended action: inspect each unit's journal and decide whether to repair, disable intentionally, or document as irrelevant.
+- Safe next step: add failed-unit triage to maintenance runbook.
+- Rollback/undo notes: unit resets are reversible; do not disable security/integrity services without approval.
+- PR can address it: documentation and diagnostics only.
+
+### Docker Images Use Floating Tags
+
+- Affected component: Docker update predictability.
+- Evidence: tracked Compose uses `minio/minio:latest` and `otel/opentelemetry-collector-contrib:latest`; running stack includes `searxng/searxng:latest`, `netdata/netdata:stable`, and `louislam/uptime-kuma:1`.
+- Likely impact: future pulls may change behavior without a clear review point.
+- Recommended action: pin operationally sensitive images by version or digest after checking update cadence.
+- Safe next step: create a ticket to pin and document image update policy.
+- Rollback/undo notes: image pinning is reversible through Compose; roll back by restoring prior image tags.
+- PR can address it: yes.
+
+### Healthcheck Coverage Is Incomplete
+
+- Affected component: Docker and monitoring reliability.
+- Evidence: `monitoring-proxy`, `studiobrain_otel_collector`, `searxng-searxng-1`, and `searxng-redis-1` have no Docker healthcheck.
+- Likely impact: Docker can report containers as `Up` even when the service is unresponsive.
+- Recommended action: add obvious read-only healthchecks where commands are stable.
+- Safe next step: add healthcheck coverage for monitoring proxy and SearXNG in a small PR.
+- Rollback/undo notes: remove healthcheck stanzas if they flap; no data rollback needed.
+- PR can address it: yes.
+
+### PostgreSQL Memory Tables And Indexes Dominate Storage
+
+- Affected component: PostgreSQL capacity and query performance.
+- Evidence: `monsoonfire_studio_os` is about 8.3GB. Largest relations are `public.swarm_memory` 3.1GB, `public.memory_relation_edge` 2.3GB, `public.memory_pattern_index` 1.3GB, and `public.memory_entity_index` 1.0GB. Largest indexes include several 240MB-590MB memory lookup indexes.
+- Likely impact: growth in memory tables can dominate backup time, query plans, and cache pressure.
+- Recommended action: add growth trend reporting and pg_stat_statements review before changing indexes.
+- Safe next step: commit read-only DBA SQL and schedule weekly size snapshots.
+- Rollback/undo notes: read-only reporting is reversible; index changes require PR, tests, and rollback SQL.
+- PR can address it: yes, diagnostics only.
+
+## Low
+
+### Docker Cleanup Candidates Exist But Are Not Urgent
+
+- Affected component: Docker storage.
+- Evidence: Docker reports 8 local volumes but only 5 active; build cache has 300.3MB reclaimable. No exited containers or dangling images were observed.
+- Likely impact: small storage waste today; can grow if left unmanaged.
+- Recommended action: document volume ownership before pruning anything.
+- Safe next step: run `docker volume inspect` and map anonymous volumes to prior Compose projects.
+- Rollback/undo notes: volume deletion is not safely reversible unless backed up.
+- PR can address it: documentation only.
+
+### Overseer Status Is Critical Despite Healthy Runtime Checks
+
+- Affected component: application operations/Control Tower signal quality.
+- Evidence: `/api/status` reports `overseer.overallStatus=critical`, 6 signal gaps, 8 actions, and 0 created proposals while health/readiness pass.
+- Likely impact: human-facing ops state may stay noisy even when the app is technically healthy.
+- Recommended action: turn overseer gaps into explicit backlog tasks and decide which are stale.
+- Safe next step: add an ops-doctor check that reports app status beyond `/healthz`.
+- Rollback/undo notes: documentation/reporting only.
+- PR can address it: yes.

--- a/docs/ops/02-kanban-backlog.md
+++ b/docs/ops/02-kanban-backlog.md
@@ -1,0 +1,205 @@
+# Studio Brain Ops Kanban Backlog
+
+Each item is issue-ready and intentionally separates investigation from changes that need a service window or approval.
+
+## Now
+
+### [backup] Unify backup evidence and restore confidence
+
+- Type: reliability, database, capacity
+- Priority: P0
+- Effort: M
+- Risk: low for diagnostics, high for any backup-path change
+- Acceptance criteria:
+  - Backup report distinguishes config archives, PostgreSQL dump, Redis state, MinIO data, and restore drill status.
+  - Latest backup evidence is current within the documented threshold.
+  - Restore-prerequisite drill is documented and can run without exposing secrets.
+- Recommended owner: Codex, DBA review
+- Suggested branch name: `codex/ops-backup-evidence`
+- Suggested PR title: `[ops] Add Studio Brain backup evidence and restore drill report`
+
+### [ubuntu] Triage apt OOM and failed system units
+
+- Type: ubuntu, security, reliability
+- Priority: P1
+- Effort: M
+- Risk: low for diagnostics, medium for package changes
+- Acceptance criteria:
+  - `apt-daily-upgrade.service` OOM root cause is documented.
+  - Failed `dailyaidecheck`, livepatch, and network-wait units have disposition: repair, disable intentionally, or ignore with reason.
+  - Maintenance-window checklist exists for pending updates.
+- Recommended owner: human, Codex
+- Suggested branch name: `codex/ops-apt-failed-units-runbook`
+- Suggested PR title: `[ops] Document apt OOM and failed-unit maintenance workflow`
+
+### [security] Review DB and SSH network exposure
+
+- Type: security, ubuntu, database
+- Priority: P1
+- Effort: M
+- Risk: medium
+- Acceptance criteria:
+  - Current listeners are captured in a redacted report.
+  - Legitimate PostgreSQL clients are identified.
+  - SSH password-auth usage is confirmed before any config change.
+  - Any proposed bind/firewall/SSH change includes rollback and console access notes.
+- Recommended owner: human, security review
+- Suggested branch name: `codex/ops-network-exposure-review`
+- Suggested PR title: `[ops] Add network exposure review and hardening checklist`
+
+### [drift] Inventory live host checkout drift
+
+- Type: reliability, cleanup, app
+- Priority: P1
+- Effort: M
+- Risk: low for inventory, high for cleanup
+- Acceptance criteria:
+  - Live dirty-file manifest exists with generated/artifact/source classifications.
+  - Gone branch status is documented.
+  - No host reset is performed without explicit approval.
+- Recommended owner: Codex, human
+- Suggested branch name: `codex/ops-host-drift-inventory`
+- Suggested PR title: `[ops] Add live host drift inventory workflow`
+
+## Next
+
+### [systemd] Source-control idle-worker timers
+
+- Type: reliability, documentation
+- Priority: P2
+- Effort: S
+- Risk: low
+- Acceptance criteria:
+  - `studio-brain-idle-worker` and overnight unit files are tracked under `config/studiobrain/systemd`.
+  - Install/reconcile scripts include them.
+  - Docs list cadence and safety mode.
+- Recommended owner: Codex
+- Suggested branch name: `codex/ops-idle-worker-systemd`
+- Suggested PR title: `[ops] Track Studio Brain idle-worker systemd timers`
+
+### [docker] Add missing container healthchecks
+
+- Type: docker, reliability
+- Priority: P2
+- Effort: M
+- Risk: medium
+- Acceptance criteria:
+  - Monitoring proxy and SearXNG healthchecks use stable local endpoints.
+  - Compose validation passes.
+  - Rollback is removing the healthcheck stanzas.
+- Recommended owner: Codex
+- Suggested branch name: `codex/ops-docker-healthchecks`
+- Suggested PR title: `[ops] Add non-invasive Docker healthchecks`
+
+### [database] Schedule weekly PostgreSQL size and activity snapshots
+
+- Type: database, capacity, performance
+- Priority: P2
+- Effort: S
+- Risk: low
+- Acceptance criteria:
+  - Read-only SQL scripts capture database sizes, largest tables/indexes, dead tuples, locks, active sessions, and key settings.
+  - Output avoids secrets and query parameter values where practical.
+  - Runbook explains how to store snapshots.
+- Recommended owner: Codex, DBA review
+- Suggested branch name: `codex/ops-postgres-readonly-review`
+- Suggested PR title: `[ops] Add read-only PostgreSQL DBA review scripts`
+
+### [docker] Pin floating image tags
+
+- Type: docker, security, reliability
+- Priority: P2
+- Effort: M
+- Risk: medium
+- Acceptance criteria:
+  - Floating tags are listed.
+  - Update policy and rollback command are documented.
+  - Image pin changes, if made, are one service group per PR.
+- Recommended owner: Codex, human
+- Suggested branch name: `codex/ops-docker-image-pinning`
+- Suggested PR title: `[ops] Document Docker image pinning plan`
+
+## Later
+
+### [capacity] Add growth trend reporting
+
+- Type: capacity, database, docker
+- Priority: P3
+- Effort: M
+- Risk: low
+- Acceptance criteria:
+  - Weekly snapshots include `/home/wuff`, Docker, Postgres relation sizes, logs, and backup sizes.
+  - 30/60/90 day projections are generated from at least 4 samples.
+- Recommended owner: Codex
+- Suggested branch name: `codex/ops-capacity-trends`
+- Suggested PR title: `[ops] Add capacity trend snapshot format`
+
+### [observability] Convert overseer critical gaps into tickets
+
+- Type: app, reliability, documentation
+- Priority: P3
+- Effort: M
+- Risk: low
+- Acceptance criteria:
+  - Current overseer gaps are exported into issue-ready markdown.
+  - Stale/accepted gaps can be acknowledged with reason.
+- Recommended owner: Codex, human
+- Suggested branch name: `codex/ops-overseer-gap-backlog`
+- Suggested PR title: `[ops] Export overseer gaps into reviewable backlog`
+
+### [cleanup] Classify Docker anonymous volumes
+
+- Type: docker, cleanup, capacity
+- Priority: P3
+- Effort: S
+- Risk: low for classification, high for deletion
+- Acceptance criteria:
+  - Anonymous volumes are mapped to containers/projects or marked unknown.
+  - Cleanup candidates are classified as safe to automate, safe with backup, requires service window, requires human approval, or do not touch.
+- Recommended owner: Codex
+- Suggested branch name: `codex/ops-docker-volume-inventory`
+- Suggested PR title: `[ops] Add Docker volume cleanup inventory`
+
+## Waiting / Needs Human Approval
+
+### [security] Bind PostgreSQL to loopback or add firewall rules
+
+- Type: security, database, ubuntu
+- Priority: P1
+- Effort: M
+- Risk: high
+- Acceptance criteria:
+  - Approved client list exists.
+  - Rollback and service-window plan exists.
+  - App, backups, and DBA probes still connect after the change.
+- Recommended owner: human, DBA review, security review
+- Suggested branch name: `codex/ops-postgres-bind-hardening`
+- Suggested PR title: `[ops] Harden PostgreSQL host binding`
+
+### [security] Move SSH to key-only auth
+
+- Type: security, ubuntu
+- Priority: P2
+- Effort: M
+- Risk: high
+- Acceptance criteria:
+  - At least two working keys or an out-of-band console path are verified.
+  - Password and keyboard-interactive auth are disabled.
+  - Fail2ban remains active.
+- Recommended owner: human, security review
+- Suggested branch name: `codex/ops-ssh-key-only-plan`
+- Suggested PR title: `[ops] Plan Studio Brain SSH key-only hardening`
+
+### [ubuntu] Apply pending package updates
+
+- Type: ubuntu, security
+- Priority: P1
+- Effort: M
+- Risk: medium
+- Acceptance criteria:
+  - Maintenance window is approved.
+  - Pre-checks and rollback notes are captured.
+  - Post-checks include Studio Brain health, Docker health, Mission Control health, and backup evidence.
+- Recommended owner: human
+- Suggested branch name: `codex/ops-package-update-window`
+- Suggested PR title: `[ops] Prepare Studio Brain package update window`

--- a/docs/ops/03-capacity-plan.md
+++ b/docs/ops/03-capacity-plan.md
@@ -1,0 +1,124 @@
+# Studio Brain Capacity Plan
+
+Snapshot time: 2026-05-06 00:16-00:20 UTC.
+
+## Current Observed Capacity Constraints
+
+- Root filesystem is healthy at 15% used: 124G of 914G.
+- Inodes are healthy at 2% used on `/`.
+- RAM is healthy at rest: 30Gi total, 25Gi available at collection.
+- Swap has light current use: 448Mi of 8Gi.
+- Docker uses about 12G on disk and reports 9.303GB in local volumes.
+- PostgreSQL database `monsoonfire_studio_os` is about 8.3GB.
+- The largest single growth area under `/home/wuff` is `/home/wuff/monsoonfire-portal` at 44G, followed by `/home/wuff/imports` at 23G.
+
+## Disk Growth Concerns
+
+| Path | Observed size | Concern |
+| --- | ---: | --- |
+| `/home/wuff/monsoonfire-portal` | 44G | repo artifacts, imports, build output, generated state, and dirty host checkout can grow invisibly |
+| `/home/wuff/imports` | 23G | mail/import pipelines need retention policy and growth trend |
+| `/var/lib/docker` | 12G | volumes/images currently manageable but should be trended |
+| `/home/wuff/.npm` | 4.2G | package cache cleanup candidate |
+| `/home/wuff/.cache` | 3.8G | cache cleanup candidate |
+| `/home/wuff/studio-brain-mission-control` | 2.8G | deployment/archive retention needs policy |
+
+Warning threshold: root filesystem above 70% or any growth area increasing by more than 10G/week.
+
+Critical threshold: root filesystem above 85%, `/boot` above 80%, or free space below 50G.
+
+## Database Growth Concerns
+
+- Database size: 8.3GB.
+- Largest relations:
+  - `public.swarm_memory`: 3.1GB.
+  - `public.memory_relation_edge`: 2.3GB.
+  - `public.memory_pattern_index`: 1.3GB.
+  - `public.memory_entity_index`: 1.0GB.
+  - `public.memory_ingest_event`: 287MB.
+- Largest indexes are memory retrieval/search indexes, several over 240MB and up to 591MB.
+- Dead tuple percentages are mostly low on large tables, but small operational tables show high dead percentages and should not be over-interpreted without row counts.
+
+Warning threshold: database grows above 20GB, any single table grows above 8GB, or dead tuples exceed 20% on a table larger than 1GB.
+
+Critical threshold: database grows above 50GB without a tested restore process.
+
+## Docker Image And Volume Growth
+
+- Images: 4.397GB.
+- Containers: 4.112MB writable layer total.
+- Volumes: 9.303GB.
+- Build cache: 300.3MB reclaimable.
+- No dangling images or exited containers were observed.
+- Docker reports 8 local volumes but only 5 active, so anonymous volume ownership should be classified before cleanup.
+
+Warning threshold: Docker root above 30G or more than 5 inactive volumes.
+
+Critical threshold: Docker root above 80G or unknown inactive volumes containing data-bearing services.
+
+## Log Growth
+
+- `/var/log`: 84M.
+- systemd journal: 48M.
+- `/tmp`: 28M.
+- Current log pressure is low.
+
+Warning threshold: `/var/log` above 2G, journal above 1G, or any single Docker json log above 512M.
+
+Critical threshold: logs consume more than 10% of root filesystem.
+
+## CPU And Memory Pressure
+
+- CPU load was low relative to typical desktop/server capacity.
+- RAM was healthy during observation, but unattended upgrades triggered an OOM kill on 2026-05-05.
+- `studio-brain-mission-control.service` was using about 980M and `studio-brain.service` about 286M.
+- Docker resource limits exist in tracked Compose for core dependencies, but user-scoped app services are not capped at the systemd level in this pass.
+
+Warning threshold: sustained load above CPU count for 15 minutes, swap above 25%, or Mission Control above 1.5GB.
+
+Critical threshold: OOM event, swap above 75%, or repeated service restarts.
+
+## Backup Storage Needs
+
+- Root-owned config archives under `/var/backups/studio-brain/daily` are tiny and current through 2026-05-05.
+- App-level backup evidence under `output/backups/latest.json` points to 2026-04-28.
+- PostgreSQL is 8.3GB; full database backups and restore drills need explicit storage and retention modeling.
+- MinIO and Redis backup posture should be proven in the same manifest as PostgreSQL.
+
+Minimum recommendation:
+
+- Keep at least 7 daily and 4 weekly restore-tested database backups.
+- Store backup manifests outside the live repo checkout.
+- Keep one restore drill artifact per month.
+
+## 30/60/90 Day Watch Items
+
+30 days:
+
+- Fix backup evidence split and prove a current PostgreSQL restore drill.
+- Triage apt OOM and pending updates.
+- Snapshot Postgres relation sizes weekly.
+- Classify anonymous Docker volumes.
+
+60 days:
+
+- Trend `/home/wuff/imports`, repo artifacts, Docker volumes, and Postgres memory tables.
+- Pin floating Docker image tags or document update cadence.
+- Add healthchecks to containers that currently only report `Up`.
+
+90 days:
+
+- Decide whether Postgres should remain LAN-bound or move to loopback/firewalled access.
+- Establish restore time objective and restore point objective.
+- Set retention for Mission Control deployment artifacts, imports, and cache directories.
+
+## Metrics Missing Or Not Yet Collected
+
+- Historical disk growth by path.
+- Historical database table/index growth.
+- pg_stat_statements top queries by total time and mean time.
+- Backup restore duration and verified restore target size.
+- Docker per-volume ownership and growth.
+- App service memory trend over time.
+- Network listener change history.
+- Failed systemd unit history beyond current state.

--- a/docs/ops/04-postgres-dba-review.md
+++ b/docs/ops/04-postgres-dba-review.md
@@ -1,0 +1,119 @@
+# Studio Brain PostgreSQL DBA Review
+
+Snapshot time: 2026-05-06 00:18 UTC. Queries were read-only against `studiobrain_postgres`.
+
+## Version And Config Facts
+
+- PostgreSQL version: 16.13, Debian build, from `pgvector/pgvector:pg16`.
+- Database: `monsoonfire_studio_os`.
+- Extensions: `pg_stat_statements`, `pg_trgm`, `pgcrypto`, `plpgsql`, `vector`.
+- Key settings:
+  - `max_connections=100`
+  - `shared_buffers=131072 8kB` (about 1GB)
+  - `effective_cache_size=1048576 8kB` (about 8GB)
+  - `work_mem=8192 kB`
+  - `maintenance_work_mem=262144 kB`
+  - `max_wal_size=2048 MB`
+  - `checkpoint_timeout=300 s`
+  - `autovacuum=on`
+  - `track_io_timing=on`
+  - `shared_preload_libraries=pg_stat_statements`
+
+## Database Size Summary
+
+| Database | Size |
+| --- | ---: |
+| `monsoonfire_studio_os` | 8285 MB |
+| `template1` | 7425 kB |
+| `postgres` | 7361 kB |
+| `template0` | 7361 kB |
+
+## Largest Tables And Indexes
+
+Largest table families:
+
+| Relation | Total | Table | Indexes | Live tuples | Dead tuples |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `public.swarm_memory` | 3142 MB | 1235 MB | 946 MB | 180,229 | 6,149 |
+| `public.memory_relation_edge` | 2287 MB | 771 MB | 1515 MB | 2,566,505 | 7,441 |
+| `public.memory_pattern_index` | 1318 MB | 315 MB | 1002 MB | 1,995,185 | 34,824 |
+| `public.memory_entity_index` | 1035 MB | 272 MB | 763 MB | 1,762,855 | 7,930 |
+| `public.memory_ingest_event` | 287 MB | 226 MB | 61 MB | 498,977 | 0 |
+
+Largest indexes:
+
+- `public.idx_swarm_memory_contextualized_tsv`: 591 MB.
+- `public.memory_relation_edge_pkey`: 559 MB.
+- `public.idx_memory_relation_edge_target_relation`: 535 MB.
+- `public.idx_memory_relation_edge_target`: 421 MB.
+- `public.memory_pattern_index_pkey`: 310 MB.
+- `public.idx_memory_pattern_lookup`: 310 MB.
+
+## Bloat And Dead Tuple Concerns
+
+- Large tables have relatively low dead tuple ratios in this snapshot.
+- `public.swarm_memory` has about 3.30% dead tuples.
+- `public.memory_pattern_index` has about 1.72% dead tuples.
+- Smaller operational tables such as `mission_control.agents`, `public.brain_ops_cases`, and `public.memory_stats_rollup` show high dead percentages, but their absolute sizes are small.
+- No index bloat estimator was run in this first pass. Use the read-only scripts in `scripts/ops/` before considering `REINDEX`, `VACUUM FULL`, or schema changes.
+
+## Slow Query Visibility
+
+- `pg_stat_statements` is installed and preloaded, so slow-query review is possible.
+- This first pass did not query pg_stat_statements output because query text may include sensitive literals depending on application behavior. Add a redacted top-query report before making index recommendations.
+
+## Connection Count And Pooling Status
+
+- Activity state snapshot:
+  - `<null>`: 5 background processes.
+  - `idle`: 2.
+  - `active`: 1, the inspection query itself.
+- No evidence of connection saturation was observed.
+- No external connection pooler was discovered in Docker inventory.
+
+## Long-Running Transaction And Lock Risks
+
+- Active activity contained only the review query.
+- Lock snapshot showed only granted locks: one `virtualxid` exclusive lock and one relation access-share lock.
+- No waiting locks were observed.
+- No idle-in-transaction session was observed in the captured output.
+
+## Vacuum And Analyze Posture
+
+- Autovacuum is enabled.
+- Large memory tables show recent autoanalyze and some recent autovacuum activity.
+- Some manual `last_vacuum`/`last_analyze` timestamps are older or null, which is normal if autovacuum is handling the table.
+- Recommendation: collect weekly relation stats before changing autovacuum thresholds.
+
+## WAL And Checkpoint Observations
+
+- `pg_stat_wal` reported about 149.8GB cumulative `wal_bytes`.
+- `pg_stat_bgwriter` showed 17,399 timed checkpoints and 171 requested checkpoints.
+- This is a point-in-time cumulative counter, not a rate. Trend it before tuning WAL/checkpoints.
+
+## Backup And Restore Posture
+
+- Systemd backup archives are current but appear config-focused.
+- App backup metadata in `output/backups/latest.json` points to 2026-04-28.
+- A database restore drill should be treated as unproven until a current artifact explicitly shows PostgreSQL dump/restore verification.
+
+## Recommended SQL Inspection Queries
+
+The repo now includes:
+
+- `scripts/ops/postgres_readonly_review.sql`
+- `scripts/ops/postgres_size_report.sql`
+
+Recommended cadence:
+
+- Weekly: size report, dead tuples, active sessions, locks, and settings snapshot.
+- Monthly: pg_stat_statements redacted top-query report and restore drill.
+- Before schema/index PRs: capture `EXPLAIN (ANALYZE, BUFFERS)` only on approved queries and scrub literals from shared artifacts.
+
+## Safe Improvement Candidates
+
+- Add weekly read-only DBA snapshots.
+- Add a redacted pg_stat_statements report.
+- Add backup manifest fields that prove PostgreSQL dump and restore-prerequisite status.
+- Add a DB network-bind check to Compose validation.
+- Avoid schema/index changes until workload evidence exists.

--- a/docs/ops/05-docker-ops-review.md
+++ b/docs/ops/05-docker-ops-review.md
@@ -1,0 +1,138 @@
+# Studio Brain Docker Ops Review
+
+Snapshot time: 2026-05-06 00:17 UTC.
+
+## Compose Files Discovered
+
+Tracked:
+
+- `studio-brain/docker-compose.yml`
+- `studio-brain/docker-compose.proxy.yml`
+- `config/studiobrain/monitoring/docker-compose.yml`
+
+Live compose projects:
+
+- `studio-brain`: `/home/wuff/monsoonfire-portal/studio-brain/docker-compose.yml`
+- `monitoring`: `/home/wuff/monitoring/docker-compose.yml`
+- `searxng`: `/home/wuff/searxng/docker-compose.yml`
+
+## Container Roles
+
+| Container | Compose project | Role |
+| --- | --- | --- |
+| `studiobrain_postgres` | `studio-brain` | PostgreSQL 16 + pgvector |
+| `studiobrain_redis` | `studio-brain` | Redis dependency |
+| `studiobrain_minio` | `studio-brain` | Artifact/object storage |
+| `studiobrain_otel_collector` | `studio-brain` | Optional telemetry collector |
+| `netdata` | `monitoring` | Host/container metrics |
+| `uptime-kuma` | `monitoring` | Synthetic monitoring |
+| `monitoring-proxy` | `monitoring` | Caddy access bridge |
+| `searxng-searxng-1` | `searxng` | Search service |
+| `searxng-redis-1` | `searxng` | SearXNG Redis |
+
+## Healthcheck Coverage
+
+Covered:
+
+- `studiobrain_postgres`
+- `studiobrain_redis`
+- `studiobrain_minio`
+- `netdata`
+- `uptime-kuma`
+
+Missing:
+
+- `studiobrain_otel_collector`
+- `monitoring-proxy`
+- `searxng-searxng-1`
+- `searxng-redis-1`
+
+## Restart Policy Coverage
+
+All observed containers use `restart=unless-stopped`.
+
+## Resource Limit Coverage
+
+Tracked `studio-brain/docker-compose.yml` includes `deploy.resources` for Postgres, Redis, MinIO, and otel collector. Tracked monitoring Compose uses `cpus`, `mem_limit`, and `mem_reservation` for Netdata, Uptime Kuma, and monitoring proxy.
+
+Note: Compose `deploy.resources` is not enforced by plain Docker Compose in all modes. For local Docker Compose, prefer `cpus` and `mem_limit` if hard limits are needed, but only after evidence supports caps.
+
+## Volume Inventory
+
+Named data volumes:
+
+- `studio-brain_postgres_data`
+- `studio-brain_minio_data`
+
+Anonymous/local volumes:
+
+- Six hash-named local volumes were observed.
+- Docker reports 8 total local volumes and 5 active volumes.
+
+Do not delete anonymous volumes until they are mapped to containers or backed up.
+
+## Network Inventory
+
+Docker networks:
+
+- `studio-brain_default`
+- `monitoring_default`
+- `searxng_default`
+- default `bridge`, `host`, and `none`
+
+Monitoring Compose attaches Uptime Kuma to `studio-brain_default` and `searxng_default`.
+
+## Image Sprawl And Dangling Artifact Concerns
+
+- Images: 9 total, 4.397GB.
+- Dangling images: none observed.
+- Build cache: 300.3MB reclaimable.
+- No exited containers observed.
+- Several images use floating tags: `latest`, `stable`, or major-only tags.
+
+## Orphan/Zombie Container Risks
+
+- No exited containers were observed.
+- No restart loops were visible in `docker ps`.
+- Containers without healthchecks can still be zombie-like if their internal service is dead while the process remains up.
+
+## Safe Cleanup Checklist
+
+Safe to automate:
+
+- Report `docker system df`.
+- Report exited containers.
+- Report dangling images.
+- Report build cache size.
+- Report container health/restart/log policy.
+
+Safe with backup:
+
+- Remove known build cache after confirming no active builds need it.
+- Remove anonymous volumes only after they are mapped and proven non-data-bearing.
+
+Requires service window:
+
+- Change port binds.
+- Change image tags.
+- Add hard resource caps.
+- Restart or recreate containers.
+
+Requires human approval:
+
+- `docker system prune`.
+- `docker volume rm`.
+- Deleting or recreating Postgres/MinIO volumes.
+- Pulling new production images.
+
+Do not touch:
+
+- `studio-brain_postgres_data` and `studio-brain_minio_data` without a verified backup and explicit approval.
+
+## Unsafe Cleanup Actions Requiring Approval
+
+- `docker system prune --volumes`
+- `docker compose down -v`
+- Removing any hash-named volume before ownership classification
+- Restarting `studiobrain_postgres`
+- Rebinding exposed ports

--- a/docs/ops/06-runbooks.md
+++ b/docs/ops/06-runbooks.md
@@ -1,0 +1,144 @@
+# Studio Brain Operations Runbooks
+
+These runbooks are written for cautious operation. Prefer read-only diagnostics first. Do not restart services, prune Docker resources, rotate secrets, modify firewall/SSH, or run package upgrades without explicit approval.
+
+## Restart App Safely
+
+1. Capture current state:
+   - `npm run studio:ops:status`
+   - `curl -fsS http://192.168.1.226:8787/healthz`
+   - `curl -fsS http://192.168.1.226:8787/readyz`
+2. Check current user service:
+   - `XDG_RUNTIME_DIR=/run/user/1000 systemctl --user status studio-brain.service`
+3. Confirm there is an approved service window.
+4. Restart:
+   - `XDG_RUNTIME_DIR=/run/user/1000 systemctl --user restart studio-brain.service`
+5. Verify:
+   - `/healthz`, `/readyz`, and `/health/dependencies`
+   - `/api/status` scheduler and latest job status
+6. Rollback:
+   - If restart fails after a deploy, redeploy the last known-good artifact or restore the previous service command from systemd history.
+
+## Restart Docker Stack Safely
+
+1. Capture inventory:
+   - `docker compose -f studio-brain/docker-compose.yml ps`
+   - `docker system df`
+   - `docker volume ls`
+2. Confirm backup evidence for Postgres and MinIO.
+3. Restart only the affected service when possible:
+   - `docker compose -f studio-brain/docker-compose.yml restart <service>`
+4. Avoid `down -v`.
+5. Verify container health and app dependencies.
+6. Rollback:
+   - Restore prior Compose file and restart the affected service.
+
+## PostgreSQL Backup
+
+1. Confirm live database and size:
+   - `docker exec -u postgres studiobrain_postgres psql -d monsoonfire_studio_os -c "select pg_size_pretty(pg_database_size(current_database()));"`
+2. Use the tracked backup tooling when available:
+   - `npm run backup:verify`
+3. For a manual approved dump, write outside the repo and restrict permissions:
+   - `install -d -m 700 /var/backups/studio-brain/postgres`
+   - `docker exec -u postgres studiobrain_postgres pg_dump -Fc monsoonfire_studio_os > /var/backups/studio-brain/postgres/<stamp>.dump`
+   - `chmod 600 /var/backups/studio-brain/postgres/<stamp>.dump`
+4. Record checksum and manifest.
+5. Never paste credentials or dump contents into chat or tickets.
+
+## PostgreSQL Restore Drill
+
+1. Use a disposable target database/container.
+2. Do not restore over production.
+3. Verify dump metadata:
+   - `pg_restore --list <dump>`
+4. Restore into disposable target.
+5. Run smoke queries:
+   - database size
+   - table count
+   - key relation row counts
+   - app migration table status
+6. Record restore duration and result.
+7. Rollback:
+   - Drop only the disposable target after approval.
+
+## Disk Pressure Emergency Response
+
+1. Identify pressure:
+   - `df -hT`
+   - `df -ih`
+   - `sudo du -xhd1 /home/wuff /var/lib/docker /var/log | sort -h`
+2. Safe first actions:
+   - rotate or compress known logs if logrotate is broken
+   - clear clearly temporary files under approved temp paths
+3. Approval-required actions:
+   - remove Docker volumes
+   - prune Docker system
+   - delete backups
+   - delete imports
+4. Verify app health after cleanup.
+
+## Container Unhealthy Response
+
+1. Inspect without restarting:
+   - `docker ps`
+   - `docker inspect <container> --format '{{json .State.Health}}'`
+   - `docker logs --tail 100 <container>`
+2. Check dependent app endpoint.
+3. Identify whether the issue is healthcheck-only or service-impacting.
+4. Restart only with approval when production impact is possible.
+5. Rollback:
+   - restore prior Compose/image if a recent deploy caused the issue.
+
+## High Memory / OOM Response
+
+1. Capture evidence:
+   - `free -h`
+   - `swapon --show`
+   - `journalctl -k --since "24 hours ago" | grep -Ei "oom|killed process"`
+   - `ps aux --sort=-rss | head`
+2. Identify the victim and trigger.
+3. For apt OOM, do not rerun unattended upgrades blindly; inspect apt logs first.
+4. Consider service-level memory trends before adding caps.
+5. Rollback:
+   - Remove experimental caps or scheduler changes if they cause service instability.
+
+## Slow App Response Triage
+
+1. Check app endpoints:
+   - `/healthz`
+   - `/readyz`
+   - `/health/dependencies`
+   - `/api/status`
+2. Check Postgres activity:
+   - `scripts/ops/postgres_readonly_review.sql`
+3. Check CPU/memory:
+   - `top`, `free -h`, service memory from `systemctl show`.
+4. Check Docker health.
+5. Escalate only after identifying whether the bottleneck is app, database, storage, or network.
+
+## Failed Migration Response
+
+1. Do not rerun migrations blindly.
+2. Capture:
+   - migration command
+   - error text
+   - current migration table
+   - DB backup evidence
+3. Determine if failure happened before or after a transaction boundary.
+4. Prepare rollback SQL only in a PR or approved incident note.
+5. Verify with tests and restore drill before production fix.
+
+## Rollback Procedure
+
+1. Stop making changes.
+2. Capture current evidence and error messages.
+3. Identify last known-good commit/artifact/service config.
+4. Restore the smallest affected surface:
+   - app service config
+   - Compose file
+   - image tag
+   - code artifact
+   - database migration
+5. Verify health, dependencies, and user-visible path.
+6. Write a handoff with what changed, what was restored, and what remains unknown.

--- a/docs/ops/07-maintenance-calendar.md
+++ b/docs/ops/07-maintenance-calendar.md
@@ -1,0 +1,94 @@
+# Studio Brain Maintenance Calendar
+
+Use this as an operating rhythm. Treat risky actions as approval-gated.
+
+## Daily Checks
+
+- `curl -fsS http://192.168.1.226:8787/healthz`
+- `curl -fsS http://192.168.1.226:8787/readyz`
+- `npm run studio:ops:status`
+- `systemctl --failed --no-pager`
+- Confirm `studio-brain-healthcheck.timer`, `studio-brain-disk-alert.timer`, and `studio-brain-reboot-watch.timer` are active.
+- Review backup freshness evidence.
+
+## Weekly Checks
+
+- Run `make ops-check` on the host or a comparable Ubuntu shell.
+- Run PostgreSQL size report:
+  - `make ops-postgres-review`
+- Review Docker:
+  - `docker ps`
+  - `docker system df`
+  - `docker volume ls`
+- Review failed units and apt state:
+  - `apt list --upgradable`
+  - `journalctl -u apt-daily-upgrade.service -n 100 --no-pager`
+- Review `/home/wuff/imports`, repo artifact growth, Docker growth, and `/var/log`.
+
+## Monthly Checks
+
+- Run a restore drill against a disposable target.
+- Review pg_stat_statements with redaction.
+- Review Docker image pins and available updates.
+- Review SSH/fail2ban status.
+- Review open ports and firewall posture.
+- Classify anonymous Docker volumes.
+- Review host checkout drift against source control.
+
+## Quarterly Checks
+
+- Validate backup retention against storage and restore objectives.
+- Test full app rollback from a known-good artifact.
+- Review OS release lifecycle for Ubuntu 25.10.
+- Review package sources, pinned packages, and deprecated packages.
+- Review access list for SSH, sudo, Docker group, and operational secrets.
+- Review capacity trend and update 30/60/90 day forecast.
+
+## Upgrade Windows
+
+Recommended cadence:
+
+- Security updates: weekly review, apply in an approved window.
+- Kernel/Docker/systemd updates: approved maintenance window with pre/post health checks.
+- PostgreSQL major upgrades: separate project with dump/restore drill and rollback host.
+- Docker image updates: one service group per PR or approved maintenance change.
+
+Pre-checks:
+
+- health/readiness/dependencies pass
+- backup evidence current
+- Docker and systemd inventory captured
+- rollback artifact identified
+
+Post-checks:
+
+- health/readiness/dependencies pass
+- Mission Control reachable
+- key scheduled timers active
+- failed-unit list reviewed
+- backup evidence still valid
+
+## Backup Restore Drill Schedule
+
+- Monthly: restore-prerequisite drill.
+- Quarterly: full PostgreSQL restore into disposable target.
+- After schema migrations: targeted restore/check drill.
+- After backup tooling changes: immediate restore drill.
+
+## Log Retention Review
+
+- Weekly: `journalctl --disk-usage`, `/var/log`, Docker json log sizes.
+- Monthly: confirm logrotate status and Docker log driver limits.
+- Emergency threshold: logs above 10% of root filesystem.
+
+## Dependency Review
+
+- Weekly: `apt list --upgradable`.
+- Monthly: Docker image updates and Node/npm package posture.
+- Quarterly: base OS release lifecycle, Docker Engine support, PostgreSQL minor updates.
+
+## Database Maintenance Review
+
+- Weekly: table/index size, dead tuples, active sessions, locks.
+- Monthly: pg_stat_statements and slow-query candidates.
+- Quarterly: backup restore duration, autovacuum posture, index usage, and bloat estimates.

--- a/scripts/ops/dependency_inventory.sh
+++ b/scripts/ops/dependency_inventory.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -u
+
+# Read-only dependency inventory for Studio Brain operations.
+
+section() {
+  printf '\n## %s\n' "$1"
+}
+
+version_of() {
+  name="$1"
+  shift
+  if command -v "${name}" >/dev/null 2>&1; then
+    printf '%s: ' "${name}"
+    "$@" 2>&1 | head -n 1
+  else
+    printf '%s: not installed\n' "${name}"
+  fi
+}
+
+section "Command Versions"
+version_of git git --version
+version_of node node --version
+version_of npm npm --version
+version_of python3 python3 --version
+version_of docker docker --version
+version_of psql psql --version
+version_of tmux tmux -V
+version_of mosh mosh --version
+version_of ansible ansible --version
+version_of curl curl --version
+version_of systemctl systemctl --version
+
+section "Repo Scripts"
+if [ -f package.json ] && command -v node >/dev/null 2>&1; then
+  node - <<'NODE'
+const fs = require("fs");
+const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
+for (const name of Object.keys(pkg.scripts || {}).sort()) {
+  if (/studio|ops|docker|backup|wiki|memory|doctor|status|deploy/i.test(name)) {
+    console.log(`${name}: ${pkg.scripts[name]}`);
+  }
+}
+NODE
+else
+  echo "package.json or node unavailable"
+fi
+
+section "Studio Brain Package Scripts"
+if [ -f studio-brain/package.json ] && command -v node >/dev/null 2>&1; then
+  node - <<'NODE'
+const fs = require("fs");
+const pkg = JSON.parse(fs.readFileSync("studio-brain/package.json", "utf8"));
+for (const [name, command] of Object.entries(pkg.scripts || {})) {
+  console.log(`${name}: ${command}`);
+}
+NODE
+else
+  echo "studio-brain/package.json or node unavailable"
+fi

--- a/scripts/ops/disk_pressure.sh
+++ b/scripts/ops/disk_pressure.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -u
+
+# Read-only disk pressure snapshot. Uses sudo only when passwordless sudo is already available.
+
+section() {
+  printf '\n## %s\n' "$1"
+}
+
+run_shell() {
+  printf '\n$ %s\n' "$1"
+  bash -lc "$1" 2>&1 || printf 'WARN: command failed: %s\n' "$1"
+}
+
+section "Filesystems"
+run_shell "df -hT"
+run_shell "df -ih"
+
+section "Top-Level Pressure"
+run_shell "(sudo -n du -sh /home /home/* /var/lib/docker /var/backups /var/log /tmp 2>/dev/null || du -sh /home /home/* /var/log /tmp 2>/dev/null || true) | sort -h"
+
+section "Home Directory Detail"
+run_shell "(sudo -n du -xhd1 /home 2>/dev/null || du -xhd1 /home 2>/dev/null || true) | sort -h | tail -n 40"
+
+section "Docker Directory Detail"
+run_shell "sudo -n du -xhd1 /var/lib/docker 2>/dev/null | sort -h | tail -n 40 || echo 'docker directory requires sudo or is unavailable'"

--- a/scripts/ops/docker_inventory.sh
+++ b/scripts/ops/docker_inventory.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -u
+
+# Read-only Docker inventory. Intentionally avoids printing container env vars.
+
+section() {
+  printf '\n## %s\n' "$1"
+}
+
+run_shell() {
+  printf '\n$ %s\n' "$1"
+  bash -lc "$1" 2>&1 || printf 'WARN: command failed: %s\n' "$1"
+}
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "docker not available"
+  exit 0
+fi
+
+section "Docker Version"
+run_shell "docker version --format json 2>/dev/null || docker version"
+run_shell "docker compose version 2>/dev/null || true"
+
+section "Compose Projects"
+run_shell "docker compose ls 2>/dev/null || true"
+
+section "Running Containers"
+run_shell "docker ps --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}\t{{.Image}}'"
+
+section "All Containers"
+run_shell "docker ps -a --format 'table {{.Names}}\t{{.Status}}\t{{.Image}}'"
+
+section "Container Policies"
+ids="$(docker ps -aq 2>/dev/null || true)"
+if [ -n "${ids}" ]; then
+  docker inspect -f '{{.Name}} restart={{.HostConfig.RestartPolicy.Name}} health={{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}} log={{.HostConfig.LogConfig.Type}} user={{.Config.User}} mounts={{len .Mounts}}' ${ids} 2>&1 || true
+else
+  echo "no containers"
+fi
+
+section "Docker Space"
+run_shell "docker system df"
+
+section "Dangling Images"
+run_shell "docker images -f dangling=true --format 'table {{.Repository}}\t{{.Tag}}\t{{.ID}}\t{{.Size}}'"
+
+section "Exited Containers"
+run_shell "docker ps -a -f status=exited --format 'table {{.Names}}\t{{.Status}}\t{{.Image}}'"
+
+section "Volumes"
+run_shell "docker volume ls"
+
+section "Networks"
+run_shell "docker network ls"

--- a/scripts/ops/generate_ops_report.sh
+++ b/scripts/ops/generate_ops_report.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -u
+
+# Generate a local read-only ops evidence bundle.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+OUT_DIR="${1:-${REPO_ROOT}/output/ops/${STAMP}}"
+PG_CONTAINER="${PG_CONTAINER:-studiobrain_postgres}"
+PGDATABASE="${PGDATABASE:-monsoonfire_studio_os}"
+
+mkdir -p "${OUT_DIR}"
+
+run_to_file() {
+  label="$1"
+  shift
+  printf 'writing %s\n' "${OUT_DIR}/${label}.txt"
+  {
+    printf '# %s\n' "${label}"
+    printf '# generated_at=%s\n\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    "$@"
+  } >"${OUT_DIR}/${label}.txt" 2>&1
+}
+
+run_to_file system_inventory bash "${SCRIPT_DIR}/system_inventory.sh"
+run_to_file docker_inventory bash "${SCRIPT_DIR}/docker_inventory.sh"
+run_to_file disk_pressure bash "${SCRIPT_DIR}/disk_pressure.sh"
+run_to_file log_pressure bash "${SCRIPT_DIR}/log_pressure.sh"
+run_to_file dependency_inventory bash "${SCRIPT_DIR}/dependency_inventory.sh"
+
+if command -v docker >/dev/null 2>&1 && docker ps --format '{{.Names}}' | grep -qx "${PG_CONTAINER}"; then
+  run_to_file postgres_readonly_review docker exec -i -u postgres "${PG_CONTAINER}" psql -d "${PGDATABASE}" -X -v ON_ERROR_STOP=1 -f - <"${SCRIPT_DIR}/postgres_readonly_review.sql"
+else
+  {
+    echo "PostgreSQL docker container ${PG_CONTAINER} was not available."
+    echo "Run manually with: psql -X -v ON_ERROR_STOP=1 -f scripts/ops/postgres_readonly_review.sql"
+  } >"${OUT_DIR}/postgres_readonly_review.txt"
+fi
+
+cat >"${OUT_DIR}/README.md" <<EOF
+# Studio Brain Ops Evidence Bundle
+
+Generated at: $(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+This bundle is read-only and should not contain secrets. Review before sharing outside the ops team.
+EOF
+
+printf 'ops report written to %s\n' "${OUT_DIR}"

--- a/scripts/ops/log_pressure.sh
+++ b/scripts/ops/log_pressure.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -u
+
+# Read-only log pressure snapshot. Does not print log contents.
+
+section() {
+  printf '\n## %s\n' "$1"
+}
+
+run_shell() {
+  printf '\n$ %s\n' "$1"
+  bash -lc "$1" 2>&1 || printf 'WARN: command failed: %s\n' "$1"
+}
+
+section "Systemd Journal Size"
+run_shell "journalctl --disk-usage 2>/dev/null || true"
+
+section "Log Directory Sizes"
+run_shell "(sudo -n du -sh /var/log /var/log/* 2>/dev/null || du -sh /var/log /var/log/* 2>/dev/null || true) | sort -h | tail -n 60"
+
+section "Docker Json Log Sizes"
+run_shell "sudo -n find /var/lib/docker/containers -name '*-json.log' -printf '%s %p\n' 2>/dev/null | sort -n | tail -n 40 || echo 'docker log paths require sudo or are unavailable'"
+
+section "Recent OOM Markers"
+run_shell "journalctl -k --since '14 days ago' --no-pager 2>/dev/null | grep -Ei 'out of memory|oom-kill|killed process' || true"

--- a/scripts/ops/postgres_readonly_review.sql
+++ b/scripts/ops/postgres_readonly_review.sql
@@ -1,0 +1,113 @@
+\pset pager off
+\timing on
+
+\echo query:version
+select current_database() as db, current_user as current_user, version();
+
+\echo query:settings
+select name, setting, coalesce(unit, '') as unit, source
+from pg_settings
+where name in (
+  'max_connections',
+  'shared_buffers',
+  'work_mem',
+  'maintenance_work_mem',
+  'effective_cache_size',
+  'wal_level',
+  'max_wal_size',
+  'min_wal_size',
+  'checkpoint_timeout',
+  'autovacuum',
+  'track_io_timing',
+  'shared_preload_libraries'
+)
+order by name;
+
+\echo query:database_sizes
+select datname,
+       pg_size_pretty(pg_database_size(datname)) as size,
+       pg_database_size(datname) as bytes
+from pg_database
+order by bytes desc;
+
+\echo query:extensions
+select extname, extversion
+from pg_extension
+order by extname;
+
+\echo query:activity_state
+select coalesce(state, '<null>') as state, count(*)
+from pg_stat_activity
+group by 1
+order by 2 desc;
+
+\echo query:active_activity
+select pid,
+       usename,
+       state,
+       now() - query_start as query_age,
+       now() - xact_start as xact_age,
+       wait_event_type,
+       wait_event,
+       left(regexp_replace(query, E'[\n\r\t]+', ' ', 'g'), 160) as query
+from pg_stat_activity
+where state <> 'idle'
+order by query_start nulls last
+limit 15;
+
+\echo query:largest_tables
+select schemaname || '.' || relname as relation,
+       pg_size_pretty(pg_total_relation_size(relid)) as total_size,
+       pg_size_pretty(pg_relation_size(relid)) as table_size,
+       pg_size_pretty(pg_indexes_size(relid)) as index_size,
+       n_live_tup,
+       n_dead_tup,
+       last_autovacuum,
+       last_autoanalyze
+from pg_stat_user_tables
+order by pg_total_relation_size(relid) desc
+limit 20;
+
+\echo query:largest_indexes
+select schemaname || '.' || indexrelname as index_name,
+       pg_size_pretty(pg_relation_size(indexrelid)) as index_size,
+       idx_scan,
+       idx_tup_read,
+       idx_tup_fetch
+from pg_stat_user_indexes
+order by pg_relation_size(indexrelid) desc
+limit 20;
+
+\echo query:dead_tuples
+select schemaname || '.' || relname as relation,
+       n_live_tup,
+       n_dead_tup,
+       round(100.0 * n_dead_tup / greatest(n_live_tup + n_dead_tup, 1), 2) as dead_pct,
+       last_vacuum,
+       last_autovacuum,
+       last_analyze,
+       last_autoanalyze
+from pg_stat_user_tables
+order by n_dead_tup desc
+limit 20;
+
+\echo query:locks
+select locktype, mode, granted, count(*)
+from pg_locks
+group by 1, 2, 3
+order by granted, count(*) desc;
+
+\echo query:wal
+select wal_records, wal_fpi, wal_bytes, wal_buffers_full, wal_write, wal_sync
+from pg_stat_wal;
+
+\echo query:bgwriter
+select checkpoints_timed,
+       checkpoints_req,
+       checkpoint_write_time,
+       checkpoint_sync_time,
+       buffers_checkpoint,
+       buffers_clean,
+       maxwritten_clean,
+       buffers_backend
+from pg_stat_bgwriter;

--- a/scripts/ops/postgres_size_report.sql
+++ b/scripts/ops/postgres_size_report.sql
@@ -1,0 +1,30 @@
+\pset pager off
+
+\echo query:database_sizes
+select datname,
+       pg_size_pretty(pg_database_size(datname)) as size,
+       pg_database_size(datname) as bytes
+from pg_database
+order by bytes desc;
+
+\echo query:schema_sizes
+select nspname as schema,
+       pg_size_pretty(sum(pg_total_relation_size(c.oid))) as total_size,
+       sum(pg_total_relation_size(c.oid)) as bytes
+from pg_class c
+join pg_namespace n on n.oid = c.relnamespace
+where c.relkind in ('r', 'p', 'm')
+  and n.nspname not in ('pg_catalog', 'information_schema')
+group by nspname
+order by bytes desc;
+
+\echo query:relation_sizes
+select schemaname || '.' || relname as relation,
+       pg_size_pretty(pg_total_relation_size(relid)) as total_size,
+       pg_size_pretty(pg_relation_size(relid)) as table_size,
+       pg_size_pretty(pg_indexes_size(relid)) as index_size,
+       n_live_tup,
+       n_dead_tup
+from pg_stat_user_tables
+order by pg_total_relation_size(relid) desc
+limit 50;

--- a/scripts/ops/system_inventory.sh
+++ b/scripts/ops/system_inventory.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -u
+
+# Read-only Studio Brain host inventory. Does not print process environments.
+
+section() {
+  printf '\n## %s\n' "$1"
+}
+
+run() {
+  printf '\n$ %s\n' "$*"
+  "$@" 2>&1 || printf 'WARN: command failed: %s\n' "$*"
+}
+
+run_shell() {
+  printf '\n$ %s\n' "$1"
+  bash -lc "$1" 2>&1 || printf 'WARN: command failed: %s\n' "$1"
+}
+
+section "Identity"
+run hostname
+run date -Is
+run whoami
+run id
+
+section "OS"
+run_shell "grep -E '^(PRETTY_NAME|VERSION_ID|ID)=' /etc/os-release || true"
+run uname -a
+
+section "Resources"
+run uptime
+run free -h
+run swapon --show
+
+section "Filesystems"
+run df -hT
+run df -ih
+
+section "Package State"
+run_shell "test -f /var/run/reboot-required && { echo reboot_required=yes; cat /var/run/reboot-required.pkgs 2>/dev/null || true; } || echo reboot_required=no"
+run_shell "apt list --upgradable 2>/dev/null | sed -n '1,80p'"
+
+section "Systemd Failed Units"
+if command -v systemctl >/dev/null 2>&1; then
+  run systemctl --failed --no-pager
+else
+  echo "systemctl not available"
+fi
+
+section "Studio Brain Units And Timers"
+if command -v systemctl >/dev/null 2>&1; then
+  run_shell "systemctl list-units --type=service --type=timer --all --no-pager | grep -Ei 'studio|brain|postgres|docker|redis|minio|mission|backup|health|disk|reboot|cron|ssh|caddy|nginx' || true"
+  run_shell "systemctl list-timers --all --no-pager | grep -Ei 'studio|brain|backup|health|disk|reboot|apt|logrotate' || true"
+else
+  echo "systemctl not available"
+fi
+
+section "Open Listening Ports"
+run_shell "(sudo -n ss -tulpen 2>/dev/null || ss -tulpen) | sed -n '1,160p'"
+
+section "Docker Summary"
+if command -v docker >/dev/null 2>&1; then
+  run docker version
+  run docker compose version
+  run docker ps
+  run docker system df
+else
+  echo "docker not available"
+fi


### PR DESCRIPTION
## Summary
- Adds the first Studio Brain ops-doctor documentation pass under `docs/ops/`.
- Adds read-only Ubuntu, Docker, disk/log, dependency, and PostgreSQL review scripts under `scripts/ops/`.
- Adds root `make ops-*` targets as a thin operator interface for future host-side checks.

## Evidence
- Live host inventory was collected read-only from `studiobrain` / `192.168.1.226`.
- PostgreSQL read-only review was verified against `studiobrain_postgres` on PostgreSQL 16.13.
- Findings are documented separately from approval-gated fixes.

## Files Changed
- `docs/ops/00-system-inventory.md` through `docs/ops/07-maintenance-calendar.md`
- `scripts/ops/*.sh`
- `scripts/ops/postgres_readonly_review.sql`
- `scripts/ops/postgres_size_report.sql`
- `Makefile`

## Testing Performed
- `bash -n scripts/ops/*.sh`
- `git diff --check`
- Piped `scripts/ops/postgres_readonly_review.sql` through the live PostgreSQL container with `ON_ERROR_STOP=1`

## Risk Level
Low. This PR only adds documentation, read-only diagnostic scripts, SQL inspection queries, and Make targets. It does not restart services, prune Docker resources, modify firewall/SSH, change database schema, or alter production configuration.

## Rollback
Revert this PR. No runtime state or production data is changed by the repository additions.

## Follow-Up Tickets
- Unify backup evidence and restore confidence.
- Triage apt OOM and failed units.
- Review DB/SSH network exposure.
- Inventory live host checkout drift.
- Source-control live idle-worker timers after review.
