### PR TITLE
[ops] Add artifact schema validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ PG_CONTAINER ?= studiobrain_postgres
 PGDATABASE ?= monsoonfire_studio_os
 OPS_TOOLING_QUALITY_FLAGS ?=
 
-.PHONY: ops-check ops-inventory ops-postgres-review ops-postgres-sql ops-postgres-top-queries ops-postgres-query-tasks ops-postgres-growth-snapshot ops-postgres-autovacuum-stats ops-postgres-roles-extensions ops-docker-review ops-docker-posture ops-capacity ops-import-pressure ops-cleanup-candidates ops-backup-evidence ops-postgres-backup-artifacts ops-restore-prereq ops-redis-minio-backup-evidence ops-ubuntu-review ops-host-failed-unit-trends ops-package-posture ops-time-sync ops-network-review ops-host-drift ops-systemd-drift ops-portal-bridge-review ops-app-review ops-dependency-review ops-idle-worker-effectivity ops-effectivity-report ops-slice-ledger ops-tool-inventory ops-admin-effectivity-audit ops-tooling-quality ops-shell-lf-guard ops-shellcheck-report ops-powershell-syntax ops-sql-parse-report ops-privileged-evidence-read ops-privileged-evidence-capture ops-privileged-evidence-capture-smoke ops-work-packet ops-incident-bundle ops-incident-bundle-v2 ops-ci-validate ops-post-deploy-verify ops-docs ops-backlog ops-report
+.PHONY: ops-check ops-inventory ops-postgres-review ops-postgres-sql ops-postgres-top-queries ops-postgres-query-tasks ops-postgres-growth-snapshot ops-postgres-autovacuum-stats ops-postgres-roles-extensions ops-docker-review ops-docker-posture ops-capacity ops-import-pressure ops-cleanup-candidates ops-backup-evidence ops-postgres-backup-artifacts ops-restore-prereq ops-redis-minio-backup-evidence ops-ubuntu-review ops-host-failed-unit-trends ops-package-posture ops-time-sync ops-network-review ops-host-drift ops-systemd-drift ops-portal-bridge-review ops-app-review ops-dependency-review ops-idle-worker-effectivity ops-effectivity-report ops-slice-ledger ops-tool-inventory ops-admin-effectivity-audit ops-tooling-quality ops-shell-lf-guard ops-shellcheck-report ops-powershell-syntax ops-sql-parse-report ops-validate-artifacts ops-privileged-evidence-read ops-privileged-evidence-capture ops-privileged-evidence-capture-smoke ops-work-packet ops-incident-bundle ops-incident-bundle-v2 ops-ci-validate ops-post-deploy-verify ops-docs ops-backlog ops-report
 
 ops-check: ops-inventory ops-docker-review ops-capacity ops-cleanup-candidates ops-backup-evidence ops-ubuntu-review ops-network-review ops-host-drift ops-systemd-drift ops-portal-bridge-review ops-app-review
 
@@ -135,6 +135,9 @@ ops-powershell-syntax:
 
 ops-sql-parse-report:
 	node scripts/ops/tooling_quality_report.mjs --mode sqlfluff --write $(OPS_TOOLING_QUALITY_FLAGS)
+
+ops-validate-artifacts:
+	node scripts/ops/validate_ops_artifacts.mjs --write
 
 ops-privileged-evidence-read:
 	bash scripts/ops/privileged_evidence_read.sh

--- a/docs/ops/admin-effectivity-loop.md
+++ b/docs/ops/admin-effectivity-loop.md
@@ -60,6 +60,14 @@ The work-packet generator still uses the durable docs as its baseline, then enri
 
 Missing or invalid fresh artifacts degrade to warnings and docs-only packet generation. The generator should not run the audit itself; run `make ops-admin-effectivity-audit` first when fresh steering is needed.
 
+Validate generated ops artifacts against their committed schemas:
+
+```bash
+node scripts/ops/validate_ops_artifacts.mjs --json --write
+```
+
+Missing ignored artifacts are warnings. Schema mismatches are failures because they mean a dashboard, swarm packet consumer, or future automation would be reading a contract it cannot trust.
+
 ## Scoring
 
 - `usefulness`: average slice usefulness score, 0 to 1.

--- a/schemas/ops/admin-effectivity-audit.v1.schema.json
+++ b/schemas/ops/admin-effectivity-audit.v1.schema.json
@@ -48,7 +48,9 @@
         "events": { "type": "array" }
       },
       "additionalProperties": true
-    }
+    },
+    "artifactPath": { "type": "string" },
+    "markdownPath": { "type": "string" }
   },
   "additionalProperties": false
 }

--- a/schemas/ops/artifact-schema-validation.v1.schema.json
+++ b/schemas/ops/artifact-schema-validation.v1.schema.json
@@ -1,0 +1,105 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://studio-brain.local/schemas/ops/artifact-schema-validation.v1.schema.json",
+  "title": "Studio Brain Ops Artifact Schema Validation v1",
+  "type": "object",
+  "required": [
+    "schema",
+    "generatedAt",
+    "runId",
+    "status",
+    "readOnly",
+    "summary",
+    "checks"
+  ],
+  "properties": {
+    "schema": {
+      "const": "studiobrain-ops-artifact-schema-validation.v1"
+    },
+    "generatedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "runId": {
+      "type": "string"
+    },
+    "status": {
+      "enum": [
+        "pass",
+        "warn",
+        "fail"
+      ]
+    },
+    "readOnly": {
+      "const": true
+    },
+    "summary": {
+      "type": "object",
+      "required": [
+        "checks",
+        "passed",
+        "missing",
+        "failed"
+      ],
+      "properties": {
+        "checks": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "passed": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "missing": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "failed": {
+          "type": "integer",
+          "minimum": 0
+        }
+      },
+      "additionalProperties": false
+    },
+    "checks": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "id",
+          "artifact",
+          "schema",
+          "status",
+          "errors"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "artifact": {
+            "type": "string"
+          },
+          "schema": {
+            "type": "string"
+          },
+          "status": {
+            "enum": [
+              "pass",
+              "warn",
+              "missing",
+              "fail"
+            ]
+          },
+          "errors": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/ops/installed-tool-inventory.v1.schema.json
+++ b/schemas/ops/installed-tool-inventory.v1.schema.json
@@ -39,6 +39,7 @@
       },
       "additionalProperties": false
     },
+    "artifactPath": { "type": "string" },
     "tools": {
       "type": "array",
       "items": {

--- a/scripts/ops/ops_ci_validate.sh
+++ b/scripts/ops/ops_ci_validate.sh
@@ -39,6 +39,7 @@ section "Required Files"
 check_file "scripts/ops/incident_bundle_v2.sh"
 check_file "scripts/ops/ops_ci_validate.sh"
 check_file "scripts/ops/post_deploy_verify.sh"
+check_file "scripts/ops/validate_ops_artifacts.mjs"
 check_file "docs/ops/17-pr-readiness-packet-template.md"
 check_file "docs/ops/18-release-verification.md"
 
@@ -53,6 +54,23 @@ for script in \
     fail "bash -n ${script}"
   fi
 done
+
+section "Node Syntax"
+for script in \
+  "scripts/ops/validate_ops_artifacts.mjs"; do
+  if [ -f "${REPO_ROOT}/${script}" ] && node --check "${REPO_ROOT}/${script}" >/dev/null; then
+    pass "node --check ${script}"
+  else
+    fail "node --check ${script}"
+  fi
+done
+
+section "Artifact Schema Smoke"
+if node "${REPO_ROOT}/scripts/ops/validate_ops_artifacts.mjs" --json --write >"${OUT_DIR}/artifact-schema-validation.json"; then
+  pass "validate_ops_artifacts schema smoke"
+else
+  fail "validate_ops_artifacts schema smoke"
+fi
 
 section "Docs Contract"
 for needle in \

--- a/scripts/ops/validate_ops_artifacts.mjs
+++ b/scripts/ops/validate_ops_artifacts.mjs
@@ -1,0 +1,284 @@
+#!/usr/bin/env node
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const REPO_ROOT = resolve(dirname(__filename), "..", "..");
+const DEFAULT_OUTPUT_DIR = resolve(REPO_ROOT, "output", "ops", "artifact-validation");
+const DEFAULT_ARTIFACTS = [
+  {
+    id: "tooling-quality-report",
+    artifact: "output/ops/tooling-quality/tooling-quality-latest.json",
+    schema: "schemas/ops/tooling-quality-report.v1.schema.json",
+  },
+  {
+    id: "installed-tool-inventory",
+    artifact: "output/ops/effectivity/installed-tool-inventory-latest.json",
+    schema: "schemas/ops/installed-tool-inventory.v1.schema.json",
+  },
+  {
+    id: "admin-effectivity-audit",
+    artifact: "output/ops/effectivity/admin-effectivity-audit-latest.json",
+    schema: "schemas/ops/admin-effectivity-audit.v1.schema.json",
+  },
+  {
+    id: "ops-work-packet",
+    artifact: "output/ops/swarm/latest-work-packet.json",
+    schema: "schemas/ops/ops-work-packet.v1.schema.json",
+  },
+  {
+    id: "artifact-schema-validation",
+    artifact: "output/ops/artifact-validation/artifact-schema-validation-latest.json",
+    schema: "schemas/ops/artifact-schema-validation.v1.schema.json",
+  },
+];
+
+function usage() {
+  return `Studio Brain ops artifact schema validator
+
+Usage:
+  node scripts/ops/validate_ops_artifacts.mjs [--json] [--write]
+
+Options:
+  --json                    Print JSON report.
+  --write                   Write timestamped and latest reports under output/ops/artifact-validation.
+  --output-dir <path>       Default: output/ops/artifact-validation.
+  --artifact <id:path:schema>  Validate an additional artifact/schema pair.
+`;
+}
+
+function clean(value) {
+  return String(value ?? "").replace(/\r/g, "").trim();
+}
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function repoRelative(path) {
+  return relative(REPO_ROOT, resolve(REPO_ROOT, path)).replace(/\\/g, "/");
+}
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function writeJson(path, value) {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+function readFlagValue(argv, index, flag) {
+  const value = argv[index];
+  if (value === flag) {
+    if (!argv[index + 1]) throw new Error(`${flag} requires a value.`);
+    return { matched: true, value: argv[index + 1], nextIndex: index + 1 };
+  }
+  if (value.startsWith(`${flag}=`)) {
+    return { matched: true, value: value.slice(flag.length + 1), nextIndex: index };
+  }
+  return { matched: false, value: "", nextIndex: index };
+}
+
+function parseArgs(argv) {
+  const options = {
+    json: false,
+    write: false,
+    outputDir: DEFAULT_OUTPUT_DIR,
+    artifacts: [...DEFAULT_ARTIFACTS],
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--help" || arg === "-h") {
+      process.stdout.write(usage());
+      process.exit(0);
+    }
+    if (arg === "--json") {
+      options.json = true;
+      continue;
+    }
+    if (arg === "--write") {
+      options.write = true;
+      continue;
+    }
+    const outputDir = readFlagValue(argv, index, "--output-dir");
+    if (outputDir.matched) {
+      options.outputDir = resolve(REPO_ROOT, outputDir.value);
+      index = outputDir.nextIndex;
+      continue;
+    }
+    const artifact = readFlagValue(argv, index, "--artifact");
+    if (artifact.matched) {
+      const [id, artifactPath, schemaPath] = artifact.value.split(":");
+      if (!id || !artifactPath || !schemaPath) throw new Error("--artifact must use id:path:schema.");
+      options.artifacts.push({ id, artifact: artifactPath, schema: schemaPath });
+      index = artifact.nextIndex;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return options;
+}
+
+function typeOf(value) {
+  if (value === null) return "null";
+  if (Array.isArray(value)) return "array";
+  if (Number.isInteger(value)) return "integer";
+  return typeof value;
+}
+
+function typeMatches(value, expected) {
+  const actual = typeOf(value);
+  if (expected === "number") return actual === "number" || actual === "integer";
+  return actual === expected;
+}
+
+function validateJsonSchema(value, schema, path = "$") {
+  const errors = [];
+  if (!schema || typeof schema !== "object") return errors;
+
+  if (Object.hasOwn(schema, "const") && value !== schema.const) {
+    errors.push(`${path}: expected const ${JSON.stringify(schema.const)}`);
+  }
+
+  if (Array.isArray(schema.enum) && !schema.enum.includes(value)) {
+    errors.push(`${path}: expected one of ${schema.enum.map((item) => JSON.stringify(item)).join(", ")}`);
+  }
+
+  if (schema.type) {
+    const expected = Array.isArray(schema.type) ? schema.type : [schema.type];
+    if (!expected.some((type) => typeMatches(value, type))) {
+      errors.push(`${path}: expected type ${expected.join("|")}, got ${typeOf(value)}`);
+      return errors;
+    }
+  }
+
+  if (schema.format === "date-time" && typeof value === "string" && Number.isNaN(Date.parse(value))) {
+    errors.push(`${path}: expected date-time string`);
+  }
+
+  if ((typeof value === "number" || Number.isInteger(value)) && typeof schema.minimum === "number" && value < schema.minimum) {
+    errors.push(`${path}: expected minimum ${schema.minimum}`);
+  }
+
+  if (Array.isArray(schema.anyOf) && !schema.anyOf.some((candidate) => validateJsonSchema(value, candidate, path).length === 0)) {
+    errors.push(`${path}: did not match anyOf schema`);
+  }
+
+  if (Array.isArray(value) && schema.items) {
+    value.forEach((item, index) => {
+      errors.push(...validateJsonSchema(item, schema.items, `${path}[${index}]`));
+    });
+  }
+
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    const required = Array.isArray(schema.required) ? schema.required : [];
+    for (const key of required) {
+      if (!Object.hasOwn(value, key)) errors.push(`${path}.${key}: missing required property`);
+    }
+    const properties = schema.properties || {};
+    for (const [key, propertySchema] of Object.entries(properties)) {
+      if (Object.hasOwn(value, key)) errors.push(...validateJsonSchema(value[key], propertySchema, `${path}.${key}`));
+    }
+    if (schema.additionalProperties === false) {
+      for (const key of Object.keys(value)) {
+        if (!Object.hasOwn(properties, key)) errors.push(`${path}.${key}: unexpected property`);
+      }
+    }
+  }
+
+  return errors;
+}
+
+function validateArtifact(definition) {
+  const artifactPath = resolve(REPO_ROOT, definition.artifact);
+  const schemaPath = resolve(REPO_ROOT, definition.schema);
+  const check = {
+    id: clean(definition.id),
+    artifact: repoRelative(artifactPath),
+    schema: repoRelative(schemaPath),
+    status: "missing",
+    errors: [],
+  };
+
+  if (!existsSync(schemaPath)) {
+    return { ...check, status: "fail", errors: [`schema missing: ${repoRelative(schemaPath)}`] };
+  }
+  if (!existsSync(artifactPath)) {
+    return check;
+  }
+
+  try {
+    const artifact = readJson(artifactPath);
+    const schema = readJson(schemaPath);
+    const errors = validateJsonSchema(artifact, schema);
+    return { ...check, status: errors.length ? "fail" : "pass", errors };
+  } catch (error) {
+    return {
+      ...check,
+      status: "fail",
+      errors: [error instanceof Error ? error.message : String(error)],
+    };
+  }
+}
+
+function buildReport(options = {}) {
+  const generatedAt = nowIso();
+  const checks = options.artifacts.map(validateArtifact);
+  const failed = checks.filter((check) => check.status === "fail").length;
+  const missing = checks.filter((check) => check.status === "missing").length;
+  const passed = checks.filter((check) => check.status === "pass").length;
+  const status = failed > 0 ? "fail" : missing > 0 ? "warn" : "pass";
+  const runId = `ops-artifact-validation-${generatedAt.replace(/[-:]/g, "").replace(/\.\d+Z$/, "Z")}`;
+  return {
+    schema: "studiobrain-ops-artifact-schema-validation.v1",
+    generatedAt,
+    runId,
+    status,
+    readOnly: true,
+    summary: {
+      checks: checks.length,
+      passed,
+      missing,
+      failed,
+    },
+    checks,
+  };
+}
+
+function run(rawArgs = process.argv.slice(2)) {
+  const options = parseArgs(rawArgs);
+  const report = buildReport(options);
+  const artifact = resolve(options.outputDir, `${report.runId}.json`);
+  const latest = resolve(options.outputDir, "artifact-schema-validation-latest.json");
+  if (options.write) {
+    writeJson(artifact, report);
+    writeJson(latest, report);
+  }
+  if (options.json) {
+    process.stdout.write(`${JSON.stringify({
+      ...report,
+      artifacts: options.write ? { jsonPath: artifact, latestPath: latest } : null,
+    }, null, 2)}\n`);
+  } else {
+    process.stdout.write(`ops artifact schema validation: ${report.status}\n`);
+    process.stdout.write(`checks: ${report.summary.checks}, passed=${report.summary.passed}, missing=${report.summary.missing}, failed=${report.summary.failed}\n`);
+  }
+  if (report.status === "fail") process.exitCode = 1;
+  return report;
+}
+
+export { buildReport, validateJsonSchema };
+
+if (process.argv[1] && resolve(process.argv[1]) === __filename) {
+  try {
+    run();
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.stack || error.message : String(error)}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/ops/validate_ops_artifacts.test.mjs
+++ b/scripts/ops/validate_ops_artifacts.test.mjs
@@ -1,0 +1,55 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { buildReport, validateJsonSchema } from "./validate_ops_artifacts.mjs";
+
+test("validateJsonSchema handles required properties, const, enum, arrays, and unexpected properties", () => {
+  const schema = {
+    type: "object",
+    required: ["schema", "items"],
+    properties: {
+      schema: { const: "example.v1" },
+      status: { enum: ["pass", "warn"] },
+      items: { type: "array", items: { type: "integer", minimum: 1 } },
+    },
+    additionalProperties: false,
+  };
+
+  assert.deepEqual(validateJsonSchema({ schema: "example.v1", status: "pass", items: [1, 2] }, schema), []);
+  const errors = validateJsonSchema({ schema: "wrong", status: "fail", items: [0], extra: true }, schema);
+  assert.ok(errors.some((error) => error.includes("expected const")));
+  assert.ok(errors.some((error) => error.includes("expected one of")));
+  assert.ok(errors.some((error) => error.includes("expected minimum")));
+  assert.ok(errors.some((error) => error.includes("unexpected property")));
+});
+
+test("buildReport treats missing artifacts as warnings and schema mismatch as failure", () => {
+  const dir = mkdtempSync(join(tmpdir(), "ops-artifact-schema-"));
+  try {
+    const schemaPath = join(dir, "schema.json");
+    const validPath = join(dir, "valid.json");
+    const invalidPath = join(dir, "invalid.json");
+    writeFileSync(schemaPath, JSON.stringify({
+      type: "object",
+      required: ["schema"],
+      properties: { schema: { const: "artifact.v1" } },
+      additionalProperties: false,
+    }));
+    writeFileSync(validPath, JSON.stringify({ schema: "artifact.v1" }));
+    writeFileSync(invalidPath, JSON.stringify({ schema: "artifact.v2" }));
+
+    const warn = buildReport({ artifacts: [{ id: "missing", artifact: join(dir, "missing.json"), schema: schemaPath }] });
+    const pass = buildReport({ artifacts: [{ id: "valid", artifact: validPath, schema: schemaPath }] });
+    const fail = buildReport({ artifacts: [{ id: "invalid", artifact: invalidPath, schema: schemaPath }] });
+
+    assert.equal(warn.status, "warn");
+    assert.equal(pass.status, "pass");
+    assert.equal(fail.status, "fail");
+    assert.ok(fail.checks[0].errors.some((error) => error.includes("expected const")));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- add a read-only ops artifact schema validator for latest ignored JSON artifacts
- add a schema for the validator report itself
- repair installed-tool and admin-effectivity schemas after the validator found real latest-artifact metadata drift
- include artifact schema smoke in ops_ci_validate

## Evidence
- validate_ops_artifacts initially failed on installed-tool artifactPath and admin-effectivity artifactPath/markdownPath fields, proving the gate caught real schema drift.
- After schema repair, the validator passed 5 of 5 latest artifact checks.

## Testing
- node --check scripts/ops/validate_ops_artifacts.mjs
- node --test scripts/ops/validate_ops_artifacts.test.mjs scripts/studiobrain-ops-work-packet.test.mjs
- node scripts/ops/validate_ops_artifacts.mjs --json --write
- bash scripts/ops/ops_ci_validate.sh
- bash -n scripts/ops/ops_ci_validate.sh
- node scripts/ops/tooling_quality_report.mjs --mode shell-lf --json
- git diff --check

## Risk
Low. Read-only artifact validation only; writes ignored reports under output/ops/artifact-validation when requested.

## Rollback
Revert commit 532d713f to remove the validator, Make target, schema repairs, and ops_ci_validate smoke.

## Follow-ups
- Add freshness thresholds for artifacts after schema compatibility is trusted.
- Promote artifact validation into the report-only GitHub workflow once the stack lands.