### PR TITLE
[ops] Add machine-readable ops report summary

### DIFF
--- a/docs/ops/06-runbooks.md
+++ b/docs/ops/06-runbooks.md
@@ -256,6 +256,22 @@ For laptop watcher lifecycle details, see `docs/ops/12-mission-control-watcher-m
    - delete only the local generated bundle if it contains sensitive local paths
    - do not use bundle output as permission to restart services or clean data
 
+## Ops Evidence Report
+
+1. Capture the read-only report:
+   - `make ops-report`
+   - or `bash scripts/ops/generate_ops_report.sh output/ops/<name>`
+2. Start with `summary.json`:
+   - confirm every report has `status: "ok"` or an intentional `status: "skipped"`
+   - review any `status: "check_failed"` text file before trusting the bundle
+   - use `bytes` to spot empty or unexpectedly tiny reports
+3. Review `README.md` and then the individual text reports.
+4. Treat `postgres_readonly_review` as skipped when the local Docker container is unavailable; run the SQL on the Studio Brain host or with a safe read-only `psql` connection if database evidence is needed.
+5. Do not attach generated output to tickets until local paths and log snippets have been reviewed for sensitivity.
+6. Rollback:
+   - delete only the local generated report directory
+   - do not use report output as permission to restart services, prune Docker, delete data, or mutate PostgreSQL
+
 ## Failed Migration Response
 
 1. Do not rerun migrations blindly.

--- a/scripts/ops/generate_ops_report.sh
+++ b/scripts/ops/generate_ops_report.sh
@@ -9,8 +9,37 @@ STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
 OUT_DIR="${1:-${REPO_ROOT}/output/ops/${STAMP}}"
 PG_CONTAINER="${PG_CONTAINER:-studiobrain_postgres}"
 PGDATABASE="${PGDATABASE:-monsoonfire_studio_os}"
+SUMMARY_ROWS=()
 
 mkdir -p "${OUT_DIR}"
+
+json_string() {
+  local value="${1:-}"
+  value="${value//\\/\\\\}"
+  value="${value//\"/\\\"}"
+  value="${value//$'\n'/\\n}"
+  value="${value//$'\r'/\\r}"
+  printf '"%s"' "${value}"
+}
+
+append_summary_row() {
+  local label="$1"
+  local file="$2"
+  local exit_code="$3"
+  local status="$4"
+  local bytes="0"
+
+  if [ -f "${OUT_DIR}/${file}" ]; then
+    bytes="$(wc -c <"${OUT_DIR}/${file}" | tr -d '[:space:]')"
+  fi
+
+  SUMMARY_ROWS+=("$(printf '{"label":%s,"file":%s,"status":%s,"exitCode":%s,"bytes":%s}' \
+    "$(json_string "${label}")" \
+    "$(json_string "${file}")" \
+    "$(json_string "${status}")" \
+    "${exit_code}" \
+    "${bytes}")")
+}
 
 run_to_file() {
   label="$1"
@@ -20,7 +49,51 @@ run_to_file() {
     printf '# %s\n' "${label}"
     printf '# generated_at=%s\n\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
     "$@"
+    exit_code="$?"
+    printf '\n# exit_code=%s\n' "${exit_code}"
   } >"${OUT_DIR}/${label}.txt" 2>&1
+
+  if [ "${exit_code:-1}" -eq 0 ]; then
+    append_summary_row "${label}" "${label}.txt" "${exit_code}" "ok"
+  else
+    append_summary_row "${label}" "${label}.txt" "${exit_code:-1}" "check_failed"
+  fi
+}
+
+write_skipped_report() {
+  label="$1"
+  shift
+  printf 'writing %s\n' "${OUT_DIR}/${label}.txt"
+  {
+    printf '# %s\n' "${label}"
+    printf '# generated_at=%s\n\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    printf '%s\n' "$@"
+    printf '\n# exit_code=0\n'
+  } >"${OUT_DIR}/${label}.txt" 2>&1
+  append_summary_row "${label}" "${label}.txt" "0" "skipped"
+}
+
+write_summary_json() {
+  local summary_path="${OUT_DIR}/summary.json"
+  printf 'writing %s\n' "${summary_path}"
+  {
+    printf '{\n'
+    printf '  "generatedAt": %s,\n' "$(json_string "$(date -u +%Y-%m-%dT%H:%M:%SZ)")"
+    printf '  "scope": "read_only_ops_report",\n'
+    printf '  "outputDir": %s,\n' "$(json_string "${OUT_DIR}")"
+    printf '  "postgresContainer": %s,\n' "$(json_string "${PG_CONTAINER}")"
+    printf '  "postgresDatabase": %s,\n' "$(json_string "${PGDATABASE}")"
+    printf '  "reports": [\n'
+    local idx
+    for idx in "${!SUMMARY_ROWS[@]}"; do
+      if [ "${idx}" -gt 0 ]; then
+        printf ',\n'
+      fi
+      printf '    %s' "${SUMMARY_ROWS[$idx]}"
+    done
+    printf '\n  ]\n'
+    printf '}\n'
+  } >"${summary_path}"
 }
 
 run_to_file system_inventory bash "${SCRIPT_DIR}/system_inventory.sh"
@@ -37,11 +110,12 @@ run_to_file app_status_review bash "${SCRIPT_DIR}/app_status_review.sh"
 if command -v docker >/dev/null 2>&1 && docker ps --format '{{.Names}}' | grep -qx "${PG_CONTAINER}"; then
   run_to_file postgres_readonly_review docker exec -i -u postgres "${PG_CONTAINER}" psql -d "${PGDATABASE}" -X -v ON_ERROR_STOP=1 -f - <"${SCRIPT_DIR}/postgres_readonly_review.sql"
 else
-  {
-    echo "PostgreSQL docker container ${PG_CONTAINER} was not available."
-    echo "Run manually with: psql -X -v ON_ERROR_STOP=1 -f scripts/ops/postgres_readonly_review.sql"
-  } >"${OUT_DIR}/postgres_readonly_review.txt"
+  write_skipped_report postgres_readonly_review \
+    "PostgreSQL docker container ${PG_CONTAINER} was not available." \
+    "Run manually with: psql -X -v ON_ERROR_STOP=1 -f scripts/ops/postgres_readonly_review.sql"
 fi
+
+write_summary_json
 
 cat >"${OUT_DIR}/README.md" <<EOF
 # Studio Brain Ops Evidence Bundle
@@ -49,6 +123,8 @@ cat >"${OUT_DIR}/README.md" <<EOF
 Generated at: $(date -u +%Y-%m-%dT%H:%M:%SZ)
 
 This bundle is read-only and should not contain secrets. Review before sharing outside the ops team.
+
+Machine-readable summary: \`summary.json\`
 EOF
 
 printf 'ops report written to %s\n' "${OUT_DIR}"


### PR DESCRIPTION
## Summary
- Adds `summary.json` output to `scripts/ops/generate_ops_report.sh`.
- Records each generated report file, byte count, status, and exit code.
- Adds an ops runbook section explaining how to read and safely handle the summary.

## Evidence
- The ops report generator already writes read-only text reports under `output/ops/`.
- The new summary gives Mission Control/import jobs a structured, redacted-by-default manifest without changing host state.

## Testing
- `bash -n scripts/ops/generate_ops_report.sh`
- `bash -n scripts/ops/*.sh`
- `bash scripts/ops/generate_ops_report.sh output/ops/summary-smoke`
- Parsed `output/ops/summary-smoke/summary.json` with Node: 11 reports, statuses `ok` and `skipped`
- `git diff --check` (passes with CRLF warnings only)

## Risk
Low. The script remains read-only and writes only local report artifacts under `output/ops/`. PostgreSQL review remains skipped when the local Docker container is unavailable.

## Rollback
Revert this commit to remove `summary.json` generation and the runbook section.

## Follow-Ups
- Import `summary.json` into Mission Control after the admin view has a safe ingestion surface.
- Add warning/critical interpretation once thresholds are stabilized.