### PR TITLE
[ops] Feed fresh evidence into work packets

### DIFF
--- a/docs/ops/admin-effectivity-loop.md
+++ b/docs/ops/admin-effectivity-loop.md
@@ -25,6 +25,13 @@ Summarize the last five slices:
 node scripts/ops/slice_ledger.mjs --summary --last 5 --json
 ```
 
+For swarm waves or stacked branches, filter to the active run id so stale rows from another lane do not pollute the five-slice audit:
+
+```bash
+node scripts/ops/slice_ledger.mjs --summary --last 5 --run-id admin-effectivity-20260507 --json
+node scripts/ops/admin_effectivity_audit.mjs --write --slice-run-id admin-effectivity-20260507
+```
+
 Inventory local tool availability:
 
 ```bash
@@ -38,6 +45,20 @@ make ops-admin-effectivity-audit
 ```
 
 The Make target writes JSON and Markdown under `output/ops/effectivity/`, which is ignored by Git. Curated summaries can be copied into docs or tickets when they become durable operator evidence.
+
+Generate the next safe ops work packets:
+
+```bash
+node scripts/studiobrain-ops-work-packet.mjs --json --write
+```
+
+The work-packet generator still uses the durable docs as its baseline, then enriches packets from ignored current artifacts when present:
+
+- `--admin-audit output/ops/effectivity/admin-effectivity-audit-latest.json`
+- `--slice-ledger output/ops/effectivity/slice-ledger-latest.json`
+- `--tool-inventory output/ops/effectivity/installed-tool-inventory-latest.json`
+
+Missing or invalid fresh artifacts degrade to warnings and docs-only packet generation. The generator should not run the audit itself; run `make ops-admin-effectivity-audit` first when fresh steering is needed.
 
 ## Scoring
 

--- a/schemas/ops/ops-work-packet-report.v1.schema.json
+++ b/schemas/ops/ops-work-packet-report.v1.schema.json
@@ -1,0 +1,104 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://studio-brain.local/schemas/ops/ops-work-packet-report.v1.schema.json",
+  "title": "Studio Brain Ops Work Packet CLI Report v1",
+  "type": "object",
+  "required": [
+    "schema",
+    "generatedAt",
+    "runId",
+    "status",
+    "written",
+    "packet",
+    "outcomeSummary"
+  ],
+  "properties": {
+    "schema": {
+      "const": "studiobrain-ops-work-packet-report.v1"
+    },
+    "generatedAt": {
+      "type": "string"
+    },
+    "runId": {
+      "type": "string"
+    },
+    "status": {
+      "enum": [
+        "pass",
+        "warn",
+        "fail"
+      ]
+    },
+    "written": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "required": [
+            "artifact",
+            "latest",
+            "outcomes"
+          ],
+          "properties": {
+            "artifact": {
+              "type": "string"
+            },
+            "latest": {
+              "type": "string"
+            },
+            "outcomes": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "packet": {
+      "type": "object"
+    },
+    "outcomeSummary": {
+      "type": "object",
+      "required": [
+        "total",
+        "helpful",
+        "staleOrMisleading",
+        "blocked",
+        "byOutcome",
+        "recent",
+        "latest"
+      ],
+      "properties": {
+        "total": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "helpful": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "staleOrMisleading": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "blocked": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "byOutcome": {
+          "type": "object"
+        },
+        "recent": {
+          "type": "array"
+        },
+        "latest": {
+          "type": "array"
+        }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/ops/ops-work-packet.v1.schema.json
+++ b/schemas/ops/ops-work-packet.v1.schema.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://studio-brain.local/schemas/ops/ops-work-packet.v1.schema.json",
+  "title": "Studio Brain Ops Work Packet",
+  "type": "object",
+  "required": ["schema", "generatedAt", "runId", "purpose", "sources", "constraints", "evidenceSummary", "freshEvidence", "packets"],
+  "properties": {
+    "schema": { "const": "studiobrain-ops-work-packet.v1" },
+    "generatedAt": { "type": "string", "format": "date-time" },
+    "runId": { "type": "string" },
+    "purpose": { "type": "string" },
+    "sources": {
+      "type": "object",
+      "required": ["riskRegister", "backlog", "effectivity", "adminAudit", "sliceLedger", "toolInventory"],
+      "properties": {
+        "riskRegister": { "type": "string" },
+        "backlog": { "type": "string" },
+        "effectivity": { "type": "string" },
+        "adminAudit": { "type": "string" },
+        "sliceLedger": { "type": "string" },
+        "toolInventory": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "constraints": {
+      "type": "object",
+      "required": ["readOnlyFirst", "noSecrets", "noServiceRestart", "noDataMutation", "defaultOutputRoot"],
+      "properties": {
+        "readOnlyFirst": { "const": true },
+        "noSecrets": { "const": true },
+        "noServiceRestart": { "const": true },
+        "noDataMutation": { "const": true },
+        "defaultOutputRoot": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "evidenceSummary": {
+      "type": "object",
+      "required": ["risks", "backlogItems", "effectivityNextSafeSlices", "remainingApprovalGates", "freshSources", "toolPromotionCandidates", "toolActionableFindings"],
+      "properties": {
+        "risks": { "type": "number", "minimum": 0 },
+        "backlogItems": { "type": "number", "minimum": 0 },
+        "effectivityNextSafeSlices": { "type": "number", "minimum": 0 },
+        "remainingApprovalGates": { "type": "number", "minimum": 0 },
+        "freshSources": { "type": "number", "minimum": 0 },
+        "toolPromotionCandidates": { "type": ["number", "null"], "minimum": 0 },
+        "toolActionableFindings": { "type": ["number", "null"], "minimum": 0 }
+      },
+      "additionalProperties": false
+    },
+    "freshEvidence": {
+      "type": "object",
+      "required": ["adminAudit", "sliceLedger", "toolInventory"],
+      "additionalProperties": true
+    },
+    "packets": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["packetId", "title", "status", "priority", "risk", "recommendedOwner", "sourceSignals", "safeNextStep", "verification", "constraints"],
+        "properties": {
+          "packetId": { "type": "string", "pattern": "^ops-wp-" },
+          "title": { "type": "string" },
+          "status": { "enum": ["ready", "approval_gated"] },
+          "priority": { "type": "string" },
+          "priorityRank": { "type": "number" },
+          "risk": { "type": "string" },
+          "recommendedOwner": { "type": "string" },
+          "sourceSignals": { "type": "array" },
+          "why": { "type": "string" },
+          "safeNextStep": { "type": "string" },
+          "suggestedBranchName": { "type": "string" },
+          "suggestedPrTitle": { "type": "string" },
+          "verification": { "type": "array", "items": { "type": "string" } },
+          "humanGate": { "type": "string" },
+          "constraints": {
+            "type": "object",
+            "required": ["readOnlyFirst", "noSecrets", "noServiceRestart", "noDataMutation", "writeScope"],
+            "properties": {
+              "readOnlyFirst": { "const": true },
+              "noSecrets": { "const": true },
+              "noServiceRestart": { "const": true },
+              "noDataMutation": { "const": true },
+              "writeScope": { "type": "array", "items": { "type": "string" } }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/scripts/ops/admin_effectivity_audit.mjs
+++ b/scripts/ops/admin_effectivity_audit.mjs
@@ -22,6 +22,7 @@ Options:
   --output-dir <path> Artifact directory. Default: output/ops/effectivity.
   --ledger <path>     Slice ledger path. Default: output/ops/effectivity/slice-ledger.jsonl.
   --last <number>     Slice window. Default: 5.
+  --slice-run-id <id> Filter slice ledger rows by run id before selecting the window.
   --run-id <id>       Stable run id. Default: admin-effectivity timestamp.
 `;
 }
@@ -72,6 +73,7 @@ function parseArgs(argv) {
     outputDir: DEFAULT_OUTPUT_DIR,
     ledger: DEFAULT_LEDGER,
     last: 5,
+    sliceRunId: "",
     runId: ""
   };
   for (let index = 0; index < argv.length; index += 1) {
@@ -92,6 +94,7 @@ function parseArgs(argv) {
       ["--output-dir", "outputDir"],
       ["--ledger", "ledger"],
       ["--last", "last"],
+      ["--slice-run-id", "sliceRunId"],
       ["--run-id", "runId"]
     ];
     let consumed = false;
@@ -172,6 +175,19 @@ function summarizeSlices(rows) {
   };
 }
 
+function rowTimestamp(row) {
+  return Date.parse(clean(row.completedAt) || clean(row.startedAt)) || 0;
+}
+
+function selectLedgerRows(rows, last, runId = "") {
+  const filtered = clean(runId) ? rows.filter((row) => clean(row.runId) === clean(runId)) : rows;
+  return filtered
+    .map((row, index) => ({ row, index }))
+    .sort((left, right) => rowTimestamp(left.row) - rowTimestamp(right.row) || left.index - right.index)
+    .slice(-last)
+    .map((entry) => entry.row);
+}
+
 function tryEffectivityReport() {
   if (!commandExists("bash")) {
     return { ok: false, status: "skipped", reason: "bash unavailable", report: null };
@@ -219,7 +235,7 @@ function buildAudit(options) {
   const generatedAt = nowIso();
   const runId = clean(options.runId) || `admin-effectivity-${generatedAt.replace(/[-:]/g, "").replace(/\.\d+Z$/, "Z")}`;
   const ledgerRows = readJsonl(options.ledger);
-  const selectedRows = ledgerRows.slice(-options.last);
+  const selectedRows = selectLedgerRows(ledgerRows, options.last, options.sliceRunId);
   const sliceSummary = summarizeSlices(selectedRows);
   const toolInventory = runJson(process.execPath, ["scripts/ops/installed_tool_inventory.mjs", "--json"]);
   const effectivityReport = tryEffectivityReport();
@@ -252,6 +268,9 @@ function buildAudit(options) {
     sections: {
       sliceLedger: {
         ledgerPath: repoRelative(options.ledger),
+        filter: {
+          runId: clean(options.sliceRunId)
+        },
         summary: sliceSummary,
         rows: selectedRows
       },

--- a/scripts/ops/slice_ledger.mjs
+++ b/scripts/ops/slice_ledger.mjs
@@ -41,7 +41,7 @@ Options:
   --dry-run                   Print the row or summary without writing.
   --json                      Print JSON instead of text.
   --slice-id <id>             Stable slice id.
-  --run-id <id>               Run id for grouping slices.
+  --run-id <id>               Run id for grouping slices; filters summaries when --append is absent.
   --lane <name>               Lane such as portal-ops, mission-control, host-readonly.
   --title <text>              Slice title.
   --intent <text>             Intended operational improvement.
@@ -270,8 +270,21 @@ function buildRow(options) {
   };
 }
 
-function summarize(rows, last) {
-  const selected = rows.slice(-last);
+function rowTimestamp(row) {
+  return Date.parse(clean(row.completedAt) || clean(row.startedAt)) || 0;
+}
+
+function selectRecentRows(rows, last, runId = "") {
+  const filtered = clean(runId) ? rows.filter((row) => clean(row.runId) === clean(runId)) : rows;
+  return filtered
+    .map((row, index) => ({ row, index }))
+    .sort((left, right) => rowTimestamp(left.row) - rowTimestamp(right.row) || left.index - right.index)
+    .slice(-last)
+    .map((entry) => entry.row);
+}
+
+function summarize(rows, last, runId = "") {
+  const selected = selectRecentRows(rows, last, runId);
   const completed = selected.filter((row) => row.status === "completed").length;
   const blocked = selected.filter((row) => row.status === "blocked").length;
   const failed = selected.filter((row) => row.status === "failed").length;
@@ -285,6 +298,9 @@ function summarize(rows, last) {
     schema: "studiobrain-admin-slice-ledger-summary.v1",
     generatedAt: nowIso(),
     ledgerPath: repoRelative(rows.ledgerPath || DEFAULT_LEDGER),
+    filters: {
+      runId: clean(runId)
+    },
     window: {
       count: selected.length,
       from: selected[0]?.sliceId ?? null,
@@ -328,7 +344,7 @@ try {
   } else {
     const rows = readJsonl(options.ledger);
     rows.ledgerPath = options.ledger;
-    const summary = summarize(rows, options.last);
+    const summary = summarize(rows, options.last, options.runId);
     if (!options.dryRun) writeJson(options.latest, summary);
     if (options.json) {
       process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);

--- a/scripts/studiobrain-ops-work-packet.mjs
+++ b/scripts/studiobrain-ops-work-packet.mjs
@@ -17,6 +17,9 @@ const DEFAULT_OUTPUT_ROOT = resolve(REPO_ROOT, "output", "ops", "swarm");
 const DEFAULT_RISK_DOC = resolve(REPO_ROOT, "docs", "ops", "01-risk-register.md");
 const DEFAULT_BACKLOG_DOC = resolve(REPO_ROOT, "docs", "ops", "02-kanban-backlog.md");
 const DEFAULT_EFFECTIVITY_DOC = resolve(REPO_ROOT, "docs", "ops", "16-effectivity-audit-2026-05-06.md");
+const DEFAULT_ADMIN_AUDIT = resolve(REPO_ROOT, "output", "ops", "effectivity", "admin-effectivity-audit-latest.json");
+const DEFAULT_SLICE_LEDGER = resolve(REPO_ROOT, "output", "ops", "effectivity", "slice-ledger-latest.json");
+const DEFAULT_TOOL_INVENTORY = resolve(REPO_ROOT, "output", "ops", "effectivity", "installed-tool-inventory-latest.json");
 const VALID_OUTCOMES = new Set([
   "used",
   "helpful",
@@ -56,6 +59,19 @@ function toRepoRelative(path) {
 function readTextIfExists(path) {
   if (!existsSync(path)) return "";
   return readFileSync(path, "utf8");
+}
+
+function readJsonIfExists(path) {
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch (error) {
+    return {
+      schema: "invalid-json",
+      status: "invalid_json",
+      parseError: error instanceof Error ? error.message : String(error),
+    };
+  }
 }
 
 function writeJson(path, value) {
@@ -255,7 +271,7 @@ function matchingRisk(backlogItem, risks) {
     .sort((left, right) => right.score - left.score || severityRank(left.risk.severity) - severityRank(right.risk.severity))[0]?.risk || null;
 }
 
-function makePacket(backlogItem, risk, effectivity) {
+function makePacket(backlogItem, risk, effectivity, freshEvidence) {
   const title = backlogItem.title;
   const acceptanceCriteria =
     backlogItem.acceptanceCriteria.length > 0
@@ -294,6 +310,7 @@ function makePacket(backlogItem, risk, effectivity) {
         path: effectivity.sourcePath,
         relevantNextSafeSlices: effectivity.nextSafeSlices.filter((slice) => overlapScore(slice, title) > 0),
       },
+      ...freshSourceSignals(freshEvidence),
     ].filter(Boolean),
     why: risk?.likelyImpact || backlogItem.status || "Issue-ready ops backlog item from current docs evidence.",
     safeNextStep: risk?.safeNextStep || firstAcceptance(backlogItem) || "Refresh the read-only evidence packet and attach it to the ops issue.",
@@ -309,6 +326,19 @@ function makePacket(backlogItem, risk, effectivity) {
       writeScope: ["output/ops/swarm"],
     },
   };
+}
+
+function freshSourceSignals(freshEvidence) {
+  if (!freshEvidence) return [];
+  return [freshEvidence.adminAudit, freshEvidence.sliceLedger, freshEvidence.toolInventory]
+    .filter((source) => source && source.status !== "missing")
+    .map((source) => ({
+      source: source.source,
+      path: source.path,
+      status: source.status,
+      generatedAt: source.generatedAt || "",
+      summary: source.summary,
+    }));
 }
 
 function collectAcceptanceFallback(body) {
@@ -344,12 +374,88 @@ function buildOutcomeSummary(outcomes) {
   const valid = outcomes.filter((entry) => VALID_OUTCOMES.has(clean(entry.outcome)));
   const helpful = valid.filter((entry) => ["used", "helpful", "resolved"].includes(entry.outcome));
   const staleOrMisleading = valid.filter((entry) => ["stale", "misleading"].includes(entry.outcome));
+  const byOutcome = Object.fromEntries(Array.from(VALID_OUTCOMES).map((outcome) => [outcome, 0]));
+  for (const entry of valid) byOutcome[entry.outcome] += 1;
+  const recent = valid.slice(-10);
   return {
     total: valid.length,
+    byOutcome,
     helpful: helpful.length,
     staleOrMisleading: staleOrMisleading.length,
     blocked: valid.filter((entry) => entry.outcome === "blocked").length,
-    latest: valid.slice(-10),
+    recent,
+    latest: recent,
+  };
+}
+
+function summarizeFreshEvidence(inputs = {}) {
+  const adminAudit = inputs.adminAudit || null;
+  const sliceLedger = inputs.sliceLedger || null;
+  const toolInventory = inputs.toolInventory || null;
+  const unavailable = (source, path, status = "missing", summary = {}) => ({
+    source,
+    path,
+    status,
+    generatedAt: "",
+    summary,
+  });
+  return {
+    adminAudit: adminAudit && adminAudit.status !== "invalid_json"
+      ? {
+          source: "fresh-admin-audit",
+          path: inputs.adminAuditPath || "output/ops/effectivity/admin-effectivity-audit-latest.json",
+          status: clean(adminAudit.status) || "unknown",
+          generatedAt: clean(adminAudit.generatedAt),
+          summary: {
+            sliceWindow: adminAudit.sliceWindow || null,
+            scores: adminAudit.scores || null,
+            privilegedEvidence: adminAudit.sections?.effectivityReport?.report?.sections?.privilegedEvidence?.status || "",
+          },
+        }
+      : unavailable(
+          "fresh-admin-audit",
+          inputs.adminAuditPath || "output/ops/effectivity/admin-effectivity-audit-latest.json",
+          adminAudit?.status || "missing",
+          adminAudit?.parseError ? { parseError: adminAudit.parseError } : {},
+        ),
+    sliceLedger: sliceLedger && sliceLedger.status !== "invalid_json"
+      ? {
+          source: "fresh-slice-ledger",
+          path: inputs.sliceLedgerPath || "output/ops/effectivity/slice-ledger-latest.json",
+          status: sliceLedger.counts?.failed > 0 ? "fail" : sliceLedger.counts?.blocked > 0 || sliceLedger.counts?.noop > 0 ? "warn" : "pass",
+          generatedAt: clean(sliceLedger.generatedAt),
+          summary: {
+            window: sliceLedger.window || null,
+            counts: sliceLedger.counts || null,
+            scores: sliceLedger.scores || null,
+          },
+        }
+      : unavailable(
+          "fresh-slice-ledger",
+          inputs.sliceLedgerPath || "output/ops/effectivity/slice-ledger-latest.json",
+          sliceLedger?.status || "missing",
+          sliceLedger?.parseError ? { parseError: sliceLedger.parseError } : {},
+        ),
+    toolInventory: toolInventory && toolInventory.status !== "invalid_json"
+      ? {
+          source: "fresh-tool-inventory",
+          path: inputs.toolInventoryPath || "output/ops/effectivity/installed-tool-inventory-latest.json",
+          status: clean(toolInventory.status) || "unknown",
+          generatedAt: clean(toolInventory.generatedAt),
+          summary: {
+            installed: toolInventory.summary?.installed ?? null,
+            missingRequired: toolInventory.summary?.missingRequired ?? null,
+            missingOptional: toolInventory.summary?.missingOptional ?? null,
+            actionableFindings: toolInventory.summary?.actionableFindings ?? null,
+            promotionCandidates: toolInventory.summary?.promotionCandidates ?? null,
+          },
+        }
+      : unavailable(
+          "fresh-tool-inventory",
+          inputs.toolInventoryPath || "output/ops/effectivity/installed-tool-inventory-latest.json",
+          toolInventory?.status || "missing",
+          toolInventory?.parseError ? { parseError: toolInventory.parseError } : {},
+        ),
   };
 }
 
@@ -357,9 +463,10 @@ export function buildOpsWorkPacket(inputs = {}, options = {}) {
   const risks = parseRiskRegister(inputs.riskMarkdown || "");
   const backlog = parseBacklog(inputs.backlogMarkdown || "");
   const effectivity = parseEffectivity(inputs.effectivityMarkdown || "");
+  const freshEvidence = summarizeFreshEvidence(inputs);
   const packets = backlog
     .filter((item) => priorityRank(item.priority) <= 2)
-    .map((item) => makePacket(item, matchingRisk(item, risks), effectivity))
+    .map((item) => makePacket(item, matchingRisk(item, risks), effectivity, freshEvidence))
     .sort((left, right) => left.priorityRank - right.priorityRank || left.title.localeCompare(right.title))
     .slice(0, Number(options.maxPackets || 8));
 
@@ -372,6 +479,9 @@ export function buildOpsWorkPacket(inputs = {}, options = {}) {
       riskRegister: "docs/ops/01-risk-register.md",
       backlog: "docs/ops/02-kanban-backlog.md",
       effectivity: "docs/ops/16-effectivity-audit-2026-05-06.md",
+      adminAudit: freshEvidence.adminAudit.path,
+      sliceLedger: freshEvidence.sliceLedger.path,
+      toolInventory: freshEvidence.toolInventory.path,
     },
     constraints: {
       readOnlyFirst: true,
@@ -385,7 +495,11 @@ export function buildOpsWorkPacket(inputs = {}, options = {}) {
       backlogItems: backlog.length,
       effectivityNextSafeSlices: effectivity.nextSafeSlices.length,
       remainingApprovalGates: effectivity.remainingApprovalGates.length,
+      freshSources: [freshEvidence.adminAudit, freshEvidence.sliceLedger, freshEvidence.toolInventory].filter((source) => !["missing", "invalid_json"].includes(source.status)).length,
+      toolPromotionCandidates: freshEvidence.toolInventory.summary.promotionCandidates ?? null,
+      toolActionableFindings: freshEvidence.toolInventory.summary.actionableFindings ?? null,
     },
+    freshEvidence,
     packets,
   };
 }
@@ -399,6 +513,9 @@ function parseArgs(argv) {
     artifact: "",
     latest: "",
     outcomes: "",
+    adminAudit: DEFAULT_ADMIN_AUDIT,
+    sliceLedger: DEFAULT_SLICE_LEDGER,
+    toolInventory: DEFAULT_TOOL_INVENTORY,
     maxPackets: 8,
     recordOutcome: "",
     outcome: "",
@@ -436,6 +553,9 @@ function parseArgs(argv) {
       "--artifact": "artifact",
       "--latest": "latest",
       "--outcomes": "outcomes",
+      "--admin-audit": "adminAudit",
+      "--slice-ledger": "sliceLedger",
+      "--tool-inventory": "toolInventory",
       "--record-outcome": "recordOutcome",
       "--outcome": "outcome",
       "--used-by": "usedBy",
@@ -446,7 +566,7 @@ function parseArgs(argv) {
     for (const [flag, key] of Object.entries(stringOptions)) {
       const value = read(flag);
       if (value !== null) {
-        args[key] = key === "outputRoot" || key === "artifact" || key === "latest" || key === "outcomes"
+        args[key] = key === "outputRoot" || key === "artifact" || key === "latest" || key === "outcomes" || key === "adminAudit" || key === "sliceLedger" || key === "toolInventory"
           ? resolve(REPO_ROOT, value)
           : value;
         matched = true;
@@ -481,6 +601,9 @@ function printUsage() {
       "  --write                 Write timestamped and latest JSON packet artifacts.",
       "  --json                  Print JSON report.",
       "  --output-root <path>    Default: output/ops/swarm.",
+      "  --admin-audit <path>    Default: output/ops/effectivity/admin-effectivity-audit-latest.json.",
+      "  --slice-ledger <path>   Default: output/ops/effectivity/slice-ledger-latest.json.",
+      "  --tool-inventory <path> Default: output/ops/effectivity/installed-tool-inventory-latest.json.",
       "  --max-packets <n>       Default: 8.",
       "  --record-outcome <id>   Append an outcome ledger entry.",
       "  --outcome <value>       used | helpful | resolved | not_used | stale | misleading | blocked | superseded",
@@ -512,6 +635,12 @@ function recordOutcome(options) {
   };
 }
 
+function workPacketReportStatus(packet) {
+  if (packet.packets.length === 0) return "warn";
+  if ((packet.evidenceSummary?.freshSources ?? 0) === 0) return "warn";
+  return "pass";
+}
+
 export function runOpsWorkPacket(rawArgs = process.argv.slice(2)) {
   const options = parseArgs(rawArgs);
   if (options.recordOutcome) {
@@ -526,6 +655,12 @@ export function runOpsWorkPacket(rawArgs = process.argv.slice(2)) {
       riskMarkdown: readTextIfExists(DEFAULT_RISK_DOC),
       backlogMarkdown: readTextIfExists(DEFAULT_BACKLOG_DOC),
       effectivityMarkdown: readTextIfExists(DEFAULT_EFFECTIVITY_DOC),
+      adminAudit: readJsonIfExists(options.adminAudit),
+      sliceLedger: readJsonIfExists(options.sliceLedger),
+      toolInventory: readJsonIfExists(options.toolInventory),
+      adminAuditPath: toRepoRelative(options.adminAudit),
+      sliceLedgerPath: toRepoRelative(options.sliceLedger),
+      toolInventoryPath: toRepoRelative(options.toolInventory),
     },
     {
       runId: options.runId,
@@ -537,7 +672,7 @@ export function runOpsWorkPacket(rawArgs = process.argv.slice(2)) {
     schema: "studiobrain-ops-work-packet-report.v1",
     generatedAt: packet.generatedAt,
     runId: options.runId,
-    status: packet.packets.length > 0 ? "pass" : "warn",
+    status: workPacketReportStatus(packet),
     written: options.write
       ? {
           artifact: toRepoRelative(options.artifact),
@@ -563,6 +698,8 @@ export function runOpsWorkPacket(rawArgs = process.argv.slice(2)) {
   }
   return report;
 }
+
+export { summarizeFreshEvidence, workPacketReportStatus };
 
 if (process.argv[1] && resolve(process.argv[1]) === __filename) {
   try {

--- a/scripts/studiobrain-ops-work-packet.test.mjs
+++ b/scripts/studiobrain-ops-work-packet.test.mjs
@@ -1,7 +1,48 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
 
-import { buildOpsWorkPacket } from "./studiobrain-ops-work-packet.mjs";
+import { buildOpsWorkPacket, runOpsWorkPacket, summarizeFreshEvidence, workPacketReportStatus } from "./studiobrain-ops-work-packet.mjs";
+
+const packetSchema = JSON.parse(readFileSync(resolve("schemas/ops/ops-work-packet.v1.schema.json"), "utf8"));
+const reportSchema = JSON.parse(readFileSync(resolve("schemas/ops/ops-work-packet-report.v1.schema.json"), "utf8"));
+
+function assertWorkPacketContract(report) {
+  for (const key of packetSchema.required) assert.ok(Object.hasOwn(report, key), `missing ${key}`);
+  assert.equal(report.schema, packetSchema.properties.schema.const);
+  assert.equal(report.constraints.readOnlyFirst, true);
+  assert.equal(report.constraints.noSecrets, true);
+  for (const key of packetSchema.properties.evidenceSummary.required) {
+    assert.ok(Object.hasOwn(report.evidenceSummary, key), `missing evidenceSummary.${key}`);
+  }
+  for (const packet of report.packets) {
+    assert.ok(packet.packetId.startsWith("ops-wp-"));
+    assert.equal(packet.constraints.readOnlyFirst, true);
+    assert.equal(packet.constraints.noDataMutation, true);
+  }
+}
+
+function assertWorkPacketReportContract(report) {
+  for (const key of reportSchema.required) assert.ok(Object.hasOwn(report, key), `missing ${key}`);
+  assert.equal(report.schema, reportSchema.properties.schema.const);
+  assert.ok(["pass", "warn", "fail"].includes(report.status));
+  assertWorkPacketContract(report.packet);
+  for (const key of reportSchema.properties.outcomeSummary.required) {
+    assert.ok(Object.hasOwn(report.outcomeSummary, key), `missing outcomeSummary.${key}`);
+  }
+}
+
+function silenceStdout(callback) {
+  const originalWrite = process.stdout.write;
+  process.stdout.write = () => true;
+  try {
+    return callback();
+  } finally {
+    process.stdout.write = originalWrite;
+  }
+}
 
 const riskMarkdown = `
 # Studio Brain Risk Register
@@ -74,27 +115,179 @@ const effectivityMarkdown = `
 2. Add a failed-unit trend artifact so the classifier can distinguish old unchanged failures from new regressions.
 `;
 
+const freshInputs = {
+  adminAudit: {
+    schema: "studiobrain-admin-effectivity-audit.v1",
+    generatedAt: "2026-05-07T08:45:48.780Z",
+    status: "pass",
+    sliceWindow: { from: "slice-016", to: "slice-020", count: 5 },
+    scores: { usefulness: 0.814, verification: 1, noOpRate: 0 },
+    sections: {
+      effectivityReport: {
+        report: {
+          sections: {
+            privilegedEvidence: { status: "sudo_unavailable" },
+          },
+        },
+      },
+    },
+  },
+  sliceLedger: {
+    schema: "studiobrain-admin-slice-ledger-summary.v1",
+    generatedAt: "2026-05-07T08:45:40.150Z",
+    window: { from: "slice-016", to: "slice-020", count: 5 },
+    counts: { completed: 5, blocked: 0, failed: 0, noop: 0 },
+    scores: { usefulness: 0.814, verification: 1, noOpRate: 0 },
+  },
+  toolInventory: {
+    schema: "studiobrain-installed-tool-inventory.v1",
+    generatedAt: "2026-05-07T08:45:51.102Z",
+    status: "warn",
+    summary: {
+      installed: 13,
+      missingRequired: 0,
+      missingOptional: 7,
+      actionableFindings: 4,
+      promotionCandidates: 2,
+    },
+  },
+  adminAuditPath: "output/ops/effectivity/admin-effectivity-audit-latest.json",
+  sliceLedgerPath: "output/ops/effectivity/slice-ledger-latest.json",
+  toolInventoryPath: "output/ops/effectivity/installed-tool-inventory-latest.json",
+};
+
 test("buildOpsWorkPacket creates bounded read-only packets from docs evidence", () => {
   const report = buildOpsWorkPacket(
     {
       riskMarkdown,
       backlogMarkdown,
       effectivityMarkdown,
+      ...freshInputs,
     },
     { runId: "unit-test", generatedAt: "2026-05-06T20:00:00.000Z" },
   );
 
   assert.equal(report.schema, "studiobrain-ops-work-packet.v1");
+  assertWorkPacketContract(report);
   assert.equal(report.constraints.noSecrets, true);
   assert.equal(report.constraints.noServiceRestart, true);
   assert.equal(report.evidenceSummary.risks, 2);
   assert.equal(report.evidenceSummary.backlogItems, 2);
+  assert.equal(report.evidenceSummary.freshSources, 3);
+  assert.equal(report.evidenceSummary.toolPromotionCandidates, 2);
+  assert.equal(report.freshEvidence.adminAudit.status, "pass");
   assert.ok(report.packets.length >= 2);
   assert.ok(report.packets.every((packet) => packet.packetId.startsWith("ops-wp-")));
   assert.ok(report.packets.every((packet) => packet.constraints.readOnlyFirst));
+  assert.ok(report.packets[0].sourceSignals.some((signal) => signal.source === "fresh-admin-audit"));
+  assert.ok(report.packets[0].sourceSignals.some((signal) => signal.source === "fresh-tool-inventory"));
   assert.equal(report.packets[0].priority, "P0");
   assert.ok(report.packets[0].humanGate.includes("PostgreSQL dump"));
   assert.ok(report.packets[0].safeNextStep.includes("restore-prerequisite"));
+});
+
+test("summarizeFreshEvidence degrades when ignored artifacts are missing", () => {
+  const fresh = summarizeFreshEvidence({});
+
+  assert.equal(fresh.adminAudit.status, "missing");
+  assert.equal(fresh.sliceLedger.status, "missing");
+  assert.equal(fresh.toolInventory.status, "missing");
+});
+
+test("summarizeFreshEvidence does not count invalid JSON as fresh", () => {
+  const report = buildOpsWorkPacket(
+    {
+      riskMarkdown,
+      backlogMarkdown,
+      effectivityMarkdown,
+      adminAudit: { status: "invalid_json", parseError: "bad admin" },
+      sliceLedger: freshInputs.sliceLedger,
+      toolInventory: { status: "invalid_json", parseError: "bad tools" },
+    },
+    { maxPackets: 1 },
+  );
+
+  assert.equal(report.evidenceSummary.freshSources, 1);
+  assert.equal(report.freshEvidence.adminAudit.status, "invalid_json");
+  assert.equal(report.freshEvidence.toolInventory.summary.parseError, "bad tools");
+  assert.equal(report.packets[0].sourceSignals.some((signal) => signal.source === "fresh-admin-audit"), true);
+});
+
+test("workPacketReportStatus warns when falling back to static docs only", () => {
+  const staticOnly = buildOpsWorkPacket(
+    {
+      riskMarkdown,
+      backlogMarkdown,
+      effectivityMarkdown,
+    },
+    { maxPackets: 1 },
+  );
+  const fresh = buildOpsWorkPacket(
+    {
+      riskMarkdown,
+      backlogMarkdown,
+      effectivityMarkdown,
+      ...freshInputs,
+    },
+    { maxPackets: 1 },
+  );
+
+  assert.equal(workPacketReportStatus(staticOnly), "warn");
+  assert.equal(workPacketReportStatus(fresh), "pass");
+});
+
+test("runOpsWorkPacket returns a schema-compatible CLI report", () => {
+  const report = silenceStdout(() => runOpsWorkPacket([
+    "--max-packets",
+    "1",
+    "--admin-audit",
+    "output/ops/missing-admin-audit.json",
+    "--slice-ledger",
+    "output/ops/missing-slice-ledger.json",
+    "--tool-inventory",
+    "output/ops/missing-tool-inventory.json",
+  ]));
+
+  assertWorkPacketReportContract(report);
+  assert.equal(report.written, null);
+  assert.equal(report.status, "warn");
+});
+
+test("outcome ledger summaries expose by-outcome and recent receipts", () => {
+  const dir = mkdtempSync(join(tmpdir(), "ops-work-packet-"));
+  const outcomes = join(dir, "outcomes.jsonl");
+  try {
+    silenceStdout(() => runOpsWorkPacket([
+      "--record-outcome",
+      "ops-wp-test",
+      "--outcome",
+      "helpful",
+      "--notes",
+      "kept agent in scope",
+      "--outcomes",
+      outcomes,
+    ]));
+    const report = silenceStdout(() => runOpsWorkPacket([
+      "--record-outcome",
+      "ops-wp-test",
+      "--outcome",
+      "stale",
+      "--notes",
+      "superseded by fresher artifact",
+      "--outcomes",
+      outcomes,
+    ]));
+
+    assert.equal(report.outcomeSummary.total, 2);
+    assert.equal(report.outcomeSummary.byOutcome.helpful, 1);
+    assert.equal(report.outcomeSummary.byOutcome.stale, 1);
+    assert.equal(report.outcomeSummary.helpful, 1);
+    assert.equal(report.outcomeSummary.staleOrMisleading, 1);
+    assert.equal(report.outcomeSummary.recent.length, 2);
+    assert.equal(report.outcomeSummary.latest.length, 2);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 test("buildOpsWorkPacket limits packet count and preserves source signals", () => {


### PR DESCRIPTION
## Summary
- enrich ops work packets with current admin audit, slice ledger, and installed-tool evidence when ignored artifacts are present
- add packet and CLI report schema contracts, including structured outcome summaries for swarm feedback
- add run-id filtering to slice-ledger and admin effectivity audits so swarm lanes can audit a specific five-slice window

## Evidence
- Work-packet generation previously used durable docs only; fresh ignored artifacts were invisible to generated packets.
- The first audit pass exposed stale duplicate slice rows from a different run in the untracked ledger; run-id filtering now keeps the five-slice audit scoped.

## Testing
- 
ode --check scripts/studiobrain-ops-work-packet.mjs
- 
ode --check scripts/ops/slice_ledger.mjs
- 
ode --check scripts/ops/admin_effectivity_audit.mjs
- 
ode --test scripts/studiobrain-ops-work-packet.test.mjs
- 
ode scripts/studiobrain-ops-work-packet.mjs --json --write --max-packets 3
- 
ode scripts/ops/slice_ledger.mjs --summary --last 5 --run-id admin-infra-20260507 --json
- 
ode scripts/ops/admin_effectivity_audit.mjs --write --json --slice-run-id admin-infra-20260507
- git diff --check

## Risk
Low. Read-only tooling and docs only; generated artifacts remain under ignored output/ops/**.

## Rollback
Revert commit 572e3983 to restore docs-only packet generation and unfiltered ledger summaries.

## Follow-ups
- Add schema validation for ignored ops artifacts.
- Add freshness age thresholds for packet input artifacts.
- Add structured verification receipts and autonomy gates to each packet.