### PR TITLE
[ops] Add ordered safe ops wave runner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ OPS_SWARM_LANE ?= tooling
 OPS_SWARM_BASE ?= origin/main
 OPS_SWARM_PREFLIGHT_FLAGS ?=
 
-.PHONY: ops-check ops-inventory ops-postgres-review ops-postgres-sql ops-postgres-top-queries ops-postgres-query-tasks ops-postgres-growth-snapshot ops-postgres-autovacuum-stats ops-postgres-roles-extensions ops-docker-review ops-docker-posture ops-capacity ops-import-pressure ops-cleanup-candidates ops-backup-evidence ops-postgres-backup-artifacts ops-restore-prereq ops-redis-minio-backup-evidence ops-ubuntu-review ops-host-failed-unit-trends ops-package-posture ops-time-sync ops-network-review ops-host-drift ops-systemd-drift ops-portal-bridge-review ops-app-review ops-dependency-review ops-idle-worker-effectivity ops-effectivity-report ops-slice-ledger ops-tool-inventory ops-admin-effectivity-audit ops-tooling-quality ops-shell-lf-guard ops-shellcheck-report ops-powershell-syntax ops-sql-parse-report ops-validate-artifacts ops-swarm-lane-preflight ops-privileged-evidence-read ops-privileged-evidence-capture ops-privileged-evidence-capture-smoke ops-work-packet ops-incident-bundle ops-incident-bundle-v2 ops-ci-validate ops-post-deploy-verify ops-docs ops-backlog ops-report
+.PHONY: ops-check ops-inventory ops-postgres-review ops-postgres-sql ops-postgres-top-queries ops-postgres-query-tasks ops-postgres-growth-snapshot ops-postgres-autovacuum-stats ops-postgres-roles-extensions ops-docker-review ops-docker-posture ops-capacity ops-import-pressure ops-cleanup-candidates ops-backup-evidence ops-postgres-backup-artifacts ops-restore-prereq ops-redis-minio-backup-evidence ops-ubuntu-review ops-host-failed-unit-trends ops-package-posture ops-time-sync ops-network-review ops-host-drift ops-systemd-drift ops-portal-bridge-review ops-app-review ops-dependency-review ops-idle-worker-effectivity ops-effectivity-report ops-slice-ledger ops-tool-inventory ops-admin-effectivity-audit ops-tooling-quality ops-shell-lf-guard ops-shellcheck-report ops-powershell-syntax ops-sql-parse-report ops-validate-artifacts ops-swarm-lane-preflight ops-wave-runner ops-privileged-evidence-read ops-privileged-evidence-capture ops-privileged-evidence-capture-smoke ops-work-packet ops-incident-bundle ops-incident-bundle-v2 ops-ci-validate ops-post-deploy-verify ops-docs ops-backlog ops-report
 
 ops-check: ops-inventory ops-docker-review ops-capacity ops-cleanup-candidates ops-backup-evidence ops-ubuntu-review ops-network-review ops-host-drift ops-systemd-drift ops-portal-bridge-review ops-app-review
 
@@ -144,6 +144,9 @@ ops-validate-artifacts:
 
 ops-swarm-lane-preflight:
 	node scripts/ops/swarm_lane_preflight.mjs --lane $(OPS_SWARM_LANE) --base $(OPS_SWARM_BASE) --write $(OPS_SWARM_PREFLIGHT_FLAGS)
+
+ops-wave-runner:
+	node scripts/ops/ops_wave_runner.mjs --write
 
 ops-privileged-evidence-read:
 	bash scripts/ops/privileged_evidence_read.sh

--- a/docs/ops/admin-effectivity-loop.md
+++ b/docs/ops/admin-effectivity-loop.md
@@ -86,6 +86,15 @@ node scripts/studiobrain-ops-work-packet.mjs --json --write --swarm-preflight ou
 
 Missing preflight evidence downgrades the packet report to `warn`; failed preflight evidence makes the report `fail` and marks packets `approval_gated` until the lane scope problem is fixed.
 
+Run the ordered safe wave when refreshing dependent latest artifacts:
+
+```bash
+node scripts/ops/ops_wave_runner.mjs --json --write
+node scripts/ops/ops_wave_runner.mjs --dry-run --json --write
+```
+
+The wave runner executes read-only checks in dependency order: preflight, tooling quality, tool inventory, admin effectivity audit, work packet generation, then artifact schema validation. Use it when a downstream command consumes a `*-latest.json` artifact from an upstream command.
+
 ## Scoring
 
 - `usefulness`: average slice usefulness score, 0 to 1.

--- a/schemas/ops/ops-wave-runner.v1.schema.json
+++ b/schemas/ops/ops-wave-runner.v1.schema.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://studio-brain.local/schemas/ops/ops-wave-runner.v1.schema.json",
+  "title": "Studio Brain Ops Wave Runner v1",
+  "type": "object",
+  "required": [
+    "schema",
+    "generatedAt",
+    "runId",
+    "status",
+    "readOnly",
+    "dryRun",
+    "safeWriteRoots",
+    "plan",
+    "receipts",
+    "nextRecommendedAction"
+  ],
+  "properties": {
+    "schema": { "const": "studiobrain-ops-wave-runner.v1" },
+    "generatedAt": { "type": "string", "format": "date-time" },
+    "runId": { "type": "string" },
+    "status": { "enum": ["planned", "pass", "warn", "fail"] },
+    "readOnly": { "const": true },
+    "dryRun": { "type": "boolean" },
+    "safeWriteRoots": { "type": "array", "items": { "type": "string" } },
+    "plan": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "order", "command", "expectedArtifacts"],
+        "properties": {
+          "id": { "type": "string" },
+          "order": { "type": "number", "minimum": 1 },
+          "command": { "type": "string" },
+          "expectedArtifacts": { "type": "array", "items": { "type": "string" } }
+        },
+        "additionalProperties": false
+      }
+    },
+    "receipts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "order", "status", "code", "command", "expectedArtifacts", "stdoutBytes", "stderrBytes"],
+        "properties": {
+          "id": { "type": "string" },
+          "order": { "type": "number", "minimum": 1 },
+          "status": { "enum": ["skipped", "pass", "warn", "fail"] },
+          "code": { "type": ["number", "null"] },
+          "command": { "type": "string" },
+          "expectedArtifacts": { "type": "array", "items": { "type": "string" } },
+          "parsedStatus": { "type": "string" },
+          "stdoutBytes": { "type": "number", "minimum": 0 },
+          "stderrBytes": { "type": "number", "minimum": 0 },
+          "stderrPreview": { "type": "string" }
+        },
+        "additionalProperties": false
+      }
+    },
+    "nextRecommendedAction": { "type": "string" }
+  },
+  "additionalProperties": false
+}

--- a/scripts/ops/ops_ci_validate.sh
+++ b/scripts/ops/ops_ci_validate.sh
@@ -41,6 +41,7 @@ check_file "scripts/ops/ops_ci_validate.sh"
 check_file "scripts/ops/post_deploy_verify.sh"
 check_file "scripts/ops/validate_ops_artifacts.mjs"
 check_file "scripts/ops/swarm_lane_preflight.mjs"
+check_file "scripts/ops/ops_wave_runner.mjs"
 check_file "docs/ops/17-pr-readiness-packet-template.md"
 check_file "docs/ops/18-release-verification.md"
 
@@ -59,7 +60,8 @@ done
 section "Node Syntax"
 for script in \
   "scripts/ops/validate_ops_artifacts.mjs" \
-  "scripts/ops/swarm_lane_preflight.mjs"; do
+  "scripts/ops/swarm_lane_preflight.mjs" \
+  "scripts/ops/ops_wave_runner.mjs"; do
   if [ -f "${REPO_ROOT}/${script}" ] && node --check "${REPO_ROOT}/${script}" >/dev/null; then
     pass "node --check ${script}"
   else
@@ -80,11 +82,24 @@ else
   fail "node --test scripts/ops/validate_ops_artifacts.test.mjs"
 fi
 
+if node --test "${REPO_ROOT}/scripts/ops/ops_wave_runner.test.mjs" >"${OUT_DIR}/ops-wave-runner.test.out" 2>&1; then
+  pass "node --test scripts/ops/ops_wave_runner.test.mjs"
+else
+  fail "node --test scripts/ops/ops_wave_runner.test.mjs"
+fi
+
 section "Swarm Lane Preflight Smoke"
 if node "${REPO_ROOT}/scripts/ops/swarm_lane_preflight.mjs" --lane tooling --base origin/main --json --write >"${OUT_DIR}/swarm-lane-preflight.json"; then
   pass "swarm_lane_preflight tooling smoke"
 else
   fail "swarm_lane_preflight tooling smoke"
+fi
+
+section "Ops Wave Runner Dry Run"
+if node "${REPO_ROOT}/scripts/ops/ops_wave_runner.mjs" --dry-run --json --write --steps swarm-preflight,work-packet,artifact-validation >"${OUT_DIR}/ops-wave-runner-dry-run.json"; then
+  pass "ops_wave_runner dry-run smoke"
+else
+  fail "ops_wave_runner dry-run smoke"
 fi
 
 section "Artifact Schema Smoke"

--- a/scripts/ops/ops_wave_runner.mjs
+++ b/scripts/ops/ops_wave_runner.mjs
@@ -1,0 +1,290 @@
+#!/usr/bin/env node
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, relative, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const REPO_ROOT = resolve(dirname(__filename), "..", "..");
+const DEFAULT_OUTPUT_DIR = resolve(REPO_ROOT, "output", "ops", "waves");
+
+const STEP_DEFINITIONS = [
+  {
+    id: "swarm-preflight",
+    command: [process.execPath, "scripts/ops/swarm_lane_preflight.mjs", "--lane", "tooling", "--base", "origin/main", "--json", "--write"],
+    expectedArtifacts: ["output/ops/swarm-lane-preflight/swarm-lane-preflight-latest.json"],
+  },
+  {
+    id: "tooling-quality",
+    command: [process.execPath, "scripts/ops/tooling_quality_report.mjs", "--mode", "all", "--json", "--write"],
+    expectedArtifacts: ["output/ops/tooling-quality/tooling-quality-latest.json"],
+  },
+  {
+    id: "tool-inventory",
+    command: [process.execPath, "scripts/ops/installed_tool_inventory.mjs", "--json", "--write"],
+    expectedArtifacts: ["output/ops/effectivity/installed-tool-inventory-latest.json"],
+  },
+  {
+    id: "admin-effectivity-audit",
+    command: [process.execPath, "scripts/ops/admin_effectivity_audit.mjs", "--write", "--json"],
+    expectedArtifacts: ["output/ops/effectivity/admin-effectivity-audit-latest.json"],
+  },
+  {
+    id: "work-packet",
+    command: [process.execPath, "scripts/studiobrain-ops-work-packet.mjs", "--json", "--write", "--max-packets", "3"],
+    expectedArtifacts: ["output/ops/swarm/latest-work-packet.json"],
+  },
+  {
+    id: "artifact-validation",
+    command: [process.execPath, "scripts/ops/validate_ops_artifacts.mjs", "--json", "--write"],
+    expectedArtifacts: ["output/ops/artifact-validation/artifact-schema-validation-latest.json"],
+  },
+];
+
+function clean(value) {
+  return String(value ?? "").replace(/\r/g, "").trim();
+}
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function repoRelative(path) {
+  return relative(REPO_ROOT, resolve(REPO_ROOT, path)).replace(/\\/g, "/");
+}
+
+function usage() {
+  return `Studio Brain safe ops wave runner
+
+Usage:
+  node scripts/ops/ops_wave_runner.mjs [--json] [--write]
+  node scripts/ops/ops_wave_runner.mjs --dry-run --json
+
+Options:
+  --json                  Print JSON manifest.
+  --write                 Write timestamped and latest manifests under output/ops/waves.
+  --dry-run               Show the ordered plan without executing steps.
+  --output-dir <path>     Default: output/ops/waves.
+  --run-id <id>           Default: generated from current UTC time.
+  --steps <a,b,c>         Restrict to step ids.
+  --skip <id>             Skip one step; repeatable.
+`;
+}
+
+function readFlagValue(argv, index, flag) {
+  const value = argv[index];
+  if (value === flag) {
+    if (!argv[index + 1]) throw new Error(`${flag} requires a value.`);
+    return { matched: true, value: argv[index + 1], nextIndex: index + 1 };
+  }
+  if (String(value).startsWith(`${flag}=`)) return { matched: true, value: String(value).slice(flag.length + 1), nextIndex: index };
+  return { matched: false, value: "", nextIndex: index };
+}
+
+function parseArgs(argv) {
+  const options = {
+    json: false,
+    write: false,
+    dryRun: false,
+    runId: "",
+    outputDir: DEFAULT_OUTPUT_DIR,
+    steps: [],
+    skip: [],
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = clean(argv[index]);
+    if (!arg) continue;
+    if (arg === "--help" || arg === "-h") {
+      process.stdout.write(usage());
+      process.exit(0);
+    }
+    if (arg === "--json") {
+      options.json = true;
+      continue;
+    }
+    if (arg === "--write") {
+      options.write = true;
+      continue;
+    }
+    if (arg === "--dry-run") {
+      options.dryRun = true;
+      continue;
+    }
+    const mappings = [
+      ["--run-id", "runId"],
+      ["--output-dir", "outputDir"],
+      ["--steps", "steps"],
+    ];
+    let consumed = false;
+    for (const [flag, key] of mappings) {
+      const parsed = readFlagValue(argv, index, flag);
+      if (!parsed.matched) continue;
+      options[key] = key === "steps" ? parsed.value.split(",").map(clean).filter(Boolean) : parsed.value;
+      index = parsed.nextIndex;
+      consumed = true;
+      break;
+    }
+    if (consumed) continue;
+    const skip = readFlagValue(argv, index, "--skip");
+    if (skip.matched) {
+      options.skip.push(skip.value);
+      index = skip.nextIndex;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+  options.outputDir = resolve(REPO_ROOT, options.outputDir);
+  options.runId ||= `ops-wave-${nowIso().replace(/[-:]/g, "").replace(/\.\d+Z$/, "Z")}`;
+  return options;
+}
+
+function buildWavePlan(options = {}) {
+  const only = new Set(options.steps || []);
+  const skip = new Set(options.skip || []);
+  const unknown = [...only, ...skip].filter((id) => !STEP_DEFINITIONS.some((step) => step.id === id));
+  if (unknown.length > 0) throw new Error(`Unknown step id(s): ${Array.from(new Set(unknown)).join(", ")}`);
+  return STEP_DEFINITIONS
+    .filter((step) => (only.size === 0 || only.has(step.id)) && !skip.has(step.id))
+    .map((step, index) => ({
+      ...step,
+      order: index + 1,
+      commandText: step.command.map((part, partIndex) => (partIndex === 0 && part === process.execPath ? "node" : part)).join(" "),
+    }));
+}
+
+function parseJsonObject(stdout) {
+  const text = clean(stdout);
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+function defaultRunner(step) {
+  const [cmd, ...args] = step.command;
+  const result = spawnSync(cmd, args, {
+    cwd: REPO_ROOT,
+    encoding: "utf8",
+    windowsHide: true,
+  });
+  return {
+    code: result.status ?? 1,
+    stdout: String(result.stdout ?? ""),
+    stderr: String(result.stderr ?? ""),
+  };
+}
+
+function statusFromReceipt(receipt) {
+  if (receipt.code !== 0) return "fail";
+  const jsonStatus = clean(receipt.parsed?.status);
+  if (["pass", "warn", "fail"].includes(jsonStatus)) return jsonStatus;
+  return "pass";
+}
+
+function runWave(options = {}, runner = defaultRunner) {
+  const generatedAt = nowIso();
+  const plan = buildWavePlan(options);
+  const receipts = [];
+  for (const step of plan) {
+    if (options.dryRun) {
+      receipts.push({
+        id: step.id,
+        order: step.order,
+        status: "skipped",
+        code: null,
+        command: step.commandText,
+        expectedArtifacts: step.expectedArtifacts,
+        parsedStatus: "",
+        stdoutBytes: 0,
+        stderrBytes: 0,
+      });
+      continue;
+    }
+    const raw = runner(step);
+    const parsed = parseJsonObject(raw.stdout);
+    const receipt = {
+      id: step.id,
+      order: step.order,
+      status: statusFromReceipt({ ...raw, parsed }),
+      code: raw.code,
+      command: step.commandText,
+      expectedArtifacts: step.expectedArtifacts,
+      parsedStatus: clean(parsed?.status),
+      stdoutBytes: Buffer.byteLength(raw.stdout || "", "utf8"),
+      stderrBytes: Buffer.byteLength(raw.stderr || "", "utf8"),
+      stderrPreview: clean(raw.stderr).slice(0, 500),
+    };
+    receipts.push(receipt);
+    if (receipt.status === "fail") break;
+  }
+  const status = options.dryRun
+    ? "planned"
+    : receipts.some((receipt) => receipt.status === "fail")
+      ? "fail"
+      : receipts.some((receipt) => receipt.status === "warn" || receipt.status === "skipped")
+        ? "warn"
+        : "pass";
+  return {
+    schema: "studiobrain-ops-wave-runner.v1",
+    generatedAt,
+    runId: options.runId || "",
+    status,
+    readOnly: true,
+    dryRun: Boolean(options.dryRun),
+    safeWriteRoots: ["output/ops"],
+    plan: plan.map((step) => ({
+      id: step.id,
+      order: step.order,
+      command: step.commandText,
+      expectedArtifacts: step.expectedArtifacts,
+    })),
+    receipts,
+    nextRecommendedAction: status === "fail"
+      ? "Inspect the failed receipt before running downstream dependent steps."
+      : status === "planned"
+        ? "Run without --dry-run to refresh ordered ops artifacts."
+        : "Use the latest work packet and artifact validation report for the next safe slice.",
+  };
+}
+
+function writeJson(path, value) {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+function run(rawArgs = process.argv.slice(2)) {
+  const options = parseArgs(rawArgs);
+  const manifest = runWave(options);
+  const artifact = resolve(options.outputDir, `${manifest.runId}.json`);
+  const latest = resolve(options.outputDir, "ops-wave-runner-latest.json");
+  if (options.write) {
+    writeJson(artifact, manifest);
+    writeJson(latest, manifest);
+  }
+  const report = {
+    ...manifest,
+    artifacts: options.write ? { jsonPath: repoRelative(artifact), latestPath: repoRelative(latest) } : null,
+  };
+  if (options.json) process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  else {
+    process.stdout.write(`ops wave runner: ${manifest.status}\n`);
+    process.stdout.write(`steps: ${manifest.receipts.length}/${manifest.plan.length}\n`);
+    if (options.write) process.stdout.write(`artifact: ${repoRelative(artifact)}\n`);
+  }
+  if (manifest.status === "fail") process.exitCode = 1;
+  return report;
+}
+
+export { buildWavePlan, runWave };
+
+if (process.argv[1] && resolve(process.argv[1]) === __filename) {
+  try {
+    run();
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.stack || error.message : String(error)}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/ops/ops_wave_runner.test.mjs
+++ b/scripts/ops/ops_wave_runner.test.mjs
@@ -1,0 +1,51 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { buildWavePlan, runWave } from "./ops_wave_runner.mjs";
+
+test("buildWavePlan keeps dependent ops steps ordered", () => {
+  const plan = buildWavePlan({ steps: ["swarm-preflight", "work-packet", "artifact-validation"] });
+
+  assert.deepEqual(plan.map((step) => step.id), ["swarm-preflight", "work-packet", "artifact-validation"]);
+  assert.equal(plan[0].order, 1);
+  assert.ok(plan[0].commandText.includes("swarm_lane_preflight.mjs"));
+});
+
+test("runWave dry-run records skipped receipts without executing", () => {
+  const manifest = runWave({ dryRun: true, runId: "unit-wave", steps: ["swarm-preflight", "work-packet"] }, () => {
+    throw new Error("runner should not execute in dry-run mode");
+  });
+
+  assert.equal(manifest.status, "planned");
+  assert.equal(manifest.dryRun, true);
+  assert.deepEqual(manifest.receipts.map((receipt) => receipt.status), ["skipped", "skipped"]);
+});
+
+test("runWave stops on failed step and keeps downstream artifacts untouched", () => {
+  const manifest = runWave(
+    { runId: "unit-wave", steps: ["swarm-preflight", "work-packet", "artifact-validation"] },
+    (step) => ({
+      code: step.id === "work-packet" ? 1 : 0,
+      stdout: JSON.stringify({ status: step.id === "work-packet" ? "fail" : "pass" }),
+      stderr: step.id === "work-packet" ? "packet failed" : "",
+    }),
+  );
+
+  assert.equal(manifest.status, "fail");
+  assert.deepEqual(manifest.receipts.map((receipt) => receipt.id), ["swarm-preflight", "work-packet"]);
+  assert.equal(manifest.receipts[1].stderrPreview, "packet failed");
+});
+
+test("runWave reports warn when a read-only step warns", () => {
+  const manifest = runWave(
+    { runId: "unit-wave", steps: ["tooling-quality", "tool-inventory"] },
+    (step) => ({
+      code: 0,
+      stdout: JSON.stringify({ status: step.id === "tooling-quality" ? "warn" : "pass" }),
+      stderr: "",
+    }),
+  );
+
+  assert.equal(manifest.status, "warn");
+  assert.deepEqual(manifest.receipts.map((receipt) => receipt.status), ["warn", "pass"]);
+});

--- a/scripts/ops/validate_ops_artifacts.mjs
+++ b/scripts/ops/validate_ops_artifacts.mjs
@@ -34,6 +34,11 @@ const DEFAULT_ARTIFACTS = [
     schema: "schemas/ops/swarm-lane-preflight.v1.schema.json",
   },
   {
+    id: "ops-wave-runner",
+    artifact: "output/ops/waves/ops-wave-runner-latest.json",
+    schema: "schemas/ops/ops-wave-runner.v1.schema.json",
+  },
+  {
     id: "artifact-schema-validation",
     artifact: "output/ops/artifact-validation/artifact-schema-validation-latest.json",
     schema: "schemas/ops/artifact-schema-validation.v1.schema.json",


### PR DESCRIPTION
## Summary
- add an ordered read-only ops wave runner for dependent latest-artifact refreshes
- record command receipts, statuses, byte counts, expected artifacts, and next action under output/ops/waves
- add dry-run support, a JSON schema, tests, Makefile wrapper, docs, and artifact validation coverage
- wire the wave-runner dry-run into ops_ci_validate

## Evidence
- The previous slice exposed a real race: artifact validation can read an old latest packet when packet generation and validation run in parallel. This runner executes dependent steps in order.
- Live mini-wave passed: swarm-preflight -> work-packet -> artifact-validation all returned pass.

## Testing
- node --check scripts/ops/ops_wave_runner.mjs
- node --test scripts/ops/ops_wave_runner.test.mjs scripts/ops/validate_ops_artifacts.test.mjs scripts/studiobrain-ops-work-packet.test.mjs scripts/ops/swarm_lane_preflight.test.mjs
- node scripts/ops/ops_wave_runner.mjs --dry-run --json --write --steps swarm-preflight,work-packet,artifact-validation
- node scripts/ops/ops_wave_runner.mjs --json --write --steps swarm-preflight,work-packet,artifact-validation
- node scripts/ops/validate_ops_artifacts.mjs --json --write
- bash scripts/ops/ops_ci_validate.sh
- git diff --check

## Risk
Low. The runner invokes existing read-only ops commands and writes only ignored artifacts under output/ops.

## Rollback
Revert this commit to remove the runner, schema, docs, and ops CI dry-run smoke. Existing individual commands still work.

## Follow-ups
- Make five-slice audit cadence machine-visible in the slice ledger summary.
- Feed wave-runner receipts into tool usefulness/effectivity scoring.