### PR TITLE
[ops] Add work verification packet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ PG_CONTAINER ?= studiobrain_postgres
 PGDATABASE ?= monsoonfire_studio_os
 OPS_TOOLING_QUALITY_FLAGS ?=
 
-.PHONY: ops-check ops-inventory ops-postgres-review ops-postgres-sql ops-postgres-top-queries ops-postgres-query-tasks ops-postgres-growth-snapshot ops-postgres-autovacuum-stats ops-postgres-roles-extensions ops-docker-review ops-docker-posture ops-capacity ops-import-pressure ops-cleanup-candidates ops-backup-evidence ops-postgres-backup-artifacts ops-restore-prereq ops-redis-minio-backup-evidence ops-ubuntu-review ops-host-failed-unit-trends ops-package-posture ops-time-sync ops-network-review ops-host-drift ops-systemd-drift ops-portal-bridge-review ops-app-review ops-dependency-review ops-idle-worker-effectivity ops-effectivity-report ops-slice-ledger ops-tool-inventory ops-admin-effectivity-audit ops-tooling-quality ops-shell-lf-guard ops-shellcheck-report ops-powershell-syntax ops-sql-parse-report ops-privileged-evidence-read ops-privileged-evidence-capture ops-privileged-evidence-capture-smoke ops-work-packet ops-incident-bundle ops-incident-bundle-v2 ops-ci-validate ops-post-deploy-verify ops-docs ops-backlog ops-report
+.PHONY: ops-check ops-inventory ops-postgres-review ops-postgres-sql ops-postgres-top-queries ops-postgres-query-tasks ops-postgres-growth-snapshot ops-postgres-autovacuum-stats ops-postgres-roles-extensions ops-docker-review ops-docker-posture ops-capacity ops-import-pressure ops-cleanup-candidates ops-backup-evidence ops-postgres-backup-artifacts ops-restore-prereq ops-redis-minio-backup-evidence ops-ubuntu-review ops-host-failed-unit-trends ops-package-posture ops-time-sync ops-network-review ops-host-drift ops-systemd-drift ops-portal-bridge-review ops-app-review ops-dependency-review ops-idle-worker-effectivity ops-effectivity-report ops-slice-ledger ops-tool-inventory ops-admin-effectivity-audit ops-tooling-quality ops-shell-lf-guard ops-shellcheck-report ops-powershell-syntax ops-sql-parse-report ops-privileged-evidence-read ops-privileged-evidence-capture ops-privileged-evidence-capture-smoke ops-work-packet ops-work-verification ops-incident-bundle ops-incident-bundle-v2 ops-ci-validate ops-post-deploy-verify ops-docs ops-backlog ops-report
 
 ops-check: ops-inventory ops-docker-review ops-capacity ops-cleanup-candidates ops-backup-evidence ops-ubuntu-review ops-network-review ops-host-drift ops-systemd-drift ops-portal-bridge-review ops-app-review
 
@@ -147,6 +147,9 @@ ops-privileged-evidence-capture-smoke:
 
 ops-work-packet:
 	node ./scripts/studiobrain-ops-work-packet.mjs --write
+
+ops-work-verification:
+	node scripts/ops/work_verification_packet.mjs --last 5 --write
 
 ops-incident-bundle:
 	bash scripts/ops/incident_bundle.sh

--- a/docs/ops/17-pr-readiness-packet-template.md
+++ b/docs/ops/17-pr-readiness-packet-template.md
@@ -21,6 +21,7 @@ Use this packet before opening or merging ops PRs that touch Studio Brain eviden
 | --- | --- | --- | --- |
 | Shell syntax | `bash -n scripts/ops/incident_bundle_v2.sh scripts/ops/ops_ci_validate.sh scripts/ops/post_deploy_verify.sh` | passes | |
 | Ops script validation | `bash scripts/ops/ops_ci_validate.sh` | passes and writes `output/ops/ci-validate` | |
+| Work verification packet | `node scripts/ops/work_verification_packet.mjs --last 5 --json --write` | writes metadata-only verification packet under `output/ops/work-verification` | |
 | Redacted incident bundle v2 | `INCIDENT_INCLUDE_LOGS=0 INCIDENT_INCLUDE_POST_DEPLOY=0 bash scripts/ops/incident_bundle_v2.sh output/ops/incidents-v2/pr-smoke` | writes `summary.json` and redacted reports | |
 | Post-deploy verification help | `bash scripts/ops/post_deploy_verify.sh --help` | documents safe flags and env vars | |
 | Docs review | Review `docs/ops/18-release-verification.md` | release verifier covers Studio Brain health/ready, Mission Control health/admin DOM, harness, and idle-worker audit | |

--- a/schemas/ops/work-verification-packet.v1.schema.json
+++ b/schemas/ops/work-verification-packet.v1.schema.json
@@ -1,0 +1,130 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://studio-brain.local/schemas/ops/work-verification-packet.v1.schema.json",
+  "title": "Studio Brain Ops Work Verification Packet",
+  "type": "object",
+  "required": ["schema", "generatedAt", "status", "redaction", "inputs", "sliceWindow", "summary", "commands", "changedFiles", "artifacts", "warnings", "failures"],
+  "properties": {
+    "schema": { "const": "studiobrain-ops-work-verification-packet.v1" },
+    "generatedAt": { "type": "string", "format": "date-time" },
+    "status": { "enum": ["pass", "warn", "fail"] },
+    "redaction": { "const": "metadata_only_no_file_contents" },
+    "inputs": {
+      "type": "object",
+      "required": ["ledgerPath", "last"],
+      "properties": {
+        "ledgerPath": { "type": "string" },
+        "last": { "type": "number", "minimum": 1 }
+      },
+      "additionalProperties": false
+    },
+    "sliceWindow": {
+      "type": "object",
+      "required": ["from", "to", "rows"],
+      "properties": {
+        "from": { "type": ["string", "null"] },
+        "to": { "type": ["string", "null"] },
+        "rows": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["sliceId", "runId", "lane", "title", "status", "usefulnessScore"],
+            "properties": {
+              "sliceId": { "type": "string" },
+              "runId": { "type": "string" },
+              "lane": { "type": "string" },
+              "title": { "type": "string" },
+              "status": { "enum": ["completed", "blocked", "noop", "failed"] },
+              "usefulnessScore": { "type": "number", "minimum": 0, "maximum": 1 }
+            },
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "summary": {
+      "type": "object",
+      "required": ["sliceCount", "commandCount", "commandFailures", "commandWarnings", "commandSkipped", "artifactCount", "missingArtifacts", "artifactWarnings", "artifactFailures", "changedFileCount", "sensitivePathCount", "sensitivePathClasses", "noOpRows", "gitDirtyFiles"],
+      "properties": {
+        "sliceCount": { "type": "number", "minimum": 0 },
+        "commandCount": { "type": "number", "minimum": 0 },
+        "commandFailures": { "type": "number", "minimum": 0 },
+        "commandWarnings": { "type": "number", "minimum": 0 },
+        "commandSkipped": { "type": "number", "minimum": 0 },
+        "artifactCount": { "type": "number", "minimum": 0 },
+        "missingArtifacts": { "type": "number", "minimum": 0 },
+        "artifactWarnings": { "type": "number", "minimum": 0 },
+        "artifactFailures": { "type": "number", "minimum": 0 },
+        "changedFileCount": { "type": "number", "minimum": 0 },
+        "sensitivePathCount": { "type": "number", "minimum": 0 },
+        "sensitivePathClasses": { "type": "array", "items": { "type": "string" } },
+        "noOpRows": { "type": "number", "minimum": 0 },
+        "gitDirtyFiles": { "type": "number", "minimum": 0 }
+      },
+      "additionalProperties": false
+    },
+    "commands": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["sliceId", "command", "status"],
+        "properties": {
+          "sliceId": { "type": "string" },
+          "command": { "type": "string" },
+          "status": { "enum": ["pass", "warn", "fail", "skipped"] }
+        },
+        "additionalProperties": false
+      }
+    },
+    "changedFiles": { "type": "array", "items": { "type": "string" } },
+    "artifacts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["path", "exists", "sizeBytes", "sha256", "schema", "status", "generatedAt", "shareable"],
+        "properties": {
+          "path": { "type": "string" },
+          "exists": { "type": "boolean" },
+          "sizeBytes": { "type": "number", "minimum": 0 },
+          "sha256": { "type": ["string", "null"] },
+          "schema": { "type": ["string", "null"] },
+          "status": { "type": ["string", "null"] },
+          "generatedAt": { "type": ["string", "null"] },
+          "shareable": { "type": "boolean" }
+        },
+        "additionalProperties": false
+      }
+    },
+    "git": {
+      "type": ["object", "null"]
+    },
+    "warnings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["code", "message"],
+        "properties": {
+          "code": { "type": "string" },
+          "path": { "type": "string" },
+          "message": { "type": "string" }
+        },
+        "additionalProperties": false
+      }
+    },
+    "failures": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["code", "message"],
+        "properties": {
+          "code": { "type": "string" },
+          "sliceId": { "type": "string" },
+          "message": { "type": "string" }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/scripts/ops/work_verification_packet.mjs
+++ b/scripts/ops/work_verification_packet.mjs
@@ -1,0 +1,419 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { dirname, relative, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const REPO_ROOT = resolve(dirname(__filename), "..", "..");
+const DEFAULT_LEDGER = resolve(REPO_ROOT, "output", "ops", "effectivity", "slice-ledger.jsonl");
+const DEFAULT_OUTPUT_DIR = resolve(REPO_ROOT, "output", "ops", "work-verification");
+
+function usage() {
+  return `Studio Brain ops work verification packet
+
+Usage:
+  node scripts/ops/work_verification_packet.mjs [--last 5] [--json] [--write]
+
+Options:
+  --ledger <path>      Slice ledger JSONL path. Default: output/ops/effectivity/slice-ledger.jsonl.
+  --last <number>      Number of latest slice rows to include. Default: 5.
+  --base <ref>         Git base ref for changed-file summary. Default: origin/main.
+  --output-dir <path>  Artifact directory. Default: output/ops/work-verification.
+  --json               Print JSON.
+  --write              Write timestamped JSON/Markdown and latest JSON artifacts.
+  --no-write           Explicitly avoid writing artifacts.
+`;
+}
+
+function clean(value) {
+  return String(value ?? "").replace(/\r/g, "").trim();
+}
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function repoRelative(root, path) {
+  const raw = clean(path);
+  if (!raw) return "";
+  return relative(root, resolve(root, raw)).replace(/\\/g, "/");
+}
+
+function normalPath(value) {
+  return clean(value).replace(/\\/g, "/");
+}
+
+function sensitivePathReason(path) {
+  const value = normalPath(path).toLowerCase();
+  if (/(^|\/)\.env($|[./-])/.test(value)) return "env_file";
+  if (/(^|\/)(secrets?|credentials?|tokens?|private)(\/|$)/.test(value)) return "sensitive_directory";
+  if (/(password|secret|token|credential|api[_-]?key)/.test(value)) return "sensitive_name";
+  if (/\.(pem|key|p12|pfx)$/i.test(value)) return "private_key_material";
+  return "";
+}
+
+function redactPath(path) {
+  const value = normalPath(path);
+  const reason = sensitivePathReason(value);
+  if (!reason) return value;
+  return `[redacted-sensitive-path:${sha256(Buffer.from(value)).slice(0, 12)}]`;
+}
+
+function sanitizePathList(paths) {
+  const source = paths.map(normalPath).filter(Boolean);
+  const sensitive = source.map(sensitivePathReason).filter(Boolean);
+  return {
+    paths: unique(source.map(redactPath)),
+    sensitiveCount: sensitive.length,
+    sensitiveClasses: unique(sensitive)
+  };
+}
+
+function parseArgs(argv) {
+  const options = {
+    ledger: DEFAULT_LEDGER,
+    last: 5,
+    base: "origin/main",
+    outputDir: DEFAULT_OUTPUT_DIR,
+    json: false,
+    write: false,
+    includeGit: true,
+    repoRoot: REPO_ROOT
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--help" || arg === "-h") {
+      process.stdout.write(usage());
+      process.exit(0);
+    }
+    if (arg === "--json") {
+      options.json = true;
+      continue;
+    }
+    if (arg === "--write") {
+      options.write = true;
+      continue;
+    }
+    if (arg === "--no-write") {
+      options.write = false;
+      continue;
+    }
+    if (arg === "--ledger") {
+      options.ledger = argv[++index];
+      continue;
+    }
+    if (arg.startsWith("--ledger=")) {
+      options.ledger = arg.slice("--ledger=".length);
+      continue;
+    }
+    if (arg === "--last") {
+      options.last = Number(argv[++index]) || 5;
+      continue;
+    }
+    if (arg.startsWith("--last=")) {
+      options.last = Number(arg.slice("--last=".length)) || 5;
+      continue;
+    }
+    if (arg === "--base") {
+      options.base = clean(argv[++index]);
+      continue;
+    }
+    if (arg.startsWith("--base=")) {
+      options.base = clean(arg.slice("--base=".length));
+      continue;
+    }
+    if (arg === "--output-dir") {
+      options.outputDir = argv[++index];
+      continue;
+    }
+    if (arg.startsWith("--output-dir=")) {
+      options.outputDir = arg.slice("--output-dir=".length);
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+  options.repoRoot = resolve(options.repoRoot);
+  options.ledger = resolve(options.repoRoot, options.ledger);
+  options.outputDir = resolve(options.repoRoot, options.outputDir);
+  options.last = Math.max(1, options.last);
+  return options;
+}
+
+function readJsonl(path) {
+  if (!existsSync(path)) return [];
+  return readFileSync(path, "utf8")
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line, index) => {
+      try {
+        return JSON.parse(line);
+      } catch (error) {
+        throw new Error(`Invalid JSONL at ${path}:${index + 1}: ${error.message}`);
+      }
+    });
+}
+
+function sha256(buffer) {
+  return createHash("sha256").update(buffer).digest("hex");
+}
+
+function unique(values) {
+  return [...new Set(values.filter(Boolean))].sort();
+}
+
+function artifactEvidence(path, repoRoot) {
+  const originalRelativePath = repoRelative(repoRoot, path);
+  const relativePath = redactPath(originalRelativePath);
+  const absolutePath = resolve(repoRoot, originalRelativePath);
+  const shareable = normalPath(originalRelativePath).startsWith("output/ops/") && !sensitivePathReason(originalRelativePath);
+  if (!existsSync(absolutePath)) {
+    return {
+      path: relativePath,
+      exists: false,
+      sizeBytes: 0,
+      sha256: null,
+      schema: null,
+      status: null,
+      generatedAt: null,
+      shareable
+    };
+  }
+  const stat = statSync(absolutePath);
+  if (!shareable) {
+    return {
+      path: relativePath,
+      exists: true,
+      sizeBytes: stat.size,
+      sha256: null,
+      schema: null,
+      status: null,
+      generatedAt: null,
+      shareable
+    };
+  }
+  const bytes = readFileSync(absolutePath);
+  let parsed = null;
+  try {
+    parsed = JSON.parse(bytes.toString("utf8"));
+  } catch {
+    parsed = null;
+  }
+  return {
+    path: relativePath,
+    exists: true,
+    sizeBytes: stat.size,
+    sha256: sha256(bytes),
+    schema: typeof parsed?.schema === "string" ? parsed.schema : null,
+    status: typeof parsed?.status === "string" ? parsed.status : null,
+    generatedAt: typeof parsed?.generatedAt === "string" ? parsed.generatedAt : null,
+    shareable
+  };
+}
+
+function runGit(args, repoRoot) {
+  const result = spawnSync("git", args, {
+    cwd: repoRoot,
+    encoding: "utf8",
+    windowsHide: true,
+    timeout: 10_000
+  });
+  return {
+    ok: !result.error && result.status === 0,
+    stdout: clean(result.stdout),
+    stderr: clean(result.stderr),
+    error: result.error?.message || ""
+  };
+}
+
+function gitSnapshot(options) {
+  if (!options.includeGit) return null;
+  const branch = runGit(["rev-parse", "--abbrev-ref", "HEAD"], options.repoRoot);
+  const head = runGit(["rev-parse", "HEAD"], options.repoRoot);
+  const diff = runGit(["diff", "--name-only", `${options.base}..HEAD`], options.repoRoot);
+  const status = runGit(["status", "--short"], options.repoRoot);
+  const changed = sanitizePathList(diff.ok ? diff.stdout.split(/\r?\n/) : []);
+  const dirty = sanitizePathList(status.ok ? status.stdout.split(/\r?\n/) : []);
+  return {
+    branch: branch.ok ? branch.stdout : null,
+    head: head.ok ? head.stdout : null,
+    base: options.base,
+    changedFilesSinceBase: changed.paths,
+    dirtyFiles: dirty.paths,
+    sensitivePathCount: changed.sensitiveCount + dirty.sensitiveCount,
+    sensitivePathClasses: unique([...changed.sensitiveClasses, ...dirty.sensitiveClasses]),
+    warnings: [
+      ...(branch.ok ? [] : [{ code: "git_branch_unavailable", message: branch.stderr || branch.error }]),
+      ...(head.ok ? [] : [{ code: "git_head_unavailable", message: head.stderr || head.error }]),
+      ...(diff.ok ? [] : [{ code: "git_diff_unavailable", message: diff.stderr || diff.error }]),
+      ...(status.ok ? [] : [{ code: "git_status_unavailable", message: status.stderr || status.error }])
+    ]
+  };
+}
+
+function statusFromSummary(summary) {
+  if (summary.commandFailures > 0 || summary.artifactFailures > 0) return "fail";
+  if (summary.missingArtifacts > 0 || summary.artifactWarnings > 0 || summary.commandWarnings > 0 || summary.commandSkipped > 0 || summary.noOpRows > 0 || summary.gitDirtyFiles > 0 || summary.sensitivePathCount > 0) return "warn";
+  return "pass";
+}
+
+function buildPacket(options) {
+  const rows = readJsonl(options.ledger);
+  const selected = rows.slice(-options.last);
+  const commands = selected.flatMap((row) => (row.commands || []).map((command) => ({
+    sliceId: row.sliceId,
+    command: command.command,
+    status: command.status
+  })));
+  const artifactPaths = unique(selected.flatMap((row) => (row.artifacts || []).map((artifact) => artifact.path)));
+  const artifacts = artifactPaths.map((path) => artifactEvidence(path, options.repoRoot));
+  const git = gitSnapshot(options);
+  const changed = sanitizePathList(selected.flatMap((row) => row.changedFiles || []));
+  const summary = {
+    sliceCount: selected.length,
+    commandCount: commands.length,
+    commandFailures: commands.filter((command) => command.status === "fail").length,
+    commandWarnings: commands.filter((command) => command.status === "warn").length,
+    commandSkipped: commands.filter((command) => command.status === "skipped").length,
+    artifactCount: artifacts.length,
+    missingArtifacts: artifacts.filter((artifact) => !artifact.exists).length,
+    artifactWarnings: artifacts.filter((artifact) => artifact.status === "warn" || artifact.status === "skipped").length,
+    artifactFailures: artifacts.filter((artifact) => artifact.status === "fail").length,
+    changedFileCount: changed.paths.length,
+    sensitivePathCount: changed.sensitiveCount + (git?.sensitivePathCount ?? 0),
+    sensitivePathClasses: unique([...changed.sensitiveClasses, ...(git?.sensitivePathClasses || [])]),
+    noOpRows: selected.filter((row) => row.status === "noop" || row.noOp?.detected).length,
+    gitDirtyFiles: git?.dirtyFiles?.length ?? 0
+  };
+  const warnings = [
+    ...(selected.length === 0 ? [{ code: "no_slice_rows", message: "No slice rows were available in the selected ledger window." }] : []),
+    ...artifacts.filter((artifact) => !artifact.exists).map((artifact) => ({ code: "missing_artifact", path: artifact.path, message: "Ledger artifact path does not exist in this checkout." })),
+    ...(summary.artifactWarnings > 0 ? [{ code: "artifact_warnings", message: `${summary.artifactWarnings} referenced artifact(s) report warn/skipped status.` }] : []),
+    ...(summary.commandWarnings > 0 ? [{ code: "command_warnings", message: `${summary.commandWarnings} verification command(s) were recorded as warn.` }] : []),
+    ...(summary.commandSkipped > 0 ? [{ code: "command_skipped", message: `${summary.commandSkipped} verification command(s) were recorded as skipped.` }] : []),
+    ...(summary.noOpRows > 0 ? [{ code: "noop_rows", message: `${summary.noOpRows} selected slice row(s) were no-op.` }] : []),
+    ...(summary.gitDirtyFiles > 0 ? [{ code: "dirty_worktree", message: `${summary.gitDirtyFiles} working-tree file(s) are dirty while packet was generated.` }] : []),
+    ...(summary.sensitivePathCount > 0 ? [{ code: "sensitive_paths_redacted", message: `${summary.sensitivePathCount} sensitive-looking path(s) were redacted.` }] : []),
+    ...(git?.warnings || [])
+  ];
+  const failures = commands
+    .filter((command) => command.status === "fail")
+    .map((command) => ({ code: "command_failed", sliceId: command.sliceId, message: command.command }));
+  failures.push(...artifacts
+    .filter((artifact) => artifact.status === "fail")
+    .map((artifact) => ({ code: "artifact_failed", message: artifact.path })));
+  return {
+    schema: "studiobrain-ops-work-verification-packet.v1",
+    generatedAt: nowIso(),
+    status: statusFromSummary(summary),
+    redaction: "metadata_only_no_file_contents",
+    inputs: {
+      ledgerPath: repoRelative(options.repoRoot, options.ledger),
+      last: options.last
+    },
+    sliceWindow: {
+      from: selected[0]?.sliceId ?? null,
+      to: selected[selected.length - 1]?.sliceId ?? null,
+      rows: selected.map((row) => ({
+        sliceId: row.sliceId,
+        runId: row.runId,
+        lane: row.lane,
+        title: row.title,
+        status: row.status,
+        usefulnessScore: Number(row.usefulness?.score) || 0
+      }))
+    },
+    summary,
+    commands,
+    changedFiles: changed.paths,
+    artifacts,
+    git,
+    warnings,
+    failures
+  };
+}
+
+function markdown(packet) {
+  const lines = [
+    "# Studio Brain Ops Work Verification Packet",
+    "",
+    `Generated: ${packet.generatedAt}`,
+    `Status: ${packet.status}`,
+    `Redaction: ${packet.redaction}`,
+    "",
+    "## Summary",
+    "",
+    `- Slices: ${packet.summary.sliceCount}`,
+    `- Commands: ${packet.summary.commandCount}`,
+    `- Command failures: ${packet.summary.commandFailures}`,
+    `- Artifacts: ${packet.summary.artifactCount}`,
+    `- Missing artifacts: ${packet.summary.missingArtifacts}`,
+    `- Artifact warnings: ${packet.summary.artifactWarnings}`,
+    `- Artifact failures: ${packet.summary.artifactFailures}`,
+    `- Changed files from ledger: ${packet.summary.changedFileCount}`,
+    `- Dirty files at generation: ${packet.summary.gitDirtyFiles}`,
+    "",
+    "## Slice Window",
+    ""
+  ];
+  for (const row of packet.sliceWindow.rows) {
+    lines.push(`- ${row.sliceId}: ${row.status} - ${row.title}`);
+  }
+  lines.push("", "## Warnings", "");
+  if (packet.warnings.length === 0) {
+    lines.push("- none");
+  } else {
+    for (const warning of packet.warnings) lines.push(`- ${warning.code}${warning.path ? ` (${warning.path})` : ""}: ${warning.message}`);
+  }
+  lines.push("", "## Artifacts", "");
+  if (packet.artifacts.length === 0) {
+    lines.push("- none");
+  } else {
+    for (const artifact of packet.artifacts) {
+      lines.push(`- ${artifact.path}: ${artifact.exists ? "exists" : "missing"}${artifact.schema ? `, schema=${artifact.schema}` : ""}${artifact.status ? `, status=${artifact.status}` : ""}`);
+    }
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+function writeArtifacts(options, packet) {
+  mkdirSync(options.outputDir, { recursive: true });
+  const timestamp = packet.generatedAt.replace(/[-:]/g, "").replace(/\.\d+Z$/, "Z");
+  const jsonPath = resolve(options.outputDir, `work-verification-${timestamp}.json`);
+  const markdownPath = resolve(options.outputDir, `work-verification-${timestamp}.md`);
+  writeFileSync(jsonPath, `${JSON.stringify(packet, null, 2)}\n`, "utf8");
+  writeFileSync(markdownPath, markdown(packet), "utf8");
+  writeFileSync(resolve(options.outputDir, "work-verification-latest.json"), `${JSON.stringify({ ...packet, artifactPath: repoRelative(options.repoRoot, jsonPath), markdownPath: repoRelative(options.repoRoot, markdownPath) }, null, 2)}\n`, "utf8");
+  return { jsonPath, markdownPath };
+}
+
+function main(argv = process.argv.slice(2)) {
+  try {
+    const options = parseArgs(argv);
+    const packet = buildPacket(options);
+    const artifacts = options.write ? writeArtifacts(options, packet) : null;
+    if (options.json || !options.write) {
+      process.stdout.write(`${JSON.stringify(artifacts ? { ...packet, artifacts: packet.artifacts, outputArtifacts: artifacts } : packet, null, 2)}\n`);
+    } else {
+      process.stdout.write(`work verification packet: ${packet.status}, slices=${packet.summary.sliceCount}, warnings=${packet.warnings.length}\n`);
+    }
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exit(1);
+  }
+}
+
+export {
+  artifactEvidence,
+  buildPacket,
+  main,
+  parseArgs,
+  statusFromSummary
+};
+
+if (process.argv[1] && resolve(process.argv[1]) === __filename) {
+  main();
+}

--- a/scripts/ops/work_verification_packet.test.mjs
+++ b/scripts/ops/work_verification_packet.test.mjs
@@ -1,0 +1,116 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+import {
+  artifactEvidence,
+  buildPacket,
+  parseArgs,
+  statusFromSummary
+} from "./work_verification_packet.mjs";
+
+const schema = JSON.parse(readFileSync(resolve("schemas/ops/work-verification-packet.v1.schema.json"), "utf8"));
+
+function withTempRepo(callback) {
+  const dir = mkdtempSync(join(tmpdir(), "work-verification-"));
+  try {
+    callback(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test("parseArgs accepts no-write and ledger options", () => {
+  const options = parseArgs(["--ledger", "output/example.jsonl", "--last=3", "--base", "origin/main", "--json", "--no-write"]);
+
+  assert.equal(options.last, 3);
+  assert.equal(options.base, "origin/main");
+  assert.equal(options.json, true);
+  assert.equal(options.write, false);
+  assert.ok(options.ledger.endsWith("output\\example.jsonl") || options.ledger.endsWith("output/example.jsonl"));
+});
+
+test("artifactEvidence records metadata without exposing content", () => {
+  withTempRepo((repoRoot) => {
+    mkdirSync(join(repoRoot, "output", "ops"), { recursive: true });
+    writeFileSync(join(repoRoot, "output", "ops", "artifact.json"), JSON.stringify({
+      schema: "example.v1",
+      status: "pass",
+      generatedAt: "2026-05-07T00:00:00.000Z",
+      secretLike: "do-not-echo"
+    }));
+
+    const evidence = artifactEvidence("output/ops/artifact.json", repoRoot);
+
+    assert.equal(evidence.exists, true);
+    assert.equal(evidence.schema, "example.v1");
+    assert.equal(evidence.status, "pass");
+    assert.equal(evidence.generatedAt, "2026-05-07T00:00:00.000Z");
+    assert.equal(evidence.shareable, true);
+    assert.equal(Object.values(evidence).includes("do-not-echo"), false);
+
+    mkdirSync(join(repoRoot, "secrets"), { recursive: true });
+    writeFileSync(join(repoRoot, "secrets", "api-key.json"), JSON.stringify({ schema: "secret.v1", value: "do-not-echo" }));
+    const sensitive = artifactEvidence("secrets/api-key.json", repoRoot);
+
+    assert.equal(sensitive.exists, true);
+    assert.equal(sensitive.shareable, false);
+    assert.equal(sensitive.sha256, null);
+    assert.equal(sensitive.schema, null);
+    assert.equal(sensitive.path.includes("api-key"), false);
+    assert.equal(Object.values(sensitive).includes("do-not-echo"), false);
+  });
+});
+
+test("buildPacket summarizes ledger commands and artifacts", () => {
+  withTempRepo((repoRoot) => {
+    mkdirSync(join(repoRoot, "output", "ops", "work-verification"), { recursive: true });
+    writeFileSync(join(repoRoot, "output", "ops", "work-verification", "report.json"), JSON.stringify({
+      schema: "report.v1",
+      status: "pass",
+      generatedAt: "2026-05-07T00:00:00.000Z"
+    }));
+    const row = {
+      schema: "studiobrain-admin-slice-ledger.v1",
+      sliceId: "slice-1",
+      runId: "run",
+      lane: "portal-ops",
+      title: "Test slice",
+      status: "completed",
+      changedFiles: ["scripts/example.mjs", "secrets/prod-token.txt"],
+      commands: [{ command: "node --test example", status: "pass" }],
+      artifacts: [{ path: "output/ops/work-verification/report.json" }],
+      usefulness: { score: 0.8 }
+    };
+    writeFileSync(join(repoRoot, "ledger.jsonl"), `${JSON.stringify(row)}\n`);
+
+    const packet = buildPacket({
+      repoRoot,
+      ledger: join(repoRoot, "ledger.jsonl"),
+      last: 5,
+      base: "origin/main",
+      outputDir: join(repoRoot, "output", "ops", "work-verification"),
+      includeGit: false
+    });
+
+    assert.equal(packet.schema, schema.properties.schema.const);
+    assert.equal(packet.status, "warn");
+    assert.equal(packet.summary.sliceCount, 1);
+    assert.equal(packet.summary.commandCount, 1);
+    assert.equal(packet.summary.sensitivePathCount, 1);
+    assert.equal(packet.artifacts[0].schema, "report.v1");
+    assert.equal(packet.changedFiles.includes("scripts/example.mjs"), true);
+    assert.equal(packet.changedFiles.some((path) => path.startsWith("[redacted-sensitive-path:")), true);
+  });
+});
+
+test("statusFromSummary fails on command failures and warns on missing evidence", () => {
+  assert.equal(statusFromSummary({ commandFailures: 1, missingArtifacts: 0, commandWarnings: 0, commandSkipped: 0, noOpRows: 0, gitDirtyFiles: 0 }), "fail");
+  assert.equal(statusFromSummary({ commandFailures: 0, artifactFailures: 1, missingArtifacts: 0, artifactWarnings: 0, commandWarnings: 0, commandSkipped: 0, noOpRows: 0, gitDirtyFiles: 0 }), "fail");
+  assert.equal(statusFromSummary({ commandFailures: 0, artifactFailures: 0, missingArtifacts: 1, artifactWarnings: 0, commandWarnings: 0, commandSkipped: 0, noOpRows: 0, gitDirtyFiles: 0 }), "warn");
+  assert.equal(statusFromSummary({ commandFailures: 0, artifactFailures: 0, missingArtifacts: 0, artifactWarnings: 1, commandWarnings: 0, commandSkipped: 0, noOpRows: 0, gitDirtyFiles: 0 }), "warn");
+  assert.equal(statusFromSummary({ commandFailures: 0, artifactFailures: 0, missingArtifacts: 0, artifactWarnings: 0, commandWarnings: 0, commandSkipped: 0, noOpRows: 0, gitDirtyFiles: 0, sensitivePathCount: 1 }), "warn");
+  assert.equal(statusFromSummary({ commandFailures: 0, artifactFailures: 0, missingArtifacts: 0, artifactWarnings: 0, commandWarnings: 0, commandSkipped: 0, noOpRows: 0, gitDirtyFiles: 0, sensitivePathCount: 0 }), "pass");
+});


### PR DESCRIPTION
## Summary
- Adds a metadata-only work verification packet for recent ops slices.
- Captures slice rows, command status, changed files, referenced artifact metadata, hashes, schemas, git context, warnings, and failures without file contents.
- Adds a schema, node:test coverage, and `make ops-work-verification` wrapper.

## Evidence
- The packet warns on dirty worktrees, missing artifacts, sensitive-looking path redactions, and referenced artifact warnings/failures.
- After commit, dirty-worktree warning cleared; the latest packet remains warn only because referenced artifacts themselves report warnings.
- Sensitive-looking paths are redacted by stable hash IDs and are counted/classified instead of printed raw.

## Testing
- `node --check scripts/ops/work_verification_packet.mjs`
- `node --test scripts/ops/work_verification_packet.test.mjs`
- `node -e JSON.parse work-verification schema`
- `node scripts/ops/work_verification_packet.mjs --last 5 --json --write`
- `git diff --check`

## Risk / rollback
- Risk: low; read-only metadata generation under ignored `output/ops/work-verification`.
- Rollback: revert this commit to remove the script, schema, test, docs row, and Makefile wrapper.

## Follow-up
- Use this packet in PR closeout and merge readiness comments.
- Optionally include effectivity-report summaries in a later slice, still without raw stdout/stderr.