### PR TITLE
[ops] Add swarm lane preflight

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,11 @@ SHELL := /bin/bash
 PG_CONTAINER ?= studiobrain_postgres
 PGDATABASE ?= monsoonfire_studio_os
 OPS_TOOLING_QUALITY_FLAGS ?=
+OPS_SWARM_LANE ?= tooling
+OPS_SWARM_BASE ?= origin/main
+OPS_SWARM_PREFLIGHT_FLAGS ?=
 
-.PHONY: ops-check ops-inventory ops-postgres-review ops-postgres-sql ops-postgres-top-queries ops-postgres-query-tasks ops-postgres-growth-snapshot ops-postgres-autovacuum-stats ops-postgres-roles-extensions ops-docker-review ops-docker-posture ops-capacity ops-import-pressure ops-cleanup-candidates ops-backup-evidence ops-postgres-backup-artifacts ops-restore-prereq ops-redis-minio-backup-evidence ops-ubuntu-review ops-host-failed-unit-trends ops-package-posture ops-time-sync ops-network-review ops-host-drift ops-systemd-drift ops-portal-bridge-review ops-app-review ops-dependency-review ops-idle-worker-effectivity ops-effectivity-report ops-slice-ledger ops-tool-inventory ops-admin-effectivity-audit ops-tooling-quality ops-shell-lf-guard ops-shellcheck-report ops-powershell-syntax ops-sql-parse-report ops-validate-artifacts ops-privileged-evidence-read ops-privileged-evidence-capture ops-privileged-evidence-capture-smoke ops-work-packet ops-incident-bundle ops-incident-bundle-v2 ops-ci-validate ops-post-deploy-verify ops-docs ops-backlog ops-report
+.PHONY: ops-check ops-inventory ops-postgres-review ops-postgres-sql ops-postgres-top-queries ops-postgres-query-tasks ops-postgres-growth-snapshot ops-postgres-autovacuum-stats ops-postgres-roles-extensions ops-docker-review ops-docker-posture ops-capacity ops-import-pressure ops-cleanup-candidates ops-backup-evidence ops-postgres-backup-artifacts ops-restore-prereq ops-redis-minio-backup-evidence ops-ubuntu-review ops-host-failed-unit-trends ops-package-posture ops-time-sync ops-network-review ops-host-drift ops-systemd-drift ops-portal-bridge-review ops-app-review ops-dependency-review ops-idle-worker-effectivity ops-effectivity-report ops-slice-ledger ops-tool-inventory ops-admin-effectivity-audit ops-tooling-quality ops-shell-lf-guard ops-shellcheck-report ops-powershell-syntax ops-sql-parse-report ops-validate-artifacts ops-swarm-lane-preflight ops-privileged-evidence-read ops-privileged-evidence-capture ops-privileged-evidence-capture-smoke ops-work-packet ops-incident-bundle ops-incident-bundle-v2 ops-ci-validate ops-post-deploy-verify ops-docs ops-backlog ops-report
 
 ops-check: ops-inventory ops-docker-review ops-capacity ops-cleanup-candidates ops-backup-evidence ops-ubuntu-review ops-network-review ops-host-drift ops-systemd-drift ops-portal-bridge-review ops-app-review
 
@@ -138,6 +141,9 @@ ops-sql-parse-report:
 
 ops-validate-artifacts:
 	node scripts/ops/validate_ops_artifacts.mjs --write
+
+ops-swarm-lane-preflight:
+	node scripts/ops/swarm_lane_preflight.mjs --lane $(OPS_SWARM_LANE) --base $(OPS_SWARM_BASE) --write $(OPS_SWARM_PREFLIGHT_FLAGS)
 
 ops-privileged-evidence-read:
 	bash scripts/ops/privileged_evidence_read.sh

--- a/docs/ops/admin-effectivity-loop.md
+++ b/docs/ops/admin-effectivity-loop.md
@@ -69,6 +69,15 @@ node scripts/ops/validate_ops_artifacts.mjs --json --write
 
 Missing ignored artifacts are warnings. Schema mismatches are failures because they mean a dashboard, swarm packet consumer, or future automation would be reading a contract it cannot trust.
 
+Preflight a swarm worker lane before delegation:
+
+```bash
+node scripts/ops/swarm_lane_preflight.mjs --lane tooling --base origin/main --json --write
+make ops-swarm-lane-preflight OPS_SWARM_LANE=docs OPS_SWARM_BASE=origin/main
+```
+
+The preflight is read-only. It checks the branch, base ref, integration-base diff, dirty files, changed files, and rename sources against a lane-owned write scope so out-of-lane edits are caught before a worker starts. Use `--base origin/main` for delegation unless you are intentionally validating a stacked branch boundary.
+
 ## Scoring
 
 - `usefulness`: average slice usefulness score, 0 to 1.

--- a/schemas/ops/swarm-lane-preflight.v1.schema.json
+++ b/schemas/ops/swarm-lane-preflight.v1.schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://studio-brain.local/schemas/ops/swarm-lane-preflight.v1.schema.json",
+  "title": "Studio Brain Swarm Lane Preflight v1",
+  "type": "object",
+  "required": [
+    "schema",
+    "generatedAt",
+    "runId",
+    "status",
+    "readOnly",
+    "lane",
+    "branch",
+    "base",
+    "integrationBase",
+    "allowed",
+    "changedFiles",
+    "dirtyFiles",
+    "outsideScope",
+    "problems",
+    "warnings",
+    "recommendation"
+  ],
+  "properties": {
+    "schema": { "const": "studiobrain-swarm-lane-preflight.v1" },
+    "generatedAt": { "type": "string", "format": "date-time" },
+    "runId": { "type": "string" },
+    "status": { "enum": ["pass", "warn", "fail"] },
+    "readOnly": { "const": true },
+    "lane": { "type": "string" },
+    "branch": { "type": "string" },
+    "base": { "type": "string" },
+    "integrationBase": {
+      "type": "object",
+      "required": ["ref", "differs", "files", "error"],
+      "properties": {
+        "ref": { "type": "string" },
+        "differs": { "type": "boolean" },
+        "files": { "type": "array", "items": { "type": "string" } },
+        "error": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "allowed": { "type": "array", "items": { "type": "string" } },
+    "changedFiles": { "type": "array", "items": { "type": "string" } },
+    "dirtyFiles": { "type": "array", "items": { "type": "string" } },
+    "outsideScope": { "type": "array", "items": { "type": "string" } },
+    "problems": { "type": "array", "items": { "type": "string" } },
+    "warnings": { "type": "array", "items": { "type": "string" } },
+    "recommendation": { "type": "string" }
+  },
+  "additionalProperties": false
+}

--- a/scripts/ops/ops_ci_validate.sh
+++ b/scripts/ops/ops_ci_validate.sh
@@ -40,6 +40,7 @@ check_file "scripts/ops/incident_bundle_v2.sh"
 check_file "scripts/ops/ops_ci_validate.sh"
 check_file "scripts/ops/post_deploy_verify.sh"
 check_file "scripts/ops/validate_ops_artifacts.mjs"
+check_file "scripts/ops/swarm_lane_preflight.mjs"
 check_file "docs/ops/17-pr-readiness-packet-template.md"
 check_file "docs/ops/18-release-verification.md"
 
@@ -57,13 +58,34 @@ done
 
 section "Node Syntax"
 for script in \
-  "scripts/ops/validate_ops_artifacts.mjs"; do
+  "scripts/ops/validate_ops_artifacts.mjs" \
+  "scripts/ops/swarm_lane_preflight.mjs"; do
   if [ -f "${REPO_ROOT}/${script}" ] && node --check "${REPO_ROOT}/${script}" >/dev/null; then
     pass "node --check ${script}"
   else
     fail "node --check ${script}"
   fi
 done
+
+section "Node Tests"
+if node --test "${REPO_ROOT}/scripts/ops/swarm_lane_preflight.test.mjs" >"${OUT_DIR}/swarm-lane-preflight.test.out" 2>&1; then
+  pass "node --test scripts/ops/swarm_lane_preflight.test.mjs"
+else
+  fail "node --test scripts/ops/swarm_lane_preflight.test.mjs"
+fi
+
+if node --test "${REPO_ROOT}/scripts/ops/validate_ops_artifacts.test.mjs" >"${OUT_DIR}/validate-ops-artifacts.test.out" 2>&1; then
+  pass "node --test scripts/ops/validate_ops_artifacts.test.mjs"
+else
+  fail "node --test scripts/ops/validate_ops_artifacts.test.mjs"
+fi
+
+section "Swarm Lane Preflight Smoke"
+if node "${REPO_ROOT}/scripts/ops/swarm_lane_preflight.mjs" --lane tooling --base origin/main --json --write >"${OUT_DIR}/swarm-lane-preflight.json"; then
+  pass "swarm_lane_preflight tooling smoke"
+else
+  fail "swarm_lane_preflight tooling smoke"
+fi
 
 section "Artifact Schema Smoke"
 if node "${REPO_ROOT}/scripts/ops/validate_ops_artifacts.mjs" --json --write >"${OUT_DIR}/artifact-schema-validation.json"; then

--- a/scripts/ops/swarm_lane_preflight.mjs
+++ b/scripts/ops/swarm_lane_preflight.mjs
@@ -1,0 +1,276 @@
+#!/usr/bin/env node
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, relative, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const REPO_ROOT = resolve(dirname(__filename), "..", "..");
+const DEFAULT_OUTPUT_DIR = resolve(REPO_ROOT, "output", "ops", "swarm-lane-preflight");
+const LANE_SCOPES = {
+  docs: ["docs/ops/**"],
+  tooling: ["scripts/ops/**", "scripts/studiobrain-ops-work-packet.mjs", "scripts/studiobrain-ops-work-packet.test.mjs", "schemas/ops/**", "docs/ops/**", "Makefile", "package.json", ".github/workflows/**"],
+  "swarm-infra": ["scripts/ops/**", "scripts/studiobrain-ops-work-packet.mjs", "scripts/studiobrain-ops-work-packet.test.mjs", "schemas/ops/**", "docs/ops/**", "Makefile"],
+  "ci-sre": [".github/workflows/**", "scripts/ops/**", "schemas/ops/**", "docs/ops/**", "Makefile", "package.json", "package-lock.json"],
+  "mission-control": ["src/mission-control/**", "server/mission/**", "scripts/mission-control/**", "docs/ops/**", "package.json"],
+};
+
+function usage() {
+  return `Studio Brain swarm lane preflight
+
+Usage:
+  node scripts/ops/swarm_lane_preflight.mjs --lane tooling [--json]
+
+Options:
+  --lane <name>         docs, tooling, swarm-infra, ci-sre, mission-control. Default: tooling.
+  --base <ref>          Base ref for changed-file scope. Default: upstream merge-base, then origin/main.
+  --allowed <pattern>   Additional allowed path pattern; repeatable. Supports exact paths and prefix/**.
+  --fail-on-dirty       Treat uncommitted files as failure instead of warning.
+  --json                Print JSON report.
+  --write               Write timestamped and latest reports under output/ops/swarm-lane-preflight.
+  --output-dir <path>   Default: output/ops/swarm-lane-preflight.
+`;
+}
+
+function clean(value) {
+  return String(value ?? "").replace(/\r/g, "").trim();
+}
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function repoRelative(path) {
+  return relative(REPO_ROOT, resolve(REPO_ROOT, path)).replace(/\\/g, "/");
+}
+
+function runGit(args) {
+  const result = spawnSync("git", args, {
+    cwd: REPO_ROOT,
+    encoding: "utf8",
+    windowsHide: true,
+  });
+  return {
+    ok: result.status === 0,
+    stdout: String(result.stdout ?? "").replace(/\r/g, "").trimEnd(),
+    stderr: clean(result.stderr),
+    status: result.status,
+  };
+}
+
+function readFlagValue(argv, index, flag) {
+  const value = argv[index];
+  if (value === flag) {
+    if (!argv[index + 1]) throw new Error(`${flag} requires a value.`);
+    return { matched: true, value: argv[index + 1], nextIndex: index + 1 };
+  }
+  if (value.startsWith(`${flag}=`)) return { matched: true, value: value.slice(flag.length + 1), nextIndex: index };
+  return { matched: false, value: "", nextIndex: index };
+}
+
+function parseArgs(argv) {
+  const options = {
+    lane: "tooling",
+    base: "",
+    allowed: [],
+    failOnDirty: false,
+    json: false,
+    write: false,
+    outputDir: DEFAULT_OUTPUT_DIR,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = clean(argv[index]);
+    if (!arg) continue;
+    if (arg === "--help" || arg === "-h") {
+      process.stdout.write(usage());
+      process.exit(0);
+    }
+    if (arg === "--json") {
+      options.json = true;
+      continue;
+    }
+    if (arg === "--write") {
+      options.write = true;
+      continue;
+    }
+    if (arg === "--fail-on-dirty") {
+      options.failOnDirty = true;
+      continue;
+    }
+    const mappings = [
+      ["--lane", "lane"],
+      ["--base", "base"],
+      ["--output-dir", "outputDir"],
+    ];
+    let consumed = false;
+    for (const [flag, key] of mappings) {
+      const parsed = readFlagValue(argv, index, flag);
+      if (!parsed.matched) continue;
+      options[key] = parsed.value;
+      index = parsed.nextIndex;
+      consumed = true;
+      break;
+    }
+    if (consumed) continue;
+    const allowed = readFlagValue(argv, index, "--allowed");
+    if (allowed.matched) {
+      options.allowed.push(allowed.value);
+      index = allowed.nextIndex;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  options.outputDir = resolve(REPO_ROOT, options.outputDir);
+  return options;
+}
+
+function normalizePath(path) {
+  return clean(path).replace(/\\/g, "/").replace(/^\.\//, "");
+}
+
+function matchesPattern(path, pattern) {
+  const normalizedPath = normalizePath(path);
+  const normalizedPattern = normalizePath(pattern);
+  if (!normalizedPattern) return false;
+  if (normalizedPattern.endsWith("/**")) {
+    const prefix = normalizedPattern.slice(0, -3);
+    return normalizedPath === prefix || normalizedPath.startsWith(`${prefix}/`);
+  }
+  if (normalizedPattern.endsWith("/*")) {
+    const prefix = normalizedPattern.slice(0, -2);
+    return normalizedPath.startsWith(`${prefix}/`) && !normalizedPath.slice(prefix.length + 1).includes("/");
+  }
+  return normalizedPath === normalizedPattern;
+}
+
+function allowedForLane(lane, extraAllowed = []) {
+  return [...(LANE_SCOPES[lane] || []), ...extraAllowed].map(normalizePath);
+}
+
+function parseStatusPorcelain(output) {
+  return output
+    .split(/\n/)
+    .map((line) => line.trimEnd())
+    .filter(Boolean)
+    .flatMap((line) => {
+      const pathPart = line.slice(3);
+      if (pathPart.includes(" -> ")) return pathPart.split(" -> ").map(normalizePath);
+      return [normalizePath(pathPart)];
+    });
+}
+
+function resolveBase(explicitBase = "", git = runGit) {
+  if (clean(explicitBase)) return clean(explicitBase);
+  const upstream = git(["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"]);
+  if (upstream.ok && upstream.stdout) return upstream.stdout;
+  return "origin/main";
+}
+
+function changedFilesSince(base, git = runGit) {
+  const result = git(["diff", "--name-only", "--no-renames", `${base}...HEAD`]);
+  if (!result.ok) return { ok: false, files: [], error: result.stderr || `git diff exited ${result.status}` };
+  return { ok: true, files: result.stdout.split(/\n/).map(normalizePath).filter(Boolean), error: "" };
+}
+
+function inspectIntegrationBase(base, git = runGit) {
+  const mainBase = "origin/main";
+  if (base === mainBase) return { ref: mainBase, differs: false, files: [], error: "" };
+  const changed = changedFilesSince(mainBase, git);
+  return {
+    ref: mainBase,
+    differs: true,
+    files: changed.files || [],
+    error: changed.error || "",
+  };
+}
+
+function buildPreflightReport(options = {}, git = runGit) {
+  const generatedAt = nowIso();
+  const lane = clean(options.lane || "tooling");
+  const branch = git(["rev-parse", "--abbrev-ref", "HEAD"]);
+  const base = resolveBase(options.base, git);
+  const changed = changedFilesSince(base, git);
+  const integrationBase = inspectIntegrationBase(base, git);
+  const dirty = git(["status", "--short"]);
+  const dirtyFiles = dirty.ok ? parseStatusPorcelain(dirty.stdout) : [];
+  const allowed = allowedForLane(lane, options.allowed || []);
+  const writeSet = Array.from(new Set([...(changed.files || []), ...(integrationBase.files || []), ...dirtyFiles])).sort();
+  const outsideScope = writeSet.filter((path) => !allowed.some((pattern) => matchesPattern(path, pattern)));
+  const problems = [];
+  const warnings = [];
+  if (!LANE_SCOPES[lane]) problems.push(`unknown lane: ${lane}`);
+  if (!branch.ok) problems.push(branch.stderr || "could not determine branch");
+  if (!changed.ok) problems.push(changed.error);
+  if (integrationBase.error) problems.push(`could not inspect ${integrationBase.ref}: ${integrationBase.error}`);
+  if (!dirty.ok) problems.push(dirty.stderr || "could not inspect dirty state");
+  if (outsideScope.length > 0) problems.push(`write scope has ${outsideScope.length} file(s) outside lane ownership`);
+  if (dirtyFiles.length > 0 && options.failOnDirty) problems.push(`dirty worktree has ${dirtyFiles.length} file(s)`);
+  if (integrationBase.differs) warnings.push(`base ${base} differs from ${integrationBase.ref}; integration-base files are included in scope checks`);
+  if (branch.stdout === "HEAD" || branch.stdout === "main") warnings.push(`branch ${branch.stdout} is not a normal feature branch for delegated work`);
+  const status = problems.length > 0 ? "fail" : dirtyFiles.length > 0 || warnings.length > 0 ? "warn" : "pass";
+  const runId = `swarm-lane-preflight-${generatedAt.replace(/[-:]/g, "").replace(/\.\d+Z$/, "Z")}`;
+  return {
+    schema: "studiobrain-swarm-lane-preflight.v1",
+    generatedAt,
+    runId,
+    status,
+    readOnly: true,
+    lane,
+    branch: branch.stdout || "",
+    base,
+    integrationBase,
+    allowed,
+    changedFiles: changed.files || [],
+    dirtyFiles,
+    outsideScope,
+    problems,
+    warnings,
+    recommendation: status === "pass"
+      ? "lane is ready for scoped work"
+      : status === "warn"
+        ? "commit, stash, or intentionally account for dirty files before delegating"
+        : "do not delegate this lane until the scope or branch issue is fixed",
+  };
+}
+
+function writeJson(path, value) {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+function run(rawArgs = process.argv.slice(2)) {
+  const options = parseArgs(rawArgs);
+  const report = buildPreflightReport(options);
+  const artifact = resolve(options.outputDir, `${report.runId}.json`);
+  const latest = resolve(options.outputDir, "swarm-lane-preflight-latest.json");
+  if (options.write) {
+    writeJson(artifact, report);
+    writeJson(latest, report);
+  }
+  if (options.json) {
+    process.stdout.write(`${JSON.stringify({
+      ...report,
+      artifacts: options.write ? { jsonPath: repoRelative(artifact), latestPath: repoRelative(latest) } : null,
+    }, null, 2)}\n`);
+  } else {
+    process.stdout.write(`swarm lane preflight: ${report.status}\n`);
+    process.stdout.write(`lane=${report.lane} branch=${report.branch} base=${report.base}\n`);
+    if (report.problems.length > 0) report.problems.forEach((problem) => process.stdout.write(`- ${problem}\n`));
+  }
+  if (report.status === "fail") process.exitCode = 1;
+  return report;
+}
+
+export { buildPreflightReport, matchesPattern };
+
+if (process.argv[1] && resolve(process.argv[1]) === __filename) {
+  try {
+    run();
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.stack || error.message : String(error)}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/ops/swarm_lane_preflight.test.mjs
+++ b/scripts/ops/swarm_lane_preflight.test.mjs
@@ -1,0 +1,101 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+import { buildPreflightReport, matchesPattern } from "./swarm_lane_preflight.mjs";
+import { validateJsonSchema } from "./validate_ops_artifacts.mjs";
+
+function fakeGit(responses) {
+  return (args) => {
+    const key = args.join(" ");
+    return responses[key] || { ok: true, stdout: "", stderr: "", status: 0 };
+  };
+}
+
+test("matchesPattern supports exact and prefix ownership patterns", () => {
+  assert.equal(matchesPattern("docs/ops/admin.md", "docs/ops/**"), true);
+  assert.equal(matchesPattern("docs/ops/admin.md", "docs/*"), false);
+  assert.equal(matchesPattern("Makefile", "Makefile"), true);
+  assert.equal(matchesPattern("scripts/other.sh", "scripts/ops/**"), false);
+});
+
+test("buildPreflightReport passes for scoped clean lane changes", () => {
+  const report = buildPreflightReport(
+    { lane: "docs", base: "origin/main" },
+    fakeGit({
+      "rev-parse --abbrev-ref HEAD": { ok: true, stdout: "codex/docs-lane", stderr: "", status: 0 },
+      "diff --name-only --no-renames origin/main...HEAD": { ok: true, stdout: "docs/ops/admin.md\n", stderr: "", status: 0 },
+      "status --short": { ok: true, stdout: "", stderr: "", status: 0 },
+    }),
+  );
+
+  assert.equal(report.status, "pass");
+  assert.deepEqual(report.outsideScope, []);
+});
+
+test("buildPreflightReport stays compatible with its JSON schema", () => {
+  const report = buildPreflightReport(
+    { lane: "tooling", base: "origin/main" },
+    fakeGit({
+      "rev-parse --abbrev-ref HEAD": { ok: true, stdout: "codex/tooling-lane", stderr: "", status: 0 },
+      "diff --name-only --no-renames origin/main...HEAD": { ok: true, stdout: "scripts/ops/swarm_lane_preflight.mjs\n", stderr: "", status: 0 },
+      "status --short": { ok: true, stdout: "", stderr: "", status: 0 },
+    }),
+  );
+  const schema = JSON.parse(readFileSync("schemas/ops/swarm-lane-preflight.v1.schema.json", "utf8"));
+
+  assert.deepEqual(validateJsonSchema(report, schema), []);
+});
+
+test("buildPreflightReport fails for out-of-lane files and can fail on dirty state", () => {
+  const report = buildPreflightReport(
+    { lane: "docs", base: "origin/main", failOnDirty: true },
+    fakeGit({
+      "rev-parse --abbrev-ref HEAD": { ok: true, stdout: "codex/docs-lane", stderr: "", status: 0 },
+      "diff --name-only --no-renames origin/main...HEAD": { ok: true, stdout: "docs/ops/admin.md\nserver/app.ts\n", stderr: "", status: 0 },
+      "status --short": { ok: true, stdout: " M docs/ops/admin.md\n", stderr: "", status: 0 },
+    }),
+  );
+
+  assert.equal(report.status, "fail");
+  assert.deepEqual(report.outsideScope, ["server/app.ts"]);
+  assert.ok(report.problems.some((problem) => problem.includes("dirty worktree")));
+});
+
+test("buildPreflightReport includes rename sources in scope checks", () => {
+  const report = buildPreflightReport(
+    { lane: "docs", base: "origin/main" },
+    fakeGit({
+      "rev-parse --abbrev-ref HEAD": { ok: true, stdout: "codex/docs-lane", stderr: "", status: 0 },
+      "diff --name-only --no-renames origin/main...HEAD": { ok: true, stdout: "docs/ops/app.md\n", stderr: "", status: 0 },
+      "status --short": { ok: true, stdout: "R  server/app.ts -> docs/ops/app.md\n", stderr: "", status: 0 },
+    }),
+  );
+
+  assert.equal(report.status, "fail");
+  assert.ok(report.dirtyFiles.includes("server/app.ts"));
+  assert.ok(report.dirtyFiles.includes("docs/ops/app.md"));
+  assert.deepEqual(report.outsideScope, ["server/app.ts"]);
+});
+
+test("buildPreflightReport warns when upstream base differs from origin main", () => {
+  const report = buildPreflightReport(
+    { lane: "docs" },
+    fakeGit({
+      "rev-parse --abbrev-ref HEAD": { ok: true, stdout: "codex/docs-lane", stderr: "", status: 0 },
+      "rev-parse --abbrev-ref --symbolic-full-name @{u}": {
+        ok: true,
+        stdout: "origin/codex/stack-base",
+        stderr: "",
+        status: 0,
+      },
+      "diff --name-only --no-renames origin/codex/stack-base...HEAD": { ok: true, stdout: "docs/ops/admin.md\n", stderr: "", status: 0 },
+      "diff --name-only --no-renames origin/main...HEAD": { ok: true, stdout: "docs/ops/admin.md\n", stderr: "", status: 0 },
+      "status --short": { ok: true, stdout: "", stderr: "", status: 0 },
+    }),
+  );
+
+  assert.equal(report.status, "warn");
+  assert.equal(report.integrationBase.differs, true);
+  assert.ok(report.warnings.some((warning) => warning.includes("differs from origin/main")));
+});

--- a/scripts/ops/validate_ops_artifacts.mjs
+++ b/scripts/ops/validate_ops_artifacts.mjs
@@ -29,6 +29,11 @@ const DEFAULT_ARTIFACTS = [
     schema: "schemas/ops/ops-work-packet.v1.schema.json",
   },
   {
+    id: "swarm-lane-preflight",
+    artifact: "output/ops/swarm-lane-preflight/swarm-lane-preflight-latest.json",
+    schema: "schemas/ops/swarm-lane-preflight.v1.schema.json",
+  },
+  {
     id: "artifact-schema-validation",
     artifact: "output/ops/artifact-validation/artifact-schema-validation-latest.json",
     schema: "schemas/ops/artifact-schema-validation.v1.schema.json",


### PR DESCRIPTION
## Summary
- add a read-only swarm lane preflight that checks branch/base, dirty files, changed files, rename sources, and lane-owned write scope
- add a JSON schema and artifact validation for preflight reports
- wire the preflight smoke and schema regression tests into the reusable ops CI validator
- expose lane/base knobs through Makefile and document origin/main delegation preflight usage

## Evidence
- Audit Scout found P2 rename-source, stacked-base, and Make target scope gaps before PR open; this patch closes them with tests.
- Post-commit preflight against origin/main returned pass with no dirty files and no outside-scope paths.
- Five-slice effectivity audit for slices 031-035 passed with usefulness 0.846, verification 1.0, and no no-op work.

## Testing
- node --test scripts/ops/swarm_lane_preflight.test.mjs scripts/ops/validate_ops_artifacts.test.mjs
- node scripts/ops/swarm_lane_preflight.mjs --lane tooling --base origin/main --json --write
- node scripts/ops/validate_ops_artifacts.mjs --json --write
- bash scripts/ops/ops_ci_validate.sh
- git diff --check

## Risk
Low. Read-only tooling and documentation only; no host, Docker, database, package, firewall, restart, or cleanup action.

## Rollback
Revert the commit to remove the preflight command, schema, docs, and ops CI smoke wiring.

## Follow-ups
- Feed swarm preflight readiness into work-packet source signals.
- Add a safe ops wave runner for preflight -> quality -> inventory -> audit -> artifact validation -> work packet.