### PR TITLE
[ops] Expose slice audit cadence

### DIFF
--- a/docs/ops/admin-effectivity-loop.md
+++ b/docs/ops/admin-effectivity-loop.md
@@ -32,6 +32,8 @@ node scripts/ops/slice_ledger.mjs --summary --last 5 --run-id admin-effectivity-
 node scripts/ops/admin_effectivity_audit.mjs --write --slice-run-id admin-effectivity-20260507
 ```
 
+The summary includes `auditCadence.auditDue`, `slicesSinceLastAudit`, and `nextAuditAt`. With the default interval of 5, `auditDue=true` means stop the slice loop long enough to run `admin_effectivity_audit.mjs`, inspect usefulness/no-op rate, and then continue with the next safe infrastructure slice.
+
 Inventory local tool availability:
 
 ```bash

--- a/schemas/ops/slice-ledger-summary.v1.schema.json
+++ b/schemas/ops/slice-ledger-summary.v1.schema.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://studio-brain.local/schemas/ops/slice-ledger-summary.v1.schema.json",
+  "title": "Studio Brain Admin Slice Ledger Summary v1",
+  "type": "object",
+  "required": [
+    "schema",
+    "generatedAt",
+    "ledgerPath",
+    "filters",
+    "window",
+    "auditCadence",
+    "counts",
+    "scores",
+    "rows"
+  ],
+  "properties": {
+    "schema": { "const": "studiobrain-admin-slice-ledger-summary.v1" },
+    "generatedAt": { "type": "string", "format": "date-time" },
+    "ledgerPath": { "type": "string" },
+    "filters": {
+      "type": "object",
+      "required": ["runId"],
+      "properties": {
+        "runId": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "window": {
+      "type": "object",
+      "required": ["count", "from", "to"],
+      "properties": {
+        "count": { "type": "number", "minimum": 0 },
+        "from": { "type": ["string", "null"] },
+        "to": { "type": ["string", "null"] }
+      },
+      "additionalProperties": false
+    },
+    "auditCadence": {
+      "type": "object",
+      "required": ["interval", "countedSlices", "slicesSinceLastAudit", "auditDue", "nextAuditAt"],
+      "properties": {
+        "interval": { "type": "number", "minimum": 1 },
+        "countedSlices": { "type": "number", "minimum": 0 },
+        "slicesSinceLastAudit": { "type": "number", "minimum": 0 },
+        "auditDue": { "type": "boolean" },
+        "nextAuditAt": { "type": "number", "minimum": 1 }
+      },
+      "additionalProperties": false
+    },
+    "counts": {
+      "type": "object",
+      "required": ["completed", "blocked", "failed", "noop", "commandCount", "commandFailures"],
+      "properties": {
+        "completed": { "type": "number", "minimum": 0 },
+        "blocked": { "type": "number", "minimum": 0 },
+        "failed": { "type": "number", "minimum": 0 },
+        "noop": { "type": "number", "minimum": 0 },
+        "commandCount": { "type": "number", "minimum": 0 },
+        "commandFailures": { "type": "number", "minimum": 0 }
+      },
+      "additionalProperties": false
+    },
+    "scores": {
+      "type": "object",
+      "required": ["usefulness", "noOpRate", "verification"],
+      "properties": {
+        "usefulness": { "type": "number", "minimum": 0 },
+        "noOpRate": { "type": "number", "minimum": 0 },
+        "verification": { "type": "number", "minimum": 0 }
+      },
+      "additionalProperties": false
+    },
+    "rows": { "type": "array" }
+  },
+  "additionalProperties": false
+}

--- a/scripts/ops/ops_ci_validate.sh
+++ b/scripts/ops/ops_ci_validate.sh
@@ -42,6 +42,7 @@ check_file "scripts/ops/post_deploy_verify.sh"
 check_file "scripts/ops/validate_ops_artifacts.mjs"
 check_file "scripts/ops/swarm_lane_preflight.mjs"
 check_file "scripts/ops/ops_wave_runner.mjs"
+check_file "scripts/ops/slice_ledger.mjs"
 check_file "docs/ops/17-pr-readiness-packet-template.md"
 check_file "docs/ops/18-release-verification.md"
 
@@ -61,7 +62,8 @@ section "Node Syntax"
 for script in \
   "scripts/ops/validate_ops_artifacts.mjs" \
   "scripts/ops/swarm_lane_preflight.mjs" \
-  "scripts/ops/ops_wave_runner.mjs"; do
+  "scripts/ops/ops_wave_runner.mjs" \
+  "scripts/ops/slice_ledger.mjs"; do
   if [ -f "${REPO_ROOT}/${script}" ] && node --check "${REPO_ROOT}/${script}" >/dev/null; then
     pass "node --check ${script}"
   else
@@ -86,6 +88,12 @@ if node --test "${REPO_ROOT}/scripts/ops/ops_wave_runner.test.mjs" >"${OUT_DIR}/
   pass "node --test scripts/ops/ops_wave_runner.test.mjs"
 else
   fail "node --test scripts/ops/ops_wave_runner.test.mjs"
+fi
+
+if node --test "${REPO_ROOT}/scripts/ops/slice_ledger.test.mjs" >"${OUT_DIR}/slice-ledger.test.out" 2>&1; then
+  pass "node --test scripts/ops/slice_ledger.test.mjs"
+else
+  fail "node --test scripts/ops/slice_ledger.test.mjs"
 fi
 
 section "Swarm Lane Preflight Smoke"

--- a/scripts/ops/slice_ledger.mjs
+++ b/scripts/ops/slice_ledger.mjs
@@ -36,6 +36,7 @@ Usage:
 Options:
   --ledger <path>             Ledger JSONL path. Default: output/ops/effectivity/slice-ledger.jsonl.
   --latest <path>             Latest summary JSON path.
+  --audit-interval <n>        Countable slices between audits. Default: 5.
   --append                    Append one row.
   --summary                   Summarize the last rows. Default when --append is absent.
   --dry-run                   Print the row or summary without writing.
@@ -121,6 +122,7 @@ function parseArgs(argv) {
     ledger: DEFAULT_LEDGER,
     latest: DEFAULT_LATEST,
     last: 5,
+    auditInterval: 5,
     sliceId: "",
     runId: "",
     lane: "",
@@ -167,6 +169,7 @@ function parseArgs(argv) {
       ["--ledger", "ledger"],
       ["--latest", "latest"],
       ["--last", "last"],
+      ["--audit-interval", "auditInterval"],
       ["--slice-id", "sliceId"],
       ["--run-id", "runId"],
       ["--lane", "lane"],
@@ -217,6 +220,7 @@ function parseArgs(argv) {
   options.ledger = resolve(REPO_ROOT, options.ledger);
   options.latest = resolve(REPO_ROOT, options.latest);
   options.last = Math.max(1, Number(options.last) || 5);
+  options.auditInterval = Math.max(1, Number(options.auditInterval) || 5);
   options.usefulnessScore = Math.max(0, Math.min(1, Number(options.usefulnessScore) || 0));
   options.minutesSaved = Math.max(0, Number(options.minutesSaved) || 0);
   return options;
@@ -288,17 +292,36 @@ function compareRows(left, right) {
   return rowTimestamp(left.row) - rowTimestamp(right.row) || left.index - right.index;
 }
 
-function selectRecentRows(rows, last, runId = "") {
+function orderedRows(rows, runId = "") {
   const filtered = clean(runId) ? rows.filter((row) => clean(row.runId) === clean(runId)) : rows;
   return filtered
     .map((row, index) => ({ row, index }))
     .sort(compareRows)
-    .slice(-last)
     .map((entry) => entry.row);
 }
 
-function summarize(rows, last, runId = "") {
-  const selected = selectRecentRows(rows, last, runId);
+function selectRecentRows(rows, last, runId = "") {
+  return orderedRows(rows, runId).slice(-last);
+}
+
+function auditCadence(rows, interval = 5) {
+  const countable = rows.filter((row) => row.status !== "noop" && !row.noOp?.detected);
+  const total = countable.length;
+  const remainder = total % interval;
+  const slicesSinceLastAudit = total === 0 ? 0 : remainder === 0 ? interval : remainder;
+  const auditDue = total > 0 && remainder === 0;
+  return {
+    interval,
+    countedSlices: total,
+    slicesSinceLastAudit,
+    auditDue,
+    nextAuditAt: auditDue ? total : total + (interval - slicesSinceLastAudit)
+  };
+}
+
+function summarize(rows, last, runId = "", auditInterval = 5) {
+  const ordered = orderedRows(rows, runId);
+  const selected = ordered.slice(-last);
   const completed = selected.filter((row) => row.status === "completed").length;
   const blocked = selected.filter((row) => row.status === "blocked").length;
   const failed = selected.filter((row) => row.status === "failed").length;
@@ -320,6 +343,7 @@ function summarize(rows, last, runId = "") {
       from: selected[0]?.sliceId ?? null,
       to: selected[selected.length - 1]?.sliceId ?? null
     },
+    auditCadence: auditCadence(ordered, auditInterval),
     counts: {
       completed,
       blocked,
@@ -340,13 +364,14 @@ function summarize(rows, last, runId = "") {
 function printTextSummary(summary) {
   process.stdout.write(`slice ledger: ${summary.window.count} row(s), ${summary.counts.completed} completed, ${summary.counts.blocked} blocked, ${summary.counts.failed} failed\n`);
   process.stdout.write(`usefulness=${summary.scores.usefulness} noOpRate=${summary.scores.noOpRate} verification=${summary.scores.verification}\n`);
+  process.stdout.write(`auditDue=${summary.auditCadence.auditDue} slicesSinceLastAudit=${summary.auditCadence.slicesSinceLastAudit} nextAuditAt=${summary.auditCadence.nextAuditAt}\n`);
   for (const row of summary.rows) {
     process.stdout.write(`- ${row.sliceId} [${row.status}] ${row.title}\n`);
   }
 }
 
-try {
-  const options = parseArgs(process.argv.slice(2));
+function run(rawArgs = process.argv.slice(2)) {
+  const options = parseArgs(rawArgs);
   if (options.append) {
     const row = buildRow(options);
     if (!options.dryRun) appendJsonl(options.ledger, row);
@@ -358,7 +383,7 @@ try {
   } else {
     const rows = readJsonl(options.ledger);
     rows.ledgerPath = options.ledger;
-    const summary = summarize(rows, options.last, options.runId);
+    const summary = summarize(rows, options.last, options.runId, options.auditInterval);
     if (!options.dryRun) writeJson(options.latest, summary);
     if (options.json) {
       process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
@@ -366,7 +391,15 @@ try {
       printTextSummary(summary);
     }
   }
-} catch (error) {
-  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
-  process.exit(1);
+}
+
+export { auditCadence, buildRow, run, selectRecentRows, summarize };
+
+if (process.argv[1] && resolve(process.argv[1]) === __filename) {
+  try {
+    run();
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exit(1);
+  }
 }

--- a/scripts/ops/slice_ledger.test.mjs
+++ b/scripts/ops/slice_ledger.test.mjs
@@ -1,0 +1,55 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { auditCadence, summarize } from "./slice_ledger.mjs";
+
+function row(id, status = "completed", runId = "run-a") {
+  return {
+    schema: "studiobrain-admin-slice-ledger.v1",
+    sliceId: `slice-20260507-${String(id).padStart(3, "0")}`,
+    runId,
+    lane: "tooling",
+    title: `Slice ${id}`,
+    startedAt: `2026-05-07T00:${String(id).padStart(2, "0")}:00.000Z`,
+    completedAt: `2026-05-07T00:${String(id).padStart(2, "0")}:30.000Z`,
+    status,
+    changedFiles: ["scripts/ops/x.mjs"],
+    commands: [{ command: "node --check x.mjs", status: "pass" }],
+    artifacts: [],
+    usefulness: { score: 0.8, minutesSaved: 1, operatorSignal: "test" },
+    noOp: { detected: status === "noop", reason: status === "noop" ? "test noop" : null },
+    blocker: { class: null, owner: null, safeNextStep: null },
+  };
+}
+
+test("auditCadence is due every five countable slices", () => {
+  assert.deepEqual(auditCadence([], 5), {
+    interval: 5,
+    countedSlices: 0,
+    slicesSinceLastAudit: 0,
+    auditDue: false,
+    nextAuditAt: 5,
+  });
+  assert.equal(auditCadence([1, 2, 3, 4].map(row), 5).auditDue, false);
+  assert.equal(auditCadence([1, 2, 3, 4].map(row), 5).slicesSinceLastAudit, 4);
+  assert.equal(auditCadence([1, 2, 3, 4, 5].map(row), 5).auditDue, true);
+  assert.equal(auditCadence([1, 2, 3, 4, 5, 6].map(row), 5).nextAuditAt, 10);
+});
+
+test("auditCadence ignores no-op rows", () => {
+  const cadence = auditCadence([row(1), row(2, "noop"), row(3), row(4), row(5), row(6)], 5);
+
+  assert.equal(cadence.countedSlices, 5);
+  assert.equal(cadence.auditDue, true);
+});
+
+test("summarize filters cadence by run id while preserving natural slice order", () => {
+  const rows = [row(10, "completed", "other"), row(2), row(1), row(3), row(4), row(5)];
+  rows.ledgerPath = "output/ops/effectivity/slice-ledger.jsonl";
+  const summary = summarize(rows, 5, "run-a", 5);
+
+  assert.equal(summary.window.from, "slice-20260507-001");
+  assert.equal(summary.window.to, "slice-20260507-005");
+  assert.equal(summary.auditCadence.countedSlices, 5);
+  assert.equal(summary.auditCadence.auditDue, true);
+});

--- a/scripts/ops/validate_ops_artifacts.mjs
+++ b/scripts/ops/validate_ops_artifacts.mjs
@@ -24,6 +24,11 @@ const DEFAULT_ARTIFACTS = [
     schema: "schemas/ops/admin-effectivity-audit.v1.schema.json",
   },
   {
+    id: "slice-ledger-summary",
+    artifact: "output/ops/effectivity/slice-ledger-latest.json",
+    schema: "schemas/ops/slice-ledger-summary.v1.schema.json",
+  },
+  {
     id: "ops-work-packet",
     artifact: "output/ops/swarm/latest-work-packet.json",
     schema: "schemas/ops/ops-work-packet.v1.schema.json",


### PR DESCRIPTION
## Summary
- add auditCadence to slice ledger summaries with auditDue, slicesSinceLastAudit, nextAuditAt, and counted slice total
- export slice ledger functions and add focused regression tests
- add a schema for slice-ledger summary artifacts and include it in artifact validation
- wire slice ledger syntax/tests into ops_ci_validate and document the cadence signal

## Evidence
- Current admin-infra run reports countedSlices=38, slicesSinceLastAudit=3, auditDue=false, nextAuditAt=40.
- Artifact validation now checks 8 ops artifact contracts including slice-ledger summary.

## Testing
- node --check scripts/ops/slice_ledger.mjs
- node --test scripts/ops/slice_ledger.test.mjs scripts/ops/validate_ops_artifacts.test.mjs scripts/ops/ops_wave_runner.test.mjs
- node scripts/ops/slice_ledger.mjs --summary --last 5 --run-id admin-infra-20260507 --json
- node scripts/ops/validate_ops_artifacts.mjs --json --write
- bash scripts/ops/ops_ci_validate.sh
- git diff --check

## Risk
Low. Ledger summary/schema/test changes only; no host, Docker, database, package, firewall, restart, or cleanup action.

## Rollback
Revert this commit to remove audit cadence fields and the summary schema. Existing ledger append/summary behavior otherwise remains straightforward.

## Follow-ups
- Feed auditCadence into work-packet ranking and wave-runner nextRecommendedAction.
- At slice 40, run the five-slice effectivity audit automatically through the ordered wave.