### PR TITLE
[ops] Refresh ops PR stack audit

### DIFF
--- a/docs/ops/01-risk-register.md
+++ b/docs/ops/01-risk-register.md
@@ -63,10 +63,10 @@ No immediate critical data-loss or outage condition was observed in the read-onl
 ### Live Idle-Worker Timers Are Host-Only Drift
 
 - Affected component: systemd timer source of truth.
-- Evidence: host has `studio-brain-idle-worker.timer` and `studio-brain-idle-worker-overnight.timer`; the ops-doctor branch now tracks matching unit and wrapper files under `config/studiobrain/systemd`.
+- Evidence: host has `studio-brain-idle-worker.timer` and `studio-brain-idle-worker-overnight.timer`; PRs through #577 now track matching unit, drop-in, and wrapper files under `config/studiobrain/systemd`. `scripts/ops/systemd_drift_review.sh --ssh-host studiobrain` reported 23 tracked files matched, 0 drift, 0 missing, 0 unreadable, 2 generated remote candidates, and 0 untracked remote candidates.
 - Likely impact: reinstall or reconcile paths may drop or fail to recreate important scheduled work.
-- Recommended action: review and merge the source-controlled unit files, then run the install/reconcile path only in an approved host maintenance window.
-- Safe next step: verify the PR diff against live unit contents and confirm timer state with `systemctl list-timers 'studio-brain-idle-worker*' --all --no-pager`.
+- Recommended action: keep the systemd drift review in weekly checks, then run the install/reconcile path only in an approved host maintenance window if host files drift again.
+- Safe next step: confirm timer state with `systemctl list-timers 'studio-brain-idle-worker*' --all --no-pager` during the next host review.
 - Rollback/undo notes: source-controlled units can be reverted; do not remove live timers until replacement is verified.
 - PR can address it: yes.
 

--- a/docs/ops/02-kanban-backlog.md
+++ b/docs/ops/02-kanban-backlog.md
@@ -6,6 +6,21 @@ Post-merge note: the first ops-doctor stack has landed in `main`. The items belo
 
 ## Now
 
+### [ops] Keep open PR stack audit current
+
+- Type: reliability, cleanup, documentation
+- Priority: P1
+- Effort: S
+- Risk: low
+- Acceptance criteria:
+  - Open portal and Mission Control PRs are listed with merge state, draft state, and recommended disposition.
+  - Recently merged ops/admin PRs are recorded with merge commits.
+  - Dirty or preview-only branches are separated from dependency updates and ops-doctor work.
+- Status: current snapshot captured in `docs/ops/13-ops-pr-stack-audit.md`.
+- Recommended owner: Codex
+- Suggested branch name: `codex/ops-pr-stack-refresh`
+- Suggested PR title: `[ops] Refresh ops PR stack audit`
+
 ### [ops] Verify merged ops-doctor stack from main
 
 - Type: reliability, documentation
@@ -95,7 +110,7 @@ Post-merge note: the first ops-doctor stack has landed in `main`. The items belo
   - `studio-brain-idle-worker` and overnight unit files are tracked under `config/studiobrain/systemd`.
   - Install/reconcile scripts include them.
   - Docs list cadence and safety mode.
-- Status: PR prepared; live installation remains approval-gated.
+- Status: source-controlled timer and drop-in files are merged; live installation remains approval-gated.
 - Recommended owner: Codex
 - Suggested branch name: `codex/ops-idle-worker-systemd`
 - Suggested PR title: `[ops] Track Studio Brain idle-worker systemd timers`

--- a/docs/ops/13-ops-pr-stack-audit.md
+++ b/docs/ops/13-ops-pr-stack-audit.md
@@ -2,61 +2,67 @@
 
 Captured: 2026-05-06
 
-This audit inventories currently open Studio Brain / ops-adjacent PRs and separates merge order from runtime approval. It is read-only evidence gathered from GitHub metadata.
+This audit inventories current Studio Brain / ops-adjacent pull requests and separates merge order from runtime approval. It is read-only evidence gathered from GitHub metadata.
 
-Post-merge note: this audit is historical. The ops-doctor stack has since landed; see `docs/ops/14-post-merge-verification.md` for the merged state.
+## Current State
 
-## Primary Ops-Doctor Stack
+- The first ops-doctor portal stack has landed through PR #580.
+- The Mission Control ingest/deploy hardening stack has landed through Mission Control PR #5.
+- The `studio-brain-mission-control` repo has no open PRs in the observed snapshot.
+- Remaining open portal PRs are older dependabot, draft, or dirty branches. Treat them as independent triage work, not blockers for the ops-doctor docs/scripts lane.
 
-Merge from the bottom upward. Each PR currently reports a clean merge state, but stacked branches should still be refreshed after the PR below lands.
+## Recently Landed Portal Ops PRs
 
-| Order | PR | Head | Base | Draft | Current role |
-| ---: | --- | --- | --- | --- | --- |
-| 1 | [#553 `[ops] Add Studio Brain ops doctor first pass`](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/pull/553) | `codex/studio-brain-ops-doctor` | `main` | yes | Root discovery and ops-doctor artifacts. |
-| 2 | [#568 `[ops] Add Studio Brain backup evidence report`](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/pull/568) | `codex/ops-backup-evidence` | `codex/studio-brain-ops-doctor` | no | Backup evidence and restore confidence. |
-| 3 | [#569 `[ops] Document apt OOM and failed-unit workflow`](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/pull/569) | `codex/ops-apt-failed-units-runbook` | `codex/ops-backup-evidence` | no | Ubuntu failed units and apt OOM triage. |
-| 4 | [#570 `[ops] Add network exposure review and hardening checklist`](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/pull/570) | `codex/ops-network-exposure-review` | `codex/ops-apt-failed-units-runbook` | no | Listener, firewall, SSH, and DB exposure review. |
-| 5 | [#571 `[ops] Add live host drift inventory workflow`](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/pull/571) | `codex/ops-host-drift-inventory` | `codex/ops-network-exposure-review` | no | Live checkout drift inventory. |
-| 6 | [#572 `[ops] Track Studio Brain idle-worker systemd timers`](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/pull/572) | `codex/ops-idle-worker-systemd` | `codex/ops-host-drift-inventory` | no | Source-controlled idle-worker timers; installation remains approval-gated. |
-| 7 | [#573 `[ops] Add Studio Brain incident evidence bundle`](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/pull/573) | `codex/ops-admin-incident-bundle` | `codex/ops-idle-worker-systemd` | yes | Incident bundle, app status review, CPU incident runbook, and watcher lifecycle. |
+| PR | Title | Merge commit | Notes |
+| --- | --- | --- | --- |
+| [#574](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/pull/574) | `[ops] Add post-merge ops doctor handoff` | `73fb3b944bdc0a4f91175b046743a97c6319c055` | Post-merge verification packet and handoff. |
+| [#575](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/pull/575) | `[ops] Add machine-readable ops report summary` | `cfaf8f652950b971a621c1fe6c4cba8ecbebada7` | Adds ops report summary JSON. |
+| [#576](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/pull/576) | `[ops] Track idle-worker live systemd drop-ins` | `a0b4b86c41ea23caa88246e11e3148fc7794eb69` | Tracks live idle-worker drop-ins; host install remains approval-gated. |
+| [#577](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/pull/577) | `[ops] Add systemd drift review` | `2d6ef800c40783c89c3f31c2ff849113a2c4b993` | Adds read-only tracked-vs-installed systemd comparison. |
+| [#578](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/pull/578) | `[ops] Classify portal bridge systemd services` | `d3eb3823c4f6be4744634c1377ee029bb963472c` | Classifies generated portal bridge units. |
+| [#579](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/pull/579) | `[ops] Add portal bridge review` | `38f6c3d9f548f7bc428b6db55a3683f8432d6ce2` | Adds read-only portal bridge service review. |
+| [#580](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/pull/580) | `[ops] Add portal bridge restart watch item` | `d1aa553138a0fd66e71e525d3116d68156663ff9` | Adds restart-history risk/backlog/calendar coverage. |
 
-## Current Check State
+## Recently Landed Mission Control PRs
 
-- PR #573 is green on the observed checks: `build_and_preview`, `intent-drift`, `lighthouse`, `functional-gate`, `drift-blocker`, `smoke`, `ios-smoke`, and `swift-build`; `supervisor-audit` is skipped.
-- PR #573 should remain stacked until #572 lands or is retargeted.
-- PR #553 is the root branch and is still draft; it is the first human review decision before the rest of the stack can land cleanly.
+| PR | Title | Merge commit | Operational note |
+| --- | --- | --- | --- |
+| [#1](https://github.com/monsoonfirepottery-byte/studio-brain-mission-control/pull/1) | `[mission-control] Harden operator surface and ingest pressure` | `4406b94f014a60f987f31192ed2ae80789699d8a` | Published the CPU/backpressure fix and telemetry. |
+| [#2](https://github.com/monsoonfirepottery-byte/studio-brain-mission-control/pull/2) | `[mission-control] Add post-merge deploy packet` | `68337f525441cda6faec2b82b99bf1e32522cd83` | Adds deployment packet and verification notes. |
+| [#3](https://github.com/monsoonfirepottery-byte/studio-brain-mission-control/pull/3) | `[mission-control] Add read-only gateway status probe` | `960b86f53767392b6d87fa9e1f5223c31e028020` | Adds laptop gateway status visibility. |
+| [#4](https://github.com/monsoonfirepottery-byte/studio-brain-mission-control/pull/4) | `[deploy] Document user-service Mission Control deploy target` | `baadf0777fb31c2d8eb6b2ede88e101548e25a9e` | Documents the actual user systemd service target. |
+| [#5](https://github.com/monsoonfirepottery-byte/studio-brain-mission-control/pull/5) | `[deploy] Guard Mission Control production deploy refs` | `c10351ad9ed157018d271df311dc9e7d7e44a024` | Prevents accidental production deploys from non-main refs unless explicitly overridden. |
 
-## Separate Mission Control PR
+## Current Open Portal PRs
 
-| PR | Repo | Head | Base | Draft | Checks | Notes |
-| --- | --- | --- | --- | --- | --- | --- |
-| [#1 `[mission-control] Harden operator surface and ingest pressure`](https://github.com/monsoonfirepottery-byte/studio-brain-mission-control/pull/1) | `studio-brain-mission-control` | `codex/mission-control-ingest-pressure` | `main` | no | `preflight` passed | Publishes the deployed CPU/backpressure hotfix plus follow-up telemetry and CI fixes. Final UI/health telemetry commits still need an approved deploy. |
-
-## Other Open Ops-Adjacent PRs
-
-| PR | Head | Draft | Merge state | Note |
+| PR | Head | Draft | Merge state | Recommended disposition |
 | --- | --- | --- | --- | --- |
-| [#552 `chore(deps): bump ip-address`](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/pull/552) | `dependabot/npm_and_yarn/studio-brain/ip-address-10.2.0` | no | clean | Dependency/security review candidate. |
-| [#547 `chore(deps): bump the routine-version-updates group`](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/pull/547) | `dependabot/npm_and_yarn/studio-brain/routine-version-updates-0d915e92d5` | no | unknown | Needs CI/status refresh before merge. |
-| [#527 `[codex] Add Postgres-backed agent wiki`](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/pull/527) | `codex/auto` | yes | unknown | Older draft; needs owner decision or archival. |
-| [#512 `[codex] Add memory ops sidecar`](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/pull/512) | `codex/memory-ops-sidecar` | yes | unknown | Older draft; likely superseded or needs rebase. |
-| [#492 `[codex] Replace public ops portal bridge`](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/pull/492) | `codex/ops-bridge-replace-472` | no | unknown | Older ops bridge change; needs explicit review before touching production surfaces. |
+| [#552 `chore(deps): bump ip-address`](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/pull/552) | `dependabot/npm_and_yarn/studio-brain/ip-address-10.2.0` | no | behind | Rebase/update and run dependency/security checks as a separate slice. |
+| [#550 `[codex] Ship Monsoon Fire website v2.1.4`](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/pull/550) | `codex/website-v2-1-4-footer` | yes | behind | Keep preview-only unless the owner approves production website work. |
+| [#547 `chore(deps): bump the routine-version-updates group`](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/pull/547) | `dependabot/npm_and_yarn/studio-brain/routine-version-updates-0d915e92d5` | no | behind | Rebase/update and validate in dependency lane. |
+| [#546 `chore(deps): bump zod`](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/pull/546) | `dependabot/npm_and_yarn/functions/routine-version-updates-8616668734` | no | behind | Rebase/update and validate functions tests. |
+| [#530 `[codex] Add polished firing care preview site`](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/pull/530) | `codex/firing-care-preview-copy-polish` | yes | behind | Preserve preview boundary; owner decision needed. |
+| [#529 `chore(deps): bump the routine-version-updates group`](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/pull/529) | `dependabot/npm_and_yarn/routine-version-updates-f507880656` | no | behind | Rebase/update and validate root dependency checks. |
+| [#527 `[codex] Add Postgres-backed agent wiki`](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/pull/527) | `codex/auto` | yes | dirty | Needs owner decision: refresh, supersede, or close. |
+| [#525 `[codex] Harden agentic audit guardrails`](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/pull/525) | `codex/agentic-audit-guardrails` | yes | dirty | Needs owner decision and conflict triage. |
+| [#519 `chore(deps-dev): bump typescript-eslint`](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/pull/519) | `dependabot/npm_and_yarn/web/routine-version-updates-ac3af5607b` | no | behind | Rebase/update and validate web lint/test lane. |
+| [#512 `[codex] Add memory ops sidecar`](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/pull/512) | `codex/memory-ops-sidecar` | yes | dirty | Likely superseded; needs explicit review before reviving. |
+| [#492 `[codex] Replace public ops portal bridge`](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/pull/492) | `codex/ops-bridge-replace-472` | no | dirty | Do not merge without a fresh bridge design review. |
+| [#490 `Align redacted curl output with actual headers`](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/pull/490) | `codex/review-model-coding-issues-and-submit-pr` | no | behind | Rebase/update or close after checking whether the fix is already present. |
 
 ## Recommended Next Actions
 
-1. Review PR #553 first; decide whether the root ops-doctor pass should become ready or remain draft.
-2. Merge the ops-doctor stack bottom-up only after each PR is green against its current base.
-3. Keep runtime installation/deploy actions separate from merge approval:
-   - idle-worker timer installation remains approval-gated
-   - Mission Control final deploy remains approval-gated
-   - any package, firewall, SSH, Docker prune, or database action remains approval-gated
-4. Triage Dependabot PR #552 separately as a security/dependency slice.
-5. Ask whether old draft PRs #527, #512, and #492 should be refreshed, superseded, or closed.
+1. Keep ops-doctor work on fresh `origin/main` branches with one small PR per documentation or read-only script slice.
+2. Triage Dependabot PR #552 first among dependency PRs because it is security-adjacent and scoped to `studio-brain`.
+3. Treat dirty draft PRs as owner-decision cleanup, not routine merge candidates.
+4. Preserve preview-only website boundaries for PRs #550 and #530.
+5. Do not use old portal bridge PR #492 as an implementation base until it is compared against the current portal bridge review in `docs/ops/15-portal-bridge-review.md`.
 
 ## Evidence Commands
 
 ```bash
-gh pr list --state open --limit 80 --json number,title,headRefName,baseRefName,isDraft,mergeStateStatus,updatedAt,url
-gh pr view 573 --json url,title,isDraft,mergeStateStatus,statusCheckRollup,headRefName,baseRefName
-gh pr view --repo monsoonfirepottery-byte/studio-brain-mission-control 1 --json url,title,isDraft,mergeStateStatus,statusCheckRollup,headRefName,baseRefName
+gh pr list --repo monsoonfirepottery-byte/monsoonfire-portal --state open --limit 30 --json number,title,headRefName,isDraft,mergeStateStatus,updatedAt
+gh pr list --repo monsoonfirepottery-byte/studio-brain-mission-control --state open --limit 30 --json number,title,headRefName,isDraft,mergeStateStatus,updatedAt
+gh pr list --repo monsoonfirepottery-byte/studio-brain-mission-control --state merged --limit 8 --json number,title,headRefName,mergedAt,mergeCommit
+git log origin/main --oneline -12
 ```

--- a/docs/ops/14-post-merge-verification.md
+++ b/docs/ops/14-post-merge-verification.md
@@ -15,6 +15,28 @@ This note records the merged state after the first Studio Brain ops-doctor stack
 | [#570](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/pull/570) | closed | landed via #573 | network exposure review |
 | [#571](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/pull/571) | closed | landed via #573 | live host drift inventory |
 | [#572](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/pull/572) | closed | landed via #573 | idle-worker timer files; runtime installation still approval-gated |
+| [#574 `[ops] Add post-merge ops doctor handoff`](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/pull/574) | merged | `73fb3b944bdc0a4f91175b046743a97c6319c055` | post-merge verification packet |
+| [#575 `[ops] Add machine-readable ops report summary`](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/pull/575) | merged | `cfaf8f652950b971a621c1fe6c4cba8ecbebada7` | summary JSON for generated ops reports |
+| [#576 `[ops] Track idle-worker live systemd drop-ins`](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/pull/576) | merged | `a0b4b86c41ea23caa88246e11e3148fc7794eb69` | source-controls live idle-worker drop-ins; install remains approval-gated |
+| [#577 `[ops] Add systemd drift review`](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/pull/577) | merged | `2d6ef800c40783c89c3f31c2ff849113a2c4b993` | read-only systemd tracked-vs-installed drift check |
+| [#578 `[ops] Classify portal bridge systemd services`](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/pull/578) | merged | `d3eb3823c4f6be4744634c1377ee029bb963472c` | generated portal bridge units classified in drift review |
+| [#579 `[ops] Add portal bridge review`](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/pull/579) | merged | `38f6c3d9f548f7bc428b6db55a3683f8432d6ce2` | read-only portal bridge service and listener review |
+| [#580 `[ops] Add portal bridge restart watch item`](https://github.com/monsoonfirepottery-byte/monsoonfire-portal/pull/580) | merged | `d1aa553138a0fd66e71e525d3116d68156663ff9` | risk/backlog/calendar coverage for tunnel restart history |
+
+## Mission Control Deploy State
+
+The Mission Control CPU/backpressure and deploy-guard stack is merged through PR #5 in `studio-brain-mission-control`. The live host was redeployed from main after a stale branch package briefly overwrote the verified release.
+
+Observed live release after repair:
+
+- Git commit: `baadf0777fb31c2d8eb6b2ede88e101548e25a9e`
+- Release id: `mission-control-20260506-main-baadf07`
+- Package SHA256: `9a1a82c87553d7add51706ba828fc85f5b720056a0ef4fdd90f6ab3375567bbe`
+- Service target: user unit `studio-brain-mission-control.service`
+- Restart command used: `XDG_RUNTIME_DIR=/run/user/1000 systemctl --user restart studio-brain-mission-control.service`
+- Health evidence: `/api/mission-control/health` reported `ok: true` with `codexIngest` counters present and Node CPU no longer pegged.
+
+Future production deploys should still use the guarded Mission Control deploy helper and avoid non-main branch deploys unless the owner explicitly passes the branch override.
 
 ## Verification Commands
 
@@ -63,7 +85,7 @@ From the clean `codex/ops-admin-next` worktree:
 
 | Gate | Why approval is needed | Pre-check |
 | --- | --- | --- |
-| Mission Control final deploy | changes host files and may restart service | use Mission Control deploy packet |
+| Future Mission Control deploys | changes host files and may restart the user service | use the guarded deploy helper and verify branch/ref metadata |
 | idle-worker timer installation | changes systemd runtime behavior | review `11-idle-worker-systemd.md` |
 | package update remediation | touches kernel/Docker/system packages and may require reboot | review `08-ubuntu-failed-unit-triage.md` |
 | network/SSH/PostgreSQL hardening | can lock out access or break clients | review `09-network-exposure-review.md` |
@@ -71,8 +93,8 @@ From the clean `codex/ops-admin-next` worktree:
 
 ## Next Safe Slices
 
-1. Run post-merge read-only command smoke from `main`.
-2. Refresh host inventory from current `.226` evidence.
-3. Add machine-readable ops report summary.
-4. Add Mission Control import/display for redacted incident summaries.
-5. Prepare approval packets for Mission Control deploy and idle-worker timer install.
+1. Refresh host inventory from current `.226` evidence.
+2. Triage the currently open dependency PR stack, starting with #552.
+3. Add Mission Control import/display for redacted incident summaries.
+4. Prepare an approval packet for idle-worker timer installation.
+5. Add a weekly comparison note for portal bridge tunnel restart counts.

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -65,11 +65,11 @@ Do not treat a report as permission to mutate the host. These actions still requ
 
 ## Current Merged State
 
-The first ops-doctor stack is merged into `main`. Runtime installation and deploy work remain separate:
+The first ops-doctor stack is merged into `main`, including post-merge verification, machine-readable report summaries, systemd drift review, and portal bridge review coverage. Runtime installation and future host mutation work remain separate:
 
-- Mission Control final deploy is approval-gated.
+- Mission Control CPU/backpressure and deploy-ref guard work is merged and deployed; future deploys should use the guarded deploy helper.
 - idle-worker systemd timer installation is approval-gated.
 - package update remediation is approval-gated.
 - network/SSH/PostgreSQL hardening is approval-gated.
 
-Use `02-kanban-backlog.md` for the next issue-ready slices.
+Use `02-kanban-backlog.md` for the next issue-ready slices, and `13-ops-pr-stack-audit.md` for current open PR triage.


### PR DESCRIPTION
## Summary
- refresh the ops PR stack audit with current open portal PRs and landed Mission Control PRs
- update post-merge verification with PRs #574-#580 and the repaired Mission Control deploy state
- update backlog/risk/index notes for the current ops-doctor state

## Evidence
- current portal PR snapshot from gh pr list on 2026-05-06
- Mission Control merged PR snapshot through PR #5
- origin/main log through PR #580

## Testing
- git diff --check

## Risk
Low. Documentation only.

## Rollback
Revert commit 0c99c888.

## Follow-up Tickets
- Triage Dependabot PR #552
- Refresh host inventory from current .226 evidence
- Prepare idle-worker timer installation approval packet