### PR TITLE
[ops] Add post-merge ops doctor handoff

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL := /bin/bash
 PG_CONTAINER ?= studiobrain_postgres
 PGDATABASE ?= monsoonfire_studio_os
 
-.PHONY: ops-check ops-inventory ops-postgres-review ops-docker-review ops-capacity ops-backup-evidence ops-ubuntu-review ops-network-review ops-host-drift ops-app-review ops-incident-bundle ops-backlog ops-report
+.PHONY: ops-check ops-inventory ops-postgres-review ops-docker-review ops-capacity ops-backup-evidence ops-ubuntu-review ops-network-review ops-host-drift ops-app-review ops-incident-bundle ops-docs ops-backlog ops-report
 
 ops-check: ops-inventory ops-docker-review ops-capacity ops-backup-evidence ops-ubuntu-review ops-network-review ops-host-drift ops-app-review
 
@@ -43,6 +43,9 @@ ops-app-review:
 
 ops-incident-bundle:
 	bash scripts/ops/incident_bundle.sh
+
+ops-docs:
+	@sed -n '1,220p' docs/ops/README.md
 
 ops-backlog:
 	@sed -n '1,260p' docs/ops/02-kanban-backlog.md

--- a/docs/ops/02-kanban-backlog.md
+++ b/docs/ops/02-kanban-backlog.md
@@ -2,23 +2,25 @@
 
 Each item is issue-ready and intentionally separates investigation from changes that need a service window or approval.
 
+Post-merge note: the first ops-doctor stack has landed in `main`. The items below now emphasize verification, approval-gated runtime work, and the next safe operational surfaces instead of merge sequencing.
+
 ## Now
 
-### [ops] Review and merge ops-doctor PR stack
+### [ops] Verify merged ops-doctor stack from main
 
 - Type: reliability, documentation
 - Priority: P1
-- Effort: M
-- Risk: low for review, medium for stacked merge conflict resolution
+- Effort: S
+- Risk: low
 - Acceptance criteria:
-  - PR stack order is documented from root PR to top PR.
-  - Draft/ready state, merge state, and check status are captured.
-  - Runtime deploy/install actions are separated from merge approval.
-  - Old ops-adjacent draft PRs have an owner decision: refresh, supersede, or close.
-- Status: stack audit prepared in `docs/ops/13-ops-pr-stack-audit.md`.
-- Recommended owner: human, Codex
-- Suggested branch name: `codex/ops-pr-stack-audit`
-- Suggested PR title: `[ops] Audit Studio Brain ops PR stack`
+  - Post-merge evidence lists merged PRs, merge commits, and superseded PR disposition.
+  - Safe command smoke checks pass or have documented local-tool limitations.
+  - Runtime deploy/install actions remain separated from repo merge work.
+  - The ops docs index points operators to the current post-merge handoff.
+- Status: follow-up prepared in `docs/ops/14-post-merge-verification.md`.
+- Recommended owner: Codex
+- Suggested branch name: `codex/ops-admin-next`
+- Suggested PR title: `[ops] Add post-merge ops doctor handoff`
 
 ### [backup] Unify backup evidence and restore confidence
 
@@ -26,6 +28,7 @@ Each item is issue-ready and intentionally separates investigation from changes 
 - Priority: P0
 - Effort: M
 - Risk: low for diagnostics, high for any backup-path change
+- Status: backup evidence scripts and docs are merged; restore confidence still needs an approval-gated drill.
 - Acceptance criteria:
   - Backup report distinguishes config archives, PostgreSQL dump, Redis state, MinIO data, and restore drill status.
   - Latest backup evidence is current within the documented threshold.
@@ -40,6 +43,7 @@ Each item is issue-ready and intentionally separates investigation from changes 
 - Priority: P1
 - Effort: M
 - Risk: low for diagnostics, medium for package changes
+- Status: diagnostic scripts and maintenance workflow are merged; package remediation remains approval-gated.
 - Acceptance criteria:
   - `apt-daily-upgrade.service` OOM root cause is documented.
   - Failed `dailyaidecheck`, livepatch, and network-wait units have disposition: repair, disable intentionally, or ignore with reason.
@@ -54,6 +58,7 @@ Each item is issue-ready and intentionally separates investigation from changes 
 - Priority: P1
 - Effort: M
 - Risk: medium
+- Status: network exposure review is merged; any firewall, bind-address, or SSH hardening remains approval-gated.
 - Acceptance criteria:
   - Current listeners are captured in a redacted report.
   - Legitimate PostgreSQL clients are identified.
@@ -69,6 +74,7 @@ Each item is issue-ready and intentionally separates investigation from changes 
 - Priority: P1
 - Effort: M
 - Risk: low for inventory, high for cleanup
+- Status: host drift inventory workflow is merged; cleanup/reset actions remain approval-gated.
 - Acceptance criteria:
   - Live dirty-file manifest exists with generated/artifact/source classifications.
   - Gone branch status is documented.

--- a/docs/ops/13-ops-pr-stack-audit.md
+++ b/docs/ops/13-ops-pr-stack-audit.md
@@ -4,6 +4,8 @@ Captured: 2026-05-06
 
 This audit inventories currently open Studio Brain / ops-adjacent PRs and separates merge order from runtime approval. It is read-only evidence gathered from GitHub metadata.
 
+Post-merge note: this audit is historical. The ops-doctor stack has since landed; see `docs/ops/14-post-merge-verification.md` for the merged state.
+
 ## Primary Ops-Doctor Stack
 
 Merge from the bottom upward. Each PR currently reports a clean merge state, but stacked branches should still be refreshed after the PR below lands.

--- a/docs/ops/14-post-merge-verification.md
+++ b/docs/ops/14-post-merge-verification.md
@@ -1,0 +1,78 @@
+# Ops Doctor Post-Merge Verification
+
+Captured: 2026-05-06
+
+This note records the merged state after the first Studio Brain ops-doctor stack landed. It is not a deploy record and does not imply runtime approval.
+
+## Merged Pull Requests
+
+| PR | Result | Merge commit | Notes |
+| --- | --- | --- | --- |
+| [#553 `[ops] Add Studio Brain ops doctor first pass`](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/pull/553) | merged | `111570e3912cb98b6c84542926ca49f3c83ed3ed` | root ops-doctor inventory, risks, backlog, capacity, DBA, Docker, runbooks, calendar |
+| [#568 `[ops] Add Studio Brain backup evidence report`](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/pull/568) | merged | `3dbb1400106cc4c29864030b685510e65a332d8f` | backup evidence and restore confidence |
+| [#569 `[ops] Document apt OOM and failed-unit workflow`](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/pull/569) | merged | `f88d446a6b6fc06ced8324d427640be4e5f70602` | apt OOM and failed-unit workflow |
+| [#573 `[ops] Add Studio Brain incident evidence bundle`](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/pull/573) | merged | `8dbb048268d8ccafdebed880eff018957ccb204d` | remaining stack: network exposure, host drift, idle-worker timer files, app review, incident bundle, CPU runbook, watcher lifecycle, PR audit |
+| [#570](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/pull/570) | closed | landed via #573 | network exposure review |
+| [#571](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/pull/571) | closed | landed via #573 | live host drift inventory |
+| [#572](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/pull/572) | closed | landed via #573 | idle-worker timer files; runtime installation still approval-gated |
+
+## Verification Commands
+
+Use a clean `origin/main` worktree:
+
+```bash
+git fetch origin main
+git log origin/main --oneline -8
+bash -n scripts/ops/*.sh
+make ops-backlog
+```
+
+Optional read-only smoke commands:
+
+```bash
+bash scripts/ops/app_status_review.sh
+bash scripts/ops/incident_bundle.sh output/ops/incidents/postmerge-smoke
+bash scripts/ops/generate_ops_report.sh output/ops/postmerge-smoke
+```
+
+Review generated output before sharing it.
+
+## Local Smoke Results
+
+From the clean `codex/ops-admin-next` worktree:
+
+- `bash -n scripts/ops/*.sh` passed.
+- `bash scripts/ops/app_status_review.sh` reached Studio Brain `/healthz`, Studio Brain `/api/status`, and Mission Control `/api/mission-control/health`.
+- Studio Brain `/api/status` reported `status: critical`; treat that as an investigation signal, not a script failure.
+- Mission Control health was reachable through `http://127.0.0.1:4100` and reported storage, cache, request, and metric fields.
+- `bash scripts/ops/generate_ops_report.sh output/ops/postmerge-smoke` completed and wrote ignored local report files under `output/ops/postmerge-smoke`.
+- `make` was not available in the local Windows shell, so direct Bash script smoke was used instead.
+
+## Not Performed
+
+- no deploy
+- no restart
+- no timer installation
+- no package upgrade
+- no firewall, SSH, sudoers, or user change
+- no Docker prune or cleanup
+- no database schema, restore, vacuum, reindex, or drop
+- no secret rotation
+
+## Current Approval Gates
+
+| Gate | Why approval is needed | Pre-check |
+| --- | --- | --- |
+| Mission Control final deploy | changes host files and may restart service | use Mission Control deploy packet |
+| idle-worker timer installation | changes systemd runtime behavior | review `11-idle-worker-systemd.md` |
+| package update remediation | touches kernel/Docker/system packages and may require reboot | review `08-ubuntu-failed-unit-triage.md` |
+| network/SSH/PostgreSQL hardening | can lock out access or break clients | review `09-network-exposure-review.md` |
+| cleanup of logs, backups, Docker artifacts, or temp files | destructive or service-impacting | capture incident/capacity evidence first |
+
+## Next Safe Slices
+
+1. Run post-merge read-only command smoke from `main`.
+2. Refresh host inventory from current `.226` evidence.
+3. Add machine-readable ops report summary.
+4. Add Mission Control import/display for redacted incident summaries.
+5. Prepare approval packets for Mission Control deploy and idle-worker timer install.

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -1,0 +1,70 @@
+# Studio Brain Ops Doctor
+
+This directory is the durable operations surface for Studio Brain. It separates evidence, risk, backlog, runbooks, and approval-gated actions so the owner can review and act without reverse-engineering the host.
+
+## Start Here
+
+| File | Purpose |
+| --- | --- |
+| `00-system-inventory.md` | Current known host, Docker, PostgreSQL, app, and dependency inventory. |
+| `01-risk-register.md` | Findings sorted by severity with evidence, impact, next step, rollback, and PR suitability. |
+| `02-kanban-backlog.md` | Issue-ready backlog grouped by Now, Next, Later, and Waiting / needs approval. |
+| `03-capacity-plan.md` | Disk, Docker, database, log, CPU, memory, backup, and watch-item planning. |
+| `04-postgres-dba-review.md` | PostgreSQL DBA notes, read-only queries, and improvement candidates. |
+| `05-docker-ops-review.md` | Compose, container, healthcheck, volume, network, image, and cleanup review. |
+| `06-runbooks.md` | Operator runbooks for restart, backup, restore, disk pressure, incidents, OOM, migrations, and rollback. |
+| `07-maintenance-calendar.md` | Daily, weekly, monthly, and quarterly checks. |
+| `13-ops-pr-stack-audit.md` | Historical PR stack audit for the merged ops-doctor stack. |
+| `14-post-merge-verification.md` | Post-merge evidence, safe smoke checks, and remaining approval gates. |
+
+## Safe Commands
+
+These commands are read-only by default:
+
+```bash
+make ops-check
+make ops-inventory
+make ops-postgres-review
+make ops-docker-review
+make ops-capacity
+make ops-backup-evidence
+make ops-ubuntu-review
+make ops-network-review
+make ops-host-drift
+make ops-app-review
+make ops-incident-bundle
+make ops-report
+```
+
+The scripts under `scripts/ops/` avoid environment dumps and degrade when Docker, PostgreSQL, or host-only tools are unavailable.
+
+On Windows shells without `make`, run the script directly with Bash, for example:
+
+```bash
+bash scripts/ops/app_status_review.sh
+bash scripts/ops/incident_bundle.sh output/ops/incidents/manual-smoke
+```
+
+## Approval Boundaries
+
+Do not treat a report as permission to mutate the host. These actions still require explicit approval:
+
+- service restarts
+- deploys
+- package upgrades
+- firewall, SSH, sudoers, or user changes
+- Docker prune, volume deletion, or container removal
+- database schema changes, drops, restores over production, or manual vacuum/reindex
+- secret rotation
+- deleting logs, backups, imports, temp files, or generated artifacts
+
+## Current Merged State
+
+The first ops-doctor stack is merged into `main`. Runtime installation and deploy work remain separate:
+
+- Mission Control final deploy is approval-gated.
+- idle-worker systemd timer installation is approval-gated.
+- package update remediation is approval-gated.
+- network/SSH/PostgreSQL hardening is approval-gated.
+
+Use `02-kanban-backlog.md` for the next issue-ready slices.


### PR DESCRIPTION
## Summary
- Adds an ops docs index for the Studio Brain ops-doctor surface.
- Adds a post-merge verification handoff for the merged first-pass ops stack.
- Refreshes the Kanban backlog so it reflects merged work and remaining approval-gated actions.
- Adds a small `make ops-docs` wrapper for discoverability.

## Evidence
- PRs #553, #568, #569, and #573 are recorded as merged with commit evidence.
- PRs #570, #571, and #572 are recorded as closed after landing through #573.
- Read-only smoke reached Studio Brain `/healthz`, Studio Brain `/api/status`, and Mission Control `/api/mission-control/health`; `/api/status` currently reports `status: critical` and is documented as an investigation signal.

## Testing
- `git diff --check` (passes with CRLF warnings only)
- `bash -n scripts/ops/*.sh`
- `bash scripts/ops/app_status_review.sh`
- `bash scripts/ops/generate_ops_report.sh output/ops/postmerge-smoke`
- Direct Bash docs smoke because local Windows shell does not have `make`

## Risk
Low. Documentation and Makefile wrapper only. No deploy, restart, package upgrade, Docker cleanup, database mutation, systemd install, firewall/SSH/sudoers change, or secret rotation.

## Rollback
Revert this commit to remove the post-merge handoff, index, backlog refresh, and `ops-docs` wrapper.

## Follow-Ups
- Mission Control deploy remains approval-gated.
- idle-worker timer installation remains approval-gated.
- Package remediation and network/SSH/PostgreSQL hardening remain approval-gated.
- Investigate the current Studio Brain `/api/status` critical state with read-only evidence first.