### PR TITLE
[ops] Add administrator effectivity infrastructure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL := /bin/bash
 PG_CONTAINER ?= studiobrain_postgres
 PGDATABASE ?= monsoonfire_studio_os
 
-.PHONY: ops-check ops-inventory ops-postgres-review ops-postgres-sql ops-postgres-top-queries ops-postgres-query-tasks ops-postgres-growth-snapshot ops-postgres-autovacuum-stats ops-postgres-roles-extensions ops-docker-review ops-docker-posture ops-capacity ops-import-pressure ops-cleanup-candidates ops-backup-evidence ops-postgres-backup-artifacts ops-restore-prereq ops-redis-minio-backup-evidence ops-ubuntu-review ops-host-failed-unit-trends ops-package-posture ops-time-sync ops-network-review ops-host-drift ops-systemd-drift ops-portal-bridge-review ops-app-review ops-dependency-review ops-idle-worker-effectivity ops-effectivity-report ops-privileged-evidence-read ops-privileged-evidence-capture ops-privileged-evidence-capture-smoke ops-work-packet ops-incident-bundle ops-incident-bundle-v2 ops-ci-validate ops-post-deploy-verify ops-docs ops-backlog ops-report
+.PHONY: ops-check ops-inventory ops-postgres-review ops-postgres-sql ops-postgres-top-queries ops-postgres-query-tasks ops-postgres-growth-snapshot ops-postgres-autovacuum-stats ops-postgres-roles-extensions ops-docker-review ops-docker-posture ops-capacity ops-import-pressure ops-cleanup-candidates ops-backup-evidence ops-postgres-backup-artifacts ops-restore-prereq ops-redis-minio-backup-evidence ops-ubuntu-review ops-host-failed-unit-trends ops-package-posture ops-time-sync ops-network-review ops-host-drift ops-systemd-drift ops-portal-bridge-review ops-app-review ops-dependency-review ops-idle-worker-effectivity ops-effectivity-report ops-slice-ledger ops-tool-inventory ops-admin-effectivity-audit ops-privileged-evidence-read ops-privileged-evidence-capture ops-privileged-evidence-capture-smoke ops-work-packet ops-incident-bundle ops-incident-bundle-v2 ops-ci-validate ops-post-deploy-verify ops-docs ops-backlog ops-report
 
 ops-check: ops-inventory ops-docker-review ops-capacity ops-cleanup-candidates ops-backup-evidence ops-ubuntu-review ops-network-review ops-host-drift ops-systemd-drift ops-portal-bridge-review ops-app-review
 
@@ -110,6 +110,15 @@ ops-idle-worker-effectivity:
 
 ops-effectivity-report:
 	bash scripts/ops/effectivity_report.sh
+
+ops-slice-ledger:
+	node scripts/ops/slice_ledger.mjs --summary --last 5
+
+ops-tool-inventory:
+	node scripts/ops/installed_tool_inventory.mjs --write
+
+ops-admin-effectivity-audit:
+	node scripts/ops/admin_effectivity_audit.mjs --write
 
 ops-privileged-evidence-read:
 	bash scripts/ops/privileged_evidence_read.sh

--- a/docs/ops/02-kanban-backlog.md
+++ b/docs/ops/02-kanban-backlog.md
@@ -44,13 +44,97 @@ Post-merge note: the first ops-doctor stack has landed in `main`. The items belo
 - Effort: M
 - Risk: low for diagnostics, high for any backup-path change
 - Status: backup evidence scripts and docs are merged; restore confidence still needs an approval-gated drill.
+- Evidence placeholder / known evidence:
+  - Known: root-owned config/archive metadata was recorded as current on 2026-05-06 18:11 UTC in ops docs.
+  - Known: PostgreSQL dump restore proof, Redis scope, MinIO scope, and current restore-drill evidence remain incomplete unless fresh verifier output is attached.
+  - Placeholder: attach latest `make ops-backup-evidence`, PostgreSQL artifact verifier, Redis/MinIO evidence verifier, and restore drill summary.
+- Safe next step: apply the score semantics and age thresholds in `docs/ops/23-backup-restore-confidence.md`, then open stale or missing evidence issues for any degraded family.
+- Rollback / undo notes: revert docs/backlog/dashboard link changes if evidence is misclassified; do not delete, overwrite, move, or prune existing backups or storage volumes.
+- Approval gate: read-only evidence capture is allowed; manual dumps, restore execution, backup job changes, retention changes, service restarts, production data copies, and privileged host capture require explicit owner approval.
 - Acceptance criteria:
   - Backup report distinguishes config archives, PostgreSQL dump, Redis state, MinIO data, and restore drill status.
   - Latest backup evidence is current within the documented threshold.
   - Restore-prerequisite drill is documented and can run without exposing secrets.
+  - Issue-ready stale and missing backup evidence bodies are present in `docs/ops/23-backup-restore-confidence.md`.
 - Recommended owner: Codex, DBA review
 - Suggested branch name: `codex/ops-backup-evidence`
 - Suggested PR title: `[ops] Add Studio Brain backup evidence and restore drill report`
+
+#### Issue Body: Stale Backup Evidence
+
+Title:
+`[backup] Refresh stale Studio Brain backup evidence`
+
+```markdown
+## Problem
+One or more Studio Brain backup evidence families are older than the documented freshness threshold.
+
+## Evidence
+- Known evidence or placeholder:
+  - Attach latest `make ops-backup-evidence` output.
+  - Attach the affected artifact family, observed mtime, age, and threshold from `docs/ops/23-backup-restore-confidence.md`.
+  - Current known baseline: config/archive metadata was recorded as fresh on 2026-05-06 18:11 UTC; data-family and restore-drill proof still require current attached evidence.
+
+## Risk
+Medium to high. Stale evidence can hide a broken backup job, missed PostgreSQL dump, stale object-store backup, or restore-drill drift.
+
+## Proposed Fix
+Refresh read-only backup evidence, classify each stale family, and update the backup confidence score conservatively.
+
+## Safe Next Step
+Run `make ops-backup-evidence` and the relevant read-only verifier. Review output for secrets or sensitive paths before attaching it.
+
+## Acceptance Criteria
+- Affected artifact family is fresh by the documented threshold, or a missing-evidence follow-up exists.
+- Evidence distinguishes config archive, PostgreSQL, Redis, MinIO, and restore-drill status.
+- The Mission Control/admin gap remains visible until evidence is current.
+
+## Safety Notes
+- Rollback / undo: revert docs/dashboard link changes if the refreshed evidence is wrong; do not delete existing backups.
+- Approval gate: read-only evidence capture does not need approval, but manual dumps, restore execution, backup job changes, retention changes, service restarts, and production data copies require explicit owner approval.
+- Production impact: none for read-only evidence capture.
+
+Labels:
+ops, reliability, backup, database, docs
+```
+
+#### Issue Body: Missing Backup Evidence
+
+Title:
+`[backup] Close missing Studio Brain backup evidence gap`
+
+```markdown
+## Problem
+One or more Studio Brain backup evidence families are missing, unreadable, permission-blocked, or not yet classified as authoritative/regenerable.
+
+## Evidence
+- Known evidence or placeholder:
+  - Attach the `missing`, `unreadable`, `missing_or_permission_denied`, or `authority_unknown` line from the latest backup evidence packet.
+  - Attach expected artifact path, affected service/data family, and whether `sudo_unavailable` or another approval gate blocked verification.
+  - Current known baseline: root-owned config/archive metadata exists in ops docs; PostgreSQL dump restore proof, Redis scope, MinIO scope, and current restore-drill evidence remain incomplete unless fresh verifier output is attached.
+
+## Risk
+High. Missing evidence can mean the data family is not backed up, is inaccessible during an incident, or cannot be restored within expected RPO/RTO.
+
+## Proposed Fix
+Classify the missing family, define the authoritative evidence source, and add the least-invasive read-only proof path. Defer runtime backup or restore changes to a separately approved ticket.
+
+## Safe Next Step
+Use the existing read-only verifier for the affected family. If permissions block verification, use the privileged evidence capture approval path rather than granting broad agent sudo.
+
+## Acceptance Criteria
+- Missing family is classified as backed up, intentionally regenerable/cache-only, or still blocked with an owner-approved next action.
+- Evidence artifact includes timestamp, redacted source/path, age, and reviewer.
+- Backup confidence score is updated conservatively.
+
+## Safety Notes
+- Rollback / undo: revert docs/backlog updates if classification is wrong; do not remove backups, buckets, volumes, dumps, or config archives.
+- Approval gate: enabling backup jobs, changing paths, copying production data, running restores, changing retention, or using privileged host capture requires explicit owner approval.
+- Production impact: none for documentation and read-only verification.
+
+Labels:
+ops, reliability, backup, database, storage, docs
+```
 
 ### [ubuntu] Triage apt OOM and failed system units
 

--- a/docs/ops/04-postgres-dba-review.md
+++ b/docs/ops/04-postgres-dba-review.md
@@ -60,7 +60,8 @@ Largest indexes:
 ## Slow Query Visibility
 
 - `pg_stat_statements` is installed and preloaded, so slow-query review is possible.
-- The read-only review now includes a top-total-time query with single-line, length-limited query text. It showed several memory retrieval/statistics families dominating total execution time.
+- The read-only review now includes a visibility check for extension presence, view visibility, preload state, and current-role `SELECT` permission.
+- When visible, `scripts/ops/postgres_pg_stat_statements_rollup.sql` emits a redacted query-family rollup by statement kind and primary relation before listing top total-time and mean-time fingerprints.
 - Highest-cost families in the 18:32 UTC snapshot included memory pattern/entity lookups, `refresh_memory_stats_rollup`, row-count snapshots for memory tables, and repeated `mission_control.task_events order by occurred_at desc limit $1`.
 - Treat these as workload leads, not index-change approval. Before schema changes, capture approved `EXPLAIN (ANALYZE, BUFFERS)` output with literal scrubbing and rollback SQL.
 
@@ -80,12 +81,15 @@ Largest indexes:
 - Lock snapshot showed only granted locks: one `virtualxid` exclusive lock and one relation access-share lock.
 - No waiting locks were observed.
 - No idle-in-transaction session was observed in the captured output.
+- Wave 2 adds `scripts/ops/postgres_long_transaction_lock_packet.sql` for a standalone read-only packet covering long transactions, idle-in-transaction sessions, waiting activity, blocking pairs, lock-mode summaries, relation-lock summaries, and prepared transactions.
+- The packet is evidence only; it does not approve cancelling queries, terminating sessions, changing timeouts, or restarting services.
 
 ## Vacuum And Analyze Posture
 
 - Autovacuum is enabled.
 - Large memory tables show recent autoanalyze and some recent autovacuum activity.
 - Some manual `last_vacuum`/`last_analyze` timestamps are older or null, which is normal if autovacuum is handling the table.
+- Wave 2 expands `scripts/ops/postgres_autovacuum_stale_stats_report.sql` with `n_mod_since_analyze`, estimated analyze/vacuum thresholds from current settings, last-analyze/vacuum age, and custom table reloptions.
 - Recommendation: collect weekly relation stats before changing autovacuum thresholds.
 
 ## WAL And Checkpoint Observations
@@ -104,13 +108,19 @@ Largest indexes:
 
 The repo now includes:
 
+- `scripts/ops/postgres_readonly_snapshot_runner.sh`
 - `scripts/ops/postgres_readonly_review.sql`
 - `scripts/ops/postgres_size_report.sql`
+- `scripts/ops/postgres_db_growth_trend_snapshot.sql`
+- `scripts/ops/postgres_pg_stat_statements_rollup.sql`
+- `scripts/ops/postgres_long_transaction_lock_packet.sql`
+- `scripts/ops/postgres_autovacuum_stale_stats_report.sql`
+- `docs/ops/postgres-readonly-dba-wave2-packet.md`
 
 Recommended cadence:
 
-- Weekly: size report, dead tuples, active sessions, locks, and settings snapshot.
-- Monthly: pg_stat_statements redacted top-query review and restore drill.
+- Weekly: run the snapshot runner or collect growth, stale-stats, and long-transaction/lock packets.
+- Monthly: pg_stat_statements redacted query-family review and restore drill.
 - Before schema/index PRs: capture `EXPLAIN (ANALYZE, BUFFERS)` only on approved queries and scrub literals from shared artifacts.
 
 ## Safe Improvement Candidates

--- a/docs/ops/06-runbooks.md
+++ b/docs/ops/06-runbooks.md
@@ -64,20 +64,30 @@ The system backup job writes `/var/backups/studio-brain/latest-metadata.json` wi
 
 1. Capture restore-prerequisite evidence:
    - `make ops-backup-evidence`
-2. Use a disposable target database/container.
-3. Do not restore over production.
-4. Verify dump metadata:
+2. Review the confidence semantics and age thresholds:
+   - `docs/ops/23-backup-restore-confidence.md`
+3. Use a disposable target database/container whose name cannot alias production.
+4. Do not restore over production.
+5. Verify dump metadata:
    - `pg_restore --list <dump>`
-5. Restore into disposable target.
-6. Run smoke queries:
+6. Restore into disposable target only after explicit owner approval.
+7. Run smoke queries:
    - database size
    - table count
    - key relation row counts
    - app migration table status
-7. Record restore duration and result.
-8. Rerun `make ops-backup-evidence` so the latest restore-drill summary is visible in the unified report.
-9. Rollback:
+8. Record restore duration, result, confidence score band, and any stale/missing evidence follow-up.
+9. Rerun `make ops-backup-evidence` so the latest restore-drill summary is visible in the unified report.
+10. Rollback:
    - Drop only the disposable target after approval.
+
+### Restore Drill Safety Matrix
+
+| Recommendation | Evidence placeholder / known evidence | Risk | Safe next step | Rollback / undo notes | Approval gate |
+| --- | --- | --- | --- | --- | --- |
+| Keep the restore drill on a disposable target with no production overwrite path. | Placeholder: target database/container/volume name and assertion that it differs from `monsoonfire_studio_os` and live `studiobrain_postgres` storage. | Critical if the target can alias production. | Write the target name into the drill ticket before running restore commands. | Stop before restore if target is ambiguous; drop only the disposable target after approval. | Explicit owner approval required before restoring production-derived data anywhere. |
+| Treat `pg_restore --list` as a prerequisite, not a restore success. | Placeholder: command exit status and summary count, not dump contents. | High if metadata is mistaken for recoverability. | Follow with an approved disposable-target restore and aggregate smoke queries. | Delete only local generated list output if sensitive; no production state changed. | Read-only list check is allowed when dump access is already approved; restore requires owner approval. |
+| Record stale or missing evidence as issue-ready follow-up. | Known evidence: ops docs record 2026-05-06 18:11 UTC config/archive metadata, while PostgreSQL/Redis/MinIO/restore proof remains incomplete unless fresh verifier output is attached. | Medium to high because stale gaps can age out silently. | Use the stale/missing issue bodies in `docs/ops/23-backup-restore-confidence.md`. | Revert docs/backlog links if evidence is misclassified; do not remove backup artifacts. | Approval required for backup job changes, retention changes, privileged capture, or service actions. |
 
 ## Disk Pressure Emergency Response
 

--- a/docs/ops/17-dba-backup-readonly-packet.md
+++ b/docs/ops/17-dba-backup-readonly-packet.md
@@ -55,11 +55,25 @@ docker exec -i -u postgres studiobrain_postgres psql -d monsoonfire_studio_os -f
   readiness. They do not prove that a restore succeeds.
 - The restore-prerequisite drill proves that a safe restore drill is ready to
   schedule. It does not restore into any target.
+- Backup confidence score semantics, artifact age thresholds, and issue-ready
+  stale/missing evidence bodies are defined in
+  `docs/ops/23-backup-restore-confidence.md`.
 - Query hotspot output is workload evidence only. Capture approved
   `EXPLAIN (ANALYZE, BUFFERS)` output with literals scrubbed before proposing
   indexes or query rewrites.
 - Role and extension packets are redacted inventory. Do not add passwords,
   connection strings, raw `.env` values, or dump contents to ticket artifacts.
+
+## Confidence And Age Semantics
+
+Use `docs/ops/23-backup-restore-confidence.md` as the shared issue and dashboard
+language for backup confidence:
+
+| Recommendation | Evidence placeholder / known evidence | Risk | Safe next step | Rollback / undo notes | Approval gate |
+| --- | --- | --- | --- | --- | --- |
+| Score backup confidence as a conservative rollup instead of a binary pass/fail. | Known evidence: root-owned config/archive metadata was recorded for 2026-05-06 18:11 UTC; PostgreSQL, Redis, MinIO, and restore-drill proof still need current attached verifier output. | Medium if partial evidence is mistaken for restore proof. | Attach current backup evidence outputs and apply the score bands from the confidence packet. | Revert docs/dashboard wording if scoring is wrong; keep all backup artifacts intact. | Approval required before backup job changes, manual dumps, restores, or retention changes. |
+| Treat artifact age as stale before it becomes missing-critical. | Placeholder: attach artifact family, mtime, age, threshold, and verifier command used. | Medium to high depending on the data family. | Open stale-evidence issue when age exceeds the documented threshold. | Revert issue/docs updates if evidence was misread; do not delete or overwrite backups. | Read-only checks do not need approval; runtime backup changes do. |
+| Keep restore confidence separate from artifact presence. | Placeholder: attach disposable-target drill summary or explicitly mark drill evidence missing. | High if operators assume `pg_restore --list` or metadata presence proves recovery. | Schedule an owner-approved disposable-target restore drill. | Drop only the disposable target after approval; never restore over production. | Explicit owner approval required before any restore using production-derived data. |
 
 ## Suggested Weekly Packet
 

--- a/docs/ops/23-backup-restore-confidence.md
+++ b/docs/ops/23-backup-restore-confidence.md
@@ -1,0 +1,171 @@
+# Backup And Restore Confidence Packet
+
+Snapshot date: 2026-05-07.
+
+This packet defines the operator-facing semantics for backup confidence, backup
+artifact age thresholds, disposable-target restore drills, and issue-ready
+follow-up bodies for stale or missing backup evidence. It is documentation and
+backlog support only. It does not approve backup path changes, production
+restores, Docker restarts, PostgreSQL writes, file deletion, or secret access.
+
+Known evidence at this snapshot:
+
+- PR #596 added root-owned backup metadata evidence and a Mission Control
+  Backup Confidence panel.
+- `docs/ops/01-risk-register.md` records that
+  `/var/backups/studio-brain/latest-metadata.json` proved a 2026-05-06
+  18:11 UTC config/archive manifest without exposing secrets.
+- `docs/ops/04-postgres-dba-review.md` records PostgreSQL restore confidence
+  as unproven until a current artifact explicitly shows dump and restore
+  verification.
+- Prior ops handoff evidence recorded `sudo_unavailable` as the blocker for
+  deeper privileged host evidence.
+
+## Slice 16: Backup Confidence Score Semantics
+
+The score is a communication aid, not proof that a restore will succeed. Treat
+it as a conservative rollup of evidence age, artifact coverage, and restore
+drill recency.
+
+| Score band | Operator meaning | Known evidence or placeholder | Risk | Safe next step | Rollback / undo notes | Approval gate |
+| --- | --- | --- | --- | --- | --- | --- |
+| 90-100, green | All required backup artifact families have fresh metadata, and a disposable-target restore drill is current. | Placeholder: attach latest `make ops-backup-evidence`, PostgreSQL artifact verifier, Redis/MinIO evidence verifier, and restore drill summary. | Low residual risk; artifact corruption or hidden dependency drift can still exist. | Keep weekly evidence capture and monthly restore drill cadence. | Revert only documentation or dashboard threshold edits; do not delete backup artifacts. | No approval for read-only evidence capture; approval required for restore execution or backup tooling changes. |
+| 70-89, yellow | Core metadata is present but one evidence family is stale, partial, or restore-drill evidence is older than threshold. | Known evidence: config/archive metadata was proven on 2026-05-06 18:11 UTC; PostgreSQL/Redis/MinIO restore confidence remains incomplete unless fresh verifier output is attached. | Medium risk of overestimating recoverability or missing RPO/RTO drift. | Open a stale-evidence ticket and refresh read-only evidence before changing runtime backup paths. | Revert docs/backlog changes if wording is wrong; keep all existing artifacts intact. | Human approval required before running restore drill, copying production data, or changing retention. |
+| 40-69, orange | Some backup evidence exists, but one required data family is missing or older than the critical age threshold. | Placeholder: attach missing-family line from backup evidence output, artifact path, and expected owner. | High risk that operators cannot prove current recoverability for the affected data family. | Open a missing-evidence ticket and classify whether the data family is authoritative, regenerable, or out of backup scope. | Roll back any proposed config change by restoring prior repo commit or service config; do not remove existing backups. | Approval required before enabling new backup jobs, creating new privileged reads, moving artifacts, or changing storage. |
+| 0-39, red | No usable current metadata, no current data-artifact evidence, or no safe path to validate a restore. | Placeholder: attach failed or missing `make ops-backup-evidence` output and exact unreadable/missing path. | Critical data-loss risk if production fails before evidence is restored. | Stop cleanup proposals that depend on backup confidence; capture root-owned metadata through the approved privileged evidence lane. | Undo docs-only changes by reverting the PR; undo runtime changes only with owner-approved rollback plan. | Explicit owner approval required for any production-impacting backup, restore, service, or storage action. |
+
+Recommended initial rollup weights:
+
+| Component | Weight | Passing condition | Known evidence or placeholder | Risk | Safe next step | Rollback / undo notes | Approval gate |
+| --- | ---: | --- | --- | --- | --- | --- | --- |
+| Root-owned config/archive metadata | 20 | Latest metadata file is readable, non-empty, and fresh by the thresholds below. | Known evidence: 2026-05-06 18:11 UTC manifest was recorded in ops docs. | Low if fresh; medium if stale because config recovery may lag host changes. | Refresh `make ops-backup-evidence`. | Revert documentation changes only; do not edit root backup metadata by hand. | No approval for read-only capture; approval required to modify the backup job. |
+| PostgreSQL dump artifact metadata | 30 | Current dump artifact metadata exists with size, mtime, checksum or manifest reference, and `pg_restore --list` readiness. | Placeholder: attach `backup_postgres_artifact_verifier.sh` output. | High if missing because PostgreSQL is authoritative application state. | Run verifier and prepare DBA review ticket. | Do not delete or overwrite dumps; revert any proposed script/docs PR if wrong. | Approval required for manual dumps, restore execution, or retention changes. |
+| Redis backup scope | 10 | Redis is classified as authoritative, cache-only, or backed up with fresh metadata. | Placeholder: attach Redis section from `redis_minio_evidence_verifier.sh`. | Medium until scope is explicit; high if Redis holds non-regenerable state. | Classify Redis authority and attach evidence. | Revert classification doc if evidence contradicts it; do not flush or restart Redis. | Approval required for backup enablement, restart, flush, or storage changes. |
+| MinIO backup scope | 15 | MinIO object data is classified and fresh backup metadata exists if authoritative. | Placeholder: attach MinIO section from `redis_minio_evidence_verifier.sh`. | High if authoritative object data lacks current backup evidence. | Classify buckets/data authority and attach artifact metadata. | Revert docs only; do not remove buckets, volumes, or objects. | Approval required for object copy, retention, bucket changes, or service restart. |
+| Disposable restore drill | 25 | A restore drill summary exists for a disposable target and is fresh by threshold. | Placeholder: attach restore drill summary path, duration, target, and smoke-query result. | High if absent because artifact presence does not prove restore correctness. | Schedule owner-approved disposable-target drill. | Drop only the disposable target after approval; never overwrite production. | Explicit owner approval required before restoring production-derived data anywhere. |
+
+## Slice 17: Backup Artifact Age Thresholds
+
+Use these thresholds for dashboard language, issue priority, and maintenance
+calendar review. If a service has a stricter RPO later, use the stricter value.
+
+| Artifact family | Fresh | Stale | Critical / missing | Evidence placeholder or known evidence | Risk | Safe next step | Rollback / undo notes | Approval gate |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Root-owned config/archive metadata | <= 36 hours | > 36 hours and <= 72 hours | > 72 hours or unreadable/missing | Known evidence: 2026-05-06 18:11 UTC manifest recorded in ops docs. | Medium if stale; config drift may not be recoverable. | Rerun backup evidence and inspect backup timer state. | Revert docs if threshold needs tuning; do not delete archives. | Approval required to run or modify backup timer/job. |
+| PostgreSQL dump metadata | <= 30 hours | > 30 hours and <= 48 hours | > 48 hours or missing/unreadable | Placeholder: PostgreSQL artifact verifier output with dump mtime, size, checksum/manifest reference. | High if stale because application data RPO is unknown. | Capture artifact verifier output and open stale/missing ticket. | Keep existing dumps; revert only proposed retention/tooling changes. | Approval required for manual dump, restore, retention, or backup path change. |
+| Redis backup evidence | <= 30 hours if authoritative; not applicable if explicitly cache-only | > 30 hours and <= 48 hours | > 48 hours, missing, or authority unknown | Placeholder: Redis authority decision plus backup metadata or cache-only rationale. | Medium to high depending on Redis authority. | Classify Redis as authoritative, cache-only, or backup-required. | Revert classification if contradicted; do not flush or restart Redis. | Approval required for Redis backup enablement or service action. |
+| MinIO backup evidence | <= 30 hours if authoritative; not applicable if explicitly regenerable | > 30 hours and <= 48 hours | > 48 hours, missing, or authority unknown | Placeholder: MinIO bucket/object authority decision plus metadata. | High if objects are authoritative. | Capture MinIO evidence and classify buckets/data. | Do not move/delete buckets or volumes; revert docs if wrong. | Approval required for object copy, lifecycle, retention, or service action. |
+| Restore drill summary | <= 30 days | > 30 days and <= 45 days | > 45 days or missing | Placeholder: disposable-target drill summary with target name, timestamp, duration, and smoke results. | High if stale because backup artifacts may be unrestorable. | Prepare owner-approved disposable restore drill. | Drop only disposable target after approval; retain drill summary. | Explicit owner approval before any restore using production-derived data. |
+
+## Slice 18: Disposable-Target Restore Drill Checklist
+
+This checklist intentionally has no production overwrite path. If any command
+targets the production database, production Docker volume, production MinIO
+bucket, or live service data path, stop and rewrite the drill plan.
+
+| Step | Checklist item | Evidence placeholder or known evidence | Risk | Safe next step | Rollback / undo notes | Approval gate |
+| --- | --- | --- | --- | --- | --- | --- |
+| 1 | Capture current backup confidence evidence. | Attach `make ops-backup-evidence` output and artifact verifier summaries. | Low for read-only capture; high if skipped because the drill may use stale input. | Review output for secrets before attaching to ticket. | Delete only local generated reports if they expose local paths. | No approval for read-only capture. |
+| 2 | Name a disposable target that cannot alias production. | Placeholder: target container/database name such as `studio_brain_restore_drill_<date>`. | High if the target can resolve to production. | Require a written target name and connection string redaction check. | Destroy only the disposable target after approval. | Human approval required before creating target with production-derived data. |
+| 3 | Verify production is not the restore target. | Placeholder: checklist assertion showing production DB/container/volume names and disposable target names differ. | Critical if not verified. | Compare host, port, database, container, and volume names before restore. | Stop before restore; no rollback needed if not executed. | Human approval required to proceed to restore step. |
+| 4 | Validate dump readability without restoring. | Placeholder: `pg_restore --list <dump>` summary, not full dump contents. | Medium if skipped; corrupt dump may be discovered too late. | Run list/readiness check and capture exit status. | No production state changed; delete local generated list if sensitive. | No approval if read-only and dump access is already approved. |
+| 5 | Restore into disposable target only. | Placeholder: command transcript with target redacted, timestamp, duration, and exit status. | High because production-derived data is materialized in a new place. | Run only during approved drill window with restricted access. | Drop disposable database/container/volume after approval and record deletion. | Explicit owner approval required. |
+| 6 | Run smoke queries against disposable target. | Placeholder: database size, relation count, migration table status, and selected row-count checks. | Medium; smoke checks can miss logical corruption. | Capture aggregate-only results without row contents or secrets. | Delete generated smoke report if sensitive. | No additional approval if covered by restore-drill approval. |
+| 7 | Record drill result and confidence score. | Placeholder: drill summary path, score band, failures, follow-up tickets. | Medium if not recorded; dashboard remains stale. | Attach summary to backlog ticket and Mission Control evidence link. | Revert docs/dashboard references if summary is wrong. | Approval required only for publishing sensitive artifact paths. |
+| 8 | Clean up disposable target. | Placeholder: approved cleanup command and post-cleanup proof target is gone. | High if cleanup accidentally targets production. | Confirm target name twice and keep production names out of cleanup command. | If cleanup fails, isolate target and open owner ticket; do not broaden deletion. | Explicit owner approval required for destructive cleanup, even on disposable target. |
+
+Hard stop rule matrix:
+
+| Rule | Evidence placeholder or known evidence | Risk | Safe next step | Rollback / undo notes | Approval gate |
+| --- | --- | --- | --- | --- | --- |
+| Do not run `pg_restore` against `monsoonfire_studio_os` or the live `studiobrain_postgres` data volume. | Placeholder: drill target assertion proving production and disposable names differ. | Critical production overwrite risk. | Stop and rewrite the drill plan with a disposable target. | If no command ran, no rollback is needed; if any restore began, escalate as an incident and stop further writes. | Explicit owner approval is required for any restore using production-derived data. |
+| Do not use `docker compose down -v`, `docker volume rm`, bucket deletion, or broad filesystem deletion as part of a restore drill. | Placeholder: cleanup command preview limited to the disposable target. | Critical data deletion risk. | Replace broad deletion with named disposable-target cleanup. | Restore only from approved backups if production data was affected; otherwise delete only the disposable target after approval. | Explicit owner approval required before destructive cleanup, even for disposable targets. |
+| Do not paste dump contents, secrets, connection strings, or raw `.env` values into the drill summary. | Placeholder: redaction review checkbox before attaching drill evidence. | High secret exposure and privacy risk. | Attach aggregate metadata, exit status, duration, and smoke-query counts only. | Remove or replace the sensitive artifact, rotate secrets only if exposure is confirmed and approved. | Owner/security approval required before publishing sensitive artifact paths or rotating secrets. |
+| Do not treat `pg_restore --list` as a successful restore drill. | Placeholder: separate fields for list-check result and actual disposable-restore result. | High false-confidence risk. | Open or keep restore-drill evidence ticket until disposable restore succeeds. | Revert any dashboard/doc claim that marked list-only evidence as restored. | Restore execution requires explicit owner approval. |
+
+## Slices 19-20: Issue-Ready Backup Evidence Bodies
+
+Use these bodies when GitHub issue creation is unavailable or when an operator
+needs copy-ready review text. Attach only redacted evidence.
+
+### Slice 19 Issue: Stale Backup Evidence
+
+Title:
+`[backup] Refresh stale Studio Brain backup evidence`
+
+Body:
+
+```markdown
+## Problem
+One or more Studio Brain backup evidence families are older than the documented freshness threshold. The dashboard/backlog may overstate restore confidence until evidence is refreshed.
+
+## Evidence
+- Known evidence or placeholder:
+  - Attach latest `make ops-backup-evidence` output.
+  - Attach PostgreSQL artifact verifier output if PostgreSQL dump evidence is stale.
+  - Attach Redis/MinIO evidence verifier output if Redis or MinIO scope/evidence is stale.
+  - Current known baseline: config/archive metadata was recorded as fresh on 2026-05-06 18:11 UTC in ops docs; PostgreSQL/Redis/MinIO restore confidence still needs current attached proof.
+
+## Risk
+Medium to high. Stale evidence can hide a broken backup job, missed PostgreSQL dump, stale object-store backup, or restore drill drift.
+
+## Proposed Fix
+Refresh read-only backup evidence, classify each stale family, and update the backup confidence packet or Mission Control evidence link with the new timestamp and score band.
+
+## Safe Next Step
+Run `make ops-backup-evidence` and the relevant read-only backup artifact verifier. Review output for secrets or sensitive local paths before attaching it.
+
+## Acceptance Criteria
+- The stale artifact family has a fresh timestamp within `docs/ops/23-backup-restore-confidence.md` thresholds.
+- Evidence distinguishes config archives, PostgreSQL dump metadata, Redis scope/evidence, MinIO scope/evidence, and restore-drill summary.
+- Any still-stale family has a follow-up ticket with owner and approval gate.
+
+## Safety Notes
+- Rollback / undo: revert documentation or dashboard link changes if the refreshed evidence is wrong; do not delete existing backups.
+- Approval gate: read-only evidence capture does not need approval, but manual dumps, restore execution, backup job changes, retention changes, service restarts, and production data copies require explicit owner approval.
+- Production impact: none for read-only evidence capture.
+
+Labels:
+ops, reliability, backup, database, docs
+```
+
+### Slice 20 Issue: Missing Backup Evidence
+
+Title:
+`[backup] Close missing Studio Brain backup evidence gap`
+
+Body:
+
+```markdown
+## Problem
+One or more Studio Brain backup evidence families are missing, unreadable, or not yet classified as authoritative/regenerable. Restore confidence must stay degraded until the missing family is proven or explicitly marked out of scope.
+
+## Evidence
+- Known evidence or placeholder:
+  - Attach the `missing`, `unreadable`, `missing_or_permission_denied`, or `authority_unknown` line from the latest backup evidence packet.
+  - Attach expected artifact path, service/data family, and whether `sudo_unavailable` or another approval gate blocked verification.
+  - Current known baseline: root-owned config/archive metadata exists in ops docs, but PostgreSQL dump restore proof, Redis scope, MinIO scope, and current restore-drill evidence remain incomplete unless fresh verifier output is attached.
+
+## Risk
+High. Missing evidence can mean the data family is not backed up, is inaccessible during an incident, or cannot be restored within the expected RPO/RTO.
+
+## Proposed Fix
+Classify the missing family, define the authoritative evidence source, and add the least-invasive read-only proof path. If the family is authoritative data, prepare an owner-approved backup or restore-drill plan before any runtime changes.
+
+## Safe Next Step
+Use the existing read-only verifier for the affected family. If verification is blocked by permissions, use the privileged evidence capture approval path rather than granting broad agent sudo.
+
+## Acceptance Criteria
+- Missing family is classified as backed up, intentionally regenerable/cache-only, or still blocked with an owner-approved next action.
+- Evidence artifact includes timestamp, path or redacted source, age, and reviewer.
+- Backup confidence score is updated conservatively.
+- Any runtime change is deferred to a separate approved PR or maintenance ticket.
+
+## Safety Notes
+- Rollback / undo: revert docs/backlog updates if classification is wrong; do not remove backups, buckets, volumes, dumps, or config archives.
+- Approval gate: enabling backup jobs, changing paths, copying production data, running restores, changing retention, or using privileged host capture requires explicit owner approval.
+- Production impact: none for documentation and read-only verification; possible impact for any future backup/restore implementation, which must be separately approved.
+
+Labels:
+ops, reliability, backup, database, storage, docs
+```

--- a/docs/ops/admin-effectivity-loop.md
+++ b/docs/ops/admin-effectivity-loop.md
@@ -1,0 +1,79 @@
+# Studio Brain Administrator Effectivity Loop
+
+This loop keeps administrator work focused on reusable infrastructure instead of one-off fixes. Each slice records intent, evidence, commands, artifacts, usefulness, and blockers. Every five slices, the audit command checks whether the work actually improved the operator system.
+
+## Commands
+
+Record a slice:
+
+```bash
+node scripts/ops/slice_ledger.mjs --append \
+  --slice-id slice-20260507-001 \
+  --run-id admin-effectivity-20260507 \
+  --lane portal-ops \
+  --title "Add slice ledger" \
+  --intent "Make swarm work auditable" \
+  --status completed \
+  --changed-file scripts/ops/slice_ledger.mjs \
+  --command "pass:node --check scripts/ops/slice_ledger.mjs" \
+  --usefulness-score 0.8
+```
+
+Summarize the last five slices:
+
+```bash
+node scripts/ops/slice_ledger.mjs --summary --last 5 --json
+```
+
+Inventory local tool availability:
+
+```bash
+node scripts/ops/installed_tool_inventory.mjs --json --write
+```
+
+Run the every-five-slices audit:
+
+```bash
+make ops-admin-effectivity-audit
+```
+
+The Make target writes JSON and Markdown under `output/ops/effectivity/`, which is ignored by Git. Curated summaries can be copied into docs or tickets when they become durable operator evidence.
+
+## Scoring
+
+- `usefulness`: average slice usefulness score, 0 to 1.
+- `verification`: passing command checks divided by total recorded command checks.
+- `noOpRate`: share of rows with no changed file, artifact, command evidence, or an explicit no-op status.
+- `blockedLaneClarity`: blocked slices with a fixed blocker class and safe next step.
+- `toolInventoryFreshness`: 1 when the inventory command can run; 0 when unavailable.
+
+The audit fails if required tools are missing or a slice failed. It warns when no slices are recorded, no-op rate is high, or the underlying ops effectivity report cannot run.
+
+## Blocker Classes
+
+Use fixed classes so blocked work is searchable and does not become vague:
+
+- `approval_required`
+- `missing_auth`
+- `sudo_unavailable`
+- `dirty_worktree`
+- `merge_conflict`
+- `cross_repo_boundary`
+- `missing_tool`
+- `live_endpoint_down`
+- `test_failure`
+- `data_safety_gate`
+- `external_service`
+- `unclear_owner`
+
+## Tooling Roadmap
+
+The first tool inventory is intentionally read-only. Recommended next tool gates are:
+
+1. Shell LF guard and ShellCheck report for Ubuntu-targeted scripts.
+2. PSScriptAnalyzer for Windows PowerShell deployment and watcher helpers.
+3. SQLFluff parser-only checks for PostgreSQL inspection packets.
+4. actionlint for GitHub Actions.
+5. Docker Compose rendered-config validation on Ubuntu or the host.
+
+Each new tool should be audited after roughly five slices: count actionable findings, false positives, and whether it prevented a broken script, failed CI run, unsafe recommendation, or operator confusion.

--- a/docs/ops/effectivity-reporting.md
+++ b/docs/ops/effectivity-reporting.md
@@ -1,0 +1,59 @@
+# Effectivity Reporting
+
+## Purpose
+
+`make ops-effectivity-report` builds a read-only Studio Brain ops packet that combines live health, idle-worker effectivity, Mission Control harness coverage, backup confidence, failed-unit classification, and privileged-capture availability.
+
+The report is intended for weekly operator review and swarm handoffs. Missing Docker, PostgreSQL, live endpoints, or privileged host captures are warnings, not reasons to mutate the host from the report command.
+
+## Command
+
+```bash
+make ops-effectivity-report
+```
+
+Without `make`:
+
+```bash
+bash scripts/ops/effectivity_report.sh
+```
+
+Optional overrides:
+
+```bash
+bash scripts/ops/effectivity_report.sh \
+  --run-id effectivity-manual-20260507 \
+  --output-dir output/ops/effectivity
+```
+
+## Output Path
+
+Default artifacts are timestamped:
+
+- `output/ops/effectivity/effectivity-YYYYMMDDTHHMMSSZ.json`
+- `output/ops/effectivity/effectivity-YYYYMMDDTHHMMSSZ.md`
+
+`output/` is ignored by git, so local report runs do not create tracked churn. Commit this documentation and script changes, but do not commit generated effectivity outputs unless the owner explicitly asks for a curated evidence packet.
+
+## Privileged Capture Status
+
+The effectivity report consumes the approval-gated privileged evidence reader. If no latest capture exists or the evidence directory is unreadable, the report emits:
+
+```text
+sudo_unavailable
+```
+
+That status means the report did not attempt sudo and the missing host-only evidence remains an approval-gated follow-up. It is not a host failure by itself.
+
+## Retention
+
+Recommended local retention:
+
+- Keep the latest 12 weekly Markdown reports for operator review.
+- Keep matching JSON only while it is useful for comparison or ingestion.
+- Delete older ignored `output/ops/effectivity/*` artifacts during routine local cleanup after confirming no active incident references them.
+- Do not delete `/var/lib/studio-brain/ops-evidence` privileged capture artifacts from an agent shell; that host evidence lane needs explicit owner approval.
+
+## Safety
+
+The command is read-only. It avoids environment dumps, does not print secrets, and degrades gracefully when optional dependencies are unavailable.

--- a/docs/ops/postgres-readonly-dba-wave2-packet.md
+++ b/docs/ops/postgres-readonly-dba-wave2-packet.md
@@ -1,0 +1,66 @@
+# PostgreSQL Read-Only DBA Wave 2 Packet
+
+Date: 2026-05-07.
+
+This packet extends the DBA evidence lane without schema changes. It is safe to
+run from an existing read-only PostgreSQL connection or on the Studio Brain host
+against the `studiobrain_postgres` container.
+
+## Artifacts
+
+| Artifact | Purpose |
+| --- | --- |
+| `scripts/ops/postgres_readonly_snapshot_runner.sh` | Runs the DBA SQL packets into timestamped text artifacts with secret-oriented stream redaction. |
+| `scripts/ops/postgres_db_growth_trend_snapshot.sql` | Captures database, schema, table, individual index, and table/index ratio snapshots for weekly growth diffs. |
+| `scripts/ops/postgres_pg_stat_statements_rollup.sql` | Detects `pg_stat_statements` visibility and, when available, rolls up redacted query families by statement kind and primary relation. |
+| `scripts/ops/postgres_long_transaction_lock_packet.sql` | Captures long transaction, idle-in-transaction, waiting activity, blocking pairs, lock summaries, and prepared transactions. |
+| `scripts/ops/postgres_autovacuum_stale_stats_report.sql` | Reports autovacuum settings, stale analyze candidates, vacuum threshold leads, and custom table autovacuum options. |
+
+## Operator Commands
+
+Run the full packet:
+
+```bash
+bash scripts/ops/postgres_readonly_snapshot_runner.sh
+```
+
+For a local socket connection without `PGHOST`, set `POSTGRES_RUNNER_DIRECT=1`
+so the runner does not accidentally prefer an unconfigured workstation `psql`
+over the Studio Brain Docker container.
+
+Run a single SQL packet with an existing safe connection:
+
+```bash
+psql "$DATABASE_URL" -X -v ON_ERROR_STOP=1 -f scripts/ops/postgres_long_transaction_lock_packet.sql
+```
+
+Run through the container on the Studio Brain host:
+
+```bash
+docker exec -i -u postgres studiobrain_postgres psql -d monsoonfire_studio_os -X -v ON_ERROR_STOP=1 < scripts/ops/postgres_long_transaction_lock_packet.sql
+```
+
+## Degraded Evidence Rules
+
+- If `pg_stat_statements` is missing, not preloaded, not visible, or not
+  selectable by the current role, the rollup prints a status row and next step
+  instead of failing the packet.
+- If PostgreSQL hides other sessions' query text for privilege reasons, the lock
+  packet still reports session, wait, lock, and age fields.
+- If no direct `psql` connection or Docker container is available, the runner
+  writes skipped reports and keeps the packet shape intact.
+
+## Boundaries
+
+This lane does not approve or perform:
+
+- schema changes, migrations, index creation, `REINDEX`, `VACUUM FULL`, or table
+  rewrites
+- `VACUUM`, `ANALYZE`, autovacuum reloption changes, or setting changes
+- `pg_cancel_backend`, `pg_terminate_backend`, service restarts, or lock-clearing
+  action
+- restore drills or backup creation
+- secret reads, environment dumps, or raw connection-string output
+
+Use the packet as evidence for a DBA review ticket. Any tuning or remediation
+needs a separate approval packet with rollback notes.

--- a/schemas/ops/admin-effectivity-audit.v1.schema.json
+++ b/schemas/ops/admin-effectivity-audit.v1.schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://studio-brain.local/schemas/ops/admin-effectivity-audit.v1.schema.json",
+  "title": "Studio Brain Administrator Effectivity Audit",
+  "type": "object",
+  "required": ["schema", "generatedAt", "status", "sliceWindow", "scores", "sections"],
+  "properties": {
+    "schema": { "const": "studiobrain-admin-effectivity-audit.v1" },
+    "generatedAt": { "type": "string", "format": "date-time" },
+    "runId": { "type": "string" },
+    "status": { "enum": ["pass", "warn", "fail"] },
+    "sliceWindow": {
+      "type": "object",
+      "required": ["count"],
+      "properties": {
+        "from": { "type": ["string", "null"] },
+        "to": { "type": ["string", "null"] },
+        "count": { "type": "integer", "minimum": 0 }
+      },
+      "additionalProperties": false
+    },
+    "scores": {
+      "type": "object",
+      "required": ["usefulness", "verification", "noOpRate", "blockedLaneClarity", "toolInventoryFreshness"],
+      "properties": {
+        "usefulness": { "type": "number", "minimum": 0, "maximum": 1 },
+        "verification": { "type": "number", "minimum": 0, "maximum": 1 },
+        "noOpRate": { "type": "number", "minimum": 0, "maximum": 1 },
+        "blockedLaneClarity": { "type": "number", "minimum": 0, "maximum": 1 },
+        "toolInventoryFreshness": { "type": "number", "minimum": 0, "maximum": 1 }
+      },
+      "additionalProperties": false
+    },
+    "sections": {
+      "type": "object",
+      "properties": {
+        "sliceLedger": { "type": "object" },
+        "installedTools": { "type": "object" },
+        "effectivityReport": { "type": "object" }
+      },
+      "additionalProperties": true
+    },
+    "missionControl": {
+      "type": "object",
+      "properties": {
+        "externalId": { "type": "string" },
+        "taskTitle": { "type": "string" },
+        "events": { "type": "array" }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/ops/installed-tool-inventory.v1.schema.json
+++ b/schemas/ops/installed-tool-inventory.v1.schema.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://studio-brain.local/schemas/ops/installed-tool-inventory.v1.schema.json",
+  "title": "Studio Brain Administrator Installed Tool Inventory",
+  "type": "object",
+  "required": ["schema", "generatedAt", "status", "tools"],
+  "properties": {
+    "schema": { "const": "studiobrain-installed-tool-inventory.v1" },
+    "generatedAt": { "type": "string", "format": "date-time" },
+    "status": { "enum": ["pass", "warn", "fail"] },
+    "summary": {
+      "type": "object",
+      "properties": {
+        "installed": { "type": "integer", "minimum": 0 },
+        "missingRequired": { "type": "integer", "minimum": 0 },
+        "missingOptional": { "type": "integer", "minimum": 0 },
+        "shadowed": { "type": "integer", "minimum": 0 }
+      },
+      "additionalProperties": false
+    },
+    "declaredRegistry": {
+      "type": "object",
+      "properties": {
+        "contractToolCount": { "type": "integer", "minimum": 0 },
+        "primitiveFamilyCount": { "type": "integer", "minimum": 0 }
+      },
+      "additionalProperties": false
+    },
+    "tools": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "status", "required"],
+        "properties": {
+          "name": { "type": "string" },
+          "status": { "enum": ["installed", "missing_required", "missing_optional", "shadowed"] },
+          "required": { "type": "boolean" },
+          "path": { "type": ["string", "null"] },
+          "allPaths": { "type": "array", "items": { "type": "string" } },
+          "version": { "type": ["string", "null"] },
+          "note": { "type": "string" }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/ops/slice-ledger.v1.schema.json
+++ b/schemas/ops/slice-ledger.v1.schema.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://studio-brain.local/schemas/ops/slice-ledger.v1.schema.json",
+  "title": "Studio Brain Administrator Slice Ledger Row",
+  "type": "object",
+  "required": ["schema", "sliceId", "runId", "lane", "title", "status", "startedAt", "completedAt"],
+  "properties": {
+    "schema": { "const": "studiobrain-admin-slice-ledger.v1" },
+    "sliceId": { "type": "string", "minLength": 1 },
+    "runId": { "type": "string", "minLength": 1 },
+    "lane": { "type": "string", "minLength": 1 },
+    "title": { "type": "string", "minLength": 1 },
+    "intent": { "type": "string" },
+    "startedAt": { "type": "string", "format": "date-time" },
+    "completedAt": { "type": "string", "format": "date-time" },
+    "status": { "enum": ["completed", "blocked", "noop", "failed"] },
+    "changedFiles": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "commands": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["command", "status"],
+        "properties": {
+          "command": { "type": "string" },
+          "status": { "enum": ["pass", "warn", "fail", "skipped"] },
+          "note": { "type": "string" }
+        },
+        "additionalProperties": false
+      }
+    },
+    "artifacts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["path"],
+        "properties": {
+          "path": { "type": "string" },
+          "schema": { "type": "string" },
+          "note": { "type": "string" }
+        },
+        "additionalProperties": false
+      }
+    },
+    "usefulness": {
+      "type": "object",
+      "properties": {
+        "score": { "type": "number", "minimum": 0, "maximum": 1 },
+        "minutesSaved": { "type": "number", "minimum": 0 },
+        "operatorSignal": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "noOp": {
+      "type": "object",
+      "properties": {
+        "detected": { "type": "boolean" },
+        "reason": { "type": ["string", "null"] }
+      },
+      "additionalProperties": false
+    },
+    "blocker": {
+      "type": "object",
+      "properties": {
+        "class": {
+          "enum": [
+            null,
+            "approval_required",
+            "missing_auth",
+            "sudo_unavailable",
+            "dirty_worktree",
+            "merge_conflict",
+            "cross_repo_boundary",
+            "missing_tool",
+            "live_endpoint_down",
+            "test_failure",
+            "data_safety_gate",
+            "external_service",
+            "unclear_owner"
+          ]
+        },
+        "owner": { "type": ["string", "null"] },
+        "safeNextStep": { "type": ["string", "null"] }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/scripts/ops/admin_effectivity_audit.mjs
+++ b/scripts/ops/admin_effectivity_audit.mjs
@@ -1,0 +1,342 @@
+#!/usr/bin/env node
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, relative, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const REPO_ROOT = resolve(dirname(__filename), "..", "..");
+const DEFAULT_OUTPUT_DIR = resolve(REPO_ROOT, "output", "ops", "effectivity");
+const DEFAULT_LEDGER = resolve(DEFAULT_OUTPUT_DIR, "slice-ledger.jsonl");
+
+function usage() {
+  return `Studio Brain administrator effectivity audit
+
+Usage:
+  node scripts/ops/admin_effectivity_audit.mjs [--json] [--write] [--last 5]
+
+Options:
+  --json              Print JSON to stdout.
+  --write             Write timestamped JSON and Markdown artifacts.
+  --output-dir <path> Artifact directory. Default: output/ops/effectivity.
+  --ledger <path>     Slice ledger path. Default: output/ops/effectivity/slice-ledger.jsonl.
+  --last <number>     Slice window. Default: 5.
+  --run-id <id>       Stable run id. Default: admin-effectivity timestamp.
+`;
+}
+
+function clean(value) {
+  return String(value ?? "").replace(/\r/g, "").trim();
+}
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function repoRelative(path) {
+  return relative(REPO_ROOT, path).replace(/\\/g, "/");
+}
+
+function readJsonl(path) {
+  if (!existsSync(path)) return [];
+  return readFileSync(path, "utf8")
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line, index) => {
+      try {
+        return JSON.parse(line);
+      } catch (error) {
+        throw new Error(`Invalid ledger JSONL at ${path}:${index + 1}: ${error.message}`);
+      }
+    });
+}
+
+function readFlagValue(argv, index, name) {
+  const arg = argv[index];
+  if (arg === name) {
+    if (!argv[index + 1]) throw new Error(`${name} requires a value.`);
+    return { matched: true, value: argv[index + 1], nextIndex: index + 1 };
+  }
+  if (arg.startsWith(`${name}=`)) {
+    return { matched: true, value: arg.slice(name.length + 1), nextIndex: index };
+  }
+  return { matched: false, value: "", nextIndex: index };
+}
+
+function parseArgs(argv) {
+  const options = {
+    json: false,
+    write: false,
+    outputDir: DEFAULT_OUTPUT_DIR,
+    ledger: DEFAULT_LEDGER,
+    last: 5,
+    runId: ""
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--help" || arg === "-h") {
+      process.stdout.write(usage());
+      process.exit(0);
+    }
+    if (arg === "--json") {
+      options.json = true;
+      continue;
+    }
+    if (arg === "--write") {
+      options.write = true;
+      continue;
+    }
+    const mappings = [
+      ["--output-dir", "outputDir"],
+      ["--ledger", "ledger"],
+      ["--last", "last"],
+      ["--run-id", "runId"]
+    ];
+    let consumed = false;
+    for (const [flag, key] of mappings) {
+      const parsed = readFlagValue(argv, index, flag);
+      if (!parsed.matched) continue;
+      options[key] = parsed.value;
+      index = parsed.nextIndex;
+      consumed = true;
+      break;
+    }
+    if (consumed) continue;
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+  options.outputDir = resolve(REPO_ROOT, options.outputDir);
+  options.ledger = resolve(REPO_ROOT, options.ledger);
+  options.last = Math.max(1, Number(options.last) || 5);
+  return options;
+}
+
+function runJson(command, args) {
+  const result = spawnSync(command, args, {
+    cwd: REPO_ROOT,
+    encoding: "utf8",
+    windowsHide: true,
+    timeout: 30_000,
+    env: { ...process.env }
+  });
+  const output = clean(result.stdout);
+  if (result.error || result.status !== 0) {
+    return {
+      ok: false,
+      error: result.error?.message || clean(result.stderr) || `exit ${result.status}`,
+      json: null
+    };
+  }
+  try {
+    return { ok: true, error: "", json: JSON.parse(output) };
+  } catch (error) {
+    return { ok: false, error: `invalid JSON: ${error.message}`, json: null };
+  }
+}
+
+function commandExists(command) {
+  const result = spawnSync(process.platform === "win32" ? "where" : "sh", process.platform === "win32" ? [command] : ["-lc", `command -v ${shellQuote(command)}`], {
+    encoding: "utf8",
+    windowsHide: true
+  });
+  return result.status === 0;
+}
+
+function shellQuote(value) {
+  return `'${String(value).replace(/'/g, "'\\''")}'`;
+}
+
+function summarizeSlices(rows) {
+  const commandCount = rows.reduce((sum, row) => sum + (Array.isArray(row.commands) ? row.commands.length : 0), 0);
+  const commandFailures = rows.reduce((sum, row) => sum + (Array.isArray(row.commands) ? row.commands.filter((command) => command.status === "fail").length : 0), 0);
+  const blockedRows = rows.filter((row) => row.status === "blocked");
+  const clearBlocked = blockedRows.filter((row) => row.blocker?.class && row.blocker?.safeNextStep).length;
+  const noop = rows.filter((row) => row.status === "noop" || row.noOp?.detected).length;
+  const usefulness = rows.length
+    ? rows.reduce((sum, row) => sum + (Number(row.usefulness?.score) || 0), 0) / rows.length
+    : 0;
+  return {
+    count: rows.length,
+    completed: rows.filter((row) => row.status === "completed").length,
+    blocked: blockedRows.length,
+    failed: rows.filter((row) => row.status === "failed").length,
+    noop,
+    commandCount,
+    commandFailures,
+    clearBlocked,
+    usefulness: Number(usefulness.toFixed(3)),
+    noOpRate: rows.length ? Number((noop / rows.length).toFixed(3)) : 0,
+    verification: commandCount ? Number(((commandCount - commandFailures) / commandCount).toFixed(3)) : 0,
+    blockedLaneClarity: blockedRows.length ? Number((clearBlocked / blockedRows.length).toFixed(3)) : 1
+  };
+}
+
+function tryEffectivityReport() {
+  if (!commandExists("bash")) {
+    return { ok: false, status: "skipped", reason: "bash unavailable", report: null };
+  }
+  const result = runJson("bash", ["scripts/ops/effectivity_report.sh", "--json", "--no-write"]);
+  if (!result.ok) return { ok: false, status: "unavailable", reason: result.error, report: null };
+  return { ok: true, status: result.json?.status || "ok", reason: "", report: summarizeEffectivityReport(result.json) };
+}
+
+function summarizeEffectivityReport(report) {
+  const sources = {};
+  for (const [key, value] of Object.entries(report?.sources || {})) {
+    sources[key] = {
+      exists: value?.exists === true,
+      status: clean(value?.status),
+      generatedAt: clean(value?.generatedAt),
+      ageMinutes: typeof value?.ageMinutes === "number" ? value.ageMinutes : null,
+      stale: value?.stale === true
+    };
+  }
+  const sections = {};
+  for (const [key, value] of Object.entries(report?.sections || {})) {
+    sections[key] = {
+      status: clean(value?.status),
+      score: typeof value?.score === "number" ? value.score : null
+    };
+  }
+  return {
+    schema: clean(report?.schema),
+    generatedAt: clean(report?.generatedAt),
+    runId: clean(report?.runId),
+    status: clean(report?.status),
+    readOnly: report?.readOnly === true,
+    redaction: clean(report?.redaction),
+    sources,
+    sections,
+    paths: {
+      json: report?.paths?.json ? repoRelative(resolve(REPO_ROOT, report.paths.json)) : "",
+      markdown: report?.paths?.markdown ? repoRelative(resolve(REPO_ROOT, report.paths.markdown)) : ""
+    }
+  };
+}
+
+function buildAudit(options) {
+  const generatedAt = nowIso();
+  const runId = clean(options.runId) || `admin-effectivity-${generatedAt.replace(/[-:]/g, "").replace(/\.\d+Z$/, "Z")}`;
+  const ledgerRows = readJsonl(options.ledger);
+  const selectedRows = ledgerRows.slice(-options.last);
+  const sliceSummary = summarizeSlices(selectedRows);
+  const toolInventory = runJson(process.execPath, ["scripts/ops/installed_tool_inventory.mjs", "--json"]);
+  const effectivityReport = tryEffectivityReport();
+  const toolFreshness = toolInventory.ok ? 1 : 0;
+  const missingRequired = Number(toolInventory.json?.summary?.missingRequired) || 0;
+  const usefulness = sliceSummary.count > 0 ? sliceSummary.usefulness : 0;
+  const scores = {
+    usefulness,
+    verification: sliceSummary.verification,
+    noOpRate: sliceSummary.noOpRate,
+    blockedLaneClarity: sliceSummary.blockedLaneClarity,
+    toolInventoryFreshness: toolFreshness
+  };
+  const status = missingRequired > 0 || sliceSummary.failed > 0
+    ? "fail"
+    : sliceSummary.count === 0 || sliceSummary.noOpRate > 0.4 || !effectivityReport.ok
+      ? "warn"
+      : "pass";
+  return {
+    schema: "studiobrain-admin-effectivity-audit.v1",
+    generatedAt,
+    runId,
+    status,
+    sliceWindow: {
+      from: selectedRows[0]?.sliceId ?? null,
+      to: selectedRows[selectedRows.length - 1]?.sliceId ?? null,
+      count: selectedRows.length
+    },
+    scores,
+    sections: {
+      sliceLedger: {
+        ledgerPath: repoRelative(options.ledger),
+        summary: sliceSummary,
+        rows: selectedRows
+      },
+      installedTools: toolInventory.ok ? toolInventory.json : { status: "unavailable", error: toolInventory.error },
+      effectivityReport
+    },
+    missionControl: {
+      externalId: `admin-effectivity:${runId}:${selectedRows[selectedRows.length - 1]?.sliceId ?? "no-slices"}`,
+      taskTitle: `Admin effectivity audit ${selectedRows[0]?.sliceId ?? "no-slices"} to ${selectedRows[selectedRows.length - 1]?.sliceId ?? "no-slices"}`,
+      events: [
+        {
+          type: "admin.audit.completed",
+          generatedAt,
+          status,
+          sliceCount: selectedRows.length,
+          usefulness: scores.usefulness,
+          noOpRate: scores.noOpRate
+        }
+      ]
+    }
+  };
+}
+
+function markdown(audit) {
+  const lines = [
+    "# Studio Brain Administrator Effectivity Audit",
+    "",
+    `Generated: ${audit.generatedAt}`,
+    `Status: ${audit.status}`,
+    `Run ID: ${audit.runId}`,
+    "",
+    "## Slice Window",
+    "",
+    `- From: ${audit.sliceWindow.from ?? "none"}`,
+    `- To: ${audit.sliceWindow.to ?? "none"}`,
+    `- Count: ${audit.sliceWindow.count}`,
+    "",
+    "## Scores",
+    "",
+    `- Usefulness: ${audit.scores.usefulness}`,
+    `- Verification: ${audit.scores.verification}`,
+    `- No-op rate: ${audit.scores.noOpRate}`,
+    `- Blocked-lane clarity: ${audit.scores.blockedLaneClarity}`,
+    `- Tool inventory freshness: ${audit.scores.toolInventoryFreshness}`,
+    "",
+    "## Installed Tools",
+    "",
+    `- Status: ${audit.sections.installedTools.status}`,
+    `- Installed: ${audit.sections.installedTools.summary?.installed ?? "unknown"}`,
+    `- Missing required: ${audit.sections.installedTools.summary?.missingRequired ?? "unknown"}`,
+    `- Missing optional: ${audit.sections.installedTools.summary?.missingOptional ?? "unknown"}`,
+    `- Shadowed: ${audit.sections.installedTools.summary?.shadowed ?? "unknown"}`,
+    "",
+    "## Slice Rows",
+    ""
+  ];
+  for (const row of audit.sections.sliceLedger.rows) {
+    lines.push(`- ${row.sliceId}: ${row.status} - ${row.title}`);
+  }
+  if (audit.sections.sliceLedger.rows.length === 0) lines.push("- No slice rows recorded yet.");
+  lines.push("", "## Mission Control Import", "", `- External ID: ${audit.missionControl.externalId}`, `- Task title: ${audit.missionControl.taskTitle}`, "");
+  return `${lines.join("\n")}\n`;
+}
+
+function writeArtifacts(options, audit) {
+  mkdirSync(options.outputDir, { recursive: true });
+  const base = audit.runId;
+  const jsonPath = resolve(options.outputDir, `${base}.json`);
+  const markdownPath = resolve(options.outputDir, `${base}.md`);
+  writeFileSync(jsonPath, `${JSON.stringify(audit, null, 2)}\n`, "utf8");
+  writeFileSync(markdownPath, markdown(audit), "utf8");
+  writeFileSync(resolve(options.outputDir, "admin-effectivity-audit-latest.json"), `${JSON.stringify({ ...audit, artifactPath: repoRelative(jsonPath), markdownPath: repoRelative(markdownPath) }, null, 2)}\n`, "utf8");
+  return { jsonPath, markdownPath };
+}
+
+try {
+  const options = parseArgs(process.argv.slice(2));
+  const audit = buildAudit(options);
+  const artifacts = options.write ? writeArtifacts(options, audit) : null;
+  if (options.json || !options.write) {
+    process.stdout.write(`${JSON.stringify(artifacts ? { ...audit, artifacts } : audit, null, 2)}\n`);
+  } else {
+    process.stdout.write(`admin effectivity audit: ${audit.status}, slices=${audit.sliceWindow.count}, usefulness=${audit.scores.usefulness}\n`);
+  }
+} catch (error) {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.exit(1);
+}

--- a/scripts/ops/effectivity_report.sh
+++ b/scripts/ops/effectivity_report.sh
@@ -195,6 +195,21 @@ function parseJsonFromOutput(commandResult) {
   }
 }
 
+function parseKeyValueOutput(commandResult) {
+  const fields = {};
+  const text = commandResult?.stdout || "";
+  for (const line of text.split(/\r?\n/)) {
+    const match = line.match(/^([A-Za-z0-9_.-]+):\s*(.*)$/);
+    if (match) fields[match[1]] = clean(match[2]);
+  }
+  const keys = ["status", "reason", "evidence_root", "safe_next_step", "run_dir", "run"];
+  const pattern = new RegExp(`(?:^|\\s)(${keys.join("|")}):\\s*([\\s\\S]*?)(?=\\s(?:${keys.join("|")}):|$)`, "g");
+  for (const match of text.matchAll(pattern)) {
+    fields[match[1]] = clean(match[2]);
+  }
+  return fields;
+}
+
 function fileRef(label, path, maxAgeMinutes = 24 * 60) {
   const abs = resolve(repoRoot, path);
   const exists = existsSync(abs);
@@ -217,6 +232,41 @@ function fileRef(label, path, maxAgeMinutes = 24 * 60) {
 function statusFromCommand(commandResult) {
   if (commandResult.skipped) return "unavailable";
   return commandResult.ok ? "pass" : "warn";
+}
+
+function privilegedEvidenceSection(commandResult) {
+  const parsed = parseJsonFromOutput(commandResult);
+  const fields = parseKeyValueOutput(commandResult);
+  const rawStatus = clean(fields.status || parsed?.status || "");
+  const absent = commandResult.skipped
+    || rawStatus === "unavailable"
+    || rawStatus === "missing"
+    || rawStatus === "missing_summary"
+    || /no privileged evidence run was found|privileged evidence directory is not readable/i.test(commandResult.stdout || commandResult.error || "");
+
+  if (absent) {
+    return {
+      status: "sudo_unavailable",
+      commandStatus: statusFromCommand(commandResult),
+      evidenceRoot: clean(fields.evidence_root || ""),
+      runDir: clean(fields.run_dir || ""),
+      generatedAt: "",
+      summaryPresent: false,
+      safeNextStep: clean(fields.safe_next_step || "run the approval-gated collector or install the root-owned timer"),
+      note: "Privileged host capture evidence is absent; no sudo attempt was made by this report.",
+    };
+  }
+
+  return {
+    status: parsed ? "pass" : statusFromCommand(commandResult),
+    commandStatus: statusFromCommand(commandResult),
+    evidenceRoot: clean(fields.evidence_root || parsed?.evidenceRoot || ""),
+    runDir: clean(fields.run_dir || parsed?.runDir || ""),
+    generatedAt: clean(parsed?.generatedAt || parsed?.completedAt || parsed?.createdAt || ""),
+    summaryPresent: Boolean(parsed),
+    safeNextStep: "",
+    note: parsed ? "Latest privileged evidence summary was readable." : "Privileged evidence reader returned output but no JSON summary was parsed.",
+  };
 }
 
 function buildSections(commands, refs) {
@@ -283,6 +333,7 @@ function buildSections(commands, refs) {
       commandStatus: statusFromCommand(commands.failedUnits),
       trueFailedUnits,
     },
+    privilegedEvidence: privilegedEvidenceSection(commands.privilegedEvidence),
   };
 }
 
@@ -293,9 +344,10 @@ function rollupStatus(sections) {
     sections.harness.status,
     sections.backup.status,
     sections.failedUnits.status,
+    sections.privilegedEvidence.status,
   ].map((status) => clean(status).toLowerCase());
   if (statuses.includes("fail")) return "fail";
-  if (statuses.includes("warn") || statuses.includes("unavailable")) return "warn";
+  if (statuses.includes("warn") || statuses.includes("unavailable") || statuses.includes("sudo_unavailable")) return "warn";
   return "pass";
 }
 
@@ -315,6 +367,13 @@ function renderMarkdown(report) {
     `- Mission Control harness coverage: ${report.sections.harness.status}, missing tickets ${report.sections.harness.missingTickets}, open tickets ${report.sections.harness.openTickets}`,
     `- Backup confidence: ${report.sections.backup.status}`,
     `- Failed-unit classifier: ${report.sections.failedUnits.status}, true failed units ${report.sections.failedUnits.trueFailedUnits}`,
+    `- Privileged capture: ${report.sections.privilegedEvidence.status}`,
+    "",
+    "## Operator Summary",
+    "",
+    `- Overall effectivity is ${report.status}; warnings and unavailable dependencies are surfaced as follow-up work, not hidden.`,
+    `- The latest report artifacts are timestamped under ${rel(dirname(jsonPath))}; this path is ignored by git.`,
+    `- Privileged evidence status is ${report.sections.privilegedEvidence.status}, so host-only reads remain approval-gated when absent.`,
     "",
     "## Evidence",
     "",
@@ -327,6 +386,21 @@ function renderMarkdown(report) {
     lines.push("- None detected by this report.");
   } else {
     for (const gap of report.sections.backup.gaps) lines.push(`- ${gap}`);
+  }
+  lines.push("", "## Privileged Capture", "");
+  lines.push(`- Status: ${report.sections.privilegedEvidence.status}`);
+  if (report.sections.privilegedEvidence.generatedAt) {
+    lines.push(`- Generated: ${report.sections.privilegedEvidence.generatedAt}`);
+  }
+  if (report.sections.privilegedEvidence.evidenceRoot) {
+    lines.push(`- Evidence root: ${report.sections.privilegedEvidence.evidenceRoot}`);
+  }
+  if (report.sections.privilegedEvidence.runDir) {
+    lines.push(`- Run dir: ${report.sections.privilegedEvidence.runDir}`);
+  }
+  lines.push(`- Note: ${report.sections.privilegedEvidence.note}`);
+  if (report.sections.privilegedEvidence.safeNextStep) {
+    lines.push(`- Safe next step: ${report.sections.privilegedEvidence.safeNextStep}`);
   }
   lines.push("", "## Commands", "");
   for (const command of Object.values(report.commands)) {
@@ -361,6 +435,9 @@ const commands = {
   failedUnits: existsSync(resolve(repoRoot, "scripts/ops/ubuntu_failed_units.sh"))
     ? runCommand("ubuntu-failed-units", "bash", ["scripts/ops/ubuntu_failed_units.sh"], { timeoutMs: 30000, maxOutput: 12000 })
     : skippedCommand("ubuntu-failed-units", "script unavailable"),
+  privilegedEvidence: existsSync(resolve(repoRoot, "scripts/ops/privileged_evidence_read.sh"))
+    ? runCommand("privileged-evidence-read", "bash", ["scripts/ops/privileged_evidence_read.sh", "--summary"], { timeoutMs: 15000, maxOutput: 12000 })
+    : skippedCommand("privileged-evidence-read", "script unavailable"),
 };
 
 const sections = buildSections(commands, sources);

--- a/scripts/ops/installed_tool_inventory.mjs
+++ b/scripts/ops/installed_tool_inventory.mjs
@@ -1,0 +1,202 @@
+#!/usr/bin/env node
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, relative, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const REPO_ROOT = resolve(dirname(__filename), "..", "..");
+const DEFAULT_OUTPUT_DIR = resolve(REPO_ROOT, "output", "ops", "effectivity");
+const DEFAULT_LATEST = resolve(DEFAULT_OUTPUT_DIR, "installed-tool-inventory-latest.json");
+
+const TOOL_PROBES = [
+  { name: "node", required: true, versionArgs: ["--version"], note: "Node scripts power the admin harness." },
+  { name: "npm", required: true, versionArgs: ["--version"], note: "Package scripts and npx-based validators." },
+  { name: "git", required: true, versionArgs: ["--version"], note: "Review surface and branch/PR workflow." },
+  { name: "bash", required: true, versionArgs: ["--version"], note: "Ubuntu-targeted ops scripts." },
+  { name: "ssh", required: true, versionArgs: ["-V"], note: "Read-only host probes and artifact capture." },
+  { name: "gh", required: false, versionArgs: ["--version"], note: "PR and issue automation." },
+  { name: "curl", required: false, versionArgs: ["--version"], note: "HTTP health probes." },
+  { name: "psql", required: false, versionArgs: ["--version"], note: "Direct PostgreSQL read-only packets." },
+  { name: "docker", required: false, versionArgs: ["--version"], note: "Docker inventory and compose validation." },
+  { name: "make", required: false, versionArgs: ["--version"], note: "Operator command router." },
+  { name: "pwsh", required: false, versionArgs: ["--version"], note: "PowerShell script analysis and Windows bridge checks." },
+  { name: "powershell", required: false, versionArgs: ["-NoProfile", "-Command", "$PSVersionTable.PSVersion.ToString()"], note: "Windows fallback for watcher checks." },
+  { name: "npx", required: false, versionArgs: ["--version"], note: "Portable one-off validators." },
+  { name: "python", required: false, versionArgs: ["--version"], note: "Existing host automation scripts." },
+  { name: "uv", required: false, versionArgs: ["--version"], note: "Portable Python tooling runner." },
+  { name: "shellcheck", required: false, versionArgs: ["--version"], note: "Shell script linting; recommended next install." },
+  { name: "gitleaks", required: false, versionArgs: ["version"], note: "Secret scanning." },
+  { name: "sqlfluff", required: false, versionArgs: ["--version"], note: "PostgreSQL SQL parser/linter." },
+  { name: "actionlint", required: false, versionArgs: ["--version"], note: "GitHub Actions workflow validation." },
+  { name: "shfmt", required: false, versionArgs: ["--version"], note: "Shell formatter." }
+];
+
+function usage() {
+  return `Studio Brain installed tool inventory
+
+Usage:
+  node scripts/ops/installed_tool_inventory.mjs [--json] [--write] [--output-dir <path>] [--output <path>]
+
+Options:
+  --json              Print JSON to stdout.
+  --write             Write timestamped and latest JSON artifacts. Default: no write.
+  --output-dir <path> Artifact directory. Default: output/ops/effectivity.
+  --output <path>     Exact JSON output path.
+`;
+}
+
+function clean(value) {
+  return String(value ?? "").replace(/\r/g, "").trim();
+}
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function resolveRepoPath(path) {
+  return resolve(REPO_ROOT, clean(path));
+}
+
+function readJson(path) {
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function whereCommand(command) {
+  const executable = process.platform === "win32" ? "where" : "sh";
+  const args = process.platform === "win32" ? [command] : ["-lc", `command -v ${shellQuote(command)}`];
+  const result = spawnSync(executable, args, { encoding: "utf8", windowsHide: true });
+  if (result.status !== 0) return [];
+  return `${result.stdout || ""}${result.stderr || ""}`
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function shellQuote(value) {
+  return `'${String(value).replace(/'/g, "'\\''")}'`;
+}
+
+function commandVersion(command, args) {
+  const result = spawnSync(command, args, { encoding: "utf8", windowsHide: true, timeout: 5000 });
+  if (result.error || result.status !== 0) return null;
+  return clean(`${result.stdout || ""}${result.stderr || ""}`.split(/\r?\n/).find(Boolean) || "");
+}
+
+function probeTool(tool) {
+  const paths = whereCommand(tool.name);
+  const installed = paths.length > 0;
+  const status = !installed
+    ? (tool.required ? "missing_required" : "missing_optional")
+    : paths.length > 1
+      ? "shadowed"
+      : "installed";
+  return {
+    name: tool.name,
+    status,
+    required: tool.required,
+    path: paths[0] ?? null,
+    allPaths: paths,
+    version: installed ? commandVersion(tool.name, tool.versionArgs) : null,
+    note: tool.note
+  };
+}
+
+function parseArgs(argv) {
+  const options = {
+    json: false,
+    write: false,
+    outputDir: DEFAULT_OUTPUT_DIR,
+    output: ""
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--help" || arg === "-h") {
+      process.stdout.write(usage());
+      process.exit(0);
+    }
+    if (arg === "--json") {
+      options.json = true;
+      continue;
+    }
+    if (arg === "--write") {
+      options.write = true;
+      continue;
+    }
+    if (arg === "--output-dir") {
+      options.outputDir = resolveRepoPath(argv[++index]);
+      continue;
+    }
+    if (arg.startsWith("--output-dir=")) {
+      options.outputDir = resolveRepoPath(arg.slice("--output-dir=".length));
+      continue;
+    }
+    if (arg === "--output") {
+      options.output = resolveRepoPath(argv[++index]);
+      continue;
+    }
+    if (arg.startsWith("--output=")) {
+      options.output = resolveRepoPath(arg.slice("--output=".length));
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+  return options;
+}
+
+function declaredRegistrySummary() {
+  const contracts = readJson(resolve(REPO_ROOT, "config", "agent-tool-contracts.json"));
+  const primitives = readJson(resolve(REPO_ROOT, "config", "agent-tool-primitives.json"));
+  return {
+    contractToolCount: Array.isArray(contracts?.tools) ? contracts.tools.length : 0,
+    primitiveFamilyCount: Array.isArray(primitives?.families) ? primitives.families.length : 0
+  };
+}
+
+function buildInventory() {
+  const tools = TOOL_PROBES.map(probeTool);
+  const summary = {
+    installed: tools.filter((tool) => tool.status === "installed" || tool.status === "shadowed").length,
+    missingRequired: tools.filter((tool) => tool.status === "missing_required").length,
+    missingOptional: tools.filter((tool) => tool.status === "missing_optional").length,
+    shadowed: tools.filter((tool) => tool.status === "shadowed").length
+  };
+  return {
+    schema: "studiobrain-installed-tool-inventory.v1",
+    generatedAt: nowIso(),
+    status: summary.missingRequired > 0 ? "fail" : summary.shadowed > 0 ? "warn" : "pass",
+    summary,
+    declaredRegistry: declaredRegistrySummary(),
+    tools
+  };
+}
+
+function writeJson(path, value) {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+try {
+  const options = parseArgs(process.argv.slice(2));
+  const inventory = buildInventory();
+  if (options.write || options.output) {
+    const timestamp = inventory.generatedAt.replace(/[-:]/g, "").replace(/\.\d+Z$/, "Z");
+    const outputPath = options.output || resolve(options.outputDir, `installed-tool-inventory-${timestamp}.json`);
+    writeJson(outputPath, inventory);
+    writeJson(resolve(dirname(outputPath), "installed-tool-inventory-latest.json"), { ...inventory, artifactPath: relative(REPO_ROOT, outputPath).replace(/\\/g, "/") });
+  }
+  if (options.json || !options.write) {
+    process.stdout.write(`${JSON.stringify(inventory, null, 2)}\n`);
+  } else {
+    process.stdout.write(`installed tool inventory: ${inventory.status}, installed=${inventory.summary.installed}, missingRequired=${inventory.summary.missingRequired}\n`);
+  }
+} catch (error) {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.exit(1);
+}

--- a/scripts/ops/postgres_autovacuum_stale_stats_report.sql
+++ b/scripts/ops/postgres_autovacuum_stale_stats_report.sql
@@ -16,9 +16,35 @@ where name in (
 order by name;
 
 \echo query:stale_stats_candidates
+with settings as (
+  select current_setting('autovacuum_analyze_threshold')::numeric as analyze_threshold,
+         current_setting('autovacuum_analyze_scale_factor')::numeric as analyze_scale_factor,
+         current_setting('autovacuum_vacuum_threshold')::numeric as vacuum_threshold,
+         current_setting('autovacuum_vacuum_scale_factor')::numeric as vacuum_scale_factor
+),
+stats as (
+  select st.schemaname,
+         st.relname,
+         st.n_live_tup,
+         st.n_dead_tup,
+         st.n_mod_since_analyze,
+         st.last_vacuum,
+         st.last_autovacuum,
+         st.last_analyze,
+         st.last_autoanalyze,
+         c.reloptions,
+         ceil(settings.analyze_threshold + settings.analyze_scale_factor * greatest(st.n_live_tup, 0)) as estimated_analyze_threshold,
+         ceil(settings.vacuum_threshold + settings.vacuum_scale_factor * greatest(st.n_live_tup, 0)) as estimated_vacuum_threshold
+  from pg_stat_user_tables st
+  join pg_class c on c.oid = st.relid
+  cross join settings
+)
 select schemaname || '.' || relname as relation,
        n_live_tup,
        n_dead_tup,
+       n_mod_since_analyze,
+       estimated_analyze_threshold,
+       estimated_vacuum_threshold,
        round(100.0 * n_dead_tup / greatest(n_live_tup + n_dead_tup, 1), 2) as dead_pct,
        last_vacuum,
        last_autovacuum,
@@ -26,27 +52,36 @@ select schemaname || '.' || relname as relation,
        last_autoanalyze,
        greatest(last_vacuum, last_autovacuum) as last_vacuum_any,
        greatest(last_analyze, last_autoanalyze) as last_analyze_any,
+       now() - greatest(last_analyze, last_autoanalyze) as analyze_age,
+       now() - greatest(last_vacuum, last_autovacuum) as vacuum_age,
+       reloptions,
        case
          when greatest(last_analyze, last_autoanalyze) is null then 'never_analyzed'
+         when n_mod_since_analyze >= estimated_analyze_threshold then 'analyze_threshold_reached'
          when greatest(last_analyze, last_autoanalyze) < now() - interval '7 days' and n_live_tup > 10000 then 'stale_analyze_over_7d_large'
+         when n_dead_tup >= estimated_vacuum_threshold then 'vacuum_threshold_reached'
          when n_dead_tup > 10000 and n_dead_tup > n_live_tup * 0.05 then 'dead_tuple_review'
          else 'watch'
        end as review_reason
-from pg_stat_user_tables
+from stats
 where n_live_tup > 1000
    or n_dead_tup > 1000
+   or n_mod_since_analyze > 1000
 order by
   case
     when greatest(last_analyze, last_autoanalyze) is null then 0
-    when greatest(last_analyze, last_autoanalyze) < now() - interval '7 days' and n_live_tup > 10000 then 1
-    when n_dead_tup > 10000 and n_dead_tup > n_live_tup * 0.05 then 2
-    else 3
+    when n_mod_since_analyze >= estimated_analyze_threshold then 1
+    when greatest(last_analyze, last_autoanalyze) < now() - interval '7 days' and n_live_tup > 10000 then 2
+    when n_dead_tup >= estimated_vacuum_threshold then 3
+    when n_dead_tup > 10000 and n_dead_tup > n_live_tup * 0.05 then 4
+    else 5
   end,
   n_dead_tup desc,
+  n_mod_since_analyze desc,
   n_live_tup desc
 limit 75;
 
-\echo query:tables_without_autovacuum_options
+\echo query:tables_with_custom_autovacuum_options
 select st.schemaname || '.' || st.relname as relation,
        reloptions
 from pg_stat_user_tables st
@@ -54,3 +89,6 @@ join pg_class c on c.oid = st.relid
 where reloptions is not null
 order by relation
 limit 75;
+
+\echo query:autovacuum_report_note
+select 'This is a read-only candidate report. It identifies stale statistics and vacuum leads but does not approve VACUUM, ANALYZE, reloptions, or schema changes.' as note;

--- a/scripts/ops/postgres_db_growth_trend_snapshot.sql
+++ b/scripts/ops/postgres_db_growth_trend_snapshot.sql
@@ -40,5 +40,30 @@ from pg_stat_user_tables
 order by total_bytes desc
 limit 75;
 
+\echo query:index_growth_snapshot
+select schemaname || '.' || indexrelname as index_name,
+       schemaname || '.' || relname as table_name,
+       pg_relation_size(indexrelid) as index_bytes,
+       pg_size_pretty(pg_relation_size(indexrelid)) as index_size,
+       idx_scan,
+       idx_tup_read,
+       idx_tup_fetch
+from pg_stat_user_indexes
+order by index_bytes desc
+limit 75;
+
+\echo query:relation_index_ratio_review
+select schemaname || '.' || relname as relation,
+       pg_total_relation_size(relid) as total_bytes,
+       pg_relation_size(relid) as table_bytes,
+       pg_indexes_size(relid) as index_bytes,
+       round(100.0 * pg_indexes_size(relid) / greatest(pg_total_relation_size(relid), 1), 2) as index_pct_of_total,
+       n_live_tup,
+       n_dead_tup
+from pg_stat_user_tables
+where pg_total_relation_size(relid) > 0
+order by index_pct_of_total desc, index_bytes desc
+limit 75;
+
 \echo query:trend_note
-select 'Store this output weekly; compute deltas outside production with captured_at_utc + relation total_bytes.' as note;
+select 'Store this output weekly; compute deltas outside production with captured_at_utc plus database, schema, relation, and index bytes.' as note;

--- a/scripts/ops/postgres_long_transaction_lock_packet.sql
+++ b/scripts/ops/postgres_long_transaction_lock_packet.sql
@@ -1,0 +1,130 @@
+\pset pager off
+\timing on
+
+\echo query:lock_packet_metadata
+select now() at time zone 'utc' as captured_at_utc,
+       current_database() as database_name,
+       current_user as captured_by,
+       'read_only_long_transaction_lock_packet' as scope,
+       'query text may be hidden by PostgreSQL privileges; this packet does not terminate sessions or change locks' as privilege_note;
+
+\echo query:long_running_transactions
+select pid,
+       datname,
+       usename,
+       application_name,
+       coalesce(client_addr::text, 'local') as client_addr,
+       coalesce(state, '<null>') as state,
+       now() - xact_start as xact_age,
+       now() - query_start as query_age,
+       now() - state_change as state_age,
+       wait_event_type,
+       wait_event,
+       left(regexp_replace(query, E'[\n\r\t]+', ' ', 'g'), 220) as query_redacted_or_privilege_limited
+from pg_stat_activity
+where xact_start is not null
+order by xact_start nulls last
+limit 50;
+
+\echo query:idle_in_transaction_packet
+select pid,
+       datname,
+       usename,
+       application_name,
+       coalesce(client_addr::text, 'local') as client_addr,
+       now() - xact_start as xact_age,
+       now() - state_change as idle_age,
+       wait_event_type,
+       wait_event,
+       left(regexp_replace(query, E'[\n\r\t]+', ' ', 'g'), 220) as query_redacted_or_privilege_limited
+from pg_stat_activity
+where state = 'idle in transaction'
+order by xact_start nulls last
+limit 50;
+
+\echo query:waiting_activity
+select pid,
+       datname,
+       usename,
+       application_name,
+       coalesce(client_addr::text, 'local') as client_addr,
+       coalesce(state, '<null>') as state,
+       now() - query_start as wait_age,
+       wait_event_type,
+       wait_event,
+       pg_blocking_pids(pid) as blocking_pids,
+       left(regexp_replace(query, E'[\n\r\t]+', ' ', 'g'), 220) as query_redacted_or_privilege_limited
+from pg_stat_activity
+where wait_event_type is not null
+   or cardinality(pg_blocking_pids(pid)) > 0
+order by query_start nulls last
+limit 50;
+
+\echo query:blocking_lock_pairs
+select blocked.pid as blocked_pid,
+       blocked.usename as blocked_user,
+       blocked.application_name as blocked_application,
+       blocking.pid as blocking_pid,
+       blocking.usename as blocking_user,
+       blocking.application_name as blocking_application,
+       now() - blocked.query_start as blocked_age,
+       blocked_locks.locktype,
+       blocked_locks.mode as blocked_mode,
+       blocking_locks.mode as blocking_mode,
+       coalesce(ns.nspname || '.' || cls.relname, '<not relation lock>') as relation,
+       left(regexp_replace(blocked.query, E'[\n\r\t]+', ' ', 'g'), 220) as blocked_query_redacted_or_privilege_limited,
+       left(regexp_replace(blocking.query, E'[\n\r\t]+', ' ', 'g'), 220) as blocking_query_redacted_or_privilege_limited
+from pg_stat_activity blocked
+join pg_locks blocked_locks on blocked_locks.pid = blocked.pid and not blocked_locks.granted
+join pg_locks blocking_locks on blocking_locks.locktype = blocked_locks.locktype
+  and blocking_locks.database is not distinct from blocked_locks.database
+  and blocking_locks.relation is not distinct from blocked_locks.relation
+  and blocking_locks.page is not distinct from blocked_locks.page
+  and blocking_locks.tuple is not distinct from blocked_locks.tuple
+  and blocking_locks.virtualxid is not distinct from blocked_locks.virtualxid
+  and blocking_locks.transactionid is not distinct from blocked_locks.transactionid
+  and blocking_locks.classid is not distinct from blocked_locks.classid
+  and blocking_locks.objid is not distinct from blocked_locks.objid
+  and blocking_locks.objsubid is not distinct from blocked_locks.objsubid
+  and blocking_locks.pid <> blocked_locks.pid
+  and blocking_locks.granted
+join pg_stat_activity blocking on blocking.pid = blocking_locks.pid
+left join pg_class cls on cls.oid = blocked_locks.relation
+left join pg_namespace ns on ns.oid = cls.relnamespace
+order by blocked.query_start nulls last
+limit 50;
+
+\echo query:lock_mode_summary
+select locktype,
+       mode,
+       granted,
+       count(*) as lock_count
+from pg_locks
+group by locktype, mode, granted
+order by granted, lock_count desc, locktype, mode;
+
+\echo query:relation_lock_summary
+select coalesce(ns.nspname || '.' || cls.relname, '<not relation lock>') as relation,
+       mode,
+       granted,
+       count(*) as lock_count
+from pg_locks locks
+left join pg_class cls on cls.oid = locks.relation
+left join pg_namespace ns on ns.oid = cls.relnamespace
+where locks.relation is not null
+group by 1, 2, 3
+order by granted, lock_count desc, relation, mode
+limit 100;
+
+\echo query:prepared_transactions
+select gid,
+       prepared,
+       owner,
+       database,
+       now() - prepared as prepared_age
+from pg_prepared_xacts
+order by prepared
+limit 50;
+
+\echo query:lock_packet_note
+select 'Read-only triage only. Do not terminate backends, cancel queries, change timeouts, or run VACUUM/DDL without a separate approval packet.' as note;

--- a/scripts/ops/postgres_pg_stat_statements_rollup.sql
+++ b/scripts/ops/postgres_pg_stat_statements_rollup.sql
@@ -1,16 +1,54 @@
 \pset pager off
 \timing on
 
-\echo query:pg_stat_statements_extension
-select exists (
-  select 1
+\echo query:pg_stat_statements_visibility
+with extension_row as (
+  select extnamespace
   from pg_extension
   where extname = 'pg_stat_statements'
-) as pg_stat_statements_available
+),
+view_row as (
+  select c.oid, n.nspname, c.relname
+  from pg_class c
+  join pg_namespace n on n.oid = c.relnamespace
+  where c.relname = 'pg_stat_statements'
+    and c.relkind in ('v', 'm')
+  order by (n.oid = (select extnamespace from extension_row)) desc, n.nspname
+  limit 1
+)
+select exists(select 1 from extension_row) as pgss_extension_installed,
+       exists(select 1 from view_row) as pgss_view_visible,
+       coalesce((select has_table_privilege(oid, 'SELECT') from view_row), false) as pgss_can_select,
+       coalesce((select format('%I.%I', nspname, relname) from view_row), '<not visible>') as pgss_view_name,
+       coalesce(position('pg_stat_statements' in current_setting('shared_preload_libraries', true)) > 0, false) as pgss_preloaded
 \gset
-select :'pg_stat_statements_available' as pg_stat_statements_available;
+with extension_row as (
+  select extnamespace
+  from pg_extension
+  where extname = 'pg_stat_statements'
+),
+view_row as (
+  select c.oid, n.nspname, c.relname
+  from pg_class c
+  join pg_namespace n on n.oid = c.relnamespace
+  where c.relname = 'pg_stat_statements'
+    and c.relkind in ('v', 'm')
+  order by (n.oid = (select extnamespace from extension_row)) desc, n.nspname
+  limit 1
+)
+select exists(select 1 from extension_row) as extension_installed,
+       exists(select 1 from view_row) as view_visible,
+       coalesce((select has_table_privilege(oid, 'SELECT') from view_row), false) as can_select,
+       coalesce((select format('%I.%I', nspname, relname) from view_row), '<not visible>') as view_name,
+       coalesce(position('pg_stat_statements' in current_setting('shared_preload_libraries', true)) > 0, false) as preloaded,
+       case
+         when not exists(select 1 from extension_row) then 'extension_missing'
+         when not exists(select 1 from view_row) then 'view_not_visible_in_catalog'
+         when not coalesce((select has_table_privilege(oid, 'SELECT') from view_row), false) then 'select_permission_missing'
+         else 'available'
+       end as visibility_status;
 
-\if :pg_stat_statements_available
+\if :pgss_can_select
 \echo query:pg_stat_statements_rollup_by_database_user
 select d.datname,
        r.rolname as role_name,
@@ -27,6 +65,81 @@ from pg_stat_statements s
 left join pg_database d on d.oid = s.dbid
 left join pg_roles r on r.oid = s.userid
 group by d.datname, r.rolname
+order by total_exec_time_ms desc nulls last
+limit 40;
+
+\echo query:pg_stat_statements_query_family_rollup
+with normalized as (
+  select calls,
+         total_exec_time,
+         mean_exec_time,
+         max_exec_time,
+         rows,
+         shared_blks_hit,
+         shared_blks_read,
+         temp_blks_read,
+         temp_blks_written,
+         case
+           when query ~* '^[[:space:]]*select[[:space:]]' then 'select'
+           when query ~* '^[[:space:]]*insert[[:space:]]' then 'insert'
+           when query ~* '^[[:space:]]*update[[:space:]]' then 'update'
+           when query ~* '^[[:space:]]*delete[[:space:]]' then 'delete'
+           when query ~* '^[[:space:]]*with[[:space:]]' then 'with'
+           when query ~* '^[[:space:]]*refresh[[:space:]]' then 'refresh'
+           when query ~* '^[[:space:]]*create[[:space:]]' then 'create'
+           else 'other'
+         end as statement_kind,
+         coalesce(
+           nullif(substring(lower(query) from 'from[[:space:]]+([a-zA-Z0-9_".]+)'), ''),
+           nullif(substring(lower(query) from 'update[[:space:]]+([a-zA-Z0-9_".]+)'), ''),
+           nullif(substring(lower(query) from 'into[[:space:]]+([a-zA-Z0-9_".]+)'), ''),
+           nullif(substring(lower(query) from 'join[[:space:]]+([a-zA-Z0-9_".]+)'), ''),
+           '<unknown>'
+         ) as primary_relation,
+         left(
+           regexp_replace(
+             regexp_replace(
+               regexp_replace(
+                 regexp_replace(
+                   regexp_replace(
+                     lower(regexp_replace(query, E'[\n\r\t]+', ' ', 'g')),
+                     E'''([^'']|'''')*''',
+                     '''?''',
+                     'g'
+                   ),
+                   E'\\$[0-9]+',
+                   '$?',
+                   'g'
+                 ),
+                 E'\\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\\b',
+                 '?',
+                 'gi'
+               ),
+               E'\\b[0-9]+(\\.[0-9]+)?\\b',
+               '?',
+               'g'
+             ),
+             E'[[:space:]]+',
+             ' ',
+             'g'
+           ),
+           220
+         ) as redacted_query_family
+  from pg_stat_statements
+)
+select statement_kind,
+       primary_relation,
+       count(*) as statement_fingerprints,
+       sum(calls) as calls,
+       round(sum(total_exec_time)::numeric, 2) as total_exec_time_ms,
+       round((sum(total_exec_time) / greatest(sum(calls), 1))::numeric, 2) as weighted_mean_exec_time_ms,
+       round(max(max_exec_time)::numeric, 2) as max_exec_time_ms,
+       sum(rows) as rows,
+       sum(shared_blks_read) as shared_blks_read,
+       sum(temp_blks_written) as temp_blks_written,
+       min(redacted_query_family) as example_redacted_family
+from normalized
+group by statement_kind, primary_relation
 order by total_exec_time_ms desc nulls last
 limit 40;
 
@@ -57,5 +170,11 @@ order by mean_exec_time desc
 limit 25;
 \else
 \echo query:pg_stat_statements_rollup
-select 'pg_stat_statements extension is not installed in this database' as status;
+select case
+         when :'pgss_extension_installed' <> 't' then 'pg_stat_statements extension is not installed in this database'
+         when :'pgss_view_visible' <> 't' then 'pg_stat_statements view is not visible in this search path/catalog'
+         when :'pgss_can_select' <> 't' then 'current role cannot SELECT from pg_stat_statements'
+         else 'pg_stat_statements unavailable for an unknown visibility reason'
+       end as status,
+       'Grant a read-only monitoring role SELECT on pg_stat_statements, or rerun with a role that can view it. No schema changes are required for this packet.' as next_step;
 \endif

--- a/scripts/ops/postgres_readonly_snapshot_runner.sh
+++ b/scripts/ops/postgres_readonly_snapshot_runner.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+set -u
+set -o pipefail
+
+# Run Studio Brain PostgreSQL read-only DBA SQL packets and write redacted
+# text artifacts. The SQL packets are SELECT-only and the runner wraps them in
+# a READ ONLY transaction where PostgreSQL permits it.
+
+SOURCE_PATH="${BASH_SOURCE[0]:-${0}}"
+SCRIPT_DIR="$(cd "$(dirname "${SOURCE_PATH}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+OUT_DIR="${1:-${REPO_ROOT}/output/ops/postgres/${STAMP}}"
+PG_CONTAINER="${PG_CONTAINER:-studiobrain_postgres}"
+PGDATABASE="${PGDATABASE:-monsoonfire_studio_os}"
+PGCONNECT_TIMEOUT="${PGCONNECT_TIMEOUT:-5}"
+PSQL_STATEMENT_TIMEOUT="${PSQL_STATEMENT_TIMEOUT:-30s}"
+POSTGRES_RUNNER_DIRECT="${POSTGRES_RUNNER_DIRECT:-0}"
+
+SQL_PACKETS=(
+  "postgres_db_growth_trend_snapshot.sql"
+  "postgres_pg_stat_statements_rollup.sql"
+  "postgres_long_transaction_lock_packet.sql"
+  "postgres_autovacuum_stale_stats_report.sql"
+  "postgres_roles_extensions_security_packet.sql"
+)
+
+mkdir -p "${OUT_DIR}"
+chmod 700 "${OUT_DIR}" 2>/dev/null || true
+
+sanitize_stream() {
+  sed -E \
+    -e 's/([Aa]uthorization:?[[:space:]]*Bearer[[:space:]]+)[^[:space:]]+/\1[redacted]/g' \
+    -e 's/([Tt]oken["=:[:space:]]+)[^",[:space:]]+/\1[redacted]/g' \
+    -e 's/([Pp]assword["=:[:space:]]+)[^",[:space:]]+/\1[redacted]/g' \
+    -e 's/([Ss]ecret["=:[:space:]]+)[^",[:space:]]+/\1[redacted]/g' \
+    -e 's/(api[_-]?key["=:[:space:]]+)[^",[:space:]]+/\1[redacted]/Ig' \
+    -e 's#(postgres(ql)?://[^:[:space:]/]+:)[^@[:space:]]+@#\1[redacted]@#Ig'
+}
+
+write_skipped_report() {
+  local label="$1"
+  local reason="$2"
+  local file="${OUT_DIR}/${label}.txt"
+
+  {
+    printf '# %s\n' "${label}"
+    printf '# generated_at=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    printf '# scope=read_only_postgres_snapshot\n\n'
+    printf 'status: skipped\n'
+    printf 'reason: %s\n' "${reason}"
+    printf 'next_step: set DATABASE_URL or PG* variables, or run on the Studio Brain host where %s is available.\n' "${PG_CONTAINER}"
+  } >"${file}"
+}
+
+run_with_direct_psql() {
+  local sql_file="$1"
+  local label="$2"
+  local file="${OUT_DIR}/${label}.txt"
+  local psql_args=()
+
+  if [ -n "${DATABASE_URL:-}" ]; then
+    psql_args+=("${DATABASE_URL}")
+  fi
+
+  {
+    printf '# %s\n' "${label}"
+    printf '# generated_at=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    printf '# scope=read_only_postgres_snapshot\n'
+    printf '# runner=direct_psql\n\n'
+    {
+      printf '\\set ON_ERROR_STOP on\n'
+      printf 'begin read only;\n'
+      printf "set local statement_timeout = '%s';\n" "${PSQL_STATEMENT_TIMEOUT}"
+      cat "${sql_file}"
+      printf '\nrollback;\n'
+    } | PGCONNECT_TIMEOUT="${PGCONNECT_TIMEOUT}" psql "${psql_args[@]}" -X -f -
+  } 2>&1 | sanitize_stream >"${file}"
+}
+
+run_with_docker_psql() {
+  local sql_file="$1"
+  local label="$2"
+  local file="${OUT_DIR}/${label}.txt"
+
+  {
+    printf '# %s\n' "${label}"
+    printf '# generated_at=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    printf '# scope=read_only_postgres_snapshot\n'
+    printf '# runner=docker_exec\n\n'
+    {
+      printf '\\set ON_ERROR_STOP on\n'
+      printf 'begin read only;\n'
+      printf "set local statement_timeout = '%s';\n" "${PSQL_STATEMENT_TIMEOUT}"
+      cat "${sql_file}"
+      printf '\nrollback;\n'
+    } | docker exec -i -u postgres "${PG_CONTAINER}" psql -d "${PGDATABASE}" -X -f -
+  } 2>&1 | sanitize_stream >"${file}"
+}
+
+can_use_direct_psql() {
+  command -v psql >/dev/null 2>&1 && {
+    [ -n "${DATABASE_URL:-}" ] ||
+    [ -n "${PGHOST:-}" ] ||
+    [ -n "${PGSERVICE:-}" ] ||
+    [ "${POSTGRES_RUNNER_DIRECT}" = "1" ]
+  }
+}
+
+can_use_docker_psql() {
+  command -v docker >/dev/null 2>&1 &&
+    docker ps --format '{{.Names}}' 2>/dev/null | grep -qx "${PG_CONTAINER}"
+}
+
+printf 'postgres snapshot output: %s\n' "${OUT_DIR}"
+
+for packet in "${SQL_PACKETS[@]}"; do
+  sql_file="${SCRIPT_DIR}/${packet}"
+  label="${packet%.sql}"
+
+  if [ ! -f "${sql_file}" ]; then
+    write_skipped_report "${label}" "SQL packet ${packet} was not found"
+    continue
+  fi
+
+  printf 'writing %s\n' "${OUT_DIR}/${label}.txt"
+  if can_use_direct_psql; then
+    if ! run_with_direct_psql "${sql_file}" "${label}"; then
+      printf 'WARN: %s failed; review %s\n' "${packet}" "${OUT_DIR}/${label}.txt"
+    fi
+  elif can_use_docker_psql; then
+    if ! run_with_docker_psql "${sql_file}" "${label}"; then
+      printf 'WARN: %s failed; review %s\n' "${packet}" "${OUT_DIR}/${label}.txt"
+    fi
+  else
+    write_skipped_report "${label}" "no configured direct psql connection and no running ${PG_CONTAINER} container"
+  fi
+done
+
+cat >"${OUT_DIR}/README.md" <<EOF
+# PostgreSQL Read-Only DBA Snapshot
+
+Generated at: $(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+Scope: read-only PostgreSQL evidence. Review files for local path sensitivity before sharing outside the ops team.
+
+Included packets:
+
+- postgres_db_growth_trend_snapshot.txt
+- postgres_pg_stat_statements_rollup.txt
+- postgres_long_transaction_lock_packet.txt
+- postgres_autovacuum_stale_stats_report.txt
+- postgres_roles_extensions_security_packet.txt
+
+Boundaries:
+
+- No schema changes, DDL, VACUUM, ANALYZE, REINDEX, session termination, restore, or secret reads.
+- Missing extensions, permissions, Docker, or psql connections are reported as skipped/degraded evidence.
+- Query text is length-limited and literal-redacted where practical; PostgreSQL may also hide text based on role privileges.
+EOF
+
+printf 'postgres snapshot complete: %s\n' "${OUT_DIR}"

--- a/scripts/ops/slice_ledger.mjs
+++ b/scripts/ops/slice_ledger.mjs
@@ -1,0 +1,342 @@
+#!/usr/bin/env node
+
+import { appendFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const REPO_ROOT = resolve(dirname(__filename), "..", "..");
+const DEFAULT_LEDGER = resolve(REPO_ROOT, "output", "ops", "effectivity", "slice-ledger.jsonl");
+const DEFAULT_LATEST = resolve(REPO_ROOT, "output", "ops", "effectivity", "slice-ledger-latest.json");
+const STATUSES = new Set(["completed", "blocked", "noop", "failed"]);
+const COMMAND_STATUSES = new Set(["pass", "warn", "fail", "skipped"]);
+const BLOCKER_CLASSES = new Set([
+  "",
+  "approval_required",
+  "missing_auth",
+  "sudo_unavailable",
+  "dirty_worktree",
+  "merge_conflict",
+  "cross_repo_boundary",
+  "missing_tool",
+  "live_endpoint_down",
+  "test_failure",
+  "data_safety_gate",
+  "external_service",
+  "unclear_owner"
+]);
+
+function usage() {
+  return `Studio Brain administrator slice ledger
+
+Usage:
+  node scripts/ops/slice_ledger.mjs --append --slice-id <id> --run-id <id> --lane <lane> --title <title> [options]
+  node scripts/ops/slice_ledger.mjs --summary [--last 5] [--json]
+
+Options:
+  --ledger <path>             Ledger JSONL path. Default: output/ops/effectivity/slice-ledger.jsonl.
+  --latest <path>             Latest summary JSON path.
+  --append                    Append one row.
+  --summary                   Summarize the last rows. Default when --append is absent.
+  --dry-run                   Print the row or summary without writing.
+  --json                      Print JSON instead of text.
+  --slice-id <id>             Stable slice id.
+  --run-id <id>               Run id for grouping slices.
+  --lane <name>               Lane such as portal-ops, mission-control, host-readonly.
+  --title <text>              Slice title.
+  --intent <text>             Intended operational improvement.
+  --status <value>            completed, blocked, noop, or failed. Default: completed.
+  --started-at <iso>          Start time. Default: now.
+  --completed-at <iso>        Completion time. Default: now.
+  --changed-file <path>       Repeatable changed file.
+  --artifact <path>           Repeatable artifact path.
+  --command "status:command"  Repeatable command record, status in pass,warn,fail,skipped.
+  --usefulness-score <0..1>   Utility score.
+  --minutes-saved <number>    Estimated operator minutes saved.
+  --operator-signal <text>    Human or observed usefulness signal.
+  --noop-reason <text>        Mark intentional no-op reason.
+  --blocker-class <class>     Fixed blocker class.
+  --blocker-owner <owner>     Owner for blocker.
+  --safe-next-step <text>     Safe next action.
+`;
+}
+
+function clean(value) {
+  return String(value ?? "").replace(/\r/g, "").trim();
+}
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function repoRelative(path) {
+  const raw = clean(path);
+  if (!raw) return "";
+  return relative(REPO_ROOT, resolve(REPO_ROOT, raw)).replace(/\\/g, "/");
+}
+
+function readJsonl(path) {
+  if (!existsSync(path)) return [];
+  return readFileSync(path, "utf8")
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line, index) => {
+      try {
+        return JSON.parse(line);
+      } catch (error) {
+        throw new Error(`Invalid JSONL at ${path}:${index + 1}: ${error.message}`);
+      }
+    });
+}
+
+function writeJson(path, value) {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+function appendJsonl(path, value) {
+  mkdirSync(dirname(path), { recursive: true });
+  appendFileSync(path, `${JSON.stringify(value)}\n`, "utf8");
+}
+
+function readFlagValue(argv, index, name) {
+  const arg = argv[index];
+  if (arg === name) {
+    if (!argv[index + 1]) throw new Error(`${name} requires a value.`);
+    return { matched: true, value: argv[index + 1], nextIndex: index + 1 };
+  }
+  if (arg.startsWith(`${name}=`)) {
+    return { matched: true, value: arg.slice(name.length + 1), nextIndex: index };
+  }
+  return { matched: false, value: "", nextIndex: index };
+}
+
+function parseArgs(argv) {
+  const options = {
+    append: false,
+    summary: false,
+    dryRun: false,
+    json: false,
+    ledger: DEFAULT_LEDGER,
+    latest: DEFAULT_LATEST,
+    last: 5,
+    sliceId: "",
+    runId: "",
+    lane: "",
+    title: "",
+    intent: "",
+    status: "completed",
+    startedAt: "",
+    completedAt: "",
+    changedFiles: [],
+    artifacts: [],
+    commands: [],
+    usefulnessScore: 0,
+    minutesSaved: 0,
+    operatorSignal: "unknown",
+    noopReason: "",
+    blockerClass: "",
+    blockerOwner: "",
+    safeNextStep: ""
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--help" || arg === "-h") {
+      process.stdout.write(usage());
+      process.exit(0);
+    }
+    if (arg === "--append") {
+      options.append = true;
+      continue;
+    }
+    if (arg === "--summary") {
+      options.summary = true;
+      continue;
+    }
+    if (arg === "--dry-run") {
+      options.dryRun = true;
+      continue;
+    }
+    if (arg === "--json") {
+      options.json = true;
+      continue;
+    }
+    const mappings = [
+      ["--ledger", "ledger"],
+      ["--latest", "latest"],
+      ["--last", "last"],
+      ["--slice-id", "sliceId"],
+      ["--run-id", "runId"],
+      ["--lane", "lane"],
+      ["--title", "title"],
+      ["--intent", "intent"],
+      ["--status", "status"],
+      ["--started-at", "startedAt"],
+      ["--completed-at", "completedAt"],
+      ["--usefulness-score", "usefulnessScore"],
+      ["--minutes-saved", "minutesSaved"],
+      ["--operator-signal", "operatorSignal"],
+      ["--noop-reason", "noopReason"],
+      ["--blocker-class", "blockerClass"],
+      ["--blocker-owner", "blockerOwner"],
+      ["--safe-next-step", "safeNextStep"]
+    ];
+    let consumed = false;
+    for (const [flag, key] of mappings) {
+      const parsed = readFlagValue(argv, index, flag);
+      if (!parsed.matched) continue;
+      options[key] = parsed.value;
+      index = parsed.nextIndex;
+      consumed = true;
+      break;
+    }
+    if (consumed) continue;
+    const changed = readFlagValue(argv, index, "--changed-file");
+    if (changed.matched) {
+      options.changedFiles.push(changed.value);
+      index = changed.nextIndex;
+      continue;
+    }
+    const artifact = readFlagValue(argv, index, "--artifact");
+    if (artifact.matched) {
+      options.artifacts.push(artifact.value);
+      index = artifact.nextIndex;
+      continue;
+    }
+    const command = readFlagValue(argv, index, "--command");
+    if (command.matched) {
+      options.commands.push(command.value);
+      index = command.nextIndex;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  options.ledger = resolve(REPO_ROOT, options.ledger);
+  options.latest = resolve(REPO_ROOT, options.latest);
+  options.last = Math.max(1, Number(options.last) || 5);
+  options.usefulnessScore = Math.max(0, Math.min(1, Number(options.usefulnessScore) || 0));
+  options.minutesSaved = Math.max(0, Number(options.minutesSaved) || 0);
+  return options;
+}
+
+function commandRecord(value) {
+  const raw = clean(value);
+  const firstColon = raw.indexOf(":");
+  const status = firstColon > 0 ? raw.slice(0, firstColon) : "skipped";
+  const command = firstColon > 0 ? raw.slice(firstColon + 1) : raw;
+  if (!COMMAND_STATUSES.has(status)) throw new Error(`Invalid command status: ${status}`);
+  return { command: clean(command), status };
+}
+
+function buildRow(options) {
+  if (!STATUSES.has(options.status)) throw new Error(`Invalid status: ${options.status}`);
+  if (!BLOCKER_CLASSES.has(options.blockerClass)) throw new Error(`Invalid blocker class: ${options.blockerClass}`);
+  for (const field of ["sliceId", "runId", "lane", "title"]) {
+    if (!clean(options[field])) throw new Error(`--${field.replace(/[A-Z]/g, (value) => `-${value.toLowerCase()}`)} is required.`);
+  }
+  const changedFiles = options.changedFiles.map(repoRelative).filter(Boolean);
+  const artifacts = options.artifacts.map((path) => ({ path: repoRelative(path) })).filter((item) => item.path);
+  const noOpDetected = options.status === "noop" || (changedFiles.length === 0 && artifacts.length === 0 && options.commands.length === 0);
+  return {
+    schema: "studiobrain-admin-slice-ledger.v1",
+    sliceId: clean(options.sliceId),
+    runId: clean(options.runId),
+    lane: clean(options.lane),
+    title: clean(options.title),
+    intent: clean(options.intent),
+    startedAt: clean(options.startedAt) || nowIso(),
+    completedAt: clean(options.completedAt) || nowIso(),
+    status: options.status,
+    changedFiles,
+    commands: options.commands.map(commandRecord),
+    artifacts,
+    usefulness: {
+      score: options.usefulnessScore,
+      minutesSaved: options.minutesSaved,
+      operatorSignal: clean(options.operatorSignal) || "unknown"
+    },
+    noOp: {
+      detected: noOpDetected,
+      reason: clean(options.noopReason) || (noOpDetected ? "no changed file, artifact, or command evidence recorded" : null)
+    },
+    blocker: {
+      class: clean(options.blockerClass) || null,
+      owner: clean(options.blockerOwner) || null,
+      safeNextStep: clean(options.safeNextStep) || null
+    }
+  };
+}
+
+function summarize(rows, last) {
+  const selected = rows.slice(-last);
+  const completed = selected.filter((row) => row.status === "completed").length;
+  const blocked = selected.filter((row) => row.status === "blocked").length;
+  const failed = selected.filter((row) => row.status === "failed").length;
+  const noop = selected.filter((row) => row.status === "noop" || row.noOp?.detected).length;
+  const commandCount = selected.reduce((sum, row) => sum + (Array.isArray(row.commands) ? row.commands.length : 0), 0);
+  const commandFailures = selected.reduce((sum, row) => sum + (Array.isArray(row.commands) ? row.commands.filter((command) => command.status === "fail").length : 0), 0);
+  const usefulness = selected.length
+    ? selected.reduce((sum, row) => sum + (Number(row.usefulness?.score) || 0), 0) / selected.length
+    : 0;
+  return {
+    schema: "studiobrain-admin-slice-ledger-summary.v1",
+    generatedAt: nowIso(),
+    ledgerPath: repoRelative(rows.ledgerPath || DEFAULT_LEDGER),
+    window: {
+      count: selected.length,
+      from: selected[0]?.sliceId ?? null,
+      to: selected[selected.length - 1]?.sliceId ?? null
+    },
+    counts: {
+      completed,
+      blocked,
+      failed,
+      noop,
+      commandCount,
+      commandFailures
+    },
+    scores: {
+      usefulness: Number(usefulness.toFixed(3)),
+      noOpRate: selected.length ? Number((noop / selected.length).toFixed(3)) : 0,
+      verification: commandCount ? Number(((commandCount - commandFailures) / commandCount).toFixed(3)) : 0
+    },
+    rows: selected
+  };
+}
+
+function printTextSummary(summary) {
+  process.stdout.write(`slice ledger: ${summary.window.count} row(s), ${summary.counts.completed} completed, ${summary.counts.blocked} blocked, ${summary.counts.failed} failed\n`);
+  process.stdout.write(`usefulness=${summary.scores.usefulness} noOpRate=${summary.scores.noOpRate} verification=${summary.scores.verification}\n`);
+  for (const row of summary.rows) {
+    process.stdout.write(`- ${row.sliceId} [${row.status}] ${row.title}\n`);
+  }
+}
+
+try {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.append) {
+    const row = buildRow(options);
+    if (!options.dryRun) appendJsonl(options.ledger, row);
+    if (options.json) {
+      process.stdout.write(`${JSON.stringify(row, null, 2)}\n`);
+    } else {
+      process.stdout.write(`${options.dryRun ? "dry-run " : ""}recorded ${row.sliceId}: ${row.title}\n`);
+    }
+  } else {
+    const rows = readJsonl(options.ledger);
+    rows.ledgerPath = options.ledger;
+    const summary = summarize(rows, options.last);
+    if (!options.dryRun) writeJson(options.latest, summary);
+    if (options.json) {
+      process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+    } else {
+      printTextSummary(summary);
+    }
+  }
+} catch (error) {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.exit(1);
+}

--- a/studio-brain/.env.integrity.json
+++ b/studio-brain/.env.integrity.json
@@ -386,8 +386,8 @@
     },
     {
       "path": "scripts/ops/effectivity_report.sh",
-      "sha256": "7b9a9df1a2dcd34bc53a28053c63067a687e923f40576c0b2547bc3cd4589415",
-      "size": 14556
+      "sha256": "bd43b0568b76968316b6bcdbc2567d0fa15d3a4cbd62370ef89673f78bd7ab92",
+      "size": 18477
     },
     {
       "path": "scripts/ops/host_failed_unit_trends.sh",
@@ -431,18 +431,18 @@
     },
     {
       "path": "scripts/ops/postgres_autovacuum_stale_stats_report.sql",
-      "sha256": "e82839d3ad4755d107723d66fd6f50d5524a63a1af9c86b545a4bd9c4007b48f",
-      "size": 1829
+      "sha256": "bbea287f88c0dfc593b07350775440c89c9c4b5df81abd9aeaa635df8e946dd6",
+      "size": 3666
     },
     {
       "path": "scripts/ops/postgres_db_growth_trend_snapshot.sql",
-      "sha256": "563314ee165adcbb7da20c689aa494ed8d1d8f2c96769f77a5333a9ea86c5309",
-      "size": 1525
+      "sha256": "91a3435bd2f0ba1b62a65f3ee7f2f792662c65403a166763362b572cef4761b3",
+      "size": 2448
     },
     {
       "path": "scripts/ops/postgres_pg_stat_statements_rollup.sql",
-      "sha256": "22c734dec3eb7c80c221368f719a123c2ee9845d0a10e7a4277230ff7cba2d65",
-      "size": 2145
+      "sha256": "16f3234a093274663127fd661832ff2a6b9b6baa90ee19b36c7c02a94b129618",
+      "size": 7363
     },
     {
       "path": "scripts/ops/postgres_query_hotspot_issue_generator.sql",


### PR DESCRIPTION
## Summary
- add the administrator effectivity infrastructure loop: slice ledger schema/writer, installed-tool inventory, every-five-slices audit, and Make targets
- add backup/restore confidence semantics and issue-ready stale/missing evidence tasks
- add PostgreSQL read-only DBA packets for growth, pg_stat_statements visibility, long transactions/locks, autovacuum stale stats, and a degraded-safe runner
- extend the ops effectivity report with privileged evidence consumption and `sudo_unavailable` classification

## Evidence
- First five infrastructure slices were recorded in `output/ops/effectivity/slice-ledger.jsonl` during validation.
- The every-five audit scored the first batch: usefulness `0.808`, verification `1`, no-op rate `0`, blocked-lane clarity `1`, tool inventory freshness `1`.
- Tool inventory found required local tools present, with optional gaps for Docker, make, ShellCheck, gitleaks, sqlfluff, actionlint, and shfmt.

## Testing
- `node --check scripts/ops/slice_ledger.mjs scripts/ops/installed_tool_inventory.mjs scripts/ops/admin_effectivity_audit.mjs`
- `node scripts/ops/installed_tool_inventory.mjs --json`
- `node scripts/ops/slice_ledger.mjs --append --dry-run --json ...`
- `node scripts/ops/admin_effectivity_audit.mjs --write --json`
- `bash -n scripts/ops/effectivity_report.sh scripts/ops/postgres_readonly_snapshot_runner.sh`
- `bash scripts/ops/postgres_readonly_snapshot_runner.sh /tmp/postgres-runner-smoke-codex`
- `bash scripts/ops/ops_ci_validate.sh`
- `git diff --check`
- secret-pattern scan across touched files

## Risk
Low. These are read-only scripts and documentation. Generated artifacts stay under ignored `output/`. No pruning, service restart, package upgrade, schema change, or production restore path is introduced.

## Rollback
Revert this PR. Generated ignored artifacts can be removed locally; no production state is changed.

## Follow-up Tickets
- Add ShellCheck/LF reporting as the next tool-effectivity slice.
- Add parser-only SQLFluff reports after measuring noise.
- Add Mission Control ingestion for admin effectivity audit payloads as a separate small PR.
