### PR TITLE
[ops] Add live host drift inventory workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,9 @@ SHELL := /bin/bash
 PG_CONTAINER ?= studiobrain_postgres
 PGDATABASE ?= monsoonfire_studio_os
 
-.PHONY: ops-check ops-inventory ops-postgres-review ops-docker-review ops-capacity ops-backup-evidence ops-ubuntu-review ops-network-review ops-backlog ops-report
+.PHONY: ops-check ops-inventory ops-postgres-review ops-docker-review ops-capacity ops-backup-evidence ops-ubuntu-review ops-network-review ops-host-drift ops-backlog ops-report
 
-ops-check: ops-inventory ops-docker-review ops-capacity ops-backup-evidence ops-ubuntu-review ops-network-review
+ops-check: ops-inventory ops-docker-review ops-capacity ops-backup-evidence ops-ubuntu-review ops-network-review ops-host-drift
 
 ops-inventory:
 	bash scripts/ops/system_inventory.sh
@@ -34,6 +34,9 @@ ops-ubuntu-review:
 
 ops-network-review:
 	bash scripts/ops/network_exposure_review.sh
+
+ops-host-drift:
+	bash scripts/ops/host_drift_inventory.sh
 
 ops-backlog:
 	@sed -n '1,260p' docs/ops/02-kanban-backlog.md

--- a/docs/ops/01-risk-register.md
+++ b/docs/ops/01-risk-register.md
@@ -18,13 +18,13 @@ No immediate critical data-loss or outage condition was observed in the read-onl
 - Rollback/undo notes: documentation/script additions can be reverted; do not delete existing backups.
 - PR can address it: yes, for documentation and read-only verification scripts. Full backup changes require approval.
 
-### Live Host Checkout Is On A Gone Branch With 211 Dirty Tracked Files
+### Live Host Checkout Is On A Gone Branch With 512 Dirty Or Untracked Paths
 
 - Affected component: deployment source of truth and drift control.
-- Evidence: `/home/wuff/monsoonfire-portal` reports `codex/next-fix-20260312...origin/codex/next-fix-20260312 [gone]` and 211 dirty tracked files, including package, migrations, Studio Brain runtime, scripts, and docs.
+- Evidence: `make ops-host-drift` on 2026-05-06 reports `/home/wuff/monsoonfire-portal` on `codex/next-fix-20260312...origin/codex/next-fix-20260312 [gone]` with 512 dirty or untracked paths: 211 modified tracked paths and 301 untracked paths. Path-name classification found 486 source/config paths, 10 sensitive-looking path names, and 16 unknown paths.
 - Likely impact: deploys and reconciliations may package host-only drift, hide unreviewed runtime changes, or make rollback hard to reason about.
 - Recommended action: inventory dirty host changes, classify them as accepted source changes, generated artifacts, or discardable runtime drift, then reconcile through PRs.
-- Safe next step: generate a redacted diff manifest and compare against `host-drift-allowlist.json`.
+- Safe next step: create a host backup branch and restricted patch bundle, then compare the manifest against `host-drift-allowlist.json`.
 - Rollback/undo notes: do not reset the host checkout until the diff manifest is reviewed and backed up.
 - PR can address it: yes, for the audit/reporting tool. Cleanup requires human approval.
 

--- a/docs/ops/06-runbooks.md
+++ b/docs/ops/06-runbooks.md
@@ -115,6 +115,22 @@ These runbooks are written for cautious operation. Prefer read-only diagnostics 
    - keep the original admin session open until post-checks pass
    - rerun `make ops-network-review` and app health checks after rollback
 
+## Live Host Checkout Drift Review
+
+1. Capture the read-only drift report:
+   - `make ops-host-drift`
+   - or `TARGET_REPO=/home/wuff/monsoonfire-portal bash scripts/ops/host_drift_inventory.sh`
+2. Do not run `git reset`, `git clean`, `git checkout`, or `git stash` on the live host without approval.
+3. Create a backup branch or patch bundle before cleanup:
+   - `git -C /home/wuff/monsoonfire-portal branch backup/live-drift-<date>`
+   - `git -C /home/wuff/monsoonfire-portal diff > /restricted/path/live-drift-<date>.patch`
+4. Classify paths as generated artifact, source/config/docs, sensitive path name, or unknown.
+5. Review source/config diffs locally; do not paste secret values into tickets.
+6. Rollback:
+   - restore the backup branch or patch bundle
+   - rerun `make ops-host-drift`
+   - verify Studio Brain health after any approved cleanup
+
 ## High Memory / OOM Response
 
 1. Capture evidence:

--- a/docs/ops/07-maintenance-calendar.md
+++ b/docs/ops/07-maintenance-calendar.md
@@ -37,6 +37,8 @@ Use this as an operating rhythm. Treat risky actions as approval-gated.
   - `make ops-network-review`
 - Classify anonymous Docker volumes.
 - Review host checkout drift against source control.
+  - `make ops-host-drift`
+  - keep a restricted backup branch/patch bundle before cleanup
 
 ## Quarterly Checks
 

--- a/docs/ops/10-host-drift-inventory.md
+++ b/docs/ops/10-host-drift-inventory.md
@@ -1,0 +1,98 @@
+# Studio Brain Live Host Drift Inventory
+
+Snapshot: 2026-05-06 01:16 UTC, captured read-only with `scripts/ops/host_drift_inventory.sh` over SSH alias `studiobrain`.
+
+This note is evidence and cleanup planning only. It does not approve `git reset`, `git clean`, branch changes, stashing, file deletion, or live host edits.
+
+## Summary
+
+The live host checkout at `/home/wuff/monsoonfire-portal` is not a clean deploy source:
+
+- Current branch: `codex/next-fix-20260312`.
+- Upstream: `origin/codex/next-fix-20260312 [gone]`.
+- Current commit: `5cc3fb8e chore(web): rebaseline reservation chunk budgets`.
+- Dirty/untracked paths: 512 total.
+  - 211 modified tracked paths.
+  - 301 untracked paths.
+- Classification from path names:
+  - 486 `source_or_config`
+  - 10 `sensitive_path_name`
+  - 16 `unknown`
+- Large local directories:
+  - `tmp`: 3.6M
+  - `output`: 294M
+  - `node_modules`: 618M
+
+This is substantial source-control drift, not just generated runtime noise. Treat the host checkout as a live forensic artifact until it is backed up and reconciled.
+
+## Representative Drift Areas
+
+Modified tracked paths include:
+
+- root scripts and package metadata
+- `config/studiobrain/systemd/studio-brain-healthcheck.sh`
+- Studio Brain environment schema/example/integrity files
+- Studio Brain Docker Compose and Caddy/OTel config
+- Studio Brain docs and migrations through `017_memory_recent_query_acceleration.sql`
+- Studio Brain runtime source under `studio-brain/lib` and `studio-brain/src`
+- website deploy/serve scripts
+
+Untracked paths include:
+
+- `.governance/planning/`
+- `config/studiobrain/ansible/`
+- `config/studiobrain/discord/`
+- `config/studiobrain/monitoring/`
+- many `config/studiobrain/systemd/*` service/timer files
+- Studio Brain control tower, ops, partner, planning, support, wiki, and agent runtime source folders
+- additional Studio Brain migrations beyond the tracked baseline
+
+The report classifies path names only. It does not read file contents and does not prove whether any path is safe to delete.
+
+## Risk
+
+Likely impacts:
+
+- Deploys can accidentally package host-only code.
+- Rollbacks are hard because the live host branch no longer maps cleanly to an upstream branch.
+- Reconciliation can lose work if the dirty tree is reset before a backup branch or patch bundle exists.
+- Sensitive-looking paths need security-aware handling even when they are examples or schema files, because contents were not inspected in this slice.
+
+## Safe Next Step
+
+1. Capture a backup branch on the host before cleanup:
+   - `git -C /home/wuff/monsoonfire-portal branch backup/live-drift-20260506`
+2. Capture a restricted patch bundle:
+   - `install -d -m 700 /home/wuff/ops-evidence`
+   - `git -C /home/wuff/monsoonfire-portal diff > /home/wuff/ops-evidence/live-drift-20260506.patch`
+3. Capture untracked path manifest without contents:
+   - `git -C /home/wuff/monsoonfire-portal status --porcelain=v1 --untracked-files=all > /home/wuff/ops-evidence/live-drift-20260506.status`
+4. Review diffs by area:
+   - systemd and host ops config
+   - Studio Brain Docker/config
+   - Studio Brain migrations and source
+   - scripts and deployment tooling
+   - website deploy scripts
+5. Convert accepted source changes into small PRs.
+6. Only after accepted work is preserved, plan generated-artifact cleanup.
+
+## Cleanup Classification
+
+| Candidate | Classification | Rationale | Approval |
+| --- | --- | --- | --- |
+| Modified source/config/docs | requires human approval | 211 tracked modifications may include live fixes | inspect diff and preserve backup first |
+| Untracked source/config/docs | requires human approval | 301 untracked paths include systemd, monitoring, migrations, and runtime source | classify and PR accepted work |
+| Sensitive path names | do not touch automatically | path names suggest env/auth/credential-adjacent files | security-aware review only |
+| `output` directory | safe with backup | likely generated evidence, but may contain backup/ops proof | review manifest before deleting |
+| `node_modules` | safe with backup/service window | reinstallable dependency cache, but live scripts may rely on it | delete only in a planned cleanup |
+| Gone upstream branch | requires human approval | reset/rebase can discard unreviewed host-only work | backup branch/patch first |
+
+## Rollback Notes
+
+- Documentation and script changes in this PR are reversible through Git.
+- No host cleanup has been performed.
+- If future cleanup is approved and goes wrong, restore from the backup branch or patch bundle before restarting services.
+
+## PR Boundary
+
+This slice adds drift inventory tooling and documents current evidence. It intentionally does not reconcile, delete, reset, stash, or move any live host files.

--- a/scripts/ops/generate_ops_report.sh
+++ b/scripts/ops/generate_ops_report.sh
@@ -31,6 +31,7 @@ run_to_file dependency_inventory bash "${SCRIPT_DIR}/dependency_inventory.sh"
 run_to_file backup_evidence bash "${SCRIPT_DIR}/backup_evidence.sh"
 run_to_file ubuntu_failed_units bash "${SCRIPT_DIR}/ubuntu_failed_units.sh"
 run_to_file network_exposure_review bash "${SCRIPT_DIR}/network_exposure_review.sh"
+run_to_file host_drift_inventory bash "${SCRIPT_DIR}/host_drift_inventory.sh"
 
 if command -v docker >/dev/null 2>&1 && docker ps --format '{{.Names}}' | grep -qx "${PG_CONTAINER}"; then
   run_to_file postgres_readonly_review docker exec -i -u postgres "${PG_CONTAINER}" psql -d "${PGDATABASE}" -X -v ON_ERROR_STOP=1 -f - <"${SCRIPT_DIR}/postgres_readonly_review.sql"

--- a/scripts/ops/host_drift_inventory.sh
+++ b/scripts/ops/host_drift_inventory.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -u
+
+# Read-only live checkout drift inventory for Studio Brain.
+# This script does not reset, clean, checkout, stash, delete, or modify files.
+# It prints paths and Git metadata only; it never prints file contents or environment values.
+
+TARGET_REPO="${1:-${TARGET_REPO:-/home/wuff/monsoonfire-portal}}"
+
+section() {
+  printf '\n## %s\n' "$1"
+}
+
+run_shell() {
+  printf '\n$ %s\n' "$1"
+  bash -lc "$1" 2>&1 || printf 'WARN: command failed: %s\n' "$1"
+}
+
+git_in_repo() {
+  local command_text="$1"
+  printf '\n$ git -C %s %s\n' "${TARGET_REPO}" "${command_text}"
+  git -C "${TARGET_REPO}" ${command_text} 2>&1 || printf 'WARN: git command failed: git -C %s %s\n' "${TARGET_REPO}" "${command_text}"
+}
+
+section "Report Metadata"
+printf 'generated_at: %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+printf 'host: %s\n' "$(hostname 2>/dev/null || printf unknown)"
+printf 'target_repo: %s\n' "${TARGET_REPO}"
+printf 'scope: read_only_live_checkout_drift_inventory\n'
+printf 'safety: no_reset_no_clean_no_checkout_no_stash_no_delete_no_file_contents\n'
+
+if ! git -C "${TARGET_REPO}" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  printf 'Target repo does not look like a Git checkout: %s\n' "${TARGET_REPO}"
+  printf 'Set TARGET_REPO or pass a repo path as the first argument.\n'
+  exit 0
+fi
+
+section "Repository Identity"
+git_in_repo "rev-parse --show-toplevel"
+git_in_repo "rev-parse --short HEAD"
+git_in_repo "branch --show-current"
+run_shell "git -C '${TARGET_REPO}' remote -v | sed -E 's#(https?://)([^/@]+@)#\\1REDACTED@#g'"
+run_shell "git -C '${TARGET_REPO}' status --short --branch | sed -n '1,220p'; total=\$(git -C '${TARGET_REPO}' status --porcelain=v1 --untracked-files=all | wc -l | awk '{print \$1}'); if [ \"\${total:-0}\" -gt 219 ]; then echo \"... status output truncated; dirty_or_untracked_paths=\${total}\"; fi"
+
+section "Upstream And Branch State"
+run_shell "branch_ref=\$(git -C '${TARGET_REPO}' symbolic-ref -q HEAD 2>/dev/null || true); upstream=\$(git -C '${TARGET_REPO}' for-each-ref --format='%(upstream:short)' \"\$branch_ref\" 2>/dev/null || true); if [ -n \"\$upstream\" ]; then if git -C '${TARGET_REPO}' show-ref --verify --quiet \"refs/remotes/\$upstream\"; then echo \"\$upstream\"; else echo \"\$upstream (gone_or_not_fetched)\"; fi; else echo 'upstream_unavailable_or_gone'; fi"
+run_shell "git -C '${TARGET_REPO}' branch -vv | sed -n '1,120p'"
+run_shell "branch_ref=\$(git -C '${TARGET_REPO}' symbolic-ref -q HEAD 2>/dev/null || true); upstream=\$(git -C '${TARGET_REPO}' for-each-ref --format='%(upstream:short)' \"\$branch_ref\" 2>/dev/null || true); if [ -n \"\$upstream\" ] && git -C '${TARGET_REPO}' show-ref --verify --quiet \"refs/remotes/\$upstream\"; then git -C '${TARGET_REPO}' rev-list --left-right --count HEAD...\"\$upstream\"; else echo 'ahead_behind_unavailable_or_upstream_gone'; fi"
+run_shell "git -C '${TARGET_REPO}' log --oneline --decorate -n 12 2>/dev/null || true"
+
+section "Dirty Counts"
+run_shell "git -C '${TARGET_REPO}' status --porcelain=v1 --untracked-files=all | awk '{code=substr(\$0,1,2); counts[code]++} END {if (length(counts)==0) print \"clean\"; else for (code in counts) print counts[code], code}' | sort"
+run_shell "git -C '${TARGET_REPO}' status --porcelain=v1 --untracked-files=all | wc -l | awk '{print \"dirty_or_untracked_paths=\" \$1}'"
+
+section "Dirty Path Classification"
+run_shell "git -C '${TARGET_REPO}' status --porcelain=v1 --untracked-files=all | awk 'function classify(path) { low=tolower(path); if (low ~ /(^|\\/)(\\.env|\\.env\\.|id_rsa|id_ed25519|secrets?|credentials?|firebase|service-account|private-key)/ || low ~ /\\.(pem|key|p12|pfx|kdbx)$/) return \"sensitive_path_name\"; if (low ~ /^(output|dist|build|coverage|\\.next|node_modules|tmp|logs|\\.turbo|\\.cache)\\// || low ~ /\\.(log|tmp|cache|tgz|zip|gz)$/) return \"generated_or_artifact\"; if (low ~ /(^|\\/)(\\.gitignore|makefile|dockerfile|caddyfile(\\..*)?)$/ || low ~ /(^|\\/)(compose|docker-compose)\\./ || low ~ /\\.(md|ts|tsx|js|jsx|mjs|cjs|json|sql|sh|ps1|yml|yaml|toml|css|html|py|service|timer|conf)$/) return \"source_or_config\"; return \"unknown\" } {code=substr(\$0,1,2); path=substr(\$0,4); class=classify(path); counts[class]++; rows++; if (rows <= 240) print code \"\\t\" class \"\\t\" path} END {if (rows > 240) print \"... path classification truncated; total_paths=\" rows; print \"--- classification_counts ---\"; for (class in counts) print counts[class], class}'"
+
+section "Potential Large Generated Directories"
+run_shell "cd '${TARGET_REPO}' && du -sh output dist build coverage .next node_modules .turbo .cache logs tmp 2>/dev/null | sort -h || true"
+
+section "Recent Git Context"
+run_shell "git -C '${TARGET_REPO}' show --stat --oneline --decorate --no-renames --max-count=1 HEAD 2>/dev/null || true"
+run_shell "git -C '${TARGET_REPO}' diff --name-status --stat 2>/dev/null | sed -n '1,180p'"
+run_shell "git -C '${TARGET_REPO}' diff --cached --name-status --stat 2>/dev/null | sed -n '1,180p'"
+
+section "Cleanup Candidate Classification"
+cat <<'EOF'
+Use this table to decide what can happen next. Do not act from this report alone.
+
+| Candidate | Classification | Why | Approval gate |
+| --- | --- | --- | --- |
+| Generated build/test/report outputs | safe with backup | Usually reproducible, but may contain useful evidence | human review of manifest first |
+| Dirty source/config/docs | requires human approval | May be live hotfixes, generated edits, or uncommitted operator work | inspect diff and preserve branch before cleanup |
+| Sensitive path names | do not touch automatically | May be env files, private keys, credentials, or service accounts | security review only |
+| Gone upstream branch | requires human approval | Reset/rebase can discard live-only work | create backup branch or patch bundle first |
+| Unknown/unclassified files | requires human approval | Intent and reproducibility are unknown | owner classification first |
+EOF
+
+section "Safe Next Steps"
+cat <<'EOF'
+1. Save this report with restricted permissions.
+2. Create a backup branch or patch bundle before any cleanup.
+3. Review dirty source/config diffs locally; do not paste secrets or env values into tickets.
+4. Classify generated artifacts separately from operator-authored source changes.
+5. Only after approval, remove or archive generated artifacts in a small PR or maintenance window.
+EOF


### PR DESCRIPTION
## Summary
- Adds `make ops-host-drift` and `scripts/ops/host_drift_inventory.sh` for read-only live checkout drift evidence.
- Adds `docs/ops/10-host-drift-inventory.md` documenting current host drift, cleanup classifications, approval gates, and backup-first workflow.
- Updates the risk register, runbook, maintenance calendar, and generated ops report bundle.

## Evidence
- Live read-only run on `studiobrain` inspected `/home/wuff/monsoonfire-portal` without reading file contents.
- The live checkout is on `codex/next-fix-20260312` with upstream `origin/codex/next-fix-20260312 (gone_or_not_fetched)`.
- Current commit is `5cc3fb8e chore(web): rebaseline reservation chunk budgets`.
- Dirty/untracked inventory: 512 paths total, including 211 modified tracked paths and 301 untracked paths.
- Path-name classification: 486 `source_or_config`, 10 `sensitive_path_name`, 16 `unknown`.
- Large local dirs observed: `output` 294M, `node_modules` 618M, `tmp` 3.6M.

## Files Changed
- `Makefile`
- `scripts/ops/host_drift_inventory.sh`
- `scripts/ops/generate_ops_report.sh`
- `docs/ops/01-risk-register.md`
- `docs/ops/06-runbooks.md`
- `docs/ops/07-maintenance-calendar.md`
- `docs/ops/10-host-drift-inventory.md`

## Testing Performed
- `bash -n scripts/ops/*.sh`
- `TARGET_REPO=. bash scripts/ops/host_drift_inventory.sh`
- `ssh studiobrain "bash -s" < scripts/ops/host_drift_inventory.sh`
- `bash scripts/ops/generate_ops_report.sh output/ops/test-host-drift-smoke`
- `git diff --check`
- `git diff --cached --check`

## Risk Level
Low. This is diagnostic and documentation only. It does not reset, clean, checkout, stash, delete, or edit files on the live host.

## Rollback Instructions
Revert this PR to remove the script, Make target, ops report inclusion, and docs updates. No live host rollback is needed because the PR made no host changes.

## Follow-Up Tickets
- #557: Inventory live host checkout drift.
- Future approval-gated cleanup: create a host backup branch and restricted patch/status bundle, then split accepted host-only work into small PRs before any artifact cleanup.
