### PR TITLE
[ops] Refresh host capacity inventory

### DIFF
--- a/docs/ops/00-system-inventory.md
+++ b/docs/ops/00-system-inventory.md
@@ -1,6 +1,6 @@
 # Studio Brain System Inventory
 
-Snapshot time: 2026-05-06 00:16-00:20 UTC, from `D:\monsoonfire-portal-ops-doctor` against SSH alias `studiobrain` and LAN API `http://192.168.1.226:8787`.
+Snapshot time: 2026-05-06 07:00-07:02 UTC, from `D:\monsoonfire-portal-idle-reconcile` against SSH alias `studiobrain` and LAN API `http://192.168.1.226:8787`.
 
 ## Host Assumptions And Known Facts
 
@@ -9,55 +9,55 @@ Snapshot time: 2026-05-06 00:16-00:20 UTC, from `D:\monsoonfire-portal-ops-docto
 - Live repo path: `/home/wuff/monsoonfire-portal`.
 - Windows repo path for reviewable changes: `D:\monsoonfire-portal`.
 - This inventory is read-only. No services were restarted, no packages were upgraded, no Docker objects were pruned, and no database writes were made.
-- The live host checkout is not currently clean: it is on `codex/next-fix-20260312...origin/codex/next-fix-20260312 [gone]` with 211 tracked dirty files.
+- The live host checkout is not currently clean: it is on `codex/next-fix-20260312...origin/codex/next-fix-20260312 [gone]` with 512 dirty or untracked paths.
 
 ## OS And Kernel
 
 - OS: Ubuntu 25.10 (`PRETTY_NAME="Ubuntu 25.10"`).
 - Kernel: `6.17.0-22-generic`.
-- Uptime: 19 days, 1 hour at collection time.
+- Uptime: 19 days, 8 hours at collection time.
 - Hostname: `studiobrain`.
 - Primary operator user: `wuff` (`uid=1000`), member of `sudo`, `docker`, and `adm`.
 
 ## Package Manager State
 
-- Reboot required: no `/var/run/reboot-required` file at collection time.
+- Reboot required: yes. `/var/run/reboot-required.pkgs` listed `linux-image-6.17.0-23-generic` and `linux-base`.
 - `unattended-upgrades.service`: enabled and active.
-- Pending upgrades include kernel packages (`linux-generic` 6.17.0-23), Docker Engine/Compose (`29.4.2`, compose `5.1.3`), `curl`, `systemd`, `nodejs` 25.9.0, `containerd.io`, `rsyslog`, `sed`, and `snapd`.
-- Failed units include `apt-daily-upgrade.service`; systemd reports `Result=oom-kill`, and the kernel log shows `unattended-upgr` was killed by the OOM killer on 2026-05-05 06:56 UTC.
+- Pending upgrades include cloud-init, Docker Engine/Compose (`29.4.2`, compose `5.1.3`), `containerd.io`, `systemd`, `nodejs` 25.9.0, `rsyslog`, `snapd`, Ubuntu Pro client, release upgrader, and kernel-related packages.
+- `apt-daily-upgrade.service` no longer appears in `systemctl --failed`; `systemctl show` reported `Result=success`, `ExecMainStatus=0`, `ActiveState=inactive`, and `SubState=dead`. The prior OOM event remains operational evidence because the kernel log showed `unattended-upgr` killed on 2026-05-05 06:56 UTC.
 
 ## Mounted Filesystems
 
 | Mount | Type | Size | Used | Available | Use |
 | --- | --- | ---: | ---: | ---: | ---: |
-| `/` | ext4 on LVM | 914G | 124G | 753G | 15% |
+| `/` | ext4 on LVM | 914G | 126G | 751G | 15% |
 | `/boot` | ext4 | 2.0G | 240M | 1.6G | 14% |
 | `/boot/efi` | vfat | 1.1G | 6.3M | 1.1G | 1% |
-| `/tmp` | tmpfs | 16G | 28M | 16G | 1% |
+| `/tmp` | tmpfs | 16G | 55M | 16G | 1% |
 
 Inodes are healthy: `/` has about 59M inodes with 2% used.
 
 ## Disk Usage Risks
 
-- `/home/wuff`: 89G.
+- `/home/wuff`: 91G.
 - `/home/wuff/monsoonfire-portal`: 44G.
-- `/home/wuff/imports`: 23G.
-- `/var/lib/docker`: 12G.
-- `/home/wuff/backups`: 2.4G.
-- `/home/wuff/studio-brain-mission-control`: 2.8G.
+- `/home/wuff/imports`: 45G.
+- Docker system data: 8.984GB in local volumes, 4.397GB in images, and 300.3MB build cache. Non-root `du` against `/var/lib/docker` is not reliable.
+- `/home/wuff/backups`: 3.5G.
+- `/home/wuff/studio-brain-mission-control`: 4.0G.
 - `/home/wuff/.npm`: 4.2G.
 - `/home/wuff/.cache`: 3.8G.
-- `/var/log`: 84M.
-- `/tmp`: 28M.
-- `/var/backups/studio-brain`: 756K.
+- `/var/log`: 93M.
+- `/tmp`: 55M.
+- `/var/backups/studio-brain`: 8.0K observed through the non-root read.
 
-Disk pressure is not immediate, but repository/import/cache growth is the largest long-term storage concern.
+Disk pressure is not immediate, but import growth is now the clearest near-term capacity watch item: `/home/wuff/imports` increased from 23G in the earlier 2026-05-06 snapshot to 45G at 07:00 UTC.
 
 ## Memory And Swap
 
-- RAM: 30Gi total, 4.5Gi used, 19Gi free, 25Gi available.
-- Swap: 8.0Gi total, 448Mi used.
-- Load average at collection: about `1.36, 1.28, 1.11`.
+- RAM: 30Gi total, 3.9Gi used, 15Gi free, 26Gi available.
+- Swap: 8.0Gi total, 445Mi used.
+- Load average at collection: about `0.23, 0.37, 0.49`.
 - One OOM event was observed in the last 14 days: `apt-daily-upgrade.service` caused an OOM kill of `unattended-upgr`.
 
 ## Systemd Services Relevant To Studio Brain
@@ -66,8 +66,8 @@ User-scoped services under `wuff`:
 
 | Unit | State | Restart | PID | Memory |
 | --- | --- | --- | ---: | ---: |
-| `studio-brain.service` | active/running | always | 525535 | ~286M |
-| `studio-brain-mission-control.service` | active/running | on-failure | 3552280 | ~980M |
+| `studio-brain.service` | active/running | always | 525535 | ~244M |
+| `studio-brain-mission-control.service` | active/running | on-failure | 3983284 | ~481M |
 
 System services/timers:
 
@@ -86,10 +86,11 @@ The idle-worker timers are present on the host. This branch adds matching tracke
 
 ## Failed Units
 
-- `apt-daily-upgrade.service`: failed, `Result=oom-kill`.
 - `dailyaidecheck.service`: failed, `ExecMainStatus=1`.
 - `snap.canonical-livepatch.canonical-livepatchd.service`: failed, 5 restarts.
 - `systemd-networkd-wait-online.service`: failed, `ExecMainStatus=1`.
+
+`apt-daily-upgrade.service` was no longer failed in the 07:00 UTC snapshot, but the host now requires a reboot for kernel packages.
 
 ## Cron And Timer Inventory
 
@@ -117,10 +118,13 @@ Observed listeners:
 - `0.0.0.0:5433` and `[::]:5433`: PostgreSQL container host port.
 - `127.0.0.1:6379`: Redis.
 - `127.0.0.1:9010` and `127.0.0.1:9011`: MinIO API/console.
+- `127.0.0.1:8889`: Docker-published local service, role to confirm.
+- `127.0.0.1:4317` and `127.0.0.1:4318`: OpenTelemetry collector.
 - `127.0.0.1:19999`: Netdata.
 - `127.0.0.1:3001`: Uptime Kuma.
 - `192.168.1.226:18080` and `192.168.1.226:18081`: monitoring proxy.
 - `127.0.0.1:8080`: SearXNG.
+- `127.0.0.1:631` and `[::1]:631`: CUPS.
 
 Follow-up network exposure capture on 2026-05-06 01:10 UTC shows `ufw` enabled and active by systemd, but non-root `ufw status`, `nft`, and `iptables` rule visibility required a privileged read. Treat firewall rule coverage as unknown until `sudo ufw status numbered verbose` or equivalent is captured. `fail2ban` is active, but jail details also required a privileged read in the follow-up.
 
@@ -133,7 +137,7 @@ SSH posture requires effective-config confirmation. Readable config fragments an
 ## Docker Version And Compose Files
 
 - Docker Engine: 29.4.0.
-- Docker Compose: v5.1.2.
+- Docker Compose: v5.1.2. Package updates are available for Docker Engine 29.4.2 and Compose 5.1.3.
 - Compose projects reported by `docker compose ls`:
   - `studio-brain`: `/home/wuff/monsoonfire-portal/studio-brain/docker-compose.yml`
   - `monitoring`: `/home/wuff/monitoring/docker-compose.yml`
@@ -161,7 +165,7 @@ Docker space summary:
 
 - Images: 9 total, 4.397GB.
 - Containers: 9 total, all active.
-- Local volumes: 8 total, 5 active, 9.303GB.
+- Local volumes: 8 total, 5 active, 8.984GB.
 - Build cache: 300.3MB, all reclaimable.
 
 ## PostgreSQL Version And Connection Method
@@ -170,7 +174,9 @@ Docker space summary:
 - Image: `pgvector/pgvector:pg16`.
 - Host port: `5433 -> 5432`, bound to all interfaces by current Compose default.
 - Database: `monsoonfire_studio_os`.
+- Database size: 8333MB (`8738126871` bytes).
 - Extensions: `pg_stat_statements`, `pg_trgm`, `pgcrypto`, `plpgsql`, `vector`.
+- Connection snapshot: 7 sessions, 0 idle-in-transaction sessions, and 0 ungranted locks.
 - App health reports PostgreSQL connected with low single-digit millisecond latency.
 
 ## Application Components And Dependency Map
@@ -192,6 +198,7 @@ flowchart LR
 ## Current Live API Health
 
 - `/healthz`: `ok=true`.
-- `/readyz`: `ok=true`, PostgreSQL connected, state snapshot age 13 minutes.
+- `/readyz`: previously `ok=true`, PostgreSQL connected, state snapshot age 13 minutes; not re-sampled in this refresh.
 - `/health/dependencies`: PostgreSQL, artifact store, vector store, skill registry, and skill sandbox OK; Redis/event bus/kilnaid provider disabled.
-- `/api/status`: scheduler healthy, `computeStudioState` has 210 successes and 0 failures since runtime start on 2026-05-03; overseer status remains `critical` with 6 signal gaps and 8 actions.
+- `/api/status`: overseer status remains `critical` with 6 signal gaps and 8 actions.
+- Mission Control `/api/mission-control/health`: `ok=true`; `codexIngest` reported 246 accepted requests, 1041 accepted events, 0 empty payload requests, 0 rate-limited requests, and `skipRatio=0`.

--- a/docs/ops/01-risk-register.md
+++ b/docs/ops/01-risk-register.md
@@ -1,6 +1,6 @@
 # Studio Brain Risk Register
 
-Snapshot time: 2026-05-06 00:16-00:20 UTC. Findings are separated from fixes. No destructive action was taken.
+Snapshot time: 2026-05-06 07:00 UTC refresh. Findings are separated from fixes. No destructive action was taken.
 
 ## Critical
 
@@ -38,12 +38,12 @@ No immediate critical data-loss or outage condition was observed in the read-onl
 - Rollback/undo notes: changing bind address is reversible but can break remote clients; requires service window and approval.
 - PR can address it: yes, detection and documentation. Actual bind/firewall change needs human approval.
 
-### Unattended Upgrade Failed Due OOM While Security Updates Are Pending
+### Unattended Upgrade OOM History And Reboot-Required State Need Maintenance Window
 
 - Affected component: Ubuntu patching and package hygiene.
-- Evidence: `apt-daily-upgrade.service` failed with `Result=oom-kill`; kernel log shows `unattended-upgr` killed after about 29GB RSS. Pending upgrades include kernel, Docker, curl, systemd, nodejs, snapd, and containerd.
+- Evidence: the earlier 2026-05-06 pass showed `apt-daily-upgrade.service` failed with `Result=oom-kill`; kernel log showed `unattended-upgr` killed after about 29GB RSS. The 07:00 UTC refresh showed `apt-daily-upgrade.service` no longer failed (`Result=success`, `ExecMainStatus=0`), but `/var/run/reboot-required` is now present for `linux-image-6.17.0-23-generic` and `linux-base`. Pending upgrades still include Docker, systemd, nodejs, snapd, containerd, cloud-init, and Ubuntu Pro client packages.
 - Likely impact: security updates may not apply reliably; unattended upgrade can create memory pressure or fail silently between admin reviews.
-- Recommended action: inspect apt logs, determine why unattended upgrade consumed excessive memory, then run updates in a supervised maintenance window.
+- Recommended action: inspect apt logs, determine why unattended upgrade consumed excessive memory, then run remaining updates/reboot in a supervised maintenance window.
 - Safe next step: capture apt/unattended-upgrades logs and create a maintenance checklist.
 - Rollback/undo notes: package upgrades need normal apt rollback planning; do not upgrade automatically from this PR.
 - PR can address it: yes, runbook and diagnostic script. Host update execution needs approval.
@@ -79,6 +79,16 @@ No immediate critical data-loss or outage condition was observed in the read-onl
 - Safe next step: run `make ops-portal-bridge-review` or `bash scripts/ops/portal_bridge_review.sh --ssh-host studiobrain` and compare the tunnel restart count to the prior snapshot before considering any service action.
 - Rollback/undo notes: documentation/script changes can be reverted; do not restart or rekey the tunnel just to reset counters.
 - PR can address it: yes, for monitoring/reporting and runbook coverage. Tunnel endpoint, key, or service changes require approval.
+
+### Import Directory Growth Accelerated
+
+- Affected component: host storage, mail/import pipelines, retention hygiene.
+- Evidence: `/home/wuff/imports` was 23G in the 2026-05-06 00:16 UTC inventory and 45G in the 2026-05-06 07:00 UTC refresh. Root filesystem pressure is still low at 15% used, but the import path is now the largest observed directory under `/home/wuff`.
+- Likely impact: a runaway or repeated import can consume disk faster than weekly capacity checks notice, and cleanup is risky without knowing which import artifacts are evidence, replayable cache, or source-of-truth data.
+- Recommended action: add import growth reporting by subdirectory/run, define retention classes, and tie cleanup candidates to an approval queue.
+- Safe next step: add a read-only import pressure script that prints sizes, age buckets, and cleanup classifications without deleting files or printing imported content.
+- Rollback/undo notes: reporting/docs can be reverted. Any import deletion, compression, or archival action requires owner approval and a backup/restore note.
+- PR can address it: yes, for reporting and documentation. Cleanup requires human approval.
 
 ### Several System Units Are Failed
 

--- a/docs/ops/02-kanban-backlog.md
+++ b/docs/ops/02-kanban-backlog.md
@@ -98,6 +98,22 @@ Post-merge note: the first ops-doctor stack has landed in `main`. The items belo
 - Suggested branch name: `codex/ops-host-drift-inventory`
 - Suggested PR title: `[ops] Add live host drift inventory workflow`
 
+### [capacity] Add import growth pressure report
+
+- Type: capacity, cleanup, app
+- Priority: P1
+- Effort: S
+- Risk: low for diagnostics, medium for any cleanup
+- Acceptance criteria:
+  - `/home/wuff/imports` subdirectories are listed by size and age without printing imported content.
+  - Cleanup candidates are classified as safe to automate, safe with backup, service-window, approval-only, or do not touch.
+  - The report captures growth deltas when prior snapshots exist.
+  - No files are deleted, compressed, moved, or modified.
+- Status: current evidence shows `/home/wuff/imports` grew from 23G to 45G between the 00:16 UTC and 07:00 UTC snapshots on 2026-05-06.
+- Recommended owner: Codex, human
+- Suggested branch name: `codex/ops-import-pressure-report`
+- Suggested PR title: `[ops] Add import growth pressure report`
+
 ## Next
 
 ### [systemd] Source-control idle-worker timers

--- a/docs/ops/03-capacity-plan.md
+++ b/docs/ops/03-capacity-plan.md
@@ -1,27 +1,29 @@
 # Studio Brain Capacity Plan
 
-Snapshot time: 2026-05-06 00:16-00:20 UTC.
+Snapshot time: 2026-05-06 07:00-07:02 UTC.
 
 ## Current Observed Capacity Constraints
 
-- Root filesystem is healthy at 15% used: 124G of 914G.
+- Root filesystem is healthy at 15% used: 126G of 914G.
 - Inodes are healthy at 2% used on `/`.
-- RAM is healthy at rest: 30Gi total, 25Gi available at collection.
-- Swap has light current use: 448Mi of 8Gi.
-- Docker uses about 12G on disk and reports 9.303GB in local volumes.
-- PostgreSQL database `monsoonfire_studio_os` is about 8.3GB.
-- The largest single growth area under `/home/wuff` is `/home/wuff/monsoonfire-portal` at 44G, followed by `/home/wuff/imports` at 23G.
+- RAM is healthy at rest: 30Gi total, 26Gi available at collection.
+- Swap has light current use: 445Mi of 8Gi.
+- Docker reports 4.397GB in images, 8.984GB in local volumes, and 300.3MB in build cache.
+- PostgreSQL database `monsoonfire_studio_os` is 8333MB.
+- The largest growth areas under `/home/wuff` are `/home/wuff/imports` at 45G and `/home/wuff/monsoonfire-portal` at 44G.
+- `/home/wuff/imports` increased from 23G in the 00:16 UTC snapshot to 45G at 07:00 UTC, so import growth should be treated as an active watch item even though total disk pressure is still low.
 
 ## Disk Growth Concerns
 
 | Path | Observed size | Concern |
 | --- | ---: | --- |
+| `/home/wuff/imports` | 45G | mail/import pipelines need retention policy and growth trend; growth accelerated in the latest same-day snapshot |
 | `/home/wuff/monsoonfire-portal` | 44G | repo artifacts, imports, build output, generated state, and dirty host checkout can grow invisibly |
-| `/home/wuff/imports` | 23G | mail/import pipelines need retention policy and growth trend |
-| `/var/lib/docker` | 12G | volumes/images currently manageable but should be trended |
+| Docker volumes/images | 8.984G volumes, 4.397G images | volumes/images currently manageable but should be trended |
 | `/home/wuff/.npm` | 4.2G | package cache cleanup candidate |
 | `/home/wuff/.cache` | 3.8G | cache cleanup candidate |
-| `/home/wuff/studio-brain-mission-control` | 2.8G | deployment/archive retention needs policy |
+| `/home/wuff/studio-brain-mission-control` | 4.0G | deployment/archive retention needs policy |
+| `/home/wuff/backups` | 3.5G | backup retention and restore evidence should be tied to the backup manifest |
 
 Warning threshold: root filesystem above 70% or any growth area increasing by more than 10G/week.
 
@@ -29,13 +31,13 @@ Critical threshold: root filesystem above 85%, `/boot` above 80%, or free space 
 
 ## Database Growth Concerns
 
-- Database size: 8.3GB.
+- Database size: 8333MB.
 - Largest relations:
   - `public.swarm_memory`: 3.1GB.
   - `public.memory_relation_edge`: 2.3GB.
   - `public.memory_pattern_index`: 1.3GB.
   - `public.memory_entity_index`: 1.0GB.
-  - `public.memory_ingest_event`: 287MB.
+  - `public.memory_ingest_event`: 288MB.
 - Largest indexes are memory retrieval/search indexes, several over 240MB and up to 591MB.
 - Dead tuple percentages are mostly low on large tables, but small operational tables show high dead percentages and should not be over-interpreted without row counts.
 
@@ -47,7 +49,7 @@ Critical threshold: database grows above 50GB without a tested restore process.
 
 - Images: 4.397GB.
 - Containers: 4.112MB writable layer total.
-- Volumes: 9.303GB.
+- Volumes: 8.984GB.
 - Build cache: 300.3MB reclaimable.
 - No dangling images or exited containers were observed.
 - Docker reports 8 local volumes but only 5 active, so anonymous volume ownership should be classified before cleanup.
@@ -58,9 +60,9 @@ Critical threshold: Docker root above 80G or unknown inactive volumes containing
 
 ## Log Growth
 
-- `/var/log`: 84M.
+- `/var/log`: 93M.
 - systemd journal: 48M.
-- `/tmp`: 28M.
+- `/tmp`: 55M.
 - Current log pressure is low.
 
 Warning threshold: `/var/log` above 2G, journal above 1G, or any single Docker json log above 512M.
@@ -69,9 +71,9 @@ Critical threshold: logs consume more than 10% of root filesystem.
 
 ## CPU And Memory Pressure
 
-- CPU load was low relative to typical desktop/server capacity.
+- CPU load was low at the 07:00 UTC observation: `0.23, 0.37, 0.49`.
 - RAM was healthy during observation, but unattended upgrades triggered an OOM kill on 2026-05-05.
-- `studio-brain-mission-control.service` was using about 980M and `studio-brain.service` about 286M.
+- `studio-brain-mission-control.service` was using about 481M and `studio-brain.service` about 244M.
 - Docker resource limits exist in tracked Compose for core dependencies, but user-scoped app services are not capped at the systemd level in this pass.
 
 Warning threshold: sustained load above CPU count for 15 minutes, swap above 25%, or Mission Control above 1.5GB.
@@ -82,7 +84,7 @@ Critical threshold: OOM event, swap above 75%, or repeated service restarts.
 
 - Root-owned config archives under `/var/backups/studio-brain/daily` are tiny and current through 2026-05-05.
 - App-level backup evidence under `output/backups/latest.json` points to 2026-04-28.
-- PostgreSQL is 8.3GB; full database backups and restore drills need explicit storage and retention modeling.
+- PostgreSQL is 8333MB; full database backups and restore drills need explicit storage and retention modeling.
 - MinIO and Redis backup posture should be proven in the same manifest as PostgreSQL.
 
 Minimum recommendation:
@@ -97,6 +99,7 @@ Minimum recommendation:
 
 - Fix backup evidence split and prove a current PostgreSQL restore drill.
 - Triage apt OOM and pending updates.
+- Investigate `/home/wuff/imports` growth and define retention for import artifacts.
 - Snapshot Postgres relation sizes weekly.
 - Classify anonymous Docker volumes.
 
@@ -115,6 +118,7 @@ Minimum recommendation:
 ## Metrics Missing Or Not Yet Collected
 
 - Historical disk growth by path.
+- Per-import-run size deltas and retention policy for `/home/wuff/imports`.
 - Historical database table/index growth.
 - pg_stat_statements top queries by total time and mean time.
 - Backup restore duration and verified restore target size.

--- a/docs/ops/04-postgres-dba-review.md
+++ b/docs/ops/04-postgres-dba-review.md
@@ -1,6 +1,6 @@
 # Studio Brain PostgreSQL DBA Review
 
-Snapshot time: 2026-05-06 00:18 UTC. Queries were read-only against `studiobrain_postgres`.
+Snapshot time: 2026-05-06 07:01 UTC. Queries were read-only against `studiobrain_postgres`.
 
 ## Version And Config Facts
 
@@ -23,7 +23,7 @@ Snapshot time: 2026-05-06 00:18 UTC. Queries were read-only against `studiobrain
 
 | Database | Size |
 | --- | ---: |
-| `monsoonfire_studio_os` | 8285 MB |
+| `monsoonfire_studio_os` | 8333 MB |
 | `template1` | 7425 kB |
 | `postgres` | 7361 kB |
 | `template0` | 7361 kB |
@@ -34,11 +34,11 @@ Largest table families:
 
 | Relation | Total | Table | Indexes | Live tuples | Dead tuples |
 | --- | ---: | ---: | ---: | ---: | ---: |
-| `public.swarm_memory` | 3142 MB | 1235 MB | 946 MB | 180,229 | 6,149 |
-| `public.memory_relation_edge` | 2287 MB | 771 MB | 1515 MB | 2,566,505 | 7,441 |
-| `public.memory_pattern_index` | 1318 MB | 315 MB | 1002 MB | 1,995,185 | 34,824 |
-| `public.memory_entity_index` | 1035 MB | 272 MB | 763 MB | 1,762,855 | 7,930 |
-| `public.memory_ingest_event` | 287 MB | 226 MB | 61 MB | 498,977 | 0 |
+| `public.swarm_memory` | 3164 MB | 1235 MB | 947 MB | 178,474 | 7,181 |
+| `public.memory_relation_edge` | 2290 MB | 771 MB | 1519 MB | 2,574,887 | 9,913 |
+| `public.memory_pattern_index` | 1318 MB | 315 MB | 1003 MB | 1,997,316 | 37,308 |
+| `public.memory_entity_index` | 1038 MB | 273 MB | 765 MB | 1,770,581 | 8,768 |
+| `public.memory_ingest_event` | 288 MB | 226 MB | 61 MB | 500,022 | 0 |
 
 Largest indexes:
 
@@ -65,9 +65,9 @@ Largest indexes:
 ## Connection Count And Pooling Status
 
 - Activity state snapshot:
-  - `<null>`: 5 background processes.
-  - `idle`: 2.
-  - `active`: 1, the inspection query itself.
+  - 7 total sessions.
+  - 0 idle-in-transaction sessions.
+  - 0 ungranted locks.
 - No evidence of connection saturation was observed.
 - No external connection pooler was discovered in Docker inventory.
 

--- a/docs/ops/05-docker-ops-review.md
+++ b/docs/ops/05-docker-ops-review.md
@@ -1,6 +1,6 @@
 # Studio Brain Docker Ops Review
 
-Snapshot time: 2026-05-06 00:17 UTC.
+Snapshot time: 2026-05-06 07:00 UTC.
 
 ## Compose Files Discovered
 
@@ -68,6 +68,7 @@ Anonymous/local volumes:
 
 - Six hash-named local volumes were observed.
 - Docker reports 8 total local volumes and 5 active volumes.
+- Local volume size is 8.984GB in the latest `docker system df` snapshot.
 
 Do not delete anonymous volumes until they are mapped to containers or backed up.
 
@@ -85,6 +86,7 @@ Monitoring Compose attaches Uptime Kuma to `studio-brain_default` and `searxng_d
 ## Image Sprawl And Dangling Artifact Concerns
 
 - Images: 9 total, 4.397GB.
+- Containers: 9 total, all active.
 - Dangling images: none observed.
 - Build cache: 300.3MB reclaimable.
 - No exited containers observed.

--- a/docs/ops/08-ubuntu-failed-unit-triage.md
+++ b/docs/ops/08-ubuntu-failed-unit-triage.md
@@ -1,19 +1,18 @@
 # Studio Brain Ubuntu Failed Unit Triage
 
-Snapshot: 2026-05-06 00:57 UTC.
+Snapshot: 2026-05-06 07:00 UTC.
 
 This note is evidence and disposition only. It does not approve package upgrades, service disables, unit resets, reboots, firewall changes, or SSH changes.
 
 ## Summary
 
-`make ops-ubuntu-review` captured four failed units:
+`systemctl --failed --no-pager` captured three failed units:
 
-- `apt-daily-upgrade.service`
 - `dailyaidecheck.service`
 - `snap.canonical-livepatch.canonical-livepatchd.service`
 - `systemd-networkd-wait-online.service`
 
-Host memory was healthy at capture time: 30Gi total, 25Gi available, 447Mi swap used. The apt failure was a prior spike, not current steady pressure.
+Host memory was healthy at capture time: 30Gi total, 26Gi available, 445Mi swap used. The apt OOM failure from 2026-05-05 no longer appears in the failed-unit list, but the host now reports a reboot requirement for kernel packages.
 
 ## Apt Daily Upgrade OOM
 
@@ -25,14 +24,16 @@ Evidence:
 - `systemd-networkd-wait-online` timed out before the apt run.
 - Unattended upgrade logs repeatedly warn: `Could not figure out development release: Distribution data outdated`.
 - Pending packages include kernel, Docker, containerd, curl, systemd, snapd, Node.js, rsyslog, sed, and Ubuntu release upgrader packages.
-- `/var/run/reboot-required` was absent at capture time.
+- At 07:00 UTC, `systemctl show apt-daily-upgrade.service` reported `Result=success`, `ExecMainStatus=0`, `ActiveState=inactive`, and `SubState=dead`.
+- `/var/run/reboot-required` is now present and lists `linux-image-6.17.0-23-generic` and `linux-base`.
 
 Disposition:
 
-- Treat the exact OOM root cause as unresolved but bounded: unattended upgrade/install path caused an extreme memory spike while package metadata and network-online warnings were already noisy.
+- Treat the exact OOM root cause as unresolved but bounded: a later apt run succeeded, but unattended upgrade/install previously caused an extreme memory spike while package metadata and network-online warnings were already noisy.
 - Do not rerun unattended upgrades blindly.
 - Run updates only in a supervised maintenance window with pre-checks and post-checks.
 - Include `distro-info-data`/release metadata freshness in the apt investigation even if it is not currently listed in `apt list --upgradable`.
+- Plan a supervised reboot window because kernel packages now require it.
 
 Safe next step:
 


### PR DESCRIPTION
## Summary
- refresh Studio Brain host inventory from read-only .226 evidence captured at 2026-05-06 07:00 UTC
- update capacity, DBA, Docker, Ubuntu failed-unit, risk, and backlog docs
- add a new import-growth capacity watch item after /home/wuff/imports grew from 23G to 45G in the same-day snapshots

## Evidence
- ssh read-only host snapshot: df/free/swapon/systemctl/ss/docker system df
- PostgreSQL read-only size and activity queries via docker exec psql
- Mission Control health showed codexIngest clean: 246 accepted requests, 1041 events, zero empty/rate-limited requests

## Testing
- git diff --check origin/main...HEAD

## Risk
Low. Documentation only; no host mutation, restart, package change, Docker prune, or database write.

## Rollback
Revert commit 1ae4a7b4.

## Follow-up Tickets
- Add read-only import pressure report script
- Schedule supervised reboot/update maintenance window
- Continue backup restore evidence work