### PR TITLE
[ops] Add npm audit inventory report

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL := /bin/bash
 PG_CONTAINER ?= studiobrain_postgres
 PGDATABASE ?= monsoonfire_studio_os
 
-.PHONY: ops-check ops-inventory ops-postgres-review ops-docker-review ops-capacity ops-import-pressure ops-cleanup-candidates ops-backup-evidence ops-ubuntu-review ops-network-review ops-host-drift ops-systemd-drift ops-portal-bridge-review ops-app-review ops-incident-bundle ops-docs ops-backlog ops-report
+.PHONY: ops-check ops-inventory ops-postgres-review ops-docker-review ops-capacity ops-import-pressure ops-cleanup-candidates ops-backup-evidence ops-ubuntu-review ops-network-review ops-host-drift ops-systemd-drift ops-portal-bridge-review ops-app-review ops-dependency-review ops-incident-bundle ops-docs ops-backlog ops-report
 
 ops-check: ops-inventory ops-docker-review ops-capacity ops-cleanup-candidates ops-backup-evidence ops-ubuntu-review ops-network-review ops-host-drift ops-systemd-drift ops-portal-bridge-review ops-app-review
 
@@ -53,6 +53,9 @@ ops-portal-bridge-review:
 
 ops-app-review:
 	bash scripts/ops/app_status_review.sh
+
+ops-dependency-review:
+	bash scripts/ops/npm_audit_inventory.sh
 
 ops-incident-bundle:
 	bash scripts/ops/incident_bundle.sh

--- a/docs/ops/02-kanban-backlog.md
+++ b/docs/ops/02-kanban-backlog.md
@@ -203,6 +203,22 @@ Post-merge note: the first ops-doctor stack has landed in `main`. The items belo
 - Suggested branch name: `codex/ops-app-status-review`
 - Suggested PR title: `[ops] Add Studio Brain app status review`
 
+### [app] Inventory Node dependency audit posture
+
+- Type: app, security, cleanup, documentation
+- Priority: P2
+- Effort: S
+- Risk: low
+- Acceptance criteria:
+  - A read-only command inventories npm workspaces, package-lock coverage, dependency counts, declared engines, overrides, and npm audit severity totals.
+  - Workspaces without lockfiles are classified as skipped instead of failing noisily.
+  - The command does not install packages, update lockfiles, run `npm audit fix`, or print environment values.
+  - Non-clean findings are treated as issue evidence for small dependency PRs with package-specific tests.
+- Status: read-only script prepared as `scripts/ops/npm_audit_inventory.sh` and wrapped by `make ops-dependency-review`.
+- Recommended owner: Codex, security review
+- Suggested branch name: `codex/ops-npm-audit-inventory`
+- Suggested PR title: `[ops] Add npm audit inventory report`
+
 ### [mission-control] Manage laptop watcher lifecycle safely
 
 - Type: reliability, app, documentation

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -37,6 +37,7 @@ make ops-host-drift
 make ops-systemd-drift
 make ops-portal-bridge-review
 make ops-app-review
+make ops-dependency-review
 make ops-incident-bundle
 make ops-report
 ```
@@ -52,6 +53,7 @@ bash scripts/ops/systemd_drift_review.sh --ssh-host studiobrain
 bash scripts/ops/portal_bridge_review.sh --ssh-host studiobrain
 bash scripts/ops/import_pressure.sh --target /home/wuff/imports
 bash scripts/ops/cleanup_candidates.sh --import-target /home/wuff/imports
+bash scripts/ops/npm_audit_inventory.sh
 ```
 
 ## Approval Boundaries
@@ -74,6 +76,7 @@ The first ops-doctor stack is merged into `main`, including post-merge verificat
 - Mission Control CPU/backpressure and deploy-ref guard work is merged and deployed; future deploys should use the guarded deploy helper.
 - idle-worker systemd timer installation is approval-gated.
 - package update remediation is approval-gated.
+- Node/npm audit inventory is available with `make ops-dependency-review`; findings are evidence for small dependency PRs, not approval to run `npm audit fix`.
 - network/SSH/PostgreSQL hardening is approval-gated.
 
 Use `02-kanban-backlog.md` for the next issue-ready slices, and `13-ops-pr-stack-audit.md` for current open PR triage.

--- a/scripts/integrity-check.mjs
+++ b/scripts/integrity-check.mjs
@@ -43,6 +43,7 @@ const DEFAULT_TARGET_FILES = [
   "scripts/ops/portal_bridge_review.sh",
   "scripts/ops/import_pressure.sh",
   "scripts/ops/cleanup_candidates.sh",
+  "scripts/ops/npm_audit_inventory.sh",
   "scripts/test-studio-brain-auth.mjs",
   "scripts/ops-cockpit.mjs",
   "scripts/scan-studiobrain-host-contract.mjs",

--- a/scripts/ops/generate_ops_report.sh
+++ b/scripts/ops/generate_ops_report.sh
@@ -108,6 +108,7 @@ run_to_file ubuntu_failed_units bash "${SCRIPT_DIR}/ubuntu_failed_units.sh"
 run_to_file network_exposure_review bash "${SCRIPT_DIR}/network_exposure_review.sh"
 run_to_file host_drift_inventory bash "${SCRIPT_DIR}/host_drift_inventory.sh"
 run_to_file app_status_review bash "${SCRIPT_DIR}/app_status_review.sh"
+run_to_file npm_audit_inventory bash "${SCRIPT_DIR}/npm_audit_inventory.sh"
 
 if command -v docker >/dev/null 2>&1 && docker ps --format '{{.Names}}' | grep -qx "${PG_CONTAINER}"; then
   run_to_file postgres_readonly_review docker exec -i -u postgres "${PG_CONTAINER}" psql -d "${PGDATABASE}" -X -v ON_ERROR_STOP=1 -f - <"${SCRIPT_DIR}/postgres_readonly_review.sql"

--- a/scripts/ops/npm_audit_inventory.sh
+++ b/scripts/ops/npm_audit_inventory.sh
@@ -1,0 +1,246 @@
+#!/usr/bin/env bash
+set -u
+
+# Read-only npm dependency and audit posture inventory.
+# This script does not install packages, run npm audit fix, update lockfiles, or
+# print environment variables. It only reads package manifests/locks and asks
+# npm for audit metadata when a package-lock.json is present.
+
+SCRIPT_NAME="$(basename "$0")"
+
+section() {
+  printf '\n## %s\n' "$1"
+}
+
+warn() {
+  printf 'warning: %s\n' "$1"
+}
+
+usage() {
+  cat <<EOF
+Usage: ${SCRIPT_NAME} [package-dir ...]
+
+Read-only npm audit inventory for package directories. When no directories are
+provided, package.json files are discovered below the current working directory,
+excluding node_modules.
+
+Safety:
+- no npm install
+- no npm update
+- no npm audit fix
+- no package or lockfile writes
+- no environment dumps
+EOF
+}
+
+if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+  usage
+  exit 0
+fi
+
+section "Safety"
+printf 'mode: read_only\n'
+printf 'mutations: none\n'
+printf 'requires: node and npm for audit details\n'
+printf 'secret_handling: does_not_print_environment_values\n'
+
+section "Command Versions"
+if command -v node >/dev/null 2>&1; then
+  printf 'node: %s\n' "$(node --version 2>&1 | head -n 1)"
+else
+  printf 'node: not installed\n'
+fi
+
+if command -v npm >/dev/null 2>&1; then
+  printf 'npm: %s\n' "$(npm --version 2>&1 | head -n 1)"
+else
+  printf 'npm: not installed\n'
+fi
+
+discover_dirs() {
+  if [ "$#" -gt 0 ]; then
+    for dir in "$@"; do
+      printf '%s\n' "${dir%/}"
+    done
+    return
+  fi
+
+  find . \
+    -path '*/node_modules' -prune -o \
+    -path '*/.git' -prune -o \
+    -name package.json -type f -print |
+    sed 's#/package.json$##' |
+    sort
+}
+
+json_package_summary() {
+  node - "$1" "$2" <<'NODE'
+const fs = require("fs");
+const [pkgPath, displayPath] = process.argv.slice(2);
+
+function countKeys(value) {
+  return value && typeof value === "object" ? Object.keys(value).length : 0;
+}
+
+try {
+  const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
+  const fields = {
+    path: displayPath,
+    name: pkg.name || "(unnamed)",
+    private: pkg.private === true ? "true" : "false",
+    packageManager: pkg.packageManager || "(not declared)",
+    dependencies: countKeys(pkg.dependencies),
+    devDependencies: countKeys(pkg.devDependencies),
+    optionalDependencies: countKeys(pkg.optionalDependencies),
+    peerDependencies: countKeys(pkg.peerDependencies),
+    overrides: countKeys(pkg.overrides),
+    scripts: countKeys(pkg.scripts),
+    enginesNode: pkg.engines && pkg.engines.node ? pkg.engines.node : "(not declared)",
+  };
+
+  for (const [key, value] of Object.entries(fields)) {
+    console.log(`${key}: ${value}`);
+  }
+} catch (error) {
+  console.log(`path: ${displayPath}`);
+  console.log("manifest_status: unreadable");
+  console.log(`manifest_error: ${error.message}`);
+}
+NODE
+}
+
+audit_summary() {
+  node - "$1" "$2" "$3" <<'NODE'
+const fs = require("fs");
+const [auditPath, errorPath, exitCode] = process.argv.slice(2);
+
+function readText(path) {
+  try {
+    return fs.readFileSync(path, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+function normalizeCounts(metadata = {}) {
+  const counts = metadata.vulnerabilities || {};
+  return {
+    info: counts.info || 0,
+    low: counts.low || 0,
+    moderate: counts.moderate || 0,
+    high: counts.high || 0,
+    critical: counts.critical || 0,
+    total: counts.total || 0,
+  };
+}
+
+const raw = readText(auditPath);
+const stderr = readText(errorPath)
+  .split(/\r?\n/)
+  .filter(Boolean)
+  .filter((line) => !/npm notice/i.test(line));
+
+try {
+  const audit = JSON.parse(raw || "{}");
+  const counts = normalizeCounts(audit.metadata || {});
+  const vulnerabilityNames = Object.keys(audit.vulnerabilities || {}).sort();
+  const status = counts.total > 0 ? "vulnerabilities_found" : "clean";
+  console.log(`npm_audit_status: ${status}`);
+  console.log(`npm_audit_exit_code: ${exitCode}`);
+  console.log(
+    `vulnerabilities: info=${counts.info} low=${counts.low} moderate=${counts.moderate} high=${counts.high} critical=${counts.critical} total=${counts.total}`,
+  );
+
+  if (vulnerabilityNames.length > 0) {
+    console.log(`affected_packages_count: ${vulnerabilityNames.length}`);
+    console.log(`affected_packages_sample: ${vulnerabilityNames.slice(0, 20).join(", ")}`);
+  } else {
+    console.log("affected_packages_count: 0");
+  }
+
+  if (stderr.length > 0) {
+    console.log(`npm_stderr_summary: ${stderr.slice(0, 3).join(" | ")}`);
+  }
+} catch (error) {
+  console.log("npm_audit_status: unparseable");
+  console.log(`npm_audit_exit_code: ${exitCode}`);
+  console.log(`npm_audit_parse_error: ${error.message}`);
+  if (stderr.length > 0) {
+    console.log(`npm_stderr_summary: ${stderr.slice(0, 3).join(" | ")}`);
+  }
+}
+NODE
+}
+
+section "Package Workspaces"
+
+mapfile -t package_dirs < <(discover_dirs "$@")
+
+if [ "${#package_dirs[@]}" -eq 0 ]; then
+  printf 'status: no_package_json_found\n'
+  exit 0
+fi
+
+for dir in "${package_dirs[@]}"; do
+  [ -n "${dir}" ] || continue
+
+  display_path="${dir#./}"
+  if [ "${display_path}" = "." ]; then
+    display_path="."
+  fi
+
+  printf '\n### %s\n' "${display_path}"
+
+  pkg_json="${dir}/package.json"
+  lock_json="${dir}/package-lock.json"
+
+  if [ ! -f "${pkg_json}" ]; then
+    printf 'manifest_status: missing_package_json\n'
+    continue
+  fi
+
+  if command -v node >/dev/null 2>&1; then
+    json_package_summary "${pkg_json}" "${display_path}"
+  else
+    printf 'path: %s\n' "${display_path}"
+    printf 'manifest_status: skipped_node_unavailable\n'
+  fi
+
+  if [ -f "${lock_json}" ]; then
+    printf 'package_lock: present\n'
+  else
+    printf 'package_lock: missing\n'
+    printf 'npm_audit_status: skipped_missing_lockfile\n'
+    continue
+  fi
+
+  if ! command -v npm >/dev/null 2>&1; then
+    printf 'npm_audit_status: skipped_npm_unavailable\n'
+    continue
+  fi
+
+  audit_file="$(mktemp)"
+  audit_err="$(mktemp)"
+  (
+    cd "${dir}" &&
+      npm audit --package-lock-only --json
+  ) >"${audit_file}" 2>"${audit_err}"
+  audit_exit="$?"
+
+  if command -v node >/dev/null 2>&1; then
+    audit_summary "${audit_file}" "${audit_err}" "${audit_exit}"
+  else
+    printf 'npm_audit_status: ran_but_summary_skipped_node_unavailable\n'
+    printf 'npm_audit_exit_code: %s\n' "${audit_exit}"
+  fi
+
+  rm -f "${audit_file}" "${audit_err}"
+done
+
+section "Safe Next Steps"
+cat <<'EOF'
+- Treat any non-clean audit result as evidence for a small dependency PR, not as approval to run npm audit fix.
+- Re-run package-specific tests after dependency changes.
+- If a workspace has no package-lock.json, decide whether it is intentionally unmanaged before adding one.
+- Do not paste environment variables or registry tokens into follow-up tickets.
+EOF

--- a/studio-brain/.env.integrity.json
+++ b/studio-brain/.env.integrity.json
@@ -1,10 +1,10 @@
 {
   "schema": "studiobrain-infra-integrity-v1",
-  "generatedAt": "2026-05-06T07:56:11.611Z",
+  "generatedAt": "2026-05-06T08:30:26.737Z",
   "generatedBy": "scripts/integrity-check.mjs",
   "allowUnknown": false,
   "metadata": {
-    "totalFiles": 71,
+    "totalFiles": 72,
     "missingOnUpdate": [],
     "partialUpdate": false,
     "updatedPaths": [
@@ -40,6 +40,7 @@
       "scripts/ops/portal_bridge_review.sh",
       "scripts/ops/import_pressure.sh",
       "scripts/ops/cleanup_candidates.sh",
+      "scripts/ops/npm_audit_inventory.sh",
       "scripts/test-studio-brain-auth.mjs",
       "scripts/ops-cockpit.mjs",
       "scripts/scan-studiobrain-host-contract.mjs",
@@ -239,8 +240,8 @@
     },
     {
       "path": "scripts/integrity-check.mjs",
-      "sha256": "7f5d0c2d194589ea4494f7a77994ca809e3eb96a24407425cd788b230f68c947",
-      "size": 18431
+      "sha256": "2df41e5a2d23ed7f731db61e67b0feffb705521d399f09fc63bd4dc2bbf39666",
+      "size": 18471
     },
     {
       "path": "scripts/lib/codex-automation-env.mjs",
@@ -306,6 +307,11 @@
       "path": "scripts/ops/import_pressure.sh",
       "sha256": "143b585354d03a993de4f0f5068191ba9f9739192a7ccd4dfcc08f54f32d1772",
       "size": 6342
+    },
+    {
+      "path": "scripts/ops/npm_audit_inventory.sh",
+      "sha256": "322c1d64a055146b8c3f64d35a6e08d7916286f95e55bc99eb2f0c0924ea88d8",
+      "size": 6637
     },
     {
       "path": "scripts/ops/portal_bridge_review.sh",


### PR DESCRIPTION
## Summary
- add `scripts/ops/npm_audit_inventory.sh`, a read-only npm workspace and audit posture report
- wrap it with `make ops-dependency-review` and include it in generated ops evidence bundles
- document the command and add an issue-ready backlog item for dependency audit posture

## Evidence
- Local run found web, functions, and studio-brain clean, skipped codex-agents because it has no lockfile, and surfaced the `@modelcontextprotocol/sdk -> express-rate-limit -> ip-address` advisory chain in root/studio-brain-mcp on this base.
- The command does not install packages, update lockfiles, run `npm audit fix`, or print environment values.

## Files Changed
- `scripts/ops/npm_audit_inventory.sh`
- `scripts/ops/generate_ops_report.sh`
- `Makefile`
- `docs/ops/README.md`
- `docs/ops/02-kanban-backlog.md`
- `scripts/integrity-check.mjs`
- `studio-brain/.env.integrity.json`

## Testing Performed
- `bash -n scripts/ops/npm_audit_inventory.sh scripts/ops/generate_ops_report.sh`
- `bash scripts/ops/npm_audit_inventory.sh . web functions studio-brain studio-brain-mcp codex-agents`
- `node ./scripts/integrity-check.mjs --update`
- `node ./scripts/integrity-check.mjs`
- `bash scripts/ops/generate_ops_report.sh output/ops/npm-audit-inventory-smoke`
- `node -e "const fs=require('fs');const s=JSON.parse(fs.readFileSync('output/ops/npm-audit-inventory-smoke/summary.json','utf8')); console.log(s.reports.map(r=>r.label+':'+r.status).join('\n'))"`
- `bash -n scripts/ops/*.sh`
- `git diff --check`

Local limitation: `make ops-dependency-review` could not be executed in this Windows shell because `make` is not installed; the underlying script and generated report integration were verified directly.

## Risk Level
Low. This is read-only diagnostics and documentation. It adds no host mutation, install, update, audit-fix, prune, restart, schema, firewall, SSH, or package actions.

## Rollback Instructions
Revert this PR to remove the npm audit inventory script, Makefile target, generated report entry, docs/backlog note, and integrity manifest entry.

## Follow-up Tickets
- Add a small dependency PR for any remaining `studio-brain-mcp` `ip-address` advisory evidence.
- Decide whether `codex-agents` intentionally lacks a package lock before adding one.