### PR TITLE
chore(deps): bump root routine deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,14 +5,14 @@
   "packages": {
     "": {
       "dependencies": {
-        "firebase": "^12.12.0",
+        "firebase": "^12.12.1",
         "firebase-functions": "^7.2.5"
       },
       "devDependencies": {
-        "@axe-core/playwright": "^4.11.2",
+        "@axe-core/playwright": "^4.11.3",
         "@firebase/rules-unit-testing": "^5.0.0",
         "@playwright/test": "^1.59.1",
-        "firebase-tools": "15.15.0",
+        "firebase-tools": "15.16.0",
         "playwright": "^1.58.2"
       },
       "engines": {
@@ -95,13 +95,13 @@
       "license": "Apache-2.0"
     },
     "node_modules/@axe-core/playwright": {
-      "version": "4.11.2",
-      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.2.tgz",
-      "integrity": "sha512-iP6hfNl9G0j/SEUSo8M7D80RbcDo9KRAAfDP4IT5OHB+Wm6zUHIrm8Y51BKI+Oyqduvipf9u1hcRy57zCBKzWQ==",
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.3.tgz",
+      "integrity": "sha512-h/kfksv4F0cVIDlKpT4700OehdRgpvuVskuQ2nb7/JmtWUXpe9ftHAPtwyXGvVSsa6SJ64A9ER7Zrzc/sIvC4w==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
-        "axe-core": "~4.11.3"
+        "axe-core": "~4.11.4"
       },
       "peerDependencies": {
         "playwright-core": ">= 1.0.0"
@@ -168,9 +168,9 @@
       "peer": true
     },
     "node_modules/@firebase/ai": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@firebase/ai/-/ai-2.11.0.tgz",
-      "integrity": "sha512-+oqOne/h5J51LezazR+VyzKe3AK455W29JXnb4jOeVvQhC7FymledN5+XE+w5vEcMhRQ6n1f62fdGs4A44X32A==",
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@firebase/ai/-/ai-2.11.1.tgz",
+      "integrity": "sha512-WGTF81W3WBKJY+c7xqTzO15OGAkCAs8cpADqflAI0skhTZjIkhF0qyf55rq4Ctt6jKygkv99rPfMrjAHTgXaVQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@firebase/app-check-interop-types": "0.3.3",
@@ -3040,9 +3040,9 @@
       "license": "MIT"
     },
     "node_modules/axe-core": {
-      "version": "4.11.3",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.3.tgz",
-      "integrity": "sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg==",
+      "version": "4.11.4",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.4.tgz",
+      "integrity": "sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==",
       "dev": true,
       "license": "MPL-2.0",
       "engines": {
@@ -5167,12 +5167,12 @@
       }
     },
     "node_modules/firebase": {
-      "version": "12.12.0",
-      "resolved": "https://registry.npmjs.org/firebase/-/firebase-12.12.0.tgz",
-      "integrity": "sha512-5Ap+pN5iEJUvBlQEZEmLuUm7Gvu6I5xv1jZ5SiSNyw4jrwlHo+4tmZv3OPPoKfN9eo1kBwyyBvi+pWHIPXwfYw==",
+      "version": "12.12.1",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-12.12.1.tgz",
+      "integrity": "sha512-ee7xA+bTJLfjB9BP/8FQr3EkxmpAAGc1lNc5QkWgTDpUw24HYXFPm7FEWRdLtGnygxIdYpFmepSc5VjkI6NHhw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/ai": "2.11.0",
+        "@firebase/ai": "2.11.1",
         "@firebase/analytics": "0.10.21",
         "@firebase/analytics-compat": "0.2.27",
         "@firebase/app": "0.14.11",
@@ -5265,9 +5265,9 @@
       }
     },
     "node_modules/firebase-tools": {
-      "version": "15.15.0",
-      "resolved": "https://registry.npmjs.org/firebase-tools/-/firebase-tools-15.15.0.tgz",
-      "integrity": "sha512-WzIDUSe2PRHhsLA2uf1xe8CKTLm+Bbfum4fCduCmjzj4ei5WBszF24Kh9MVS1D3clQbyuIlQKbYhEZZTW+5DUw==",
+      "version": "15.16.0",
+      "resolved": "https://registry.npmjs.org/firebase-tools/-/firebase-tools-15.16.0.tgz",
+      "integrity": "sha512-+x0AK8IXQFnyOsiVxcm/wHCxqi0Yj9iD659rZum91uxoayn23h6kX4CFL9dVqVkodh43luzilKh2iyfXU6QgFg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -533,14 +533,14 @@
     "node": "22"
   },
   "dependencies": {
-    "firebase": "^12.12.0",
+    "firebase": "^12.12.1",
     "firebase-functions": "^7.2.5"
   },
   "devDependencies": {
-    "@axe-core/playwright": "^4.11.2",
+    "@axe-core/playwright": "^4.11.3",
     "@firebase/rules-unit-testing": "^5.0.0",
     "@playwright/test": "^1.59.1",
-    "firebase-tools": "15.15.0",
+    "firebase-tools": "15.16.0",
     "playwright": "^1.58.2"
   },
   "overrides": {

--- a/scripts/test-rules.mjs
+++ b/scripts/test-rules.mjs
@@ -93,7 +93,7 @@ function main() {
   const options = parseArgs(process.argv.slice(2));
   const { javaHome } = ensureJavaRuntime();
   const rulesTests = resolveRulesTestFiles();
-  const testCommand = `node --test ${rulesTests.join(" ")}`;
+  const testCommand = `${process.execPath} --test ${rulesTests.join(" ")}`;
   const javaEnv = prependPathEntries([resolve(javaHome, "bin")], {
     ...process.env,
     JAVA_HOME: javaHome,


### PR DESCRIPTION
## Summary
- Supersedes Dependabot PR #529 with a fresh `origin/main` based branch.
- Updates root `firebase` to `^12.12.1`, `@axe-core/playwright` to `^4.11.3`, and `firebase-tools` to `15.16.0`.
- Hardens `scripts/test-rules.mjs` to pass the absolute Node executable into `firebase emulators:exec`, fixing a Windows PATH handoff failure seen during local verification.

## Evidence
- Dependency diff matches the routine update group: Firebase SDK patch, axe Playwright patch, Firebase CLI minor.
- `npm audit --package-lock-only --json` reports 3 moderate findings in the existing Firebase tooling transitive chain (`@modelcontextprotocol/sdk` -> `express-rate-limit` -> `ip-address`); the locked paths are already present on `origin/main` and this PR does not widen into that remediation.

## Testing
- `npm ci --ignore-scripts` at repo root.
- `npm run test:rules`: 33 Firestore rules tests passed.
- `npm run firestore:rules:sync:check`: Firestore releases are in sync.
- `npx firebase --version`: 15.16.0.
- `npm ls firebase firebase-tools @axe-core/playwright --depth=0 --json`: confirmed 12.12.1 / 15.16.0 / 4.11.3.
- `git diff --check`.

## Risk
Low to medium. Dependency updates are routine, but `firebase-tools` is a minor CLI update and the rules test runner changes command invocation. No production deploy, host mutation, schema change, Docker change, or database change is included.

## Rollback
Revert this PR to restore the previous root dependency versions and the prior `node --test` emulator command.

## Follow-ups
- Close Dependabot PR #529 after this merges.
- Track the root Firebase tooling moderate `ip-address` audit chain as a separate security/dependency slice instead of hiding it inside this routine bump.