### PR TITLE
[ops] Promote shell LF policy

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,6 @@ wiki/00_source_index/source-map.md text eol=lf
 wiki/00_source_index/extracted-facts.jsonl text eol=lf
 wiki/50_contradictions/*.md text eol=lf
 wiki/70_agent_context_packs/*.md text eol=lf
+*.sh text eol=lf
+scripts/codexr text eol=lf
+android/gradlew text eol=lf

--- a/docs/ops/tooling-quality-gates.md
+++ b/docs/ops/tooling-quality-gates.md
@@ -19,7 +19,7 @@ The Makefile wrapper keeps installs off by default. Use `make ops-tooling-qualit
 
 ## Modes
 
-- `shell-lf`: scans tracked `.sh` files for CRLF bytes. This is the first gate to promote because Ubuntu scripts should be LF-only.
+- `shell-lf`: scans tracked `.sh` files plus extensionless `sh`/`bash` shebang scripts for CRLF bytes. This is the first gate to promote because Ubuntu scripts should be LF-only.
 - `shellcheck`: runs `shellcheck -f json -S warning` when installed. With `--allow-install`, it can use `npx --yes shellcheck` and stores structured file/line/code findings.
 - `powershell`: parses tracked `.ps1` files with `pwsh` or Windows PowerShell.
 - `sqlfluff`: runs PostgreSQL parser checks when `sqlfluff` is installed. With `--allow-install`, it can use `uv tool run --from sqlfluff`.

--- a/scripts/ops/tooling_quality_report.mjs
+++ b/scripts/ops/tooling_quality_report.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { dirname, relative, resolve } from "node:path";
+import { basename, dirname, relative, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
@@ -164,8 +164,33 @@ function limited(files, limit) {
   return limit > 0 ? files.slice(0, limit) : files;
 }
 
+function hasShellShebang(content) {
+  const firstLine = Buffer.from(content).toString("utf8", 0, 256).split(/\r?\n/, 1)[0] || "";
+  return /^#!.*\b(?:bash|sh)\b/.test(firstLine);
+}
+
+function isShellScriptFile(file, content = null) {
+  if (file.endsWith(".sh")) return true;
+  if (basename(file).includes(".")) return false;
+  if (!content) return false;
+  return hasShellShebang(content);
+}
+
+function shellFiles(limit) {
+  const candidates = gitFiles((file) => file.endsWith(".sh") || !basename(file).includes("."));
+  const files = candidates.filter((file) => {
+    if (file.endsWith(".sh")) return true;
+    try {
+      return isShellScriptFile(file, readFileSync(resolve(REPO_ROOT, file)));
+    } catch {
+      return false;
+    }
+  });
+  return limited(files, limit);
+}
+
 function shellLfReport(options) {
-  const files = limited(gitFiles((file) => file.endsWith(".sh")), options.limit);
+  const files = shellFiles(options.limit);
   const offenders = [];
   for (const file of files) {
     const content = readFileSync(resolve(REPO_ROOT, file));
@@ -181,7 +206,7 @@ function shellLfReport(options) {
 }
 
 function shellcheckReport(options) {
-  const files = limited(gitFiles((file) => file.endsWith(".sh")), options.limit);
+  const files = shellFiles(options.limit);
   if (files.length === 0) return { id: "shellcheck", status: "pass", tool: "shellcheck", checkedFiles: 0, findings: [] };
   let command = "";
   let args = [];
@@ -406,6 +431,7 @@ function main(argv = process.argv.slice(2)) {
 
 export {
   buildReport,
+  isShellScriptFile,
   main,
   parseArgs,
   parseShellCheckJson,

--- a/scripts/ops/tooling_quality_report.test.mjs
+++ b/scripts/ops/tooling_quality_report.test.mjs
@@ -5,6 +5,7 @@ import { resolve } from "node:path";
 
 import {
   buildReport,
+  isShellScriptFile,
   parseArgs,
   parseShellCheckJson,
   statusFromSections
@@ -65,6 +66,14 @@ test("parseShellCheckJson extracts structured findings", () => {
       message: "Literal carriage return."
     }
   ]);
+});
+
+test("isShellScriptFile includes extensionless shell shebangs", () => {
+  assert.equal(isShellScriptFile("scripts/example.sh"), true);
+  assert.equal(isShellScriptFile("scripts/codexr", Buffer.from("#!/usr/bin/env bash\nset -e\n")), true);
+  assert.equal(isShellScriptFile("android/gradlew", Buffer.from("#!/bin/sh\n")), true);
+  assert.equal(isShellScriptFile("scripts/not-shell", Buffer.from("#!/usr/bin/env node\n")), false);
+  assert.equal(isShellScriptFile("scripts/not-shell.txt", Buffer.from("#!/bin/sh\n")), false);
 });
 
 test("statusFromSections preserves worst section state", () => {


### PR DESCRIPTION
## Summary
- Adds a shell-focused `.gitattributes` policy so Windows checkouts keep Ubuntu-targeted shell surfaces LF-only.
- Expands the tooling quality LF guard to include extensionless `sh`/`bash` shebang scripts such as `scripts/codexr` and `android/gradlew`.
- Documents the broader guard behavior and adds a focused contract test.

## Evidence
- The prior tooling report found CRLF bytes across shell scripts and missed two extensionless shell entrypoints.
- After the change, `node scripts/ops/tooling_quality_report.mjs --mode shell-lf --json` checks 59 shell surfaces and passes with 0 findings.
- Full tooling report now separates remaining real warnings from CRLF noise.

## Testing
- `node --check scripts/ops/tooling_quality_report.mjs`
- `node --test scripts/ops/tooling_quality_report.test.mjs`
- `node scripts/ops/tooling_quality_report.mjs --mode shell-lf --json`
- `node scripts/ops/tooling_quality_report.mjs --mode all --allow-install --json --write`
- `git diff --check`
- `node scripts/ops/admin_effectivity_audit.mjs --write --json`

## Risk / rollback
- Risk: low; repo policy and read-only reporting only, no runtime host mutation.
- Rollback: revert this commit to remove the `.gitattributes` shell policy and guard expansion.

## Follow-up
- Promote `ops-shell-lf-guard` to CI after the tooling-quality base PR lands.
- Triage the remaining ShellCheck and SQLFluff warnings as separate slices.