### PR TITLE
chore(deps): override studio-brain-mcp ip-address

### DIFF
--- a/studio-brain-mcp/package-lock.json
+++ b/studio-brain-mcp/package-lock.json
@@ -620,9 +620,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/studio-brain-mcp/package.json
+++ b/studio-brain-mcp/package.json
@@ -12,5 +12,8 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.26.0",
     "zod": "^3.25.76"
+  },
+  "overrides": {
+    "ip-address": "^10.2.0"
   }
 }


### PR DESCRIPTION
## Summary
- add a narrow `studio-brain-mcp` npm override for `ip-address` `^10.2.0`
- refresh only `studio-brain-mcp/package-lock.json`
- keep `@modelcontextprotocol/sdk` and `express-rate-limit` versions otherwise unchanged

## Evidence
- Before the change, `npm audit --package-lock-only --json` reported the `@modelcontextprotocol/sdk -> express-rate-limit -> ip-address` moderate advisory chain in `studio-brain-mcp`.
- After the change, `studio-brain-mcp` resolves `ip-address` to `10.2.0` and audit reports 0 vulnerabilities.

## Files Changed
- `studio-brain-mcp/package.json`
- `studio-brain-mcp/package-lock.json`

## Testing Performed
- `npm install --package-lock-only --ignore-scripts`
- `npm audit --package-lock-only --json`
- `npm ci --ignore-scripts`
- `npm ls ip-address express-rate-limit @modelcontextprotocol/sdk --json`
- `npm test`
- `npm run smoke`
- `git diff --check`

## Risk Level
Low. This is a transitive dependency override and lockfile refresh scoped to the standalone MCP bridge. No host services, secrets, database schema, firewall, Docker resources, or production configuration are changed.

## Rollback Instructions
Revert this PR to remove the `ip-address` override and restore the previous `studio-brain-mcp/package-lock.json` resolution.

## Follow-up Tickets
- Remove the override once the upstream MCP SDK or express-rate-limit dependency range resolves to a non-vulnerable `ip-address` without a local override.