### PR TITLE
chore(deps): bump studio-brain routine deps

### DIFF
--- a/studio-brain/package-lock.json
+++ b/studio-brain/package-lock.json
@@ -11,13 +11,13 @@
         "dotenv": "^16.4.7",
         "firebase-admin": "^13.8.0",
         "googleapis": "^169.0.0",
-        "imapflow": "^1.3.2",
+        "imapflow": "^1.3.3",
         "mailparser": "^3.9.8",
         "minio": "^8.0.7",
-        "nodemailer": "^8.0.5",
+        "nodemailer": "^8.0.7",
         "pg": "^8.20.0",
         "redis": "^4.7.0",
-        "zod": "^4.3.6"
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@types/node": "^22.19.17",
@@ -1974,9 +1974,9 @@
       }
     },
     "node_modules/imapflow": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/imapflow/-/imapflow-1.3.2.tgz",
-      "integrity": "sha512-lIhVpjAf+o/1SELeR34vqeoEjAyBOMd6xq2Vdx2E4XIRwDi5sfqfBqqr5YkTwp7G/Q3f5ACpU7/zuGklJeCj9Q==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/imapflow/-/imapflow-1.3.3.tgz",
+      "integrity": "sha512-lx7nWcUDfNgITEKYYfunUDqJ3LT6ImuiA1ReqJepVEA2nqBQNUqa3ppF7Yz5CNjuDYG95pmzsCcNqRjMrwh/Vg==",
       "license": "MIT",
       "dependencies": {
         "@zone-eu/mailsplit": "5.4.9",
@@ -1985,9 +1985,9 @@
         "libbase64": "1.3.0",
         "libmime": "5.3.8",
         "libqp": "2.1.1",
-        "nodemailer": "8.0.5",
+        "nodemailer": "8.0.7",
         "pino": "10.3.1",
-        "socks": "2.8.7"
+        "socks": "2.8.8"
       }
     },
     "node_modules/imapflow/node_modules/@zone-eu/mailsplit": {
@@ -2300,6 +2300,15 @@
         "tlds": "1.261.0"
       }
     },
+    "node_modules/mailparser/node_modules/nodemailer": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.5.tgz",
+      "integrity": "sha512-0PF8Yb1yZuQfQbq+5/pZJrtF6WQcjTd5/S4JOHs9PGFxuTqoB/icwuB44pOdURHJbRKX1PPoJZtY7R4VUoCC8w==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -2448,9 +2457,9 @@
       }
     },
     "node_modules/nodemailer": {
-      "version": "8.0.5",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.5.tgz",
-      "integrity": "sha512-0PF8Yb1yZuQfQbq+5/pZJrtF6WQcjTd5/S4JOHs9PGFxuTqoB/icwuB44pOdURHJbRKX1PPoJZtY7R4VUoCC8w==",
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.7.tgz",
+      "integrity": "sha512-pkjE4mkBzQjdJT4/UmlKl3pX0rC9fZmjh7c6C9o7lv66Ac6w9WCnzPzhbPNxwZAzlF4mdq4CSWB5+FbK6FWCow==",
       "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"
@@ -3128,12 +3137,12 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.8.7",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
-      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.8.tgz",
+      "integrity": "sha512-NlGELfPrgX2f1TAAcz0WawlLn+0r3FyhhCRpFFK2CemXenPYvzMWWZINv3eDNo9ucdwme7oCHRY0Jnbs4aIkog==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "^10.0.1",
+        "ip-address": "^10.1.1",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
@@ -3600,9 +3609,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/studio-brain/package.json
+++ b/studio-brain/package.json
@@ -27,13 +27,13 @@
     "dotenv": "^16.4.7",
     "firebase-admin": "^13.8.0",
     "googleapis": "^169.0.0",
-    "imapflow": "^1.3.2",
+    "imapflow": "^1.3.3",
     "mailparser": "^3.9.8",
     "minio": "^8.0.7",
-    "nodemailer": "^8.0.5",
+    "nodemailer": "^8.0.7",
     "pg": "^8.20.0",
     "redis": "^4.7.0",
-    "zod": "^4.3.6"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/node": "^22.19.17",


### PR DESCRIPTION
## Summary
- bump Studio Brain imapflow 1.3.2 -> 1.3.3
- bump Studio Brain nodemailer 8.0.5 -> 8.0.7
- bump Studio Brain zod 4.3.6 -> 4.4.3
- supersedes stale/behind Dependabot PR #547 with a fresh main-based branch

## Evidence
- Dependabot PR #547 identified these scoped /studio-brain routine dependency updates
- npm audit for studio-brain reports 0 vulnerabilities after update

## Testing
- npm audit --package-lock-only --json in studio-brain: 0 vulnerabilities
- npm ci --ignore-scripts in studio-brain
- npm test -- --run in studio-brain: 272 tests passed plus connector contract harness passed
- git diff --check

## Risk
Low-medium. Small dependency updates in mail parsing/sending and validation packages; covered by Studio Brain build/tests.

## Rollback
Revert commit 56d083fb.

## Follow-up Tickets
- Close/supersede Dependabot PR #547 after this merges
- Triage remaining functions/root/web Dependabot PRs separately