### PR TITLE
[ops] Include studio-brain-mcp in agentic inventory

### DIFF
--- a/docs/runbooks/DOCS_HYGIENE.md
+++ b/docs/runbooks/DOCS_HYGIENE.md
@@ -6,7 +6,7 @@ This runbook keeps Markdown guidance aligned with live scripts, paths, and gener
 
 ## What It Checks
 
-`npm run docs:hygiene` scans selected Markdown surfaces and reports:
+`npm run docs:hygiene` scans selected Markdown surfaces (`docs`, app packages, `studio-brain-mcp`, and agent coordination docs) and reports:
 
 - broken local markdown links
 - invalid `npm run` script references for the expected package

--- a/scripts/docs-hygiene-audit.mjs
+++ b/scripts/docs-hygiene-audit.mjs
@@ -8,7 +8,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const ROOT = resolve(__dirname, "..");
 
-const DEFAULT_TARGET_DIRS = ["docs", "web", "functions", "ios", "android", "codex-agents"];
+const DEFAULT_TARGET_DIRS = ["docs", "web", "functions", "ios", "android", "studio-brain-mcp", "codex-agents"];
 const EXCLUDED_PATH_PREFIXES = new Set([
   "automation",
   "artifacts",
@@ -82,7 +82,7 @@ function isExcluded(pathRelativeToRoot) {
 
 function loadPackageScriptMap() {
   const map = new Map();
-  const packageDirs = [".", "web", "functions", "studio-brain"];
+  const packageDirs = [".", "web", "functions", "studio-brain", "studio-brain-mcp"];
   for (const dir of packageDirs) {
     const absolutePackagePath = resolve(ROOT, dir, "package.json");
     if (!existsSync(absolutePackagePath)) continue;

--- a/scripts/repo-agentic-health-inventory.mjs
+++ b/scripts/repo-agentic-health-inventory.mjs
@@ -47,7 +47,7 @@ const generatedPolicy = [
   },
 ];
 
-const packageDirs = [".", "web", "functions", "studio-brain", "codex-agents"];
+const packageDirs = [".", "web", "functions", "studio-brain", "studio-brain-mcp", "codex-agents"];
 const workflowDir = resolve(repoRoot, ".github", "workflows");
 
 function parseArgs(argv) {


### PR DESCRIPTION
## Summary
- include `studio-brain-mcp` in repo agentic health package-script inventory
- include `studio-brain-mcp` in docs hygiene markdown/script-reference scope
- update the docs hygiene runbook to name the MCP bridge as covered

## Evidence
- `studio-brain-mcp` has its own package scripts, tests, smoke command, and dependency posture, but the fixed package lists previously skipped it.
- This made the MCP bridge less visible to the agentic inventory and docs command-reference checks.

## Files Changed
- `scripts/repo-agentic-health-inventory.mjs`
- `scripts/docs-hygiene-audit.mjs`
- `docs/runbooks/DOCS_HYGIENE.md`

## Testing Performed
- `node --check scripts/repo-agentic-health-inventory.mjs && node --check scripts/docs-hygiene-audit.mjs`
- `npm run audit:agentic:inventory -- --artifact output/qa/repo-agentic-health-inventory-mcp-scope.json --markdown output/qa/repo-agentic-health-inventory-mcp-scope.md`
- `npm run docs:hygiene`
- `git diff --check`

Docs hygiene remained `pass` with existing advisory warnings for historical missing output links and known script-reference quirks; no new `studio-brain-mcp` failures were introduced.

## Risk Level
Low. This expands read-only inventory and documentation checks. It does not change runtime app behavior, host state, secrets, package versions, Docker, database schema, or deploy configuration.

## Rollback Instructions
Revert this PR to remove `studio-brain-mcp` from the two audit scopes and restore the prior runbook wording.

## Follow-up Tickets
- Decide whether `codex-agents/package.json` is an intentional package surface or a stale copied stub before adding lockfile requirements there.