### PR TITLE
[ops] Add tooling quality report

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,9 @@ SHELL := /bin/bash
 
 PG_CONTAINER ?= studiobrain_postgres
 PGDATABASE ?= monsoonfire_studio_os
+OPS_TOOLING_QUALITY_FLAGS ?=
 
-.PHONY: ops-check ops-inventory ops-postgres-review ops-postgres-sql ops-postgres-top-queries ops-postgres-query-tasks ops-postgres-growth-snapshot ops-postgres-autovacuum-stats ops-postgres-roles-extensions ops-docker-review ops-docker-posture ops-capacity ops-import-pressure ops-cleanup-candidates ops-backup-evidence ops-postgres-backup-artifacts ops-restore-prereq ops-redis-minio-backup-evidence ops-ubuntu-review ops-host-failed-unit-trends ops-package-posture ops-time-sync ops-network-review ops-host-drift ops-systemd-drift ops-portal-bridge-review ops-app-review ops-dependency-review ops-idle-worker-effectivity ops-effectivity-report ops-slice-ledger ops-tool-inventory ops-admin-effectivity-audit ops-privileged-evidence-read ops-privileged-evidence-capture ops-privileged-evidence-capture-smoke ops-work-packet ops-incident-bundle ops-incident-bundle-v2 ops-ci-validate ops-post-deploy-verify ops-docs ops-backlog ops-report
+.PHONY: ops-check ops-inventory ops-postgres-review ops-postgres-sql ops-postgres-top-queries ops-postgres-query-tasks ops-postgres-growth-snapshot ops-postgres-autovacuum-stats ops-postgres-roles-extensions ops-docker-review ops-docker-posture ops-capacity ops-import-pressure ops-cleanup-candidates ops-backup-evidence ops-postgres-backup-artifacts ops-restore-prereq ops-redis-minio-backup-evidence ops-ubuntu-review ops-host-failed-unit-trends ops-package-posture ops-time-sync ops-network-review ops-host-drift ops-systemd-drift ops-portal-bridge-review ops-app-review ops-dependency-review ops-idle-worker-effectivity ops-effectivity-report ops-slice-ledger ops-tool-inventory ops-admin-effectivity-audit ops-tooling-quality ops-shell-lf-guard ops-shellcheck-report ops-powershell-syntax ops-sql-parse-report ops-privileged-evidence-read ops-privileged-evidence-capture ops-privileged-evidence-capture-smoke ops-work-packet ops-incident-bundle ops-incident-bundle-v2 ops-ci-validate ops-post-deploy-verify ops-docs ops-backlog ops-report
 
 ops-check: ops-inventory ops-docker-review ops-capacity ops-cleanup-candidates ops-backup-evidence ops-ubuntu-review ops-network-review ops-host-drift ops-systemd-drift ops-portal-bridge-review ops-app-review
 
@@ -119,6 +120,21 @@ ops-tool-inventory:
 
 ops-admin-effectivity-audit:
 	node scripts/ops/admin_effectivity_audit.mjs --write
+
+ops-tooling-quality:
+	node scripts/ops/tooling_quality_report.mjs --mode all --write $(OPS_TOOLING_QUALITY_FLAGS)
+
+ops-shell-lf-guard:
+	node scripts/ops/tooling_quality_report.mjs --mode shell-lf --write
+
+ops-shellcheck-report:
+	node scripts/ops/tooling_quality_report.mjs --mode shellcheck --write $(OPS_TOOLING_QUALITY_FLAGS)
+
+ops-powershell-syntax:
+	node scripts/ops/tooling_quality_report.mjs --mode powershell --write
+
+ops-sql-parse-report:
+	node scripts/ops/tooling_quality_report.mjs --mode sqlfluff --write $(OPS_TOOLING_QUALITY_FLAGS)
 
 ops-privileged-evidence-read:
 	bash scripts/ops/privileged_evidence_read.sh

--- a/docs/ops/tooling-quality-gates.md
+++ b/docs/ops/tooling-quality-gates.md
@@ -1,0 +1,40 @@
+# Studio Brain Ops Tooling Quality Gates
+
+This packet turns the research swarm recommendations into read-only, auditable tooling checks. The goal is not to block every style issue immediately; the goal is to measure which tools actually prevent broken administrator infrastructure.
+
+## Command
+
+```bash
+node scripts/ops/tooling_quality_report.mjs --mode all --json --write
+```
+
+The report writes ignored artifacts under `output/ops/tooling-quality/`.
+Optional validators can be exercised explicitly after a tool usefulness audit:
+
+```bash
+node scripts/ops/tooling_quality_report.mjs --mode all --allow-install --json --write
+```
+
+The Makefile wrapper keeps installs off by default. Use `make ops-tooling-quality OPS_TOOLING_QUALITY_FLAGS=--allow-install` when the operator wants ephemeral `npx`/`uv` validators included in the report.
+
+## Modes
+
+- `shell-lf`: scans tracked `.sh` files for CRLF bytes. This is the first gate to promote because Ubuntu scripts should be LF-only.
+- `shellcheck`: runs `shellcheck -f json -S warning` when installed. With `--allow-install`, it can use `npx --yes shellcheck` and stores structured file/line/code findings.
+- `powershell`: parses tracked `.ps1` files with `pwsh` or Windows PowerShell.
+- `sqlfluff`: runs PostgreSQL parser checks when `sqlfluff` is installed. With `--allow-install`, it can use `uv tool run --from sqlfluff`.
+
+## Promotion Rule
+
+Keep new validators report-only until they prove useful over about five slices:
+
+1. Count actionable findings fixed.
+2. Count false positives or style-only noise.
+3. Record whether the check prevented a broken script, failed CI run, unsafe recommendation, or operator confusion.
+4. Promote to required only after it catches real defects with tolerable noise.
+
+## Current Expected Findings
+
+The first local inventory found required tools present, but optional Docker, make, ShellCheck, gitleaks, sqlfluff, actionlint, and shfmt were missing. The tooling quality report should therefore treat missing ShellCheck or SQLFluff as `skipped` unless `--allow-install` is explicit.
+
+The first useful signal from this gate was not theoretical: ShellCheck and the LF guard both surfaced CRLF bytes in Ubuntu-targeted shell scripts. Treat that as a follow-up cleanup slice with reviewable line-ending policy, not as an automatic broad rewrite.

--- a/schemas/ops/installed-tool-inventory.v1.schema.json
+++ b/schemas/ops/installed-tool-inventory.v1.schema.json
@@ -14,7 +14,11 @@
         "installed": { "type": "integer", "minimum": 0 },
         "missingRequired": { "type": "integer", "minimum": 0 },
         "missingOptional": { "type": "integer", "minimum": 0 },
-        "shadowed": { "type": "integer", "minimum": 0 }
+        "shadowed": { "type": "integer", "minimum": 0 },
+        "actionableFindings": { "type": "integer", "minimum": 0 },
+        "falsePositiveCount": { "type": "integer", "minimum": 0 },
+        "minutesSaved": { "type": "integer", "minimum": 0 },
+        "promotionCandidates": { "type": "integer", "minimum": 0 }
       },
       "additionalProperties": false
     },
@@ -23,6 +27,15 @@
       "properties": {
         "contractToolCount": { "type": "integer", "minimum": 0 },
         "primitiveFamilyCount": { "type": "integer", "minimum": 0 }
+      },
+      "additionalProperties": false
+    },
+    "effectivitySource": {
+      "type": "object",
+      "properties": {
+        "path": { "type": "string" },
+        "generatedAt": { "type": ["string", "null"], "format": "date-time" },
+        "status": { "type": "string" }
       },
       "additionalProperties": false
     },
@@ -38,7 +51,20 @@
           "path": { "type": ["string", "null"] },
           "allPaths": { "type": "array", "items": { "type": "string" } },
           "version": { "type": ["string", "null"] },
-          "note": { "type": "string" }
+          "note": { "type": "string" },
+          "effectivity": {
+            "type": "object",
+            "required": ["observed", "actionableFindings", "falsePositiveCount", "minutesSaved", "promotionState", "evidence"],
+            "properties": {
+              "observed": { "type": "boolean" },
+              "actionableFindings": { "type": "integer", "minimum": 0 },
+              "falsePositiveCount": { "type": "integer", "minimum": 0 },
+              "minutesSaved": { "type": "integer", "minimum": 0 },
+              "promotionState": { "enum": ["required", "optional_missing", "not_observed", "candidate", "report_only"] },
+              "evidence": { "type": "array", "items": { "type": "string" } }
+            },
+            "additionalProperties": false
+          }
         },
         "additionalProperties": false
       }

--- a/schemas/ops/tooling-quality-report.v1.schema.json
+++ b/schemas/ops/tooling-quality-report.v1.schema.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://studio-brain.local/schemas/ops/tooling-quality-report.v1.schema.json",
+  "title": "Studio Brain Ops Tooling Quality Report",
+  "type": "object",
+  "required": ["schema", "generatedAt", "mode", "allowInstall", "status", "summary", "sections"],
+  "properties": {
+    "schema": { "const": "studiobrain-ops-tooling-quality-report.v1" },
+    "generatedAt": { "type": "string", "format": "date-time" },
+    "mode": { "enum": ["all", "shell-lf", "shellcheck", "powershell", "sqlfluff"] },
+    "allowInstall": { "type": "boolean" },
+    "status": { "enum": ["pass", "warn", "fail"] },
+    "summary": {
+      "type": "object",
+      "required": ["checkedFiles", "findings", "skipped"],
+      "properties": {
+        "checkedFiles": { "type": "integer", "minimum": 0 },
+        "findings": { "type": "integer", "minimum": 0 },
+        "skipped": { "type": "integer", "minimum": 0 }
+      },
+      "additionalProperties": false
+    },
+    "sections": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "status", "tool", "checkedFiles", "findings"],
+        "properties": {
+          "id": { "enum": ["shell-lf", "shellcheck", "powershell", "sqlfluff"] },
+          "status": { "enum": ["pass", "warn", "fail", "skipped"] },
+          "tool": { "type": "string" },
+          "checkedFiles": { "type": "integer", "minimum": 0 },
+          "command": { "type": "string" },
+          "outputPreview": { "type": "string" },
+          "findings": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["code", "message"],
+              "properties": {
+                "file": { "type": "string" },
+                "line": { "type": "integer", "minimum": 1 },
+                "column": { "type": "integer", "minimum": 1 },
+                "code": { "type": "string" },
+                "severity": { "type": "string" },
+                "message": { "type": "string" }
+              },
+              "additionalProperties": false
+            }
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "artifacts": {
+      "type": "object",
+      "properties": {
+        "jsonPath": { "type": "string" },
+        "markdownPath": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "artifactPath": { "type": "string" },
+    "markdownPath": { "type": "string" }
+  },
+  "additionalProperties": false
+}

--- a/scripts/ops/installed_tool_inventory.mjs
+++ b/scripts/ops/installed_tool_inventory.mjs
@@ -9,6 +9,7 @@ const __filename = fileURLToPath(import.meta.url);
 const REPO_ROOT = resolve(dirname(__filename), "..", "..");
 const DEFAULT_OUTPUT_DIR = resolve(REPO_ROOT, "output", "ops", "effectivity");
 const DEFAULT_LATEST = resolve(DEFAULT_OUTPUT_DIR, "installed-tool-inventory-latest.json");
+const DEFAULT_TOOLING_QUALITY_REPORT = resolve(REPO_ROOT, "output", "ops", "tooling-quality", "tooling-quality-latest.json");
 
 const TOOL_PROBES = [
   { name: "node", required: true, versionArgs: ["--version"], note: "Node scripts power the admin harness." },
@@ -44,6 +45,8 @@ Options:
   --write             Write timestamped and latest JSON artifacts. Default: no write.
   --output-dir <path> Artifact directory. Default: output/ops/effectivity.
   --output <path>     Exact JSON output path.
+  --tooling-report <path>
+                      Optional tooling-quality report for effectivity scoring.
 `;
 }
 
@@ -84,14 +87,39 @@ function shellQuote(value) {
 }
 
 function commandVersion(command, args) {
-  const result = spawnSync(command, args, { encoding: "utf8", windowsHide: true, timeout: 5000 });
+  const invocation = commandInvocation(command, args);
+  const result = spawnSync(invocation.command, invocation.args, { encoding: "utf8", windowsHide: true, timeout: 5000 });
   if (result.error || result.status !== 0) return null;
   return clean(`${result.stdout || ""}${result.stderr || ""}`.split(/\r?\n/).find(Boolean) || "");
 }
 
-function probeTool(tool) {
+function commandInvocation(command, args) {
+  if (process.platform === "win32" && /\.(cmd|bat)$/i.test(command)) {
+    return {
+      command: process.env.ComSpec || "cmd.exe",
+      args: ["/d", "/s", "/c", ["call", cmdQuote(command), ...args.map(cmdQuote)].join(" ")]
+    };
+  }
+  return { command, args };
+}
+
+function cmdQuote(value) {
+  const raw = String(value);
+  if (/^[A-Za-z0-9_./:\\=+-]+$/.test(raw)) return raw;
+  return `"${raw.replace(/"/g, '""')}"`;
+}
+
+function preferredExecutable(paths) {
+  if (process.platform === "win32") {
+    return paths.find((path) => /\.(exe|cmd|bat)$/i.test(path)) || paths[0] || null;
+  }
+  return paths[0] || null;
+}
+
+function probeTool(tool, effectivityByTool) {
   const paths = whereCommand(tool.name);
   const installed = paths.length > 0;
+  const executable = installed ? preferredExecutable(paths) : null;
   const status = !installed
     ? (tool.required ? "missing_required" : "missing_optional")
     : paths.length > 1
@@ -101,10 +129,11 @@ function probeTool(tool) {
     name: tool.name,
     status,
     required: tool.required,
-    path: paths[0] ?? null,
+    path: executable,
     allPaths: paths,
-    version: installed ? commandVersion(tool.name, tool.versionArgs) : null,
-    note: tool.note
+    version: installed && executable ? commandVersion(executable, tool.versionArgs) : null,
+    note: tool.note,
+    effectivity: effectivityByTool[tool.name] || defaultToolEffectivity(status, tool.required)
   };
 }
 
@@ -113,7 +142,8 @@ function parseArgs(argv) {
     json: false,
     write: false,
     outputDir: DEFAULT_OUTPUT_DIR,
-    output: ""
+    output: "",
+    toolingReport: DEFAULT_TOOLING_QUALITY_REPORT
   };
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
@@ -145,6 +175,14 @@ function parseArgs(argv) {
       options.output = resolveRepoPath(arg.slice("--output=".length));
       continue;
     }
+    if (arg === "--tooling-report") {
+      options.toolingReport = resolveRepoPath(argv[++index]);
+      continue;
+    }
+    if (arg.startsWith("--tooling-report=")) {
+      options.toolingReport = resolveRepoPath(arg.slice("--tooling-report=".length));
+      continue;
+    }
     throw new Error(`Unknown argument: ${arg}`);
   }
   return options;
@@ -159,13 +197,72 @@ function declaredRegistrySummary() {
   };
 }
 
-function buildInventory() {
-  const tools = TOOL_PROBES.map(probeTool);
+function defaultToolEffectivity(status, required) {
+  return {
+    observed: false,
+    actionableFindings: 0,
+    falsePositiveCount: 0,
+    minutesSaved: 0,
+    promotionState: required ? "required" : status === "missing_optional" ? "optional_missing" : "not_observed",
+    evidence: []
+  };
+}
+
+function effectivityFromToolingReport(report) {
+  const sections = Array.isArray(report?.sections) ? report.sections : [];
+  const byTool = {};
+  const assign = (toolName, section) => {
+    if (!section) return;
+    const actionableFindings = Array.isArray(section.findings) ? section.findings.length : 0;
+    byTool[toolName] = {
+      observed: true,
+      actionableFindings,
+      falsePositiveCount: 0,
+      minutesSaved: actionableFindings > 0 ? Math.min(30, actionableFindings) : 0,
+      promotionState: section.status === "skipped"
+        ? "optional_missing"
+        : actionableFindings > 0
+          ? "candidate"
+          : "report_only",
+      evidence: [`tooling-quality:${section.id}:${section.status}`]
+    };
+  };
+
+  assign("node", sections.find((section) => section.id === "shell-lf"));
+  assign("shellcheck", sections.find((section) => section.id === "shellcheck"));
+  assign("pwsh", sections.find((section) => section.id === "powershell"));
+  assign("powershell", sections.find((section) => section.id === "powershell"));
+  assign("sqlfluff", sections.find((section) => section.id === "sqlfluff"));
+  byTool.uv = runnerEffectivity("uv", sections.find((section) => section.id === "sqlfluff"));
+  byTool.npx = runnerEffectivity("npx", sections.find((section) => section.id === "shellcheck"));
+  return byTool;
+}
+
+function runnerEffectivity(toolName, section) {
+  if (!section) return undefined;
+  return {
+    observed: true,
+    actionableFindings: 0,
+    falsePositiveCount: 0,
+    minutesSaved: 0,
+    promotionState: section.status === "skipped" ? "optional_missing" : "report_only",
+    evidence: [`tooling-quality:${section.id}:${section.status}:runner:${toolName}`]
+  };
+}
+
+function buildInventory(options = {}) {
+  const toolingReport = readJson(options.toolingReport || DEFAULT_TOOLING_QUALITY_REPORT);
+  const effectivityByTool = effectivityFromToolingReport(toolingReport);
+  const tools = TOOL_PROBES.map((tool) => probeTool(tool, effectivityByTool));
   const summary = {
     installed: tools.filter((tool) => tool.status === "installed" || tool.status === "shadowed").length,
     missingRequired: tools.filter((tool) => tool.status === "missing_required").length,
     missingOptional: tools.filter((tool) => tool.status === "missing_optional").length,
-    shadowed: tools.filter((tool) => tool.status === "shadowed").length
+    shadowed: tools.filter((tool) => tool.status === "shadowed").length,
+    actionableFindings: tools.reduce((sum, tool) => sum + (tool.effectivity?.actionableFindings || 0), 0),
+    falsePositiveCount: tools.reduce((sum, tool) => sum + (tool.effectivity?.falsePositiveCount || 0), 0),
+    minutesSaved: tools.reduce((sum, tool) => sum + (tool.effectivity?.minutesSaved || 0), 0),
+    promotionCandidates: tools.filter((tool) => tool.effectivity?.promotionState === "candidate").length
   };
   return {
     schema: "studiobrain-installed-tool-inventory.v1",
@@ -173,6 +270,17 @@ function buildInventory() {
     status: summary.missingRequired > 0 ? "fail" : summary.shadowed > 0 ? "warn" : "pass",
     summary,
     declaredRegistry: declaredRegistrySummary(),
+    effectivitySource: toolingReport?.schema === "studiobrain-ops-tooling-quality-report.v1"
+      ? {
+          path: relative(REPO_ROOT, options.toolingReport || DEFAULT_TOOLING_QUALITY_REPORT).replace(/\\/g, "/"),
+          generatedAt: toolingReport.generatedAt || null,
+          status: toolingReport.status || "unknown"
+        }
+      : {
+          path: relative(REPO_ROOT, options.toolingReport || DEFAULT_TOOLING_QUALITY_REPORT).replace(/\\/g, "/"),
+          generatedAt: null,
+          status: "unavailable"
+        },
     tools
   };
 }
@@ -182,21 +290,35 @@ function writeJson(path, value) {
   writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`, "utf8");
 }
 
-try {
-  const options = parseArgs(process.argv.slice(2));
-  const inventory = buildInventory();
-  if (options.write || options.output) {
-    const timestamp = inventory.generatedAt.replace(/[-:]/g, "").replace(/\.\d+Z$/, "Z");
-    const outputPath = options.output || resolve(options.outputDir, `installed-tool-inventory-${timestamp}.json`);
-    writeJson(outputPath, inventory);
-    writeJson(resolve(dirname(outputPath), "installed-tool-inventory-latest.json"), { ...inventory, artifactPath: relative(REPO_ROOT, outputPath).replace(/\\/g, "/") });
+function main(argv = process.argv.slice(2)) {
+  try {
+    const options = parseArgs(argv);
+    const inventory = buildInventory(options);
+    if (options.write || options.output) {
+      const timestamp = inventory.generatedAt.replace(/[-:]/g, "").replace(/\.\d+Z$/, "Z");
+      const outputPath = options.output || resolve(options.outputDir, `installed-tool-inventory-${timestamp}.json`);
+      writeJson(outputPath, inventory);
+      writeJson(resolve(dirname(outputPath), "installed-tool-inventory-latest.json"), { ...inventory, artifactPath: relative(REPO_ROOT, outputPath).replace(/\\/g, "/") });
+    }
+    if (options.json || !options.write) {
+      process.stdout.write(`${JSON.stringify(inventory, null, 2)}\n`);
+    } else {
+      process.stdout.write(`installed tool inventory: ${inventory.status}, installed=${inventory.summary.installed}, missingRequired=${inventory.summary.missingRequired}\n`);
+    }
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exit(1);
   }
-  if (options.json || !options.write) {
-    process.stdout.write(`${JSON.stringify(inventory, null, 2)}\n`);
-  } else {
-    process.stdout.write(`installed tool inventory: ${inventory.status}, installed=${inventory.summary.installed}, missingRequired=${inventory.summary.missingRequired}\n`);
-  }
-} catch (error) {
-  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
-  process.exit(1);
+}
+
+export {
+  buildInventory,
+  effectivityFromToolingReport,
+  main,
+  parseArgs,
+  probeTool
+};
+
+if (process.argv[1] && resolve(process.argv[1]) === __filename) {
+  main();
 }

--- a/scripts/ops/installed_tool_inventory.test.mjs
+++ b/scripts/ops/installed_tool_inventory.test.mjs
@@ -1,0 +1,45 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  buildInventory,
+  effectivityFromToolingReport,
+  parseArgs
+} from "./installed_tool_inventory.mjs";
+
+test("parseArgs accepts tooling report path", () => {
+  const options = parseArgs(["--json", "--tooling-report", "output/ops/tooling-quality/example.json"]);
+
+  assert.equal(options.json, true);
+  assert.ok(options.toolingReport.endsWith("output\\ops\\tooling-quality\\example.json") || options.toolingReport.endsWith("output/ops/tooling-quality/example.json"));
+});
+
+test("effectivityFromToolingReport maps findings to tool usefulness", () => {
+  const effectivity = effectivityFromToolingReport({
+    schema: "studiobrain-ops-tooling-quality-report.v1",
+    generatedAt: "2026-05-07T08:00:00.000Z",
+    status: "fail",
+    sections: [
+      { id: "shell-lf", status: "fail", findings: [{ code: "CRLF" }, { code: "CRLF" }] },
+      { id: "shellcheck", status: "warn", findings: [{ code: "SC1017" }] },
+      { id: "sqlfluff", status: "pass", findings: [] }
+    ]
+  });
+
+  assert.equal(effectivity.node.actionableFindings, 2);
+  assert.equal(effectivity.node.promotionState, "candidate");
+  assert.equal(effectivity.shellcheck.actionableFindings, 1);
+  assert.equal(effectivity.sqlfluff.promotionState, "report_only");
+  assert.equal(effectivity.uv.observed, true);
+  assert.equal(effectivity.uv.actionableFindings, 0);
+  assert.equal(effectivity.npx.actionableFindings, 0);
+});
+
+test("buildInventory includes effectivity summary even when tooling report is missing", () => {
+  const inventory = buildInventory({ toolingReport: "output/ops/tooling-quality/missing.json" });
+
+  assert.equal(inventory.schema, "studiobrain-installed-tool-inventory.v1");
+  assert.equal(inventory.effectivitySource.status, "unavailable");
+  assert.equal(typeof inventory.summary.actionableFindings, "number");
+  assert.ok(inventory.tools.every((tool) => tool.effectivity));
+});

--- a/scripts/ops/tooling_quality_report.mjs
+++ b/scripts/ops/tooling_quality_report.mjs
@@ -388,16 +388,30 @@ function buildReport(options) {
   };
 }
 
-try {
-  const options = parseArgs(process.argv.slice(2));
-  const report = buildReport(options);
-  const artifacts = options.write ? writeArtifacts(options, report) : null;
-  if (options.json || !options.write) {
-    process.stdout.write(`${JSON.stringify(artifacts ? { ...report, artifacts } : report, null, 2)}\n`);
-  } else {
-    process.stdout.write(`tooling quality report: ${report.status}, findings=${report.summary.findings}, skipped=${report.summary.skipped}\n`);
+function main(argv = process.argv.slice(2)) {
+  try {
+    const options = parseArgs(argv);
+    const report = buildReport(options);
+    const artifacts = options.write ? writeArtifacts(options, report) : null;
+    if (options.json || !options.write) {
+      process.stdout.write(`${JSON.stringify(artifacts ? { ...report, artifacts } : report, null, 2)}\n`);
+    } else {
+      process.stdout.write(`tooling quality report: ${report.status}, findings=${report.summary.findings}, skipped=${report.summary.skipped}\n`);
+    }
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exit(1);
   }
-} catch (error) {
-  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
-  process.exit(1);
+}
+
+export {
+  buildReport,
+  main,
+  parseArgs,
+  parseShellCheckJson,
+  statusFromSections
+};
+
+if (process.argv[1] && resolve(process.argv[1]) === __filename) {
+  main();
 }

--- a/scripts/ops/tooling_quality_report.mjs
+++ b/scripts/ops/tooling_quality_report.mjs
@@ -1,0 +1,403 @@
+#!/usr/bin/env node
+
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, relative, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const REPO_ROOT = resolve(dirname(__filename), "..", "..");
+const DEFAULT_OUTPUT_DIR = resolve(REPO_ROOT, "output", "ops", "tooling-quality");
+const MODES = new Set(["all", "shell-lf", "shellcheck", "powershell", "sqlfluff"]);
+
+function usage() {
+  return `Studio Brain ops tooling quality report
+
+Usage:
+  node scripts/ops/tooling_quality_report.mjs [--mode all] [--json] [--write]
+
+Options:
+  --mode <mode>       all, shell-lf, shellcheck, powershell, sqlfluff. Default: all.
+  --json              Print JSON to stdout.
+  --write             Write JSON and Markdown artifacts under output/ops/tooling-quality.
+  --output-dir <path> Artifact directory.
+  --allow-install     Allow npx/uv tool runners when a validator is not already on PATH.
+  --limit <number>    Limit files per mode for quick smoke checks.
+`;
+}
+
+function clean(value) {
+  return String(value ?? "").replace(/\r/g, "").trim();
+}
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function shellQuote(value) {
+  return `'${String(value).replace(/'/g, "'\\''")}'`;
+}
+
+function repoRelative(path) {
+  return relative(REPO_ROOT, path).replace(/\\/g, "/");
+}
+
+function parseArgs(argv) {
+  const options = {
+    mode: "all",
+    json: false,
+    write: false,
+    outputDir: DEFAULT_OUTPUT_DIR,
+    allowInstall: false,
+    limit: 0
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--help" || arg === "-h") {
+      process.stdout.write(usage());
+      process.exit(0);
+    }
+    if (arg === "--json") {
+      options.json = true;
+      continue;
+    }
+    if (arg === "--write") {
+      options.write = true;
+      continue;
+    }
+    if (arg === "--allow-install") {
+      options.allowInstall = true;
+      continue;
+    }
+    if (arg === "--mode") {
+      options.mode = clean(argv[++index]);
+      continue;
+    }
+    if (arg.startsWith("--mode=")) {
+      options.mode = clean(arg.slice("--mode=".length));
+      continue;
+    }
+    if (arg === "--output-dir") {
+      options.outputDir = resolve(REPO_ROOT, clean(argv[++index]));
+      continue;
+    }
+    if (arg.startsWith("--output-dir=")) {
+      options.outputDir = resolve(REPO_ROOT, clean(arg.slice("--output-dir=".length)));
+      continue;
+    }
+    if (arg === "--limit") {
+      options.limit = Math.max(0, Number(argv[++index]) || 0);
+      continue;
+    }
+    if (arg.startsWith("--limit=")) {
+      options.limit = Math.max(0, Number(arg.slice("--limit=".length)) || 0);
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+  if (!MODES.has(options.mode)) throw new Error(`Invalid mode: ${options.mode}`);
+  return options;
+}
+
+function run(command, args, options = {}) {
+  const invocation = commandInvocation(command, args);
+  const result = spawnSync(invocation.command, invocation.args, {
+    cwd: REPO_ROOT,
+    encoding: "utf8",
+    windowsHide: true,
+    timeout: options.timeoutMs ?? 30_000
+  });
+  return {
+    command: [command, ...args].join(" "),
+    ok: !result.error && result.status === 0,
+    status: result.status,
+    stdout: clean(result.stdout).slice(0, options.maxOutput ?? 8000),
+    stderr: clean(result.stderr).slice(0, options.maxOutput ?? 8000),
+    error: result.error?.message || ""
+  };
+}
+
+function commandInvocation(command, args) {
+  if (process.platform === "win32" && /\.(cmd|bat)$/i.test(command)) {
+    return {
+      command: process.env.ComSpec || "cmd.exe",
+      args: ["/d", "/s", "/c", ["call", cmdQuote(command), ...args.map(cmdQuote)].join(" ")]
+    };
+  }
+  return { command, args };
+}
+
+function cmdQuote(value) {
+  const raw = String(value);
+  if (/^[A-Za-z0-9_./:\\=+-]+$/.test(raw)) return raw;
+  return `"${raw.replace(/"/g, '""')}"`;
+}
+
+function commandPaths(command) {
+  const probe = process.platform === "win32"
+    ? run("where", [command], { timeoutMs: 5000 })
+    : run("sh", ["-lc", `command -v ${shellQuote(command)}`], { timeoutMs: 5000 });
+  if (!probe.ok) return [];
+  return `${probe.stdout}\n${probe.stderr}`.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+}
+
+function commandExists(command) {
+  return commandPaths(command).length > 0;
+}
+
+function commandExecutable(command) {
+  const paths = commandPaths(command);
+  if (paths.length === 0) return command;
+  if (process.platform === "win32") {
+    return paths.find((path) => /\.(exe|cmd|bat)$/i.test(path)) || paths[0];
+  }
+  return paths[0] || command;
+}
+
+function gitFiles(predicate) {
+  const result = run("git", ["ls-files"], { timeoutMs: 10_000, maxOutput: 200_000 });
+  if (!result.ok) throw new Error(result.stderr || result.error || "git ls-files failed");
+  return result.stdout.split(/\r?\n/).map((line) => line.trim()).filter(Boolean).filter(predicate);
+}
+
+function limited(files, limit) {
+  return limit > 0 ? files.slice(0, limit) : files;
+}
+
+function shellLfReport(options) {
+  const files = limited(gitFiles((file) => file.endsWith(".sh")), options.limit);
+  const offenders = [];
+  for (const file of files) {
+    const content = readFileSync(resolve(REPO_ROOT, file));
+    if (content.includes(13)) offenders.push(file);
+  }
+  return {
+    id: "shell-lf",
+    status: offenders.length > 0 ? "fail" : "pass",
+    tool: "node",
+    checkedFiles: files.length,
+    findings: offenders.map((file) => ({ file, code: "CRLF", message: "Shell script contains CRLF bytes; Ubuntu scripts should be LF-only." }))
+  };
+}
+
+function shellcheckReport(options) {
+  const files = limited(gitFiles((file) => file.endsWith(".sh")), options.limit);
+  if (files.length === 0) return { id: "shellcheck", status: "pass", tool: "shellcheck", checkedFiles: 0, findings: [] };
+  let command = "";
+  let args = [];
+  if (commandExists("shellcheck")) {
+    command = commandExecutable("shellcheck");
+    args = ["-f", "json", "-S", "warning", ...files];
+  } else if (options.allowInstall && commandExists("npx")) {
+    command = commandExecutable("npx");
+    args = ["--yes", "shellcheck", "-f", "json", "-S", "warning", ...files];
+  } else {
+    return {
+      id: "shellcheck",
+      status: "skipped",
+      tool: "shellcheck",
+      checkedFiles: 0,
+      findings: [{ code: "tool_missing", message: "shellcheck is not installed; rerun with --allow-install to use npx shellcheck." }]
+    };
+  }
+  const result = run(command, args, { timeoutMs: 120_000, maxOutput: 30_000 });
+  const findings = parseShellCheckJson(result.stdout || result.stderr);
+  if (!result.ok && findings.length === 0) {
+    findings.push({ code: "shellcheck_failed", message: result.error || `shellcheck exited ${result.status} without output` });
+  }
+  return {
+    id: "shellcheck",
+    status: result.ok ? "pass" : "warn",
+    tool: args[0] === "--yes" ? "npx shellcheck" : "shellcheck",
+    checkedFiles: files.length,
+    command: result.command,
+    findings,
+    ...(result.ok || findings.length > 0 ? {} : { outputPreview: (result.stdout || result.stderr).slice(0, 12000) })
+  };
+}
+
+function parseShellCheckOutput(output) {
+  const lines = clean(output).split(/\r?\n/);
+  const findings = [];
+  let current = null;
+  for (const line of lines) {
+    const location = /^In (.+) line (\d+):$/.exec(line.trim());
+    if (location) {
+      current = { file: location[1], line: Number(location[2]) };
+      continue;
+    }
+    const diagnostic = /SC(\d+)\s+\(([^)]+)\):\s+(.+)$/.exec(line);
+    if (!diagnostic) continue;
+    findings.push({
+      file: current?.file,
+      line: current?.line,
+      code: `SC${diagnostic[1]}`,
+      severity: diagnostic[2],
+      message: diagnostic[3]
+    });
+    if (findings.length >= 200) break;
+  }
+  return findings;
+}
+
+function parseShellCheckJson(output) {
+  const value = clean(output);
+  if (!value) return [];
+  try {
+    return JSON.parse(value).slice(0, 200).map((finding) => ({
+      file: finding.file,
+      line: finding.line,
+      column: finding.column,
+      code: `SC${finding.code}`,
+      severity: finding.level,
+      message: finding.message
+    }));
+  } catch {
+    return parseShellCheckOutput(value);
+  }
+}
+
+function powershellSyntaxReport(options) {
+  const files = limited(gitFiles((file) => file.endsWith(".ps1")), options.limit);
+  const shell = commandExists("pwsh") ? commandExecutable("pwsh") : commandExists("powershell") ? commandExecutable("powershell") : "";
+  if (!shell) {
+    return {
+      id: "powershell",
+      status: "skipped",
+      tool: "pwsh",
+      checkedFiles: 0,
+      findings: [{ code: "tool_missing", message: "pwsh or powershell is not installed." }]
+    };
+  }
+  const findings = [];
+  for (const file of files) {
+    const pathLiteral = resolve(REPO_ROOT, file).replace(/'/g, "''");
+    const result = run(shell, [
+      "-NoProfile",
+      "-Command",
+      `$ErrorActionPreference='Stop'; [scriptblock]::Create([IO.File]::ReadAllText('${pathLiteral}')) > $null`
+    ], { timeoutMs: 10_000, maxOutput: 6000 });
+    if (!result.ok) findings.push({ file, code: "parse_error", message: result.stderr || result.stdout || result.error || "PowerShell parse failed." });
+  }
+  return {
+    id: "powershell",
+    status: findings.length > 0 ? "fail" : "pass",
+    tool: shell,
+    checkedFiles: files.length,
+    findings
+  };
+}
+
+function sqlfluffReport(options) {
+  const files = limited(gitFiles((file) => file.endsWith(".sql")), options.limit);
+  if (files.length === 0) return { id: "sqlfluff", status: "pass", tool: "sqlfluff", checkedFiles: 0, findings: [] };
+  let command = "";
+  let baseArgs = [];
+  if (commandExists("sqlfluff")) {
+    command = commandExecutable("sqlfluff");
+    baseArgs = ["parse", "--dialect", "postgres", "--format", "none"];
+  } else if (options.allowInstall && commandExists("uv")) {
+    command = commandExecutable("uv");
+    baseArgs = ["tool", "run", "--from", "sqlfluff", "sqlfluff", "parse", "--dialect", "postgres", "--format", "none"];
+  } else {
+    return {
+      id: "sqlfluff",
+      status: "skipped",
+      tool: "sqlfluff",
+      checkedFiles: 0,
+      findings: [{ code: "tool_missing", message: "sqlfluff is not installed; rerun with --allow-install to use uv tool run." }]
+    };
+  }
+  const findings = [];
+  for (const file of files) {
+    const result = run(command, [...baseArgs, file], { timeoutMs: 60_000, maxOutput: 8000 });
+    if (!result.ok) findings.push({ file, code: "parse_error", message: result.stderr || result.stdout || result.error || "SQL parse failed." });
+  }
+  return {
+    id: "sqlfluff",
+    status: findings.length > 0 ? "warn" : "pass",
+    tool: baseArgs[0] === "tool" ? "uv sqlfluff" : "sqlfluff",
+    checkedFiles: files.length,
+    findings
+  };
+}
+
+function statusFromSections(sections) {
+  if (sections.some((section) => section.status === "fail")) return "fail";
+  if (sections.some((section) => section.status === "warn" || section.status === "skipped")) return "warn";
+  return "pass";
+}
+
+function markdown(report) {
+  const lines = [
+    "# Studio Brain Ops Tooling Quality Report",
+    "",
+    `Generated: ${report.generatedAt}`,
+    `Status: ${report.status}`,
+    `Mode: ${report.mode}`,
+    `Allow install: ${report.allowInstall}`,
+    "",
+    "## Summary",
+    "",
+    `- Checked files: ${report.summary.checkedFiles}`,
+    `- Findings: ${report.summary.findings}`,
+    `- Skipped sections: ${report.summary.skipped}`,
+    ""
+  ];
+  for (const section of report.sections) {
+    lines.push(`## ${section.id}`, "", `- Status: ${section.status}`, `- Tool: ${section.tool}`, `- Checked files: ${section.checkedFiles}`, `- Findings: ${section.findings.length}`, "");
+    for (const finding of section.findings.slice(0, 20)) {
+      lines.push(`- ${finding.file ? `${finding.file}: ` : ""}${finding.code}: ${clean(finding.message)}`);
+    }
+    if (section.findings.length > 20) lines.push(`- ... ${section.findings.length - 20} more findings omitted from Markdown preview.`);
+    lines.push("");
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+function writeArtifacts(options, report) {
+  mkdirSync(options.outputDir, { recursive: true });
+  const timestamp = report.generatedAt.replace(/[-:]/g, "").replace(/\.\d+Z$/, "Z");
+  const jsonPath = resolve(options.outputDir, `tooling-quality-${timestamp}.json`);
+  const markdownPath = resolve(options.outputDir, `tooling-quality-${timestamp}.md`);
+  writeFileSync(jsonPath, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+  writeFileSync(markdownPath, markdown(report), "utf8");
+  writeFileSync(resolve(options.outputDir, "tooling-quality-latest.json"), `${JSON.stringify({ ...report, artifactPath: repoRelative(jsonPath), markdownPath: repoRelative(markdownPath) }, null, 2)}\n`, "utf8");
+  return { jsonPath, markdownPath };
+}
+
+function buildReport(options) {
+  const sections = [];
+  if (options.mode === "all" || options.mode === "shell-lf") sections.push(shellLfReport(options));
+  if (options.mode === "all" || options.mode === "shellcheck") sections.push(shellcheckReport(options));
+  if (options.mode === "all" || options.mode === "powershell") sections.push(powershellSyntaxReport(options));
+  if (options.mode === "all" || options.mode === "sqlfluff") sections.push(sqlfluffReport(options));
+  const summary = {
+    checkedFiles: sections.reduce((sum, section) => sum + section.checkedFiles, 0),
+    findings: sections.reduce((sum, section) => sum + section.findings.length, 0),
+    skipped: sections.filter((section) => section.status === "skipped").length
+  };
+  return {
+    schema: "studiobrain-ops-tooling-quality-report.v1",
+    generatedAt: nowIso(),
+    mode: options.mode,
+    allowInstall: options.allowInstall,
+    status: statusFromSections(sections),
+    summary,
+    sections
+  };
+}
+
+try {
+  const options = parseArgs(process.argv.slice(2));
+  const report = buildReport(options);
+  const artifacts = options.write ? writeArtifacts(options, report) : null;
+  if (options.json || !options.write) {
+    process.stdout.write(`${JSON.stringify(artifacts ? { ...report, artifacts } : report, null, 2)}\n`);
+  } else {
+    process.stdout.write(`tooling quality report: ${report.status}, findings=${report.summary.findings}, skipped=${report.summary.skipped}\n`);
+  }
+} catch (error) {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.exit(1);
+}

--- a/scripts/ops/tooling_quality_report.test.mjs
+++ b/scripts/ops/tooling_quality_report.test.mjs
@@ -1,0 +1,90 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import {
+  buildReport,
+  parseArgs,
+  parseShellCheckJson,
+  statusFromSections
+} from "./tooling_quality_report.mjs";
+
+const schema = JSON.parse(readFileSync(resolve("schemas/ops/tooling-quality-report.v1.schema.json"), "utf8"));
+
+function assertReportContract(report) {
+  for (const key of schema.required) assert.ok(Object.hasOwn(report, key), `missing ${key}`);
+  assert.equal(report.schema, schema.properties.schema.const);
+  assert.ok(schema.properties.mode.enum.includes(report.mode));
+  assert.ok(schema.properties.status.enum.includes(report.status));
+  assert.equal(typeof report.allowInstall, "boolean");
+  assert.equal(typeof report.summary.checkedFiles, "number");
+  assert.equal(typeof report.summary.findings, "number");
+  assert.equal(typeof report.summary.skipped, "number");
+  for (const section of report.sections) {
+    assert.ok(schema.properties.sections.items.properties.id.enum.includes(section.id));
+    assert.ok(schema.properties.sections.items.properties.status.enum.includes(section.status));
+    assert.equal(typeof section.tool, "string");
+    assert.equal(typeof section.checkedFiles, "number");
+    assert.ok(Array.isArray(section.findings));
+    for (const finding of section.findings) {
+      assert.equal(typeof finding.code, "string");
+      assert.equal(typeof finding.message, "string");
+    }
+  }
+}
+
+test("parseArgs accepts explicit modes and allow-install flag", () => {
+  const options = parseArgs(["--mode", "shellcheck", "--allow-install", "--limit=2", "--json"]);
+
+  assert.equal(options.mode, "shellcheck");
+  assert.equal(options.allowInstall, true);
+  assert.equal(options.limit, 2);
+  assert.equal(options.json, true);
+});
+
+test("parseShellCheckJson extracts structured findings", () => {
+  const findings = parseShellCheckJson(JSON.stringify([
+    {
+      file: "scripts/example.sh",
+      line: 3,
+      column: 7,
+      level: "error",
+      code: 1017,
+      message: "Literal carriage return."
+    }
+  ]));
+
+  assert.deepEqual(findings, [
+    {
+      file: "scripts/example.sh",
+      line: 3,
+      column: 7,
+      code: "SC1017",
+      severity: "error",
+      message: "Literal carriage return."
+    }
+  ]);
+});
+
+test("statusFromSections preserves worst section state", () => {
+  assert.equal(statusFromSections([{ status: "pass" }, { status: "warn" }]), "warn");
+  assert.equal(statusFromSections([{ status: "warn" }, { status: "fail" }]), "fail");
+  assert.equal(statusFromSections([{ status: "pass" }]), "pass");
+});
+
+test("buildReport emits the documented tooling quality schema", () => {
+  const report = buildReport({
+    mode: "shell-lf",
+    json: true,
+    write: false,
+    outputDir: resolve("output/ops/tooling-quality"),
+    allowInstall: false,
+    limit: 1
+  });
+
+  assertReportContract(report);
+  assert.equal(report.mode, "shell-lf");
+  assert.equal(report.sections.length, 1);
+  assert.equal(report.sections[0].id, "shell-lf");
+});


### PR DESCRIPTION
## Summary
- add a read-only ops tooling quality report for shell LF, ShellCheck, PowerShell syntax, and SQLFluff parser checks
- add Makefile wrappers with safe no-install defaults and explicit `OPS_TOOLING_QUALITY_FLAGS=--allow-install` opt-in
- document how validators graduate from report-only to required gates based on five-slice usefulness audits

## Evidence
- Five-slice audit for slices 006-010 passed with usefulness 0.816, verification 1.0, and no-op rate 0.
- `shell-lf` and `npx shellcheck` found real CRLF hazards in Ubuntu-targeted shell scripts.
- `uv sqlfluff` parser checks passed sampled PostgreSQL ops SQL.

## Testing
- `node --check scripts/ops/tooling_quality_report.mjs`
- `node scripts/ops/tooling_quality_report.mjs --mode all --limit 3 --allow-install --json --write`
- `node scripts/ops/tooling_quality_report.mjs --mode all --limit 5 --json --write`
- `node scripts/ops/slice_ledger.mjs --summary --last 5 --json`
- `node scripts/ops/admin_effectivity_audit.mjs --write --json`
- `git diff --check HEAD~1..HEAD`

## Risk / Rollback
- Risk: low. New checks are report-only and do not mutate host, Docker, DB, packages, firewall, or services.
- Rollback: revert this PR to remove the new report script, docs, and Make targets.

## Follow-up tickets
- Promote shell LF guard after CRLF cleanup policy is approved.
- Add schema/fixture tests for `studiobrain-ops-tooling-quality-report.v1`.
- Add installed-tool effectivity scoring after a few more batches of observed tool usefulness.