### PR TITLE
[ops] Add portal bridge restart watch item

### DIFF
--- a/docs/ops/01-risk-register.md
+++ b/docs/ops/01-risk-register.md
@@ -70,6 +70,16 @@ No immediate critical data-loss or outage condition was observed in the read-onl
 - Rollback/undo notes: source-controlled units can be reverted; do not remove live timers until replacement is verified.
 - PR can address it: yes.
 
+### Portal Bridge Tunnel Has High Restart History
+
+- Affected component: Studio Brain portal bridge, reverse SSH tunnel, admin reachability.
+- Evidence: `scripts/ops/portal_bridge_review.sh --ssh-host studiobrain` on 2026-05-06 showed `studio-brain-control-tower-proxy.service` active with `NRestarts=0`, and `studio-brain-namecheap-tunnel.service` active with `NRestarts=354`. The proxy was listening on `127.0.0.1:18788`.
+- Likely impact: the bridge can appear healthy at a point in time while historical restart churn hides transient tunnel instability, remote port conflicts, network interruption, SSH keepalive issues, or key permission problems.
+- Recommended action: keep the portal bridge review in weekly checks and inspect journal/remote endpoint evidence if the restart counter continues increasing.
+- Safe next step: run `make ops-portal-bridge-review` or `bash scripts/ops/portal_bridge_review.sh --ssh-host studiobrain` and compare the tunnel restart count to the prior snapshot before considering any service action.
+- Rollback/undo notes: documentation/script changes can be reverted; do not restart or rekey the tunnel just to reset counters.
+- PR can address it: yes, for monitoring/reporting and runbook coverage. Tunnel endpoint, key, or service changes require approval.
+
 ### Several System Units Are Failed
 
 - Affected component: base OS hygiene.

--- a/docs/ops/02-kanban-backlog.md
+++ b/docs/ops/02-kanban-backlog.md
@@ -172,6 +172,21 @@ Post-merge note: the first ops-doctor stack has landed in `main`. The items belo
 - Suggested branch name: `codex/ops-mission-control-watcher-plan`
 - Suggested PR title: `[ops] Document Mission Control watcher lifecycle`
 
+### [ops] Watch portal bridge tunnel restart history
+
+- Type: reliability, app, ubuntu
+- Priority: P2
+- Effort: S
+- Risk: low for diagnostics, medium for service changes
+- Acceptance criteria:
+  - Portal bridge review reports proxy/tunnel active state, restart count, and localhost listener posture without dumping env or key material.
+  - A restart-count increase is classified as a watch item with safe next steps before any service action.
+  - Maintenance calendar or weekly ops checks include the portal bridge review command.
+- Status: review script/docs prepared; runtime restart/rekey remains approval-gated.
+- Recommended owner: Codex, human
+- Suggested branch name: `codex/ops-portal-bridge-review`
+- Suggested PR title: `[ops] Add portal bridge review`
+
 ### [docker] Pin floating image tags
 
 - Type: docker, security, reliability

--- a/docs/ops/07-maintenance-calendar.md
+++ b/docs/ops/07-maintenance-calendar.md
@@ -17,6 +17,7 @@ Use this as an operating rhythm. Treat risky actions as approval-gated.
 - Run `make ops-check` on the host or a comparable Ubuntu shell.
 - Run `make ops-incident-bundle` before any non-trivial incident cleanup or service restart, then review the generated bundle before sharing it.
 - Attach `make ops-backup-evidence` output to any backup/restore-confidence ticket before changing backup paths.
+- Run `make ops-portal-bridge-review` and compare the tunnel restart count against the prior snapshot.
 - Run PostgreSQL size report:
   - `make ops-postgres-review`
 - Review Docker:


### PR DESCRIPTION
## Summary
- add the portal bridge tunnel restart history to the risk register
- add an issue-ready backlog item for watching the tunnel restart counter
- add the portal bridge review to weekly maintenance checks

## Evidence
- `scripts/ops/portal_bridge_review.sh --ssh-host studiobrain` showed the proxy active with `NRestarts=0`, the tunnel active with `NRestarts=354`, and the proxy listening on `127.0.0.1:18788`.

## Testing
- `git diff --check origin/main...HEAD`

## Risk
Low. Documentation-only. Runtime tunnel restart/rekey/endpoint changes remain approval-gated.

## Rollback
Revert this PR to remove the risk/backlog/calendar entries.
