### PR TITLE
[ops] Summarize Ubuntu update posture

### DIFF
--- a/docs/ops/08-ubuntu-failed-unit-triage.md
+++ b/docs/ops/08-ubuntu-failed-unit-triage.md
@@ -14,6 +14,8 @@ This note is evidence and disposition only. It does not approve package upgrades
 
 Host memory was healthy at capture time: 30Gi total, 26Gi available, 445Mi swap used. The apt OOM failure from 2026-05-05 no longer appears in the failed-unit list, but the host now reports a reboot requirement for kernel packages.
 
+`make ops-ubuntu-review` now prints a top-level `Reboot And Update Posture` section before the longer unit journals. Use that section for the quick go/no-go maintenance signal, then attach the deeper unit and apt log evidence to any package/reboot ticket.
+
 ## Apt Daily Upgrade OOM
 
 Evidence:

--- a/scripts/ops/ubuntu_failed_units.sh
+++ b/scripts/ops/ubuntu_failed_units.sh
@@ -39,6 +39,12 @@ run_shell "free -h"
 run_shell "swapon --show"
 run_shell "ps -eo pid,ppid,user,stat,pcpu,pmem,rss,comm,args --sort=-rss | head -n 25"
 
+section "Reboot And Update Posture"
+run_shell "test -f /var/run/reboot-required && { echo reboot_required=yes; cat /var/run/reboot-required.pkgs 2>/dev/null || true; } || echo reboot_required=no"
+run_shell "apt list --upgradable 2>/dev/null | awk 'NR>1 && /upgradable from:/ {count++; split(\$1, parts, \"/\"); packages[parts[1]]=1} END {print \"upgradable_count=\" count+0; for (name in packages) print \"upgradable_package=\" name}' | sort"
+run_shell "systemctl show apt-daily-upgrade.service --no-pager -p ActiveState -p SubState -p Result -p ExecMainStatus -p NRestarts"
+run_shell "systemctl show unattended-upgrades.service --no-pager -p ActiveState -p SubState -p Result -p ExecMainStatus -p NRestarts"
+
 section "Failed Units"
 if command -v systemctl >/dev/null 2>&1; then
   run_shell "systemctl --failed --no-pager"

--- a/studio-brain/.env.integrity.json
+++ b/studio-brain/.env.integrity.json
@@ -1,6 +1,6 @@
 {
   "schema": "studiobrain-infra-integrity-v1",
-  "generatedAt": "2026-05-06T07:15:40.968Z",
+  "generatedAt": "2026-05-06T07:20:12.387Z",
   "generatedBy": "scripts/integrity-check.mjs",
   "allowUnknown": false,
   "metadata": {


### PR DESCRIPTION
## Summary
- add a top-level reboot/update posture section to the read-only Ubuntu ops review
- show reboot-required packages, upgradable package count/list, apt-daily-upgrade state, and unattended-upgrades state before the long unit journals
- document the quick posture section in the Ubuntu failed-unit triage note

## Evidence
- live host smoke showed reboot_required=yes, 30 upgradable packages, apt-daily-upgrade Result=success, unattended-upgrades active/running

## Testing
- bash -n scripts/ops/ubuntu_failed_units.sh
- remote read-only smoke via ssh piping script to bash and extracting Reboot And Update Posture section
- node scripts/integrity-check.mjs --update --manifest studio-brain/.env.integrity.json
- node scripts/integrity-check.mjs --json
- git diff --check

## Risk
Low. Read-only diagnostics and documentation only.

## Rollback
Revert commit d4bb7f08.

## Follow-up Tickets
- Schedule supervised update/reboot maintenance window
- Add apt metadata freshness check if release metadata warnings continue