### PR TITLE
chore(deps): bump studio-brain ip-address

### DIFF
--- a/studio-brain/package-lock.json
+++ b/studio-brain/package-lock.json
@@ -2008,9 +2008,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"


### PR DESCRIPTION
## Summary
- bump transitive studio-brain lockfile entry for ip-address from 10.1.0 to 10.2.0
- supersedes the stale/behind Dependabot PR #552 with a fresh branch from current main

## Evidence
- Dependabot PR #552 identified the scoped studio-brain lockfile update
- studio-brain npm audit reports 0 vulnerabilities after the bump

## Testing
- npm audit --package-lock-only --json in studio-brain: 0 vulnerabilities
- npm ci --ignore-scripts in studio-brain
- npm test -- --run in studio-brain: 272 tests passed plus connector contract harness passed
- git diff --check

## Risk
Low. Lockfile-only transitive dependency update.

## Rollback
Revert commit d1ec00b1.

## Follow-up Tickets
- Close/supersede Dependabot PR #552 after this merges
- Triage remaining root/web/functions Dependabot PRs separately