### PR TITLE
[ops] Document apt OOM and failed-unit workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,9 @@ SHELL := /bin/bash
 PG_CONTAINER ?= studiobrain_postgres
 PGDATABASE ?= monsoonfire_studio_os
 
-.PHONY: ops-check ops-inventory ops-postgres-review ops-docker-review ops-capacity ops-backup-evidence ops-backlog ops-report
+.PHONY: ops-check ops-inventory ops-postgres-review ops-docker-review ops-capacity ops-backup-evidence ops-ubuntu-review ops-backlog ops-report
 
-ops-check: ops-inventory ops-docker-review ops-capacity ops-backup-evidence
+ops-check: ops-inventory ops-docker-review ops-capacity ops-backup-evidence ops-ubuntu-review
 
 ops-inventory:
 	bash scripts/ops/system_inventory.sh
@@ -28,6 +28,9 @@ ops-capacity:
 
 ops-backup-evidence:
 	bash scripts/ops/backup_evidence.sh
+
+ops-ubuntu-review:
+	bash scripts/ops/ubuntu_failed_units.sh
 
 ops-backlog:
 	@sed -n '1,260p' docs/ops/02-kanban-backlog.md

--- a/docs/ops/06-runbooks.md
+++ b/docs/ops/06-runbooks.md
@@ -110,6 +110,24 @@ These runbooks are written for cautious operation. Prefer read-only diagnostics 
 5. Rollback:
    - Remove experimental caps or scheduler changes if they cause service instability.
 
+## Apt OOM And Failed Unit Triage
+
+1. Capture the read-only triage report:
+   - `make ops-ubuntu-review`
+   - or `bash scripts/ops/ubuntu_failed_units.sh`
+2. For `apt-daily-upgrade.service`, confirm whether the OOM happened during unattended upgrades and attach:
+   - kernel OOM lines
+   - apt/unattended-upgrades logs
+   - pending package list
+   - reboot-required state
+3. For each failed unit, write one disposition:
+   - repair
+   - disable intentionally with reason
+   - ignore as harmless with reason
+4. Do not reset failed units merely to make the dashboard green; keep the failure until the cause is understood or documented.
+5. Do not run upgrades, disable AIDE/livepatch, or change network-online behavior without approval.
+6. Use the maintenance-window checklist from `scripts/ops/ubuntu_failed_units.sh` before package changes.
+
 ## Slow App Response Triage
 
 1. Check app endpoints:

--- a/docs/ops/07-maintenance-calendar.md
+++ b/docs/ops/07-maintenance-calendar.md
@@ -22,6 +22,7 @@ Use this as an operating rhythm. Treat risky actions as approval-gated.
   - `docker system df`
   - `docker volume ls`
 - Review failed units and apt state:
+  - `make ops-ubuntu-review`
   - `apt list --upgradable`
   - `journalctl -u apt-daily-upgrade.service -n 100 --no-pager`
 - Review `/home/wuff/imports`, repo artifact growth, Docker growth, and `/var/log`.

--- a/docs/ops/08-ubuntu-failed-unit-triage.md
+++ b/docs/ops/08-ubuntu-failed-unit-triage.md
@@ -1,0 +1,143 @@
+# Studio Brain Ubuntu Failed Unit Triage
+
+Snapshot: 2026-05-06 00:57 UTC.
+
+This note is evidence and disposition only. It does not approve package upgrades, service disables, unit resets, reboots, firewall changes, or SSH changes.
+
+## Summary
+
+`make ops-ubuntu-review` captured four failed units:
+
+- `apt-daily-upgrade.service`
+- `dailyaidecheck.service`
+- `snap.canonical-livepatch.canonical-livepatchd.service`
+- `systemd-networkd-wait-online.service`
+
+Host memory was healthy at capture time: 30Gi total, 25Gi available, 447Mi swap used. The apt failure was a prior spike, not current steady pressure.
+
+## Apt Daily Upgrade OOM
+
+Evidence:
+
+- `apt-daily-upgrade.service` failed on 2026-05-05 06:56 UTC with `Result=oom-kill`.
+- systemd reported `Mem peak: 28.2G` and `swap: 7.4G`.
+- The same run logged `apt.systemd.daily[2580886]: Killed`.
+- `systemd-networkd-wait-online` timed out before the apt run.
+- Unattended upgrade logs repeatedly warn: `Could not figure out development release: Distribution data outdated`.
+- Pending packages include kernel, Docker, containerd, curl, systemd, snapd, Node.js, rsyslog, sed, and Ubuntu release upgrader packages.
+- `/var/run/reboot-required` was absent at capture time.
+
+Disposition:
+
+- Treat the exact OOM root cause as unresolved but bounded: unattended upgrade/install path caused an extreme memory spike while package metadata and network-online warnings were already noisy.
+- Do not rerun unattended upgrades blindly.
+- Run updates only in a supervised maintenance window with pre-checks and post-checks.
+- Include `distro-info-data`/release metadata freshness in the apt investigation even if it is not currently listed in `apt list --upgradable`.
+
+Safe next step:
+
+- Capture `make ops-ubuntu-review` and `make ops-backup-evidence` immediately before any package work.
+- Inspect apt logs around 2026-05-05 06:40-06:56 UTC.
+- Decide whether unattended upgrades should stay enabled as-is, be tuned, or be replaced with a scheduled supervised update workflow.
+
+Rollback notes:
+
+- Documentation and script changes are reversible through Git.
+- Package changes need package-specific rollback notes and should not be bundled into this documentation PR.
+
+## Dailyaidecheck Failure
+
+Evidence:
+
+- `dailyaidecheck.service` fails daily with `ExecMainStatus=1`.
+- Journal lines repeat: `WARN: it is not possible to use mail(1) unless aide is run as root or as non-root with added capabilities`.
+- `aide --version` reports AIDE 0.19.1.
+
+Disposition:
+
+- Repair or explicitly document AIDE posture. Do not reset the failed unit just to clear the dashboard.
+- Likely repair paths are AIDE execution/capability configuration, mail notification configuration, or a documented decision to replace/disable the daily AIDE check.
+
+Safe next step:
+
+- Inspect AIDE configuration and Debian README guidance under `/usr/share/doc/aide-common/`.
+- Decide whether this host needs daily AIDE reports, and where notifications should go.
+
+Approval gate:
+
+- Disabling AIDE or integrity checks requires human approval.
+
+## Canonical Livepatch Failure
+
+Evidence:
+
+- `snap.canonical-livepatch.canonical-livepatchd.service` is failed, enabled, and has `NRestarts=5`.
+- Non-root `canonical-livepatch status` could not read `/var/snap/canonical-livepatch/406/livepatchd.err`.
+- Unit journal did not expose useful recent entries to the unprivileged read.
+
+Disposition:
+
+- Requires privileged inspection before repair/disable decision.
+- Do not assume livepatch is working just because the package exists.
+
+Safe next step:
+
+- Run a privileged read-only livepatch status and inspect the livepatch error file.
+- Decide whether the host should use livepatch, and document unsupported-kernel or Ubuntu Pro requirements if relevant.
+
+Approval gate:
+
+- Disabling livepatch or changing Ubuntu Pro/livepatch registration requires human approval.
+
+## Network Wait Online Failure
+
+Evidence:
+
+- `systemd-networkd-wait-online.service` failed since boot with `ExecMainStatus=1`.
+- `apt-daily-upgrade.service` repeatedly logs wait-online timeouts before unattended-upgrade work starts.
+- Prior apt runs still completed despite wait-online errors, so this is noisy and potentially contributory rather than proven causal.
+
+Disposition:
+
+- Repair or document network-online expectations. Do not disable until dependency impact is understood.
+
+Safe next step:
+
+- Inspect netplan/networkd ownership and the `/run/systemd/system/systemd-networkd-wait-online.service.d/10-netplan.conf` drop-in.
+- Identify units that actually require `network-online.target`.
+
+Approval gate:
+
+- Disabling wait-online or changing network manager behavior requires approval.
+
+## Maintenance Window Checklist
+
+Pre-checks:
+
+- `make ops-ubuntu-review`
+- `make ops-backup-evidence`
+- `make ops-docker-review`
+- Studio Brain `/healthz`, `/readyz`, and `/health/dependencies`
+- Mission Control health if the control center is part of the window
+- Confirm SSH access from a second shell
+- Confirm package-specific rollback notes for kernel, Docker, containerd, systemd, and Node.js
+
+Approved execution only:
+
+- Run package updates in a supervised shell.
+- Keep a second SSH session open.
+- Do not reboot until health checks and rollback notes are captured.
+
+Post-checks:
+
+- `systemctl --failed --no-pager`
+- `journalctl -k --since "1 hour ago" | grep -Ei "oom|killed process|error|fail"`
+- Studio Brain `/healthz`, `/readyz`, and `/health/dependencies`
+- Docker container health
+- Backup evidence freshness
+
+## Follow-Up PR Candidates
+
+- Add a privileged-read instructions block for livepatch/AIDE diagnostics.
+- Add a supervised update-window checklist script that prints commands but does not execute upgrades.
+- Add an apt metadata freshness check to `make ops-ubuntu-review`.

--- a/scripts/ops/generate_ops_report.sh
+++ b/scripts/ops/generate_ops_report.sh
@@ -29,6 +29,7 @@ run_to_file disk_pressure bash "${SCRIPT_DIR}/disk_pressure.sh"
 run_to_file log_pressure bash "${SCRIPT_DIR}/log_pressure.sh"
 run_to_file dependency_inventory bash "${SCRIPT_DIR}/dependency_inventory.sh"
 run_to_file backup_evidence bash "${SCRIPT_DIR}/backup_evidence.sh"
+run_to_file ubuntu_failed_units bash "${SCRIPT_DIR}/ubuntu_failed_units.sh"
 
 if command -v docker >/dev/null 2>&1 && docker ps --format '{{.Names}}' | grep -qx "${PG_CONTAINER}"; then
   run_to_file postgres_readonly_review docker exec -i -u postgres "${PG_CONTAINER}" psql -d "${PGDATABASE}" -X -v ON_ERROR_STOP=1 -f - <"${SCRIPT_DIR}/postgres_readonly_review.sql"

--- a/scripts/ops/ubuntu_failed_units.sh
+++ b/scripts/ops/ubuntu_failed_units.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+set -u
+
+# Read-only Ubuntu failed-unit and apt/OOM triage for Studio Brain.
+# This script does not reset units, disable services, install packages, run upgrades, or modify logs.
+
+section() {
+  printf '\n## %s\n' "$1"
+}
+
+run_shell() {
+  printf '\n$ %s\n' "$1"
+  bash -lc "$1" 2>&1 || printf 'WARN: command failed: %s\n' "$1"
+}
+
+unit_report() {
+  local unit="$1"
+
+  printf '\n### %s\n' "${unit}"
+  if ! command -v systemctl >/dev/null 2>&1; then
+    printf 'systemctl unavailable\n'
+    return 0
+  fi
+
+  run_shell "systemctl status ${unit} --no-pager --lines=25"
+  run_shell "systemctl show ${unit} --no-pager -p Id -p LoadState -p ActiveState -p SubState -p Result -p ExecMainStatus -p NRestarts -p FragmentPath -p UnitFileState"
+  run_shell "journalctl -u ${unit} --since '14 days ago' --no-pager -n 120"
+}
+
+section "Report Metadata"
+printf 'generated_at: %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+printf 'host: %s\n' "$(hostname 2>/dev/null || printf unknown)"
+printf 'scope: read_only_failed_unit_and_apt_oom_triage\n'
+printf 'safety: no_unit_resets_no_service_disables_no_package_changes\n'
+
+section "Host Resource Snapshot"
+run_shell "uptime"
+run_shell "free -h"
+run_shell "swapon --show"
+run_shell "ps -eo pid,ppid,user,stat,pcpu,pmem,rss,comm,args --sort=-rss | head -n 25"
+
+section "Failed Units"
+if command -v systemctl >/dev/null 2>&1; then
+  run_shell "systemctl --failed --no-pager"
+  run_shell "systemctl list-units --type=service --state=failed --no-legend --plain | awk '{print \$1}'"
+else
+  printf 'systemctl unavailable\n'
+fi
+
+section "Known Studio Brain Ops Units"
+unit_report "apt-daily-upgrade.service"
+unit_report "unattended-upgrades.service"
+unit_report "dailyaidecheck.service"
+unit_report "snap.canonical-livepatch.canonical-livepatchd.service"
+unit_report "systemd-networkd-wait-online.service"
+
+section "OOM Evidence"
+run_shell "journalctl -k --since '14 days ago' --no-pager | grep -Ei 'out of memory|oom-kill|killed process|invoked oom-killer' || true"
+run_shell "journalctl -u apt-daily-upgrade.service --since '14 days ago' --no-pager | grep -Ei 'oom|killed|memory|unattended|error|fail' || true"
+
+section "Apt And Unattended Upgrade State"
+run_shell "test -f /var/run/reboot-required && { echo reboot_required=yes; cat /var/run/reboot-required.pkgs 2>/dev/null || true; } || echo reboot_required=no"
+run_shell "systemctl is-enabled unattended-upgrades.service 2>/dev/null || true"
+run_shell "systemctl is-active unattended-upgrades.service 2>/dev/null || true"
+run_shell "apt list --upgradable 2>/dev/null | sed -n '1,120p'"
+run_shell "test -f /etc/apt/apt.conf.d/20auto-upgrades && sed -n '1,120p' /etc/apt/apt.conf.d/20auto-upgrades || true"
+run_shell "test -f /etc/apt/apt.conf.d/50unattended-upgrades && sed -n '1,180p' /etc/apt/apt.conf.d/50unattended-upgrades | sed -E 's#//.*##' || true"
+
+section "Apt Logs"
+run_shell "for file in /var/log/unattended-upgrades/unattended-upgrades.log /var/log/unattended-upgrades/unattended-upgrades-dpkg.log /var/log/apt/history.log /var/log/apt/term.log /var/log/dpkg.log; do if [ -f \"\$file\" ]; then echo \"### \$file\"; tail -n 160 \"\$file\"; fi; done"
+
+section "AIDE And Livepatch Readiness"
+run_shell "command -v aide >/dev/null 2>&1 && aide --version | head -n 5 || echo 'aide command unavailable'"
+run_shell "command -v canonical-livepatch >/dev/null 2>&1 && canonical-livepatch status || echo 'canonical-livepatch command unavailable'"
+
+section "Disposition Worklist"
+cat <<'EOF'
+Use this table to convert evidence into an operator decision. Do not reset, disable, or upgrade from this report alone.
+
+| Unit or area | Decision needed | Evidence to attach | Approval gate |
+| --- | --- | --- | --- |
+| apt-daily-upgrade.service | repair unattended upgrade OOM or move updates to supervised window | OOM evidence, apt logs, pending package list | package changes require approval |
+| dailyaidecheck.service | repair AIDE database/config or intentionally disable with reason | unit journal, aide version/config path | disabling integrity checks requires approval |
+| snap.canonical-livepatch.canonical-livepatchd.service | repair livepatch or document unsupported host posture | unit journal, livepatch status | disabling livepatch requires approval |
+| systemd-networkd-wait-online.service | repair network-online dependency or document harmless boot noise | unit journal, network stack facts | disabling boot dependency requires approval |
+| pending packages | schedule maintenance window with rollback notes | apt list, reboot-required state, pre/post health checklist | upgrades require approval |
+EOF
+
+section "Maintenance Window Checklist"
+cat <<'EOF'
+Pre-checks:
+- capture `make ops-ubuntu-review`
+- capture `make ops-backup-evidence`
+- capture Studio Brain `/healthz`, `/readyz`, and `/health/dependencies`
+- capture Docker health with `make ops-docker-review`
+- confirm SSH access from a second shell
+- confirm rollback notes for kernel/Docker/systemd packages
+
+Approved execution only:
+- run package updates in a supervised shell
+- avoid unattended rerun if OOM cause remains unexplained
+- reboot only with approval and post-check owner present
+
+Post-checks:
+- `systemctl --failed --no-pager`
+- `journalctl -k --since "1 hour ago" | grep -Ei "oom|killed process|error|fail"`
+- Studio Brain `/healthz`, `/readyz`, and `/health/dependencies`
+- Docker container health
+- backup evidence freshness
+EOF


### PR DESCRIPTION
## Summary
- Adds `scripts/ops/ubuntu_failed_units.sh`, a read-only Ubuntu failed-unit and apt/OOM triage report.
- Adds `make ops-ubuntu-review` and includes the report in `scripts/ops/generate_ops_report.sh`.
- Adds `docs/ops/08-ubuntu-failed-unit-triage.md` with evidence-backed disposition notes and a maintenance-window checklist.

## Evidence
- Issue #555 asks for apt OOM root-cause evidence, failed-unit disposition, and a supervised update checklist.
- Live read-only run on `studiobrain` showed `apt-daily-upgrade.service` failed with `Result=oom-kill`, `Mem peak: 28.2G`, and `swap: 7.4G`; `systemd-networkd-wait-online` timed out before apt runs; `dailyaidecheck.service` fails daily with AIDE/mail capability warnings; livepatch is failed and needs privileged read-only inspection.

## Files Changed
- `scripts/ops/ubuntu_failed_units.sh`
- `docs/ops/08-ubuntu-failed-unit-triage.md`
- `scripts/ops/generate_ops_report.sh`
- `Makefile`
- `docs/ops/06-runbooks.md`
- `docs/ops/07-maintenance-calendar.md`

## Testing Performed
- `bash -n scripts/ops/*.sh`
- `bash scripts/ops/ubuntu_failed_units.sh` on Windows/Git Bash degraded mode
- Piped `scripts/ops/ubuntu_failed_units.sh` read-only to `studiobrain`
- `bash scripts/ops/generate_ops_report.sh output/ops/test-ubuntu-failed-units-smoke`
- `git diff --check`

## Risk Level
Low. This adds docs and read-only reporting only. It does not run package upgrades, reset failed units, disable services, restart services, reboot, or change production configuration.

## Rollback
Revert this PR. No runtime state or production data is changed.

## Follow-Up Tickets
- Refs #555. Privileged livepatch/AIDE reads and any package maintenance window remain approval-gated.
