### PR TITLE
chore(deps): bump functions zod

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -10,7 +10,7 @@
         "firebase-functions": "^7.2.5",
         "googleapis": "^169.0.0",
         "stripe": "^19.1.0",
-        "zod": "^4.3.6"
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.12.0",
@@ -9844,9 +9844,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/functions/package.json
+++ b/functions/package.json
@@ -28,7 +28,7 @@
     "firebase-functions": "^7.2.5",
     "googleapis": "^169.0.0",
     "stripe": "^19.1.0",
-    "zod": "^4.3.6"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.12.0",


### PR DESCRIPTION
## Summary
- Supersedes Dependabot PR #546 with a fresh `origin/main` based branch.
- Updates Functions `zod` from `^4.3.6` to `^4.4.3` in `functions/package.json` and `functions/package-lock.json`.

## Evidence
- Dependency diff is limited to `functions/package.json` and `functions/package-lock.json`.
- `npm audit --package-lock-only --json` reports 0 vulnerabilities in `functions`.

## Testing
- `npm ci --ignore-scripts` in `functions`.
- `npm test` in `functions`: archive guard, type-safety guard, TypeScript build, and 318 Node tests passed.
- `git diff --check`.

## Risk
Low. This is a direct routine dependency bump isolated to Functions package metadata. No schema, runtime config, host, Docker, or PostgreSQL changes.

## Rollback
Revert this PR to restore `zod` `^4.3.6` in Functions package metadata.

## Follow-ups
- Close Dependabot PR #546 after this merges.