### PR TITLE
[ops] Feed swarm preflight into work packets

### DIFF
--- a/docs/ops/admin-effectivity-loop.md
+++ b/docs/ops/admin-effectivity-loop.md
@@ -78,6 +78,14 @@ make ops-swarm-lane-preflight OPS_SWARM_LANE=docs OPS_SWARM_BASE=origin/main
 
 The preflight is read-only. It checks the branch, base ref, integration-base diff, dirty files, changed files, and rename sources against a lane-owned write scope so out-of-lane edits are caught before a worker starts. Use `--base origin/main` for delegation unless you are intentionally validating a stacked branch boundary.
 
+Work packets consume the latest preflight report by default:
+
+```bash
+node scripts/studiobrain-ops-work-packet.mjs --json --write --swarm-preflight output/ops/swarm-lane-preflight/swarm-lane-preflight-latest.json
+```
+
+Missing preflight evidence downgrades the packet report to `warn`; failed preflight evidence makes the report `fail` and marks packets `approval_gated` until the lane scope problem is fixed.
+
 ## Scoring
 
 - `usefulness`: average slice usefulness score, 0 to 1.

--- a/schemas/ops/ops-work-packet.v1.schema.json
+++ b/schemas/ops/ops-work-packet.v1.schema.json
@@ -11,14 +11,15 @@
     "purpose": { "type": "string" },
     "sources": {
       "type": "object",
-      "required": ["riskRegister", "backlog", "effectivity", "adminAudit", "sliceLedger", "toolInventory"],
+      "required": ["riskRegister", "backlog", "effectivity", "adminAudit", "sliceLedger", "toolInventory", "swarmPreflight"],
       "properties": {
         "riskRegister": { "type": "string" },
         "backlog": { "type": "string" },
         "effectivity": { "type": "string" },
         "adminAudit": { "type": "string" },
         "sliceLedger": { "type": "string" },
-        "toolInventory": { "type": "string" }
+        "toolInventory": { "type": "string" },
+        "swarmPreflight": { "type": "string" }
       },
       "additionalProperties": false
     },
@@ -36,7 +37,7 @@
     },
     "evidenceSummary": {
       "type": "object",
-      "required": ["risks", "backlogItems", "effectivityNextSafeSlices", "remainingApprovalGates", "freshSources", "staleSources", "toolPromotionCandidates", "toolActionableFindings"],
+      "required": ["risks", "backlogItems", "effectivityNextSafeSlices", "remainingApprovalGates", "freshSources", "staleSources", "toolPromotionCandidates", "toolActionableFindings", "swarmPreflightStatus", "swarmPreflightOutsideScope", "swarmPreflightProblems"],
       "properties": {
         "risks": { "type": "number", "minimum": 0 },
         "backlogItems": { "type": "number", "minimum": 0 },
@@ -45,13 +46,16 @@
         "freshSources": { "type": "number", "minimum": 0 },
         "staleSources": { "type": "number", "minimum": 0 },
         "toolPromotionCandidates": { "type": ["number", "null"], "minimum": 0 },
-        "toolActionableFindings": { "type": ["number", "null"], "minimum": 0 }
+        "toolActionableFindings": { "type": ["number", "null"], "minimum": 0 },
+        "swarmPreflightStatus": { "type": "string" },
+        "swarmPreflightOutsideScope": { "type": ["number", "null"], "minimum": 0 },
+        "swarmPreflightProblems": { "type": ["number", "null"], "minimum": 0 }
       },
       "additionalProperties": false
     },
     "freshEvidence": {
       "type": "object",
-      "required": ["adminAudit", "sliceLedger", "toolInventory"],
+      "required": ["adminAudit", "sliceLedger", "toolInventory", "swarmPreflight"],
       "additionalProperties": true
     },
     "packets": {

--- a/scripts/studiobrain-ops-work-packet.mjs
+++ b/scripts/studiobrain-ops-work-packet.mjs
@@ -20,6 +20,7 @@ const DEFAULT_EFFECTIVITY_DOC = resolve(REPO_ROOT, "docs", "ops", "16-effectivit
 const DEFAULT_ADMIN_AUDIT = resolve(REPO_ROOT, "output", "ops", "effectivity", "admin-effectivity-audit-latest.json");
 const DEFAULT_SLICE_LEDGER = resolve(REPO_ROOT, "output", "ops", "effectivity", "slice-ledger-latest.json");
 const DEFAULT_TOOL_INVENTORY = resolve(REPO_ROOT, "output", "ops", "effectivity", "installed-tool-inventory-latest.json");
+const DEFAULT_SWARM_PREFLIGHT = resolve(REPO_ROOT, "output", "ops", "swarm-lane-preflight", "swarm-lane-preflight-latest.json");
 const VALID_OUTCOMES = new Set([
   "used",
   "helpful",
@@ -279,10 +280,14 @@ function makePacket(backlogItem, risk, effectivity, freshEvidence) {
       : collectAcceptanceFallback(backlogItem.rawBody || "");
   const packetKey = [title, backlogItem.priority, risk?.title || "", risk?.safeNextStep || firstAcceptance(backlogItem)].join("|");
   const approvalGate = effectivity.remainingApprovalGates.find((gate) => overlapScore(gate, title) > 0) || "";
+  const preflightGate = freshEvidence?.swarmPreflight?.status === "fail"
+    ? freshEvidence.swarmPreflight.summary?.recommendation || "Fix failed swarm lane preflight before delegating this packet."
+    : "";
+  const humanGate = [approvalGate, preflightGate].filter(Boolean).join(" / ");
   return {
     packetId: `ops-wp-${stableHash(packetKey)}`,
     title,
-    status: approvalGate ? "approval_gated" : "ready",
+    status: humanGate ? "approval_gated" : "ready",
     priority: backlogItem.priority || "P?",
     priorityRank: priorityRank(backlogItem.priority),
     risk: backlogItem.risk || risk?.severity || "unknown",
@@ -317,7 +322,7 @@ function makePacket(backlogItem, risk, effectivity, freshEvidence) {
     suggestedBranchName: backlogItem.suggestedBranchName || "",
     suggestedPrTitle: backlogItem.suggestedPrTitle || "",
     verification: buildVerification({ ...backlogItem, acceptanceCriteria }, risk),
-    humanGate: approvalGate,
+    humanGate,
     constraints: {
       readOnlyFirst: true,
       noSecrets: true,
@@ -330,7 +335,7 @@ function makePacket(backlogItem, risk, effectivity, freshEvidence) {
 
 function freshSourceSignals(freshEvidence) {
   if (!freshEvidence) return [];
-  return [freshEvidence.adminAudit, freshEvidence.sliceLedger, freshEvidence.toolInventory]
+  return [freshEvidence.adminAudit, freshEvidence.sliceLedger, freshEvidence.toolInventory, freshEvidence.swarmPreflight]
     .filter((source) => source && source.status !== "missing")
     .map((source) => ({
       source: source.source,
@@ -423,6 +428,7 @@ function summarizeFreshEvidence(inputs = {}, options = {}) {
   const adminAudit = inputs.adminAudit || null;
   const sliceLedger = inputs.sliceLedger || null;
   const toolInventory = inputs.toolInventory || null;
+  const swarmPreflight = inputs.swarmPreflight || null;
   const unavailable = (source, path, status = "missing", summary = {}) => ({
     source,
     path,
@@ -487,6 +493,30 @@ function summarizeFreshEvidence(inputs = {}, options = {}) {
           toolInventory?.status || "missing",
           toolInventory?.parseError ? { parseError: toolInventory.parseError } : {},
         ),
+    swarmPreflight: swarmPreflight && swarmPreflight.status !== "invalid_json"
+      ? applyFreshness({
+          source: "fresh-swarm-preflight",
+          path: inputs.swarmPreflightPath || "output/ops/swarm-lane-preflight/swarm-lane-preflight-latest.json",
+          status: clean(swarmPreflight.status) || "unknown",
+          generatedAt: clean(swarmPreflight.generatedAt),
+          summary: {
+            lane: swarmPreflight.lane || "",
+            branch: swarmPreflight.branch || "",
+            base: swarmPreflight.base || "",
+            changedFiles: Array.isArray(swarmPreflight.changedFiles) ? swarmPreflight.changedFiles.length : null,
+            dirtyFiles: Array.isArray(swarmPreflight.dirtyFiles) ? swarmPreflight.dirtyFiles.length : null,
+            outsideScope: Array.isArray(swarmPreflight.outsideScope) ? swarmPreflight.outsideScope.length : null,
+            problems: Array.isArray(swarmPreflight.problems) ? swarmPreflight.problems.length : null,
+            warnings: Array.isArray(swarmPreflight.warnings) ? swarmPreflight.warnings.length : null,
+            recommendation: swarmPreflight.recommendation || "",
+          },
+        }, options)
+      : unavailable(
+          "fresh-swarm-preflight",
+          inputs.swarmPreflightPath || "output/ops/swarm-lane-preflight/swarm-lane-preflight-latest.json",
+          swarmPreflight?.status || "missing",
+          swarmPreflight?.parseError ? { parseError: swarmPreflight.parseError } : {},
+        ),
   };
 }
 
@@ -498,7 +528,7 @@ export function buildOpsWorkPacket(inputs = {}, options = {}) {
     maxAgeHours: options.maxAgeHours,
     now: options.now || options.generatedAt,
   });
-  const freshEvidenceSources = [freshEvidence.adminAudit, freshEvidence.sliceLedger, freshEvidence.toolInventory];
+  const freshEvidenceSources = [freshEvidence.adminAudit, freshEvidence.sliceLedger, freshEvidence.toolInventory, freshEvidence.swarmPreflight];
   const freshSources = freshEvidenceSources.filter((source) => !["missing", "invalid_json", "invalid_timestamp", "stale"].includes(source.status));
   const staleSources = freshEvidenceSources.filter((source) => ["invalid_timestamp", "stale"].includes(source.status));
   const packets = backlog
@@ -519,6 +549,7 @@ export function buildOpsWorkPacket(inputs = {}, options = {}) {
       adminAudit: freshEvidence.adminAudit.path,
       sliceLedger: freshEvidence.sliceLedger.path,
       toolInventory: freshEvidence.toolInventory.path,
+      swarmPreflight: freshEvidence.swarmPreflight.path,
     },
     constraints: {
       readOnlyFirst: true,
@@ -536,6 +567,9 @@ export function buildOpsWorkPacket(inputs = {}, options = {}) {
       staleSources: staleSources.length,
       toolPromotionCandidates: freshEvidence.toolInventory.summary.promotionCandidates ?? null,
       toolActionableFindings: freshEvidence.toolInventory.summary.actionableFindings ?? null,
+      swarmPreflightStatus: freshEvidence.swarmPreflight.status,
+      swarmPreflightOutsideScope: freshEvidence.swarmPreflight.summary.outsideScope ?? null,
+      swarmPreflightProblems: freshEvidence.swarmPreflight.summary.problems ?? null,
     },
     freshEvidence,
     packets,
@@ -554,6 +588,7 @@ function parseArgs(argv) {
     adminAudit: DEFAULT_ADMIN_AUDIT,
     sliceLedger: DEFAULT_SLICE_LEDGER,
     toolInventory: DEFAULT_TOOL_INVENTORY,
+    swarmPreflight: DEFAULT_SWARM_PREFLIGHT,
     maxAgeHours: 24,
     maxPackets: 8,
     recordOutcome: "",
@@ -595,6 +630,7 @@ function parseArgs(argv) {
       "--admin-audit": "adminAudit",
       "--slice-ledger": "sliceLedger",
       "--tool-inventory": "toolInventory",
+      "--swarm-preflight": "swarmPreflight",
       "--record-outcome": "recordOutcome",
       "--outcome": "outcome",
       "--used-by": "usedBy",
@@ -605,7 +641,7 @@ function parseArgs(argv) {
     for (const [flag, key] of Object.entries(stringOptions)) {
       const value = read(flag);
       if (value !== null) {
-        args[key] = key === "outputRoot" || key === "artifact" || key === "latest" || key === "outcomes" || key === "adminAudit" || key === "sliceLedger" || key === "toolInventory"
+        args[key] = key === "outputRoot" || key === "artifact" || key === "latest" || key === "outcomes" || key === "adminAudit" || key === "sliceLedger" || key === "toolInventory" || key === "swarmPreflight"
           ? resolve(REPO_ROOT, value)
           : value;
         matched = true;
@@ -648,6 +684,7 @@ function printUsage() {
       "  --admin-audit <path>    Default: output/ops/effectivity/admin-effectivity-audit-latest.json.",
       "  --slice-ledger <path>   Default: output/ops/effectivity/slice-ledger-latest.json.",
       "  --tool-inventory <path> Default: output/ops/effectivity/installed-tool-inventory-latest.json.",
+      "  --swarm-preflight <path> Default: output/ops/swarm-lane-preflight/swarm-lane-preflight-latest.json.",
       "  --max-age-hours <n>     Warn when fresh-input artifacts are older than this. Default: 24.",
       "  --max-packets <n>       Default: 8.",
       "  --record-outcome <id>   Append an outcome ledger entry.",
@@ -682,6 +719,9 @@ function recordOutcome(options) {
 
 function workPacketReportStatus(packet) {
   if (packet.packets.length === 0) return "warn";
+  const preflightStatus = packet.freshEvidence?.swarmPreflight?.status;
+  if (preflightStatus === "fail") return "fail";
+  if (["missing", "invalid_json", "warn"].includes(preflightStatus)) return "warn";
   if ((packet.evidenceSummary?.staleSources ?? 0) > 0) return "warn";
   if ((packet.evidenceSummary?.freshSources ?? 0) === 0) return "warn";
   return "pass";
@@ -704,9 +744,11 @@ export function runOpsWorkPacket(rawArgs = process.argv.slice(2)) {
       adminAudit: readJsonIfExists(options.adminAudit),
       sliceLedger: readJsonIfExists(options.sliceLedger),
       toolInventory: readJsonIfExists(options.toolInventory),
+      swarmPreflight: readJsonIfExists(options.swarmPreflight),
       adminAuditPath: toRepoRelative(options.adminAudit),
       sliceLedgerPath: toRepoRelative(options.sliceLedger),
       toolInventoryPath: toRepoRelative(options.toolInventory),
+      swarmPreflightPath: toRepoRelative(options.swarmPreflight),
     },
     {
       runId: options.runId,

--- a/scripts/studiobrain-ops-work-packet.test.mjs
+++ b/scripts/studiobrain-ops-work-packet.test.mjs
@@ -151,9 +151,25 @@ const freshInputs = {
       promotionCandidates: 2,
     },
   },
+  swarmPreflight: {
+    schema: "studiobrain-swarm-lane-preflight.v1",
+    generatedAt: "2026-05-07T08:46:12.000Z",
+    status: "pass",
+    readOnly: true,
+    lane: "tooling",
+    branch: "codex/ops-tooling",
+    base: "origin/main",
+    changedFiles: ["scripts/ops/tool.mjs"],
+    dirtyFiles: [],
+    outsideScope: [],
+    problems: [],
+    warnings: [],
+    recommendation: "lane is ready for scoped work",
+  },
   adminAuditPath: "output/ops/effectivity/admin-effectivity-audit-latest.json",
   sliceLedgerPath: "output/ops/effectivity/slice-ledger-latest.json",
   toolInventoryPath: "output/ops/effectivity/installed-tool-inventory-latest.json",
+  swarmPreflightPath: "output/ops/swarm-lane-preflight/swarm-lane-preflight-latest.json",
 };
 
 test("buildOpsWorkPacket creates bounded read-only packets from docs evidence", () => {
@@ -173,9 +189,11 @@ test("buildOpsWorkPacket creates bounded read-only packets from docs evidence", 
   assert.equal(report.constraints.noServiceRestart, true);
   assert.equal(report.evidenceSummary.risks, 2);
   assert.equal(report.evidenceSummary.backlogItems, 2);
-  assert.equal(report.evidenceSummary.freshSources, 3);
+  assert.equal(report.evidenceSummary.freshSources, 4);
   assert.equal(report.evidenceSummary.staleSources, 0);
   assert.equal(report.evidenceSummary.toolPromotionCandidates, 2);
+  assert.equal(report.evidenceSummary.swarmPreflightStatus, "pass");
+  assert.equal(report.evidenceSummary.swarmPreflightOutsideScope, 0);
   assert.equal(report.freshEvidence.adminAudit.status, "pass");
   assert.equal(report.freshEvidence.adminAudit.freshness.stale, false);
   assert.ok(report.packets.length >= 2);
@@ -183,6 +201,7 @@ test("buildOpsWorkPacket creates bounded read-only packets from docs evidence", 
   assert.ok(report.packets.every((packet) => packet.constraints.readOnlyFirst));
   assert.ok(report.packets[0].sourceSignals.some((signal) => signal.source === "fresh-admin-audit"));
   assert.ok(report.packets[0].sourceSignals.some((signal) => signal.source === "fresh-tool-inventory"));
+  assert.ok(report.packets[0].sourceSignals.some((signal) => signal.source === "fresh-swarm-preflight"));
   assert.equal(report.packets[0].priority, "P0");
   assert.ok(report.packets[0].humanGate.includes("PostgreSQL dump"));
   assert.ok(report.packets[0].safeNextStep.includes("restore-prerequisite"));
@@ -194,6 +213,7 @@ test("summarizeFreshEvidence degrades when ignored artifacts are missing", () =>
   assert.equal(fresh.adminAudit.status, "missing");
   assert.equal(fresh.sliceLedger.status, "missing");
   assert.equal(fresh.toolInventory.status, "missing");
+  assert.equal(fresh.swarmPreflight.status, "missing");
 });
 
 test("summarizeFreshEvidence does not count invalid JSON as fresh", () => {
@@ -239,6 +259,47 @@ test("workPacketReportStatus warns when falling back to static docs only", () =>
   assert.equal(workPacketReportStatus(fresh), "pass");
 });
 
+test("workPacketReportStatus warns when swarm preflight is missing", () => {
+  const missingPreflight = buildOpsWorkPacket(
+    {
+      riskMarkdown,
+      backlogMarkdown,
+      effectivityMarkdown,
+      ...freshInputs,
+      swarmPreflight: null,
+    },
+    { maxPackets: 1 },
+  );
+
+  assert.equal(missingPreflight.freshEvidence.swarmPreflight.status, "missing");
+  assert.equal(workPacketReportStatus(missingPreflight), "warn");
+});
+
+test("failed swarm preflight gates packets and fails the report", () => {
+  const failedPreflight = buildOpsWorkPacket(
+    {
+      riskMarkdown,
+      backlogMarkdown,
+      effectivityMarkdown,
+      ...freshInputs,
+      swarmPreflight: {
+        ...freshInputs.swarmPreflight,
+        status: "fail",
+        outsideScope: ["server/app.ts"],
+        problems: ["write scope has 1 file outside lane ownership"],
+        recommendation: "do not delegate this lane until the scope issue is fixed",
+      },
+    },
+    { maxPackets: 1 },
+  );
+
+  assert.equal(failedPreflight.evidenceSummary.swarmPreflightStatus, "fail");
+  assert.equal(failedPreflight.evidenceSummary.swarmPreflightOutsideScope, 1);
+  assert.equal(failedPreflight.packets[0].status, "approval_gated");
+  assert.ok(failedPreflight.packets[0].humanGate.includes("do not delegate"));
+  assert.equal(workPacketReportStatus(failedPreflight), "fail");
+});
+
 test("workPacketReportStatus warns when fresh evidence is stale", () => {
   const stale = buildOpsWorkPacket(
     {
@@ -255,7 +316,7 @@ test("workPacketReportStatus warns when fresh evidence is stale", () => {
   );
 
   assert.equal(stale.evidenceSummary.freshSources, 0);
-  assert.equal(stale.evidenceSummary.staleSources, 3);
+  assert.equal(stale.evidenceSummary.staleSources, 4);
   assert.equal(stale.freshEvidence.adminAudit.status, "stale");
   assert.equal(stale.freshEvidence.adminAudit.sourceStatus, "pass");
   assert.equal(stale.freshEvidence.adminAudit.freshness.stale, true);
@@ -272,6 +333,8 @@ test("runOpsWorkPacket returns a schema-compatible CLI report", () => {
     "output/ops/missing-slice-ledger.json",
     "--tool-inventory",
     "output/ops/missing-tool-inventory.json",
+    "--swarm-preflight",
+    "output/ops/missing-swarm-preflight.json",
   ]));
 
   assertWorkPacketReportContract(report);


### PR DESCRIPTION
## Summary
- add swarm lane preflight as a default fresh input for ops work-packet generation
- include preflight lane/base/scope status in packet source signals and evidence summary
- warn when preflight evidence is missing or warning, and fail/gate packets when preflight fails
- update the work-packet schema and tests for pass, missing, stale, and failed preflight states

## Evidence
- Parallel validation exposed why ordered wave execution matters: artifact validation can read the previous latest packet if writers run concurrently. The final validation was rerun sequentially and passed.
- Latest packet now includes swarmPreflightStatus, outside-scope count, and preflight source signals.

## Testing
- node --check scripts/studiobrain-ops-work-packet.mjs
- node --test scripts/studiobrain-ops-work-packet.test.mjs scripts/ops/validate_ops_artifacts.test.mjs scripts/ops/swarm_lane_preflight.test.mjs
- node scripts/ops/swarm_lane_preflight.mjs --lane tooling --base origin/main --json --write
- node scripts/studiobrain-ops-work-packet.mjs --json --write --max-packets 1
- node scripts/ops/validate_ops_artifacts.mjs --json --write
- bash scripts/ops/ops_ci_validate.sh
- git diff --check

## Risk
Low. Read-only packet generation and docs/schema changes only; no host, Docker, database, package, firewall, restart, or cleanup action.

## Rollback
Revert this commit to remove preflight consumption from work-packet generation; the standalone preflight tool in the parent PR remains usable.

## Follow-ups
- Add an ordered safe ops wave runner so dependent latest artifacts are never refreshed in parallel.
- Make five-slice audit cadence machine-visible in the slice ledger summary.