### PR TITLE
[ops] Add network exposure review and hardening checklist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,9 @@ SHELL := /bin/bash
 PG_CONTAINER ?= studiobrain_postgres
 PGDATABASE ?= monsoonfire_studio_os
 
-.PHONY: ops-check ops-inventory ops-postgres-review ops-docker-review ops-capacity ops-backup-evidence ops-ubuntu-review ops-backlog ops-report
+.PHONY: ops-check ops-inventory ops-postgres-review ops-docker-review ops-capacity ops-backup-evidence ops-ubuntu-review ops-network-review ops-backlog ops-report
 
-ops-check: ops-inventory ops-docker-review ops-capacity ops-backup-evidence ops-ubuntu-review
+ops-check: ops-inventory ops-docker-review ops-capacity ops-backup-evidence ops-ubuntu-review ops-network-review
 
 ops-inventory:
 	bash scripts/ops/system_inventory.sh
@@ -31,6 +31,9 @@ ops-backup-evidence:
 
 ops-ubuntu-review:
 	bash scripts/ops/ubuntu_failed_units.sh
+
+ops-network-review:
+	bash scripts/ops/network_exposure_review.sh
 
 ops-backlog:
 	@sed -n '1,260p' docs/ops/02-kanban-backlog.md

--- a/docs/ops/00-system-inventory.md
+++ b/docs/ops/00-system-inventory.md
@@ -122,15 +122,13 @@ Observed listeners:
 - `192.168.1.226:18080` and `192.168.1.226:18081`: monitoring proxy.
 - `127.0.0.1:8080`: SearXNG.
 
-`ufw` is inactive. `fail2ban` is active for `sshd` with 0 current bans and 2 total failed attempts.
+Follow-up network exposure capture on 2026-05-06 01:10 UTC shows `ufw` enabled and active by systemd, but non-root `ufw status`, `nft`, and `iptables` rule visibility required a privileged read. Treat firewall rule coverage as unknown until `sudo ufw status numbered verbose` or equivalent is captured. `fail2ban` is active, but jail details also required a privileged read in the follow-up.
 
-SSH posture from `sshd -T`:
+SSH posture requires effective-config confirmation. Readable config fragments and prior diagnostics show password-based settings need review:
 
-- `permitrootlogin without-password`
-- `pubkeyauthentication yes`
 - `passwordauthentication yes`
 - `kbdinteractiveauthentication yes`
-- `x11forwarding yes`
+- `AuthenticationMethods any`
 
 ## Docker Version And Compose Files
 

--- a/docs/ops/01-risk-register.md
+++ b/docs/ops/01-risk-register.md
@@ -28,13 +28,13 @@ No immediate critical data-loss or outage condition was observed in the read-onl
 - Rollback/undo notes: do not reset the host checkout until the diff manifest is reviewed and backed up.
 - PR can address it: yes, for the audit/reporting tool. Cleanup requires human approval.
 
-### PostgreSQL Is Bound To All Interfaces While UFW Is Inactive
+### PostgreSQL Is Bound To All Interfaces While Firewall Rule Coverage Is Unverified
 
 - Affected component: PostgreSQL network exposure.
-- Evidence: `ss` shows `0.0.0.0:5433` and `[::]:5433` listening via Docker; `ufw` reports inactive. Compose default is `"${PGPORT:-5433}:5432"`.
+- Evidence: `make ops-network-review` on 2026-05-06 shows `0.0.0.0:5433` and `[::]:5433` listening via Docker, PostgreSQL `listen_addresses='*'`, and `pg_hba_file_rules` allowing `host all all all scram-sha-256`. `systemctl` reports `ufw` enabled and active, but non-root `ufw status`, `nft`, and `iptables` rules required a privileged read. Compose default is `"${PGPORT:-5433}:5432"`.
 - Likely impact: the database is reachable from more than localhost. If credentials or LAN trust assumptions are weak, this increases blast radius.
-- Recommended action: confirm all legitimate clients, then bind Postgres to `127.0.0.1:5433` or add a host firewall rule.
-- Safe next step: add a docs/task item and a Compose validation check that reports non-loopback DB binds.
+- Recommended action: confirm all legitimate clients and privileged firewall rules, then bind Postgres to `127.0.0.1:5433` or add an explicit host firewall allowlist.
+- Safe next step: run `make ops-network-review`, capture `sudo ufw status numbered verbose`, and identify every direct PostgreSQL client before hardening.
 - Rollback/undo notes: changing bind address is reversible but can break remote clients; requires service window and approval.
 - PR can address it: yes, detection and documentation. Actual bind/firewall change needs human approval.
 
@@ -53,10 +53,10 @@ No immediate critical data-loss or outage condition was observed in the read-onl
 ### SSH Password And Keyboard-Interactive Auth Are Enabled
 
 - Affected component: SSH access posture.
-- Evidence: `sshd -T` reports `passwordauthentication yes`, `kbdinteractiveauthentication yes`, `permitrootlogin without-password`; `fail2ban` is active and currently has no bans.
+- Evidence: SSH listens on `0.0.0.0:22` and `[::]:22`. Readable config fragments include `PasswordAuthentication yes`, `KbdInteractiveAuthentication yes`, `AuthenticationMethods any`, and `UsePAM yes`; the 2026-05-06 non-root run could not obtain effective `sshd -T` output. `fail2ban` is active, but jail details required a privileged read.
 - Likely impact: password auth increases remote brute-force exposure, especially with `ssh` listening on all interfaces.
 - Recommended action: confirm any legitimate password-based access, then plan key-only SSH with fail2ban retained.
-- Safe next step: add a key-only SSH migration checklist and current-posture diagnostic.
+- Safe next step: run `make ops-network-review`, capture privileged effective SSH config with `sudo sshd -T`, verify at least two key-based access paths, and then prepare a key-only SSH migration checklist.
 - Rollback/undo notes: keep an out-of-band console or verified second key before changing SSH auth.
 - PR can address it: documentation only; host SSH changes require approval.
 

--- a/docs/ops/06-runbooks.md
+++ b/docs/ops/06-runbooks.md
@@ -97,6 +97,24 @@ These runbooks are written for cautious operation. Prefer read-only diagnostics 
 5. Rollback:
    - restore prior Compose/image if a recent deploy caused the issue.
 
+## Network Exposure Review And Hardening
+
+1. Capture the read-only report:
+   - `make ops-network-review`
+   - or `bash scripts/ops/network_exposure_review.sh`
+2. Capture privileged read-only firewall and SSH facts before changing anything:
+   - `sudo ufw status numbered verbose`
+   - `sudo nft list ruleset`
+   - `sudo sshd -T`
+   - `sudo fail2ban-client status sshd`
+3. Identify every legitimate PostgreSQL client before changing Docker port binds, firewall rules, or `pg_hba.conf`.
+4. Verify a second SSH session, a second key, or console access before SSH hardening.
+5. Do not reload SSH, restart Docker containers, edit firewall rules, or change PostgreSQL config without approval.
+6. Rollback:
+   - restore prior Compose port mapping, SSH config, firewall rule, or PostgreSQL config
+   - keep the original admin session open until post-checks pass
+   - rerun `make ops-network-review` and app health checks after rollback
+
 ## High Memory / OOM Response
 
 1. Capture evidence:

--- a/docs/ops/07-maintenance-calendar.md
+++ b/docs/ops/07-maintenance-calendar.md
@@ -34,6 +34,7 @@ Use this as an operating rhythm. Treat risky actions as approval-gated.
 - Review Docker image pins and available updates.
 - Review SSH/fail2ban status.
 - Review open ports and firewall posture.
+  - `make ops-network-review`
 - Classify anonymous Docker volumes.
 - Review host checkout drift against source control.
 

--- a/docs/ops/09-network-exposure-review.md
+++ b/docs/ops/09-network-exposure-review.md
@@ -1,0 +1,153 @@
+# Studio Brain Network Exposure Review
+
+Snapshot: 2026-05-06 01:10 UTC, captured read-only with `scripts/ops/network_exposure_review.sh` over SSH alias `studiobrain`.
+
+This note is evidence and decision support only. It does not approve firewall changes, SSH changes, PostgreSQL bind changes, Docker restarts, or service restarts.
+
+## Summary
+
+Studio Brain has several intentional LAN/local listeners, but PostgreSQL is the highest-risk exposure candidate because Docker publishes it on both IPv4 and IPv6 wildcard host addresses:
+
+- `0.0.0.0:5433 -> studiobrain_postgres:5432`
+- `[::]:5433 -> studiobrain_postgres:5432`
+- PostgreSQL reports `listen_addresses='*'`.
+- `pg_hba_file_rules` allows `host all all all scram-sha-256`.
+
+At capture time, active PostgreSQL clients were only local/container-bridge clients (`local` and `172.20.0.1/32`). No external PostgreSQL client was observed in `pg_stat_activity`, but that is a point-in-time observation, not proof that no external clients ever connect.
+
+The host also has a global IPv6 address on `wlp3s0`. Because PostgreSQL, SSH, and Postfix listen on `[::]`, external reachability must be verified from outside the host and from the LAN before hardening decisions are made.
+
+## Current Non-Loopback Listeners
+
+Observed non-loopback listeners:
+
+| Listener | Component | Notes |
+| --- | --- | --- |
+| `0.0.0.0:22`, `[::]:22` | SSH | Remote administration path; hardening requires verified alternate access. |
+| `0.0.0.0:25`, `[::]:25` | Postfix | Mail role unknown from this slice. |
+| `0.0.0.0:5433`, `[::]:5433` | PostgreSQL Docker publish | Highest priority review item. |
+| `192.168.1.226:8787` | Studio Brain API | LAN API; existing app behavior depends on this. |
+| `192.168.1.226:18080-18081` | monitoring proxy | LAN-bound monitoring proxy. |
+| `0.0.0.0/5353`, `[::]/5353` | Avahi | Service-discovery exposure; likely local-network only but should be intentional. |
+
+Most other Studio Brain dependency ports were loopback-only at capture time, including Redis, MinIO, SearXNG, Netdata, Uptime Kuma, OpenTelemetry, Mission Control, and the Control Tower proxy.
+
+## Firewall Status
+
+Evidence:
+
+- `systemctl is-enabled ufw` returned `enabled`.
+- `systemctl is-active ufw` returned `active`.
+- Non-root `ufw status verbose` returned `ufw status requires privileged read`.
+- Non-root `nft list ruleset` and `iptables-save` did not expose rules.
+
+Disposition:
+
+- Treat firewall rule coverage as unknown until a privileged read-only check is captured.
+- Do not assume wildcard listeners are blocked by UFW based only on `systemctl is-active ufw`.
+
+Safe next step:
+
+- Run, with human approval for privileged read-only inspection:
+  - `sudo ufw status numbered verbose`
+  - `sudo nft list ruleset`
+  - `sudo iptables-save`
+
+## PostgreSQL Exposure
+
+Evidence:
+
+- Docker publishes `studiobrain_postgres` as `0.0.0.0:5433->5432/tcp` and `[::]:5433->5432/tcp`.
+- PostgreSQL settings:
+  - `listen_addresses='*'`
+  - `port=5432`
+  - `ssl=off`
+  - `password_encryption=scram-sha-256`
+- `pg_hba_file_rules` includes:
+  - local trust rules
+  - loopback trust rules
+  - `host all all all scram-sha-256`
+- Current observed clients were `local` and `172.20.0.1/32`; no non-host LAN/WAN PostgreSQL client was active during the snapshot.
+- The only login-capable role listed by the read-only review was `postgres`, which is also superuser.
+
+Likely impact:
+
+- If PostgreSQL credentials leak or LAN/IPv6 exposure is broader than expected, the database is reachable without first entering an SSH tunnel or local Docker network.
+- Using the `postgres` superuser for app connections increases blast radius compared with an app-specific least-privilege role.
+
+Recommended action:
+
+1. Identify all legitimate PostgreSQL clients: app, backup tooling, DBA access, diagnostics, and any remote automation.
+2. If all legitimate clients are local, prepare an approved change to bind the Docker-published host port to loopback only.
+3. If LAN DBA access is required, use firewall allowlisting and documented SSH-tunnel alternatives.
+4. Create an app-specific PostgreSQL role plan separately; do not combine role changes with listener hardening.
+
+Approval gate:
+
+- Any PostgreSQL bind, `pg_hba.conf`, Docker Compose port mapping, firewall, or role change requires human and DBA approval.
+
+Rollback notes:
+
+- Revert the Compose port mapping and recreate only the PostgreSQL container during an approved window.
+- Restore prior `pg_hba.conf`/PostgreSQL config and reload/restart under the same window.
+- Keep the prior working DBA connection method open until post-checks pass.
+
+## SSH Exposure
+
+Evidence:
+
+- SSH listens on `0.0.0.0:22` and `[::]:22`.
+- `systemctl is-enabled ssh` returned `enabled`.
+- `systemctl is-active ssh` returned `active`.
+- Readable SSH config fragments included:
+  - `PasswordAuthentication yes`
+  - `KbdInteractiveAuthentication yes`
+  - `AuthenticationMethods any`
+  - `UsePAM yes`
+- This non-root run could not get effective `sshd -T` output, so the exact effective posture still needs privileged confirmation.
+- `fail2ban` is active, but jail details required privileged read.
+
+Disposition:
+
+- Treat key-only hardening as desirable but approval-gated.
+- Do not disable password or keyboard-interactive auth until at least two key-based access paths or an out-of-band console path are verified.
+
+Safe next step:
+
+- Run a privileged effective-config read:
+  - `sudo sshd -T | grep -Ei '^(passwordauthentication|kbdinteractiveauthentication|challengeresponseauthentication|pubkeyauthentication|permitrootlogin|authenticationmethods|usepam|maxauthtries)'`
+- Confirm fail2ban jail coverage:
+  - `sudo fail2ban-client status`
+  - `sudo fail2ban-client status sshd`
+
+Rollback notes:
+
+- Keep a second live SSH session open before changing `sshd_config`.
+- Validate `sshd -t` before reload.
+- Reload, not restart, when possible.
+- Roll back by restoring the previous SSH config and reloading SSH from the still-open session or console.
+
+## Approval-Gated Hardening Candidates
+
+| Candidate | Benefit | Risk | Safe next step | Rollback |
+| --- | --- | --- | --- | --- |
+| Bind PostgreSQL host port to `127.0.0.1` | Removes LAN/IPv6 direct DB reachability | Can break remote DBA/backups if they rely on direct port 5433 | Identify clients and test app/backup/DBA paths in a window | Restore previous Compose port mapping and recreate container |
+| Add UFW allowlist/deny rules for `5433` | Limits DB reachability without changing container config | Firewall mistakes can lock out access or break clients | Capture privileged rules and console path first | `sudo ufw delete <rule>` from console/second session |
+| Move SSH to key-only auth | Reduces brute-force/password exposure | Can lock out admin access | Verify two keys or console path first | Restore prior sshd config from open session |
+| Review Postfix listener | Clarifies whether inbound SMTP is intentional | Mail delivery can break if disabled blindly | Identify mail role and dependencies | Restore prior Postfix config/service state |
+| Review Avahi listener | Reduces service-discovery noise if not needed | Local discovery may rely on it | Inventory dependent devices/services | Re-enable Avahi if needed |
+
+## Verification Checklist Before Any Hardening PR
+
+- `make ops-network-review`
+- `make ops-backup-evidence`
+- `make ops-docker-review`
+- Studio Brain `/healthz`, `/readyz`, and `/health/dependencies`
+- Confirm SSH access from a second shell.
+- Capture privileged firewall and SSH effective-config reads.
+- Identify every active and expected PostgreSQL client.
+- Write exact rollback commands in the PR body before applying changes.
+
+## PR Boundary
+
+This slice adds diagnostics and documentation only. A future PR can propose concrete bind/firewall/SSH changes after privileged evidence and human approval are available.

--- a/scripts/ops/generate_ops_report.sh
+++ b/scripts/ops/generate_ops_report.sh
@@ -30,6 +30,7 @@ run_to_file log_pressure bash "${SCRIPT_DIR}/log_pressure.sh"
 run_to_file dependency_inventory bash "${SCRIPT_DIR}/dependency_inventory.sh"
 run_to_file backup_evidence bash "${SCRIPT_DIR}/backup_evidence.sh"
 run_to_file ubuntu_failed_units bash "${SCRIPT_DIR}/ubuntu_failed_units.sh"
+run_to_file network_exposure_review bash "${SCRIPT_DIR}/network_exposure_review.sh"
 
 if command -v docker >/dev/null 2>&1 && docker ps --format '{{.Names}}' | grep -qx "${PG_CONTAINER}"; then
   run_to_file postgres_readonly_review docker exec -i -u postgres "${PG_CONTAINER}" psql -d "${PGDATABASE}" -X -v ON_ERROR_STOP=1 -f - <"${SCRIPT_DIR}/postgres_readonly_review.sql"

--- a/scripts/ops/network_exposure_review.sh
+++ b/scripts/ops/network_exposure_review.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+set -u
+
+# Read-only network exposure review for Studio Brain.
+# This script does not change firewall rules, SSH config, PostgreSQL config, or Docker state.
+# It avoids printing process environments and secrets. Review output before sharing externally.
+
+PG_CONTAINER="${PG_CONTAINER:-studiobrain_postgres}"
+PGDATABASE="${PGDATABASE:-monsoonfire_studio_os}"
+
+section() {
+  printf '\n## %s\n' "$1"
+}
+
+run_shell() {
+  printf '\n$ %s\n' "$1"
+  bash -lc "$1" 2>&1 || printf 'WARN: command failed: %s\n' "$1"
+}
+
+postgres_review() {
+  if command -v docker >/dev/null 2>&1 && docker ps --format '{{.Names}}' | grep -qx "${PG_CONTAINER}"; then
+    printf '\n$ docker exec -u postgres %s psql -d %s -X -v ON_ERROR_STOP=1\n' "${PG_CONTAINER}" "${PGDATABASE}"
+    docker exec -i -u postgres "${PG_CONTAINER}" psql -d "${PGDATABASE}" -X -v ON_ERROR_STOP=1 <<'SQL' 2>&1 || printf 'WARN: PostgreSQL Docker review failed\n'
+\pset pager off
+\pset border 2
+\pset null '(null)'
+
+select name, setting
+from pg_settings
+where name in ('listen_addresses', 'port', 'ssl', 'password_encryption')
+order by name;
+
+select line_number, type, database, user_name, address, auth_method, error
+from pg_hba_file_rules
+order by line_number;
+
+select coalesce(client_addr::text, 'local') as client_addr,
+       usename,
+       application_name,
+       state,
+       count(*) as connections
+from pg_stat_activity
+group by 1, 2, 3, 4
+order by connections desc, client_addr, usename, application_name, state;
+
+select rolname, rolsuper, rolcreaterole, rolcreatedb, rolcanlogin
+from pg_roles
+order by rolname;
+SQL
+  elif command -v psql >/dev/null 2>&1; then
+    printf '\n$ PGCONNECT_TIMEOUT=5 psql -w -X -v ON_ERROR_STOP=1\n'
+    PGCONNECT_TIMEOUT="${PGCONNECT_TIMEOUT:-5}" psql -w -X -v ON_ERROR_STOP=1 <<'SQL' 2>&1 || printf 'WARN: PostgreSQL psql review failed. Set PGHOST/PGPORT/PGDATABASE/PGUSER as needed.\n'
+\pset pager off
+\pset border 2
+\pset null '(null)'
+
+select name, setting
+from pg_settings
+where name in ('listen_addresses', 'port', 'ssl', 'password_encryption')
+order by name;
+
+select line_number, type, database, user_name, address, auth_method, error
+from pg_hba_file_rules
+order by line_number;
+
+select coalesce(client_addr::text, 'local') as client_addr,
+       usename,
+       application_name,
+       state,
+       count(*) as connections
+from pg_stat_activity
+group by 1, 2, 3, 4
+order by connections desc, client_addr, usename, application_name, state;
+
+select rolname, rolsuper, rolcreaterole, rolcreatedb, rolcanlogin
+from pg_roles
+order by rolname;
+SQL
+  else
+    printf 'PostgreSQL review unavailable: neither Docker container %s nor psql was available.\n' "${PG_CONTAINER}"
+    printf 'Set PG_CONTAINER/PGDATABASE or PGHOST/PGPORT/PGDATABASE/PGUSER and rerun.\n'
+  fi
+}
+
+section "Report Metadata"
+printf 'generated_at: %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+printf 'host: %s\n' "$(hostname 2>/dev/null || printf unknown)"
+printf 'scope: read_only_network_exposure_review\n'
+printf 'safety: no_firewall_changes_no_ssh_changes_no_postgres_changes_no_restarts\n'
+
+section "Local Addresses And Routes"
+run_shell "ip -br addr 2>/dev/null || ifconfig 2>/dev/null || true"
+run_shell "ip route 2>/dev/null | sed -n '1,80p' || true"
+
+section "Listening Ports"
+run_shell "(sudo -n ss -tulpen 2>/dev/null || ss -tulpen 2>/dev/null || ss -tuln 2>/dev/null) | sed -E 's/pid=[0-9]+/pid=REDACTED/g' | sed -n '1,220p'"
+run_shell "command -v docker >/dev/null 2>&1 && docker ps --format 'table {{.Names}}\t{{.Image}}\t{{.Ports}}\t{{.Status}}' || true"
+run_shell "command -v docker >/dev/null 2>&1 && docker ps -q | while read -r id; do docker inspect --format '{{.Name}} ports={{json .NetworkSettings.Ports}}' \"\$id\"; docker inspect --format '{{.Name}} networks={{range \$name,\$net := .NetworkSettings.Networks}}{{\$name}}={{\$net.IPAddress}} {{end}}' \"\$id\"; done || true"
+
+section "Firewall Posture"
+run_shell "command -v ufw >/dev/null 2>&1 && (sudo -n ufw status verbose 2>/dev/null || ufw status verbose 2>/dev/null || echo 'ufw status requires privileged read') || echo 'ufw command unavailable'"
+run_shell "systemctl is-enabled ufw 2>/dev/null || true"
+run_shell "systemctl is-active ufw 2>/dev/null || true"
+run_shell "command -v nft >/dev/null 2>&1 && (sudo -n nft list ruleset 2>/dev/null || nft list ruleset 2>/dev/null) | awk 'NR<=220 {print} END {if (NR==0) print \"nft ruleset requires privileged read or is empty\"}' || true"
+run_shell "command -v iptables-save >/dev/null 2>&1 && (sudo -n iptables-save 2>/dev/null || iptables-save 2>/dev/null) | awk 'NR<=220 {print} END {if (NR==0) print \"iptables rules require privileged read or are empty\"}' || true"
+
+section "SSH Authentication Posture"
+run_shell "command -v sshd >/dev/null 2>&1 && { out=\"\$( (sudo -n sshd -T 2>/dev/null || sshd -T 2>/dev/null) | awk '/^(port|listenaddress|passwordauthentication|kbdinteractiveauthentication|challengeresponseauthentication|pubkeyauthentication|permitrootlogin|authenticationmethods|allowusers|allowgroups|usepam|maxauthtries|logingracetime|clientaliveinterval|clientalivecountmax)[[:space:]]/ {print}' | sort )\"; test -n \"\$out\" && printf '%s\n' \"\$out\" || echo 'sshd -T unavailable or returned no selected settings'; } || echo 'sshd command unavailable'"
+run_shell "grep -RhsE '^[[:space:]]*(Port|ListenAddress|PasswordAuthentication|KbdInteractiveAuthentication|ChallengeResponseAuthentication|PubkeyAuthentication|PermitRootLogin|AuthenticationMethods|AllowUsers|AllowGroups|UsePAM|MaxAuthTries|ClientAliveInterval|ClientAliveCountMax|Match)[[:space:]]+' /etc/ssh/sshd_config /etc/ssh/sshd_config.d/*.conf 2>/dev/null | sed -E 's/[[:space:]]+#.*$//' | sed -n '1,160p' || true"
+run_shell "systemctl is-enabled ssh 2>/dev/null || systemctl is-enabled sshd 2>/dev/null || true"
+run_shell "systemctl is-active ssh 2>/dev/null || systemctl is-active sshd 2>/dev/null || true"
+run_shell "systemctl is-active fail2ban 2>/dev/null || true"
+run_shell "command -v fail2ban-client >/dev/null 2>&1 && (sudo -n fail2ban-client status 2>/dev/null || fail2ban-client status 2>/dev/null || echo 'fail2ban status requires privileged read') || true"
+
+section "PostgreSQL Exposure"
+run_shell "(sudo -n ss -ltnp 2>/dev/null || ss -ltnp 2>/dev/null || ss -ltn 2>/dev/null) | grep -E '(:5432|:5433)[[:space:]]' | sed -E 's/pid=[0-9]+/pid=REDACTED/g' || true"
+postgres_review
+
+section "Approval-Gated Hardening Worklist"
+cat <<'EOF'
+Use this table to turn the read-only evidence into a safe hardening decision.
+
+| Area | Decision needed | Evidence to attach | Approval gate |
+| --- | --- | --- | --- |
+| PostgreSQL listener | bind to loopback, keep LAN listener, or restrict with firewall | listener socket, listen_addresses, pg_hba_file_rules, active client list | DB connectivity change requires human and DBA approval |
+| PostgreSQL clients | identify every legitimate app, backup, DBA, and diagnostic client | pg_stat_activity client_addr/application_name summary | unknown clients must be investigated before blocking |
+| Firewall | keep inactive, enable UFW, or manage rules elsewhere | ufw/nft/iptables output and open listener list | firewall changes require console/rollback access |
+| SSH auth | keep password/kbdinteractive temporarily or move to key-only | sshd -T auth settings and verified working keys | disabling password auth requires second key or console path |
+| Fail2ban | confirm active jail coverage for SSH | fail2ban status and auth posture | changing bans/jails requires approval |
+EOF
+
+section "Safe Next Steps"
+cat <<'EOF'
+1. Run this report from the Studio Brain host and save the output with restricted permissions.
+2. Identify every non-loopback PostgreSQL client before changing bind addresses or firewall rules.
+3. Open a second SSH session and verify at least two key-based access paths before SSH hardening.
+4. Prepare rollback notes before any firewall change:
+   - how to disable the new firewall rule
+   - how to restore the previous PostgreSQL listen_addresses/pg_hba.conf
+   - how to restore the previous sshd_config
+   - how to regain access through console or local admin path
+5. Schedule an approved maintenance window for any actual hardening change.
+EOF


### PR DESCRIPTION
## Summary
- Adds `make ops-network-review` and `scripts/ops/network_exposure_review.sh` for read-only network/firewall/SSH/PostgreSQL exposure evidence.
- Adds `docs/ops/09-network-exposure-review.md` with current findings, approval gates, rollback notes, and hardening candidates.
- Updates the system inventory, risk register, runbooks, maintenance calendar, and ops report bundle to include the new review.

## Evidence
- Live read-only run on `studiobrain` showed PostgreSQL published on `0.0.0.0:5433` and `[::]:5433`, PostgreSQL `listen_addresses=*`, and `pg_hba_file_rules` allowing `host all all all scram-sha-256`.
- The host has a global IPv6 address and SSH/Postfix/PostgreSQL wildcard listeners, so external reachability still needs privileged firewall and outside-host verification.
- `ufw` is enabled and active by systemd, but non-root `ufw status`, `nft`, and `iptables` rule visibility required privileged read-only inspection.
- Readable SSH config fragments show `PasswordAuthentication yes`, `KbdInteractiveAuthentication yes`, `AuthenticationMethods any`, and `UsePAM yes`; effective `sshd -T` still needs privileged confirmation.

## Files Changed
- `Makefile`
- `scripts/ops/network_exposure_review.sh`
- `scripts/ops/generate_ops_report.sh`
- `docs/ops/00-system-inventory.md`
- `docs/ops/01-risk-register.md`
- `docs/ops/06-runbooks.md`
- `docs/ops/07-maintenance-calendar.md`
- `docs/ops/09-network-exposure-review.md`

## Testing Performed
- `bash -n scripts/ops/*.sh`
- `bash scripts/ops/network_exposure_review.sh`
- `ssh studiobrain "bash -s" < scripts/ops/network_exposure_review.sh`
- `bash scripts/ops/generate_ops_report.sh output/ops/test-network-exposure-smoke-2`
- `git diff --cached --check`

## Risk Level
Low. This is diagnostic and documentation only. It does not edit firewall rules, SSH config, PostgreSQL config, Docker Compose, containers, or services.

## Rollback Instructions
Revert this PR to remove the new script, Make target, ops report inclusion, and documentation updates. No live host configuration rollback is needed because this PR makes no live changes.

## Follow-Up Tickets
- #556: Review DB and SSH network exposure.
- Future approval-gated hardening PR: bind PostgreSQL to loopback or add firewall allowlist after client inventory and privileged firewall evidence.
- Future approval-gated hardening PR: move SSH to key-only auth after two working keys or console access are verified.
