### PR TITLE
[ops] Add work-packet freshness gates

### DIFF
--- a/docs/ops/admin-effectivity-loop.md
+++ b/docs/ops/admin-effectivity-loop.md
@@ -57,8 +57,9 @@ The work-packet generator still uses the durable docs as its baseline, then enri
 - `--admin-audit output/ops/effectivity/admin-effectivity-audit-latest.json`
 - `--slice-ledger output/ops/effectivity/slice-ledger-latest.json`
 - `--tool-inventory output/ops/effectivity/installed-tool-inventory-latest.json`
+- `--max-age-hours 24`
 
-Missing or invalid fresh artifacts degrade to warnings and docs-only packet generation. The generator should not run the audit itself; run `make ops-admin-effectivity-audit` first when fresh steering is needed.
+Missing, invalid, or stale fresh artifacts degrade to warnings and docs-only packet generation. The generator should not run the audit itself; run `make ops-admin-effectivity-audit` first when fresh steering is needed.
 
 Validate generated ops artifacts against their committed schemas:
 

--- a/schemas/ops/ops-work-packet.v1.schema.json
+++ b/schemas/ops/ops-work-packet.v1.schema.json
@@ -36,13 +36,14 @@
     },
     "evidenceSummary": {
       "type": "object",
-      "required": ["risks", "backlogItems", "effectivityNextSafeSlices", "remainingApprovalGates", "freshSources", "toolPromotionCandidates", "toolActionableFindings"],
+      "required": ["risks", "backlogItems", "effectivityNextSafeSlices", "remainingApprovalGates", "freshSources", "staleSources", "toolPromotionCandidates", "toolActionableFindings"],
       "properties": {
         "risks": { "type": "number", "minimum": 0 },
         "backlogItems": { "type": "number", "minimum": 0 },
         "effectivityNextSafeSlices": { "type": "number", "minimum": 0 },
         "remainingApprovalGates": { "type": "number", "minimum": 0 },
         "freshSources": { "type": "number", "minimum": 0 },
+        "staleSources": { "type": "number", "minimum": 0 },
         "toolPromotionCandidates": { "type": ["number", "null"], "minimum": 0 },
         "toolActionableFindings": { "type": ["number", "null"], "minimum": 0 }
       },

--- a/scripts/ops/admin_effectivity_audit.mjs
+++ b/scripts/ops/admin_effectivity_audit.mjs
@@ -179,11 +179,25 @@ function rowTimestamp(row) {
   return Date.parse(clean(row.completedAt) || clean(row.startedAt)) || 0;
 }
 
+function sliceSequence(row) {
+  const match = clean(row.sliceId).match(/-(\d+)$/);
+  return match ? Number(match[1]) : null;
+}
+
+function compareRows(left, right) {
+  const leftSequence = sliceSequence(left.row);
+  const rightSequence = sliceSequence(right.row);
+  if (leftSequence !== null && rightSequence !== null && leftSequence !== rightSequence) {
+    return leftSequence - rightSequence;
+  }
+  return rowTimestamp(left.row) - rowTimestamp(right.row) || left.index - right.index;
+}
+
 function selectLedgerRows(rows, last, runId = "") {
   const filtered = clean(runId) ? rows.filter((row) => clean(row.runId) === clean(runId)) : rows;
   return filtered
     .map((row, index) => ({ row, index }))
-    .sort((left, right) => rowTimestamp(left.row) - rowTimestamp(right.row) || left.index - right.index)
+    .sort(compareRows)
     .slice(-last)
     .map((entry) => entry.row);
 }

--- a/scripts/ops/slice_ledger.mjs
+++ b/scripts/ops/slice_ledger.mjs
@@ -274,11 +274,25 @@ function rowTimestamp(row) {
   return Date.parse(clean(row.completedAt) || clean(row.startedAt)) || 0;
 }
 
+function sliceSequence(row) {
+  const match = clean(row.sliceId).match(/-(\d+)$/);
+  return match ? Number(match[1]) : null;
+}
+
+function compareRows(left, right) {
+  const leftSequence = sliceSequence(left.row);
+  const rightSequence = sliceSequence(right.row);
+  if (leftSequence !== null && rightSequence !== null && leftSequence !== rightSequence) {
+    return leftSequence - rightSequence;
+  }
+  return rowTimestamp(left.row) - rowTimestamp(right.row) || left.index - right.index;
+}
+
 function selectRecentRows(rows, last, runId = "") {
   const filtered = clean(runId) ? rows.filter((row) => clean(row.runId) === clean(runId)) : rows;
   return filtered
     .map((row, index) => ({ row, index }))
-    .sort((left, right) => rowTimestamp(left.row) - rowTimestamp(right.row) || left.index - right.index)
+    .sort(compareRows)
     .slice(-last)
     .map((entry) => entry.row);
 }

--- a/scripts/studiobrain-ops-work-packet.mjs
+++ b/scripts/studiobrain-ops-work-packet.mjs
@@ -388,7 +388,38 @@ function buildOutcomeSummary(outcomes) {
   };
 }
 
-function summarizeFreshEvidence(inputs = {}) {
+function freshness(generatedAt, options = {}) {
+  const maxAgeHours = Number(options.maxAgeHours ?? 24);
+  const now = options.now || nowIso();
+  const generatedMs = Date.parse(clean(generatedAt));
+  const nowMs = Date.parse(clean(now));
+  if (!clean(generatedAt)) return { status: "", ageHours: null, maxAgeHours, stale: false };
+  if (Number.isNaN(generatedMs) || Number.isNaN(nowMs)) {
+    return { status: "invalid_timestamp", ageHours: null, maxAgeHours, stale: true };
+  }
+  const ageHours = Number(Math.max(0, (nowMs - generatedMs) / 3_600_000).toFixed(2));
+  const stale = maxAgeHours > 0 && ageHours > maxAgeHours;
+  return { status: stale ? "stale" : "", ageHours, maxAgeHours, stale };
+}
+
+function applyFreshness(source, options = {}) {
+  const result = freshness(source.generatedAt, options);
+  if (!result.status) {
+    return {
+      ...source,
+      sourceStatus: source.status,
+      freshness: result,
+    };
+  }
+  return {
+    ...source,
+    sourceStatus: source.status,
+    status: result.status,
+    freshness: result,
+  };
+}
+
+function summarizeFreshEvidence(inputs = {}, options = {}) {
   const adminAudit = inputs.adminAudit || null;
   const sliceLedger = inputs.sliceLedger || null;
   const toolInventory = inputs.toolInventory || null;
@@ -401,7 +432,7 @@ function summarizeFreshEvidence(inputs = {}) {
   });
   return {
     adminAudit: adminAudit && adminAudit.status !== "invalid_json"
-      ? {
+      ? applyFreshness({
           source: "fresh-admin-audit",
           path: inputs.adminAuditPath || "output/ops/effectivity/admin-effectivity-audit-latest.json",
           status: clean(adminAudit.status) || "unknown",
@@ -411,7 +442,7 @@ function summarizeFreshEvidence(inputs = {}) {
             scores: adminAudit.scores || null,
             privilegedEvidence: adminAudit.sections?.effectivityReport?.report?.sections?.privilegedEvidence?.status || "",
           },
-        }
+        }, options)
       : unavailable(
           "fresh-admin-audit",
           inputs.adminAuditPath || "output/ops/effectivity/admin-effectivity-audit-latest.json",
@@ -419,7 +450,7 @@ function summarizeFreshEvidence(inputs = {}) {
           adminAudit?.parseError ? { parseError: adminAudit.parseError } : {},
         ),
     sliceLedger: sliceLedger && sliceLedger.status !== "invalid_json"
-      ? {
+      ? applyFreshness({
           source: "fresh-slice-ledger",
           path: inputs.sliceLedgerPath || "output/ops/effectivity/slice-ledger-latest.json",
           status: sliceLedger.counts?.failed > 0 ? "fail" : sliceLedger.counts?.blocked > 0 || sliceLedger.counts?.noop > 0 ? "warn" : "pass",
@@ -429,7 +460,7 @@ function summarizeFreshEvidence(inputs = {}) {
             counts: sliceLedger.counts || null,
             scores: sliceLedger.scores || null,
           },
-        }
+        }, options)
       : unavailable(
           "fresh-slice-ledger",
           inputs.sliceLedgerPath || "output/ops/effectivity/slice-ledger-latest.json",
@@ -437,7 +468,7 @@ function summarizeFreshEvidence(inputs = {}) {
           sliceLedger?.parseError ? { parseError: sliceLedger.parseError } : {},
         ),
     toolInventory: toolInventory && toolInventory.status !== "invalid_json"
-      ? {
+      ? applyFreshness({
           source: "fresh-tool-inventory",
           path: inputs.toolInventoryPath || "output/ops/effectivity/installed-tool-inventory-latest.json",
           status: clean(toolInventory.status) || "unknown",
@@ -449,7 +480,7 @@ function summarizeFreshEvidence(inputs = {}) {
             actionableFindings: toolInventory.summary?.actionableFindings ?? null,
             promotionCandidates: toolInventory.summary?.promotionCandidates ?? null,
           },
-        }
+        }, options)
       : unavailable(
           "fresh-tool-inventory",
           inputs.toolInventoryPath || "output/ops/effectivity/installed-tool-inventory-latest.json",
@@ -463,7 +494,13 @@ export function buildOpsWorkPacket(inputs = {}, options = {}) {
   const risks = parseRiskRegister(inputs.riskMarkdown || "");
   const backlog = parseBacklog(inputs.backlogMarkdown || "");
   const effectivity = parseEffectivity(inputs.effectivityMarkdown || "");
-  const freshEvidence = summarizeFreshEvidence(inputs);
+  const freshEvidence = summarizeFreshEvidence(inputs, {
+    maxAgeHours: options.maxAgeHours,
+    now: options.now || options.generatedAt,
+  });
+  const freshEvidenceSources = [freshEvidence.adminAudit, freshEvidence.sliceLedger, freshEvidence.toolInventory];
+  const freshSources = freshEvidenceSources.filter((source) => !["missing", "invalid_json", "invalid_timestamp", "stale"].includes(source.status));
+  const staleSources = freshEvidenceSources.filter((source) => ["invalid_timestamp", "stale"].includes(source.status));
   const packets = backlog
     .filter((item) => priorityRank(item.priority) <= 2)
     .map((item) => makePacket(item, matchingRisk(item, risks), effectivity, freshEvidence))
@@ -495,7 +532,8 @@ export function buildOpsWorkPacket(inputs = {}, options = {}) {
       backlogItems: backlog.length,
       effectivityNextSafeSlices: effectivity.nextSafeSlices.length,
       remainingApprovalGates: effectivity.remainingApprovalGates.length,
-      freshSources: [freshEvidence.adminAudit, freshEvidence.sliceLedger, freshEvidence.toolInventory].filter((source) => !["missing", "invalid_json"].includes(source.status)).length,
+      freshSources: freshSources.length,
+      staleSources: staleSources.length,
       toolPromotionCandidates: freshEvidence.toolInventory.summary.promotionCandidates ?? null,
       toolActionableFindings: freshEvidence.toolInventory.summary.actionableFindings ?? null,
     },
@@ -516,6 +554,7 @@ function parseArgs(argv) {
     adminAudit: DEFAULT_ADMIN_AUDIT,
     sliceLedger: DEFAULT_SLICE_LEDGER,
     toolInventory: DEFAULT_TOOL_INVENTORY,
+    maxAgeHours: 24,
     maxPackets: 8,
     recordOutcome: "",
     outcome: "",
@@ -579,6 +618,11 @@ function parseArgs(argv) {
       args.maxPackets = Math.max(1, Number(maxPackets) || args.maxPackets);
       continue;
     }
+    const maxAgeHours = read("--max-age-hours");
+    if (maxAgeHours !== null) {
+      args.maxAgeHours = Math.max(0, Number(maxAgeHours) || 0);
+      continue;
+    }
     throw new Error(`Unknown argument: ${arg}`);
   }
   args.runId ||= `ops-work-packet-${new Date().toISOString().replace(/[:.]/g, "-")}`;
@@ -604,6 +648,7 @@ function printUsage() {
       "  --admin-audit <path>    Default: output/ops/effectivity/admin-effectivity-audit-latest.json.",
       "  --slice-ledger <path>   Default: output/ops/effectivity/slice-ledger-latest.json.",
       "  --tool-inventory <path> Default: output/ops/effectivity/installed-tool-inventory-latest.json.",
+      "  --max-age-hours <n>     Warn when fresh-input artifacts are older than this. Default: 24.",
       "  --max-packets <n>       Default: 8.",
       "  --record-outcome <id>   Append an outcome ledger entry.",
       "  --outcome <value>       used | helpful | resolved | not_used | stale | misleading | blocked | superseded",
@@ -637,6 +682,7 @@ function recordOutcome(options) {
 
 function workPacketReportStatus(packet) {
   if (packet.packets.length === 0) return "warn";
+  if ((packet.evidenceSummary?.staleSources ?? 0) > 0) return "warn";
   if ((packet.evidenceSummary?.freshSources ?? 0) === 0) return "warn";
   return "pass";
 }
@@ -665,6 +711,7 @@ export function runOpsWorkPacket(rawArgs = process.argv.slice(2)) {
     {
       runId: options.runId,
       maxPackets: options.maxPackets,
+      maxAgeHours: options.maxAgeHours,
     },
   );
   const outcomes = readJsonl(options.outcomes);

--- a/scripts/studiobrain-ops-work-packet.test.mjs
+++ b/scripts/studiobrain-ops-work-packet.test.mjs
@@ -174,8 +174,10 @@ test("buildOpsWorkPacket creates bounded read-only packets from docs evidence", 
   assert.equal(report.evidenceSummary.risks, 2);
   assert.equal(report.evidenceSummary.backlogItems, 2);
   assert.equal(report.evidenceSummary.freshSources, 3);
+  assert.equal(report.evidenceSummary.staleSources, 0);
   assert.equal(report.evidenceSummary.toolPromotionCandidates, 2);
   assert.equal(report.freshEvidence.adminAudit.status, "pass");
+  assert.equal(report.freshEvidence.adminAudit.freshness.stale, false);
   assert.ok(report.packets.length >= 2);
   assert.ok(report.packets.every((packet) => packet.packetId.startsWith("ops-wp-")));
   assert.ok(report.packets.every((packet) => packet.constraints.readOnlyFirst));
@@ -208,6 +210,7 @@ test("summarizeFreshEvidence does not count invalid JSON as fresh", () => {
   );
 
   assert.equal(report.evidenceSummary.freshSources, 1);
+  assert.equal(report.evidenceSummary.staleSources, 0);
   assert.equal(report.freshEvidence.adminAudit.status, "invalid_json");
   assert.equal(report.freshEvidence.toolInventory.summary.parseError, "bad tools");
   assert.equal(report.packets[0].sourceSignals.some((signal) => signal.source === "fresh-admin-audit"), true);
@@ -234,6 +237,29 @@ test("workPacketReportStatus warns when falling back to static docs only", () =>
 
   assert.equal(workPacketReportStatus(staticOnly), "warn");
   assert.equal(workPacketReportStatus(fresh), "pass");
+});
+
+test("workPacketReportStatus warns when fresh evidence is stale", () => {
+  const stale = buildOpsWorkPacket(
+    {
+      riskMarkdown,
+      backlogMarkdown,
+      effectivityMarkdown,
+      ...freshInputs,
+    },
+    {
+      maxPackets: 1,
+      maxAgeHours: 1,
+      now: "2026-05-07T12:00:00.000Z",
+    },
+  );
+
+  assert.equal(stale.evidenceSummary.freshSources, 0);
+  assert.equal(stale.evidenceSummary.staleSources, 3);
+  assert.equal(stale.freshEvidence.adminAudit.status, "stale");
+  assert.equal(stale.freshEvidence.adminAudit.sourceStatus, "pass");
+  assert.equal(stale.freshEvidence.adminAudit.freshness.stale, true);
+  assert.equal(workPacketReportStatus(stale), "warn");
 });
 
 test("runOpsWorkPacket returns a schema-compatible CLI report", () => {


### PR DESCRIPTION
## Summary
- add max-age freshness gates for work-packet admin audit, slice ledger, and installed-tool inputs
- distinguish freshSources from staleSources and preserve sourceStatus on stale inputs
- make work-packet reports warn when fresh-input artifacts are stale
- sort slice-ledger/effectivity windows by natural slice id so concurrent swarm appends do not scramble audits

## Evidence
- A normal packet run passed with 3 fresh sources and 0 stale sources.
- A tiny max-age smoke returned warn with 0 fresh sources and 3 stale sources.
- The 026-030 audit initially showed 027 before 026 due concurrent append timestamps; natural slice-id sorting fixed the window to 026 through 030.

## Testing
- node --check scripts/studiobrain-ops-work-packet.mjs
- node --check scripts/ops/slice_ledger.mjs
- node --check scripts/ops/admin_effectivity_audit.mjs
- node --test scripts/studiobrain-ops-work-packet.test.mjs scripts/ops/validate_ops_artifacts.test.mjs
- node scripts/studiobrain-ops-work-packet.mjs --json --write --max-packets 2
- node scripts/studiobrain-ops-work-packet.mjs --json --max-packets 1 --max-age-hours 0.001
- node scripts/ops/slice_ledger.mjs --summary --last 5 --run-id admin-infra-20260507 --json
- node scripts/ops/admin_effectivity_audit.mjs --write --json --slice-run-id admin-infra-20260507
- node scripts/ops/validate_ops_artifacts.mjs --json --write
- bash scripts/ops/ops_ci_validate.sh
- git diff --check

## Risk
Low. Read-only packet/audit metadata only; no service, host, Docker, database, firewall, SSH, package, or cleanup changes.

## Rollback
Revert commit d8c5463f to restore presence-only fresh evidence counting and timestamp-ordered slice windows.

## Follow-ups
- Add structured packet verification receipts.
- Add artifact freshness thresholds to the generic artifact validator too.