### PR TITLE
[ops] Add Studio Brain backup evidence report

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,9 @@ SHELL := /bin/bash
 PG_CONTAINER ?= studiobrain_postgres
 PGDATABASE ?= monsoonfire_studio_os
 
-.PHONY: ops-check ops-inventory ops-postgres-review ops-docker-review ops-capacity ops-backlog ops-report
+.PHONY: ops-check ops-inventory ops-postgres-review ops-docker-review ops-capacity ops-backup-evidence ops-backlog ops-report
 
-ops-check: ops-inventory ops-docker-review ops-capacity
+ops-check: ops-inventory ops-docker-review ops-capacity ops-backup-evidence
 
 ops-inventory:
 	bash scripts/ops/system_inventory.sh
@@ -25,6 +25,9 @@ ops-docker-review:
 ops-capacity:
 	bash scripts/ops/disk_pressure.sh
 	bash scripts/ops/log_pressure.sh
+
+ops-backup-evidence:
+	bash scripts/ops/backup_evidence.sh
 
 ops-backlog:
 	@sed -n '1,260p' docs/ops/02-kanban-backlog.md

--- a/docs/ops/06-runbooks.md
+++ b/docs/ops/06-runbooks.md
@@ -37,29 +37,36 @@ These runbooks are written for cautious operation. Prefer read-only diagnostics 
 
 1. Confirm live database and size:
    - `docker exec -u postgres studiobrain_postgres psql -d monsoonfire_studio_os -c "select pg_size_pretty(pg_database_size(current_database()));"`
-2. Use the tracked backup tooling when available:
+2. Capture unified evidence before changing anything:
+   - `make ops-backup-evidence`
+   - or `bash scripts/ops/backup_evidence.sh`
+3. Use the tracked backup tooling when available:
    - `npm run backup:verify`
-3. For a manual approved dump, write outside the repo and restrict permissions:
+4. For a manual approved dump, write outside the repo and restrict permissions:
    - `install -d -m 700 /var/backups/studio-brain/postgres`
    - `docker exec -u postgres studiobrain_postgres pg_dump -Fc monsoonfire_studio_os > /var/backups/studio-brain/postgres/<stamp>.dump`
    - `chmod 600 /var/backups/studio-brain/postgres/<stamp>.dump`
-4. Record checksum and manifest.
-5. Never paste credentials or dump contents into chat or tickets.
+5. Record checksum and manifest.
+6. Rerun `make ops-backup-evidence` and confirm the report separates config archives, PostgreSQL dump evidence, Redis evidence, MinIO evidence, freshness, and restore-drill status.
+7. Never paste credentials or dump contents into chat or tickets.
 
 ## PostgreSQL Restore Drill
 
-1. Use a disposable target database/container.
-2. Do not restore over production.
-3. Verify dump metadata:
+1. Capture restore-prerequisite evidence:
+   - `make ops-backup-evidence`
+2. Use a disposable target database/container.
+3. Do not restore over production.
+4. Verify dump metadata:
    - `pg_restore --list <dump>`
-4. Restore into disposable target.
-5. Run smoke queries:
+5. Restore into disposable target.
+6. Run smoke queries:
    - database size
    - table count
    - key relation row counts
    - app migration table status
-6. Record restore duration and result.
-7. Rollback:
+7. Record restore duration and result.
+8. Rerun `make ops-backup-evidence` so the latest restore-drill summary is visible in the unified report.
+9. Rollback:
    - Drop only the disposable target after approval.
 
 ## Disk Pressure Emergency Response

--- a/docs/ops/07-maintenance-calendar.md
+++ b/docs/ops/07-maintenance-calendar.md
@@ -14,6 +14,7 @@ Use this as an operating rhythm. Treat risky actions as approval-gated.
 ## Weekly Checks
 
 - Run `make ops-check` on the host or a comparable Ubuntu shell.
+- Attach `make ops-backup-evidence` output to any backup/restore-confidence ticket before changing backup paths.
 - Run PostgreSQL size report:
   - `make ops-postgres-review`
 - Review Docker:

--- a/scripts/ops/backup_evidence.sh
+++ b/scripts/ops/backup_evidence.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+set -u
+
+# Read-only Studio Brain backup evidence report.
+# Prints metadata only: paths, timestamps, sizes, service readiness, and restore-drill evidence.
+# It does not run backups, restore data, print environment variables, or read secret files.
+
+SOURCE_PATH="${BASH_SOURCE[0]:-${0}}"
+SCRIPT_DIR="$(cd "$(dirname "${SOURCE_PATH}")" && pwd)"
+DEFAULT_REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+REPO_ROOT="${REPO_ROOT:-${DEFAULT_REPO_ROOT}}"
+
+APP_BACKUP_ROOT="${APP_BACKUP_ROOT:-${REPO_ROOT}/output/backups}"
+SYSTEM_BACKUP_ROOT="${SYSTEM_BACKUP_ROOT:-/var/backups/studio-brain}"
+SYSTEM_DAILY_ROOT="${SYSTEM_DAILY_ROOT:-${SYSTEM_BACKUP_ROOT}/daily}"
+POSTGRES_BACKUP_ROOT="${POSTGRES_BACKUP_ROOT:-${SYSTEM_BACKUP_ROOT}/postgres}"
+HOST_BACKUP_ROOT="${HOST_BACKUP_ROOT:-/home/wuff/backups}"
+
+PG_CONTAINER="${PG_CONTAINER:-studiobrain_postgres}"
+REDIS_CONTAINER="${REDIS_CONTAINER:-studiobrain_redis}"
+MINIO_CONTAINER="${MINIO_CONTAINER:-studiobrain_minio}"
+PGDATABASE="${PGDATABASE:-monsoonfire_studio_os}"
+
+FRESHNESS_HOURS="${STUDIO_BRAIN_BACKUP_MAX_AGE_HOURS:-24}"
+
+section() {
+  printf '\n## %s\n' "$1"
+}
+
+warn() {
+  printf 'WARN: %s\n' "$1"
+}
+
+run_shell() {
+  printf '\n$ %s\n' "$1"
+  bash -lc "$1" 2>&1 || warn "command failed: $1"
+}
+
+json_summary() {
+  local latest_path="$1"
+  local freshness_hours="$2"
+
+  if ! command -v node >/dev/null 2>&1; then
+    warn "node is unavailable; cannot parse ${latest_path}"
+    return 0
+  fi
+
+  node - "${latest_path}" "${freshness_hours}" "${REPO_ROOT}" <<'NODE'
+const fs = require("fs");
+const path = require("path");
+
+const latestPath = process.argv[2];
+const freshnessHours = Number.parseInt(process.argv[3] || "24", 10);
+const repoRoot = process.argv[4] || process.cwd();
+const maxAgeMinutes = Number.isFinite(freshnessHours) && freshnessHours > 0 ? freshnessHours * 60 : 24 * 60;
+
+function readJson(file) {
+  try {
+    return JSON.parse(fs.readFileSync(file, "utf8"));
+  } catch (error) {
+    return null;
+  }
+}
+
+function ageMinutes(iso) {
+  const date = new Date(iso || "");
+  if (!Number.isFinite(date.getTime())) {
+    return null;
+  }
+  return Math.max(0, Math.round((Date.now() - date.getTime()) / 60000));
+}
+
+function print(key, value) {
+  console.log(`${key}: ${value === undefined || value === null || value === "" ? "<missing>" : value}`);
+}
+
+const latest = readJson(latestPath);
+if (!latest) {
+  console.log(`latest_status: missing_or_unreadable`);
+  process.exit(0);
+}
+
+print("latest_status", latest.status);
+print("latest_gate_status", latest.gateStatus);
+print("latest_generated_at", latest.generatedAt);
+print("latest_manifest_path", latest.manifestPath);
+print("latest_checksum_path", latest.checksumPath);
+
+const latestAge = ageMinutes(latest.generatedAt);
+print("latest_age_minutes", latestAge);
+print("latest_freshness", latestAge === null ? "unknown" : latestAge <= maxAgeMinutes ? "fresh" : "stale");
+
+const manifestPath = latest.manifestPath ? path.resolve(repoRoot, latest.manifestPath) : "";
+const manifest = manifestPath ? readJson(manifestPath) : null;
+if (!manifest) {
+  console.log("manifest_status: missing_or_unreadable");
+  process.exit(0);
+}
+
+print("manifest_status", manifest.status);
+print("manifest_generated_at", manifest.generatedAt);
+print("manifest_command", manifest.command);
+print("manifest_redaction_state", manifest.provenance?.redactionState || "");
+print("manifest_data_classification", manifest.provenance?.dataClassification || "");
+
+const checks = Array.isArray(manifest.serviceChecks) ? manifest.serviceChecks : [];
+for (const service of ["postgres", "redis", "minio"]) {
+  const check = checks.find((entry) => entry?.service === service);
+  print(`${service}_check_status`, check?.status || "missing");
+  print(`${service}_check_summary`, check?.summary || "No service check in manifest.");
+  const freshness = manifest.freshness?.services?.[service];
+  print(`${service}_freshness_status`, freshness?.status || "missing");
+  print(`${service}_freshness_message`, freshness?.message || "No freshness entry in manifest.");
+}
+NODE
+}
+
+list_latest_files() {
+  local label="$1"
+  local dir="$2"
+  local pattern="$3"
+  local limit="${4:-5}"
+
+  printf '\n### %s\n' "${label}"
+  printf 'directory: %s\n' "${dir}"
+  printf 'pattern: %s\n' "${pattern}"
+
+  if [ ! -d "${dir}" ]; then
+    printf 'status: missing_directory\n'
+    return 0
+  fi
+
+  local command="find \"${dir}\" -type f -name \"${pattern}\" -printf '%T@ %TY-%Tm-%TdT%TH:%TM:%TSZ %s %p\n' 2>/dev/null | sort -nr | head -n ${limit}"
+  local output
+  output="$(bash -lc "${command}" 2>/dev/null || true)"
+
+  if [ -z "${output}" ] && command -v sudo >/dev/null 2>&1; then
+    output="$(sudo -n bash -lc "${command}" 2>/dev/null || true)"
+  fi
+
+  if [ -z "${output}" ]; then
+    printf 'status: no_matching_files_or_permission_denied\n'
+    return 0
+  fi
+
+  printf 'status: found\n'
+  printf 'latest files:\n'
+  printf '%s\n' "${output}" | awk '{epoch=$1; time=$2; size=$3; $1=""; $2=""; $3=""; sub(/^   /, ""); printf "- %s bytes=%s path=%s\n", time, size, $0}'
+}
+
+container_summary() {
+  local label="$1"
+  local container="$2"
+
+  printf '\n### %s\n' "${label}"
+  printf 'container: %s\n' "${container}"
+
+  if ! command -v docker >/dev/null 2>&1; then
+    printf 'status: docker_unavailable\n'
+    return 0
+  fi
+
+  if ! docker ps -a --format '{{.Names}}' | grep -qx "${container}"; then
+    printf 'status: container_missing\n'
+    return 0
+  fi
+
+  docker inspect -f 'status={{.State.Status}} health={{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}} image={{.Config.Image}} mounts={{len .Mounts}}' "${container}" 2>&1 || true
+}
+
+section "Report Metadata"
+printf 'generated_at: %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+printf 'host: %s\n' "$(hostname 2>/dev/null || printf unknown)"
+printf 'repo_root: %s\n' "${REPO_ROOT}"
+printf 'freshness_threshold_hours: %s\n' "${FRESHNESS_HOURS}"
+printf 'redaction: metadata_only_no_env_or_secret_values\n'
+
+section "Unified Source Manifest"
+printf 'This report separates source systems. A passing readiness check is not the same as a tested data restore.\n'
+printf '\n| Source | Evidence class | What this script proves | What remains unproven |\n'
+printf '| --- | --- | --- | --- |\n'
+printf '| config archives | filesystem metadata | archive presence, age, size | restore content correctness |\n'
+printf '| PostgreSQL | manifest + service readiness + dump artifact search | container readiness, pg_dump/pg_restore tools, dump file presence if found | successful restore unless restore summary exists |\n'
+printf '| Redis | manifest + container metadata | container/manifest status | RDB/AOF backup completeness unless separate artifact exists |\n'
+printf '| MinIO | manifest + container metadata | container/manifest status | object backup completeness unless separate artifact exists |\n'
+printf '| restore drill | manifest search + tool checks | restore-prerequisite summary presence | full production restore over real data |\n'
+
+section "Application Backup Manifest"
+printf 'latest_path: %s\n' "${APP_BACKUP_ROOT}/latest.json"
+json_summary "${APP_BACKUP_ROOT}/latest.json" "${FRESHNESS_HOURS}"
+
+section "Config Archive Evidence"
+list_latest_files "system host config archives" "${SYSTEM_DAILY_ROOT}" "host-config-*.tgz" 5
+list_latest_files "studio-brain config archives" "${SYSTEM_DAILY_ROOT}" "studio-brain-config-*.tgz" 5
+list_latest_files "home backup files" "${HOST_BACKUP_ROOT}" "*" 5
+
+section "PostgreSQL Evidence"
+container_summary "postgres container" "${PG_CONTAINER}"
+if command -v docker >/dev/null 2>&1 && docker ps --format '{{.Names}}' | grep -qx "${PG_CONTAINER}"; then
+  run_shell "docker exec -u postgres ${PG_CONTAINER} pg_isready -d ${PGDATABASE}"
+  run_shell "docker exec -u postgres ${PG_CONTAINER} pg_dump --version"
+  run_shell "docker exec -u postgres ${PG_CONTAINER} pg_restore --version"
+else
+  printf 'postgres_tool_status: unavailable_without_running_container\n'
+fi
+list_latest_files "postgres dump artifacts" "${POSTGRES_BACKUP_ROOT}" "*.dump" 5
+list_latest_files "postgres sql archives" "${POSTGRES_BACKUP_ROOT}" "*.sql*" 5
+
+section "Redis Evidence"
+container_summary "redis container" "${REDIS_CONTAINER}"
+if command -v docker >/dev/null 2>&1 && docker ps --format '{{.Names}}' | grep -qx "${REDIS_CONTAINER}"; then
+  run_shell "docker exec ${REDIS_CONTAINER} sh -lc 'redis-cli ping 2>&1 || true'"
+else
+  printf 'redis_ping_status: unavailable_without_running_container\n'
+fi
+list_latest_files "redis backup artifacts" "${SYSTEM_BACKUP_ROOT}/redis" "*" 5
+
+section "MinIO Evidence"
+container_summary "minio container" "${MINIO_CONTAINER}"
+if command -v docker >/dev/null 2>&1 && docker ps --format '{{.Names}}' | grep -qx "${MINIO_CONTAINER}"; then
+  run_shell "docker exec ${MINIO_CONTAINER} sh -lc 'if command -v curl >/dev/null 2>&1; then curl -fsS http://127.0.0.1:9000/minio/health/live >/dev/null && echo minio_live=pass || echo minio_live=fail; elif command -v wget >/dev/null 2>&1; then wget -qO- http://127.0.0.1:9000/minio/health/live >/dev/null && echo minio_live=pass || echo minio_live=fail; else echo minio_live=skipped_no_curl_or_wget; fi'"
+else
+  printf 'minio_health_status: unavailable_without_running_container\n'
+fi
+list_latest_files "minio backup artifacts" "${SYSTEM_BACKUP_ROOT}/minio" "*" 5
+
+section "Restore Drill Evidence"
+list_latest_files "restore drill summaries" "${APP_BACKUP_ROOT}" "restore-drill-summary.json" 5
+printf '\nrestore_prerequisite_command: npm run backup:restore:drill\n'
+printf 'restore_prerequisite_note: run against a disposable target or advisory prerequisite mode; do not restore over production.\n'
+printf 'script_scope: read_only_metadata_report\n'
+
+section "Operator Reading Guide"
+printf -- '- Treat missing dump, Redis, or MinIO artifacts as restore-confidence gaps, even if containers are healthy.\n'
+printf -- '- Treat stale latest.json as a freshness gap until a new verified manifest exists.\n'
+printf -- '- Attach this output to ops tickets only after a quick human review for local path sensitivity.\n'

--- a/scripts/ops/generate_ops_report.sh
+++ b/scripts/ops/generate_ops_report.sh
@@ -28,6 +28,7 @@ run_to_file docker_inventory bash "${SCRIPT_DIR}/docker_inventory.sh"
 run_to_file disk_pressure bash "${SCRIPT_DIR}/disk_pressure.sh"
 run_to_file log_pressure bash "${SCRIPT_DIR}/log_pressure.sh"
 run_to_file dependency_inventory bash "${SCRIPT_DIR}/dependency_inventory.sh"
+run_to_file backup_evidence bash "${SCRIPT_DIR}/backup_evidence.sh"
 
 if command -v docker >/dev/null 2>&1 && docker ps --format '{{.Names}}' | grep -qx "${PG_CONTAINER}"; then
   run_to_file postgres_readonly_review docker exec -i -u postgres "${PG_CONTAINER}" psql -d "${PGDATABASE}" -X -v ON_ERROR_STOP=1 -f - <"${SCRIPT_DIR}/postgres_readonly_review.sql"


### PR DESCRIPTION
## Summary
- Adds `scripts/ops/backup_evidence.sh`, a read-only, redacted backup evidence report for Studio Brain.
- Adds `make ops-backup-evidence` and includes the backup report in `scripts/ops/generate_ops_report.sh`.
- Updates backup and restore runbooks to capture unified evidence before backup-path changes or restore drills.

## Evidence
- Issue #554 asks for one report that separates config archives, PostgreSQL dump evidence, Redis evidence, MinIO evidence, freshness, and restore-drill status.
- Live read-only run on `studiobrain` showed stale app backup metadata from 2026-04-28, healthy Postgres tools, missing `/var/backups/studio-brain/postgres`, missing Redis/MinIO backup artifact directories, and an old restore-drill summary from 2026-02-23.

## Files Changed
- `scripts/ops/backup_evidence.sh`
- `scripts/ops/generate_ops_report.sh`
- `Makefile`
- `docs/ops/06-runbooks.md`
- `docs/ops/07-maintenance-calendar.md`

## Testing Performed
- `bash -n scripts/ops/*.sh`
- `bash scripts/ops/backup_evidence.sh` on Windows/Git Bash degraded mode
- Piped `scripts/ops/backup_evidence.sh` read-only to `studiobrain` with `REPO_ROOT=/home/wuff/monsoonfire-portal`
- `bash scripts/ops/generate_ops_report.sh output/ops/test-backup-evidence-smoke`
- `git diff --check`

## Risk Level
Low. This adds docs and read-only reporting only. It does not run backups, restore data, delete backups, print env vars, restart services, or change production configuration.

## Rollback
Revert this PR. No runtime state or production data is changed.

## Follow-Up Tickets
- Refs #554. The report confirms the next approval-gated work is to create/prove current PostgreSQL, Redis, and MinIO backup artifacts and run a fresh restore drill.
