### PR TITLE
[ops] Add actionlint workflow validation

### DIFF
--- a/.github/workflows/ops-tooling-quality.yml
+++ b/.github/workflows/ops-tooling-quality.yml
@@ -43,6 +43,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      - name: Download actionlint
+        id: get_actionlint
+        run: >-
+          bash <(curl -fsSL
+          https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+          1.7.12
+        shell: bash
+
+      - name: Validate workflow files
+        run: ${{ steps.get_actionlint.outputs.executable }} -color
+        shell: bash
+
       - name: Setup Node
         uses: actions/setup-node@v5
         with:

--- a/docs/ops/tooling-quality-gates.md
+++ b/docs/ops/tooling-quality-gates.md
@@ -24,6 +24,15 @@ The Makefile wrapper keeps installs off by default. Use `make ops-tooling-qualit
 - `powershell`: parses tracked `.ps1` files with `pwsh` or Windows PowerShell.
 - `sqlfluff`: runs PostgreSQL parser checks when `sqlfluff` is installed. With `--allow-install`, it can use `uv tool run --from sqlfluff`.
 
+## Workflow Validation
+
+Use pinned `actionlint` release binaries for GitHub workflow checks. The npm package name is not the official rhysd actionlint distribution and should not be used as an install path.
+
+- CI path: use the official `download-actionlint.bash` script pinned to an explicit version.
+- Windows local no-install path: download the pinned release with `gh release download`, verify attestation with `gh attestation verify`, expand to `%TEMP%`, and run `actionlint.exe`.
+- Persistent Windows path: `winget install --id rhysd.actionlint --exact`.
+- Avoid for this repo: `npx actionlint`, `go install` without Go already present, or Docker-based actionlint when Docker is unavailable locally.
+
 ## Promotion Rule
 
 Keep new validators report-only until they prove useful over about five slices:


### PR DESCRIPTION
## Summary
- Adds pinned actionlint validation to the report-only ops tooling workflow.
- Documents the audited actionlint install decision and avoids the invalid npm package route.
- Keeps workflow validation in the report lane rather than making broad smoke CI heavier.

## Evidence
- `npx actionlint` failed as an install route and is now documented as avoid-for-now.
- A temp-only pinned actionlint 1.7.12 Windows release binary validated the repo workflows locally.
- Yamllint caught CRLF/line-length issues in the workflow; those were fixed before commit.

## Testing
- temp pinned `actionlint` 1.7.12 local audit
- `uv tool run --from yamllint yamllint .github/workflows/ops-tooling-quality.yml`
- `rg actionlint docs/ops/tooling-quality-gates.md`
- `git diff --check`
- `node scripts/ops/admin_effectivity_audit.mjs --write --json`

## Risk / rollback
- Risk: low; CI workflow syntax validation and docs only.
- Rollback: revert this commit to remove the actionlint steps and docs note.

## Follow-up
- Observe this in the report-only workflow before adding actionlint as a tooling-quality report mode.
- Use the attested release download path if we want extra supply-chain polish later.