### PR TITLE
[ops] Add actionlint tooling quality mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ OPS_SWARM_LANE ?= tooling
 OPS_SWARM_BASE ?= origin/main
 OPS_SWARM_PREFLIGHT_FLAGS ?=
 
-.PHONY: ops-check ops-inventory ops-postgres-review ops-postgres-sql ops-postgres-top-queries ops-postgres-query-tasks ops-postgres-growth-snapshot ops-postgres-autovacuum-stats ops-postgres-roles-extensions ops-docker-review ops-docker-posture ops-capacity ops-import-pressure ops-cleanup-candidates ops-backup-evidence ops-postgres-backup-artifacts ops-restore-prereq ops-redis-minio-backup-evidence ops-ubuntu-review ops-host-failed-unit-trends ops-package-posture ops-time-sync ops-network-review ops-host-drift ops-systemd-drift ops-portal-bridge-review ops-app-review ops-dependency-review ops-idle-worker-effectivity ops-effectivity-report ops-slice-ledger ops-tool-inventory ops-admin-effectivity-audit ops-tooling-quality ops-shell-lf-guard ops-shellcheck-report ops-powershell-syntax ops-sql-parse-report ops-validate-artifacts ops-swarm-lane-preflight ops-wave-runner ops-privileged-evidence-read ops-privileged-evidence-capture ops-privileged-evidence-capture-smoke ops-work-packet ops-incident-bundle ops-incident-bundle-v2 ops-ci-validate ops-post-deploy-verify ops-docs ops-backlog ops-report
+.PHONY: ops-check ops-inventory ops-postgres-review ops-postgres-sql ops-postgres-top-queries ops-postgres-query-tasks ops-postgres-growth-snapshot ops-postgres-autovacuum-stats ops-postgres-roles-extensions ops-docker-review ops-docker-posture ops-capacity ops-import-pressure ops-cleanup-candidates ops-backup-evidence ops-postgres-backup-artifacts ops-restore-prereq ops-redis-minio-backup-evidence ops-ubuntu-review ops-host-failed-unit-trends ops-package-posture ops-time-sync ops-network-review ops-host-drift ops-systemd-drift ops-portal-bridge-review ops-app-review ops-dependency-review ops-idle-worker-effectivity ops-effectivity-report ops-slice-ledger ops-tool-inventory ops-admin-effectivity-audit ops-tooling-quality ops-shell-lf-guard ops-shellcheck-report ops-powershell-syntax ops-sql-parse-report ops-actionlint-report ops-validate-artifacts ops-swarm-lane-preflight ops-wave-runner ops-privileged-evidence-read ops-privileged-evidence-capture ops-privileged-evidence-capture-smoke ops-work-packet ops-incident-bundle ops-incident-bundle-v2 ops-ci-validate ops-post-deploy-verify ops-docs ops-backlog ops-report
 
 ops-check: ops-inventory ops-docker-review ops-capacity ops-cleanup-candidates ops-backup-evidence ops-ubuntu-review ops-network-review ops-host-drift ops-systemd-drift ops-portal-bridge-review ops-app-review
 
@@ -138,6 +138,9 @@ ops-powershell-syntax:
 
 ops-sql-parse-report:
 	node scripts/ops/tooling_quality_report.mjs --mode sqlfluff --write $(OPS_TOOLING_QUALITY_FLAGS)
+
+ops-actionlint-report:
+	node scripts/ops/tooling_quality_report.mjs --mode actionlint --write $(OPS_TOOLING_QUALITY_FLAGS)
 
 ops-validate-artifacts:
 	node scripts/ops/validate_ops_artifacts.mjs --write

--- a/docs/ops/tooling-quality-gates.md
+++ b/docs/ops/tooling-quality-gates.md
@@ -23,6 +23,7 @@ The Makefile wrapper keeps installs off by default. Use `make ops-tooling-qualit
 - `shellcheck`: runs `shellcheck -f json -S warning` when installed. With `--allow-install`, it can use `npx --yes shellcheck` and stores structured file/line/code findings.
 - `powershell`: parses tracked `.ps1` files with `pwsh` or Windows PowerShell.
 - `sqlfluff`: runs PostgreSQL parser checks when `sqlfluff` is installed. With `--allow-install`, it can use `uv tool run --from sqlfluff`.
+- `actionlint`: validates tracked GitHub Actions workflow YAML when `actionlint` is installed. With `--allow-install`, it can use `go run github.com/rhysd/actionlint/cmd/actionlint@latest` if Go is available.
 
 ## Promotion Rule
 
@@ -35,6 +36,6 @@ Keep new validators report-only until they prove useful over about five slices:
 
 ## Current Expected Findings
 
-The first local inventory found required tools present, but optional Docker, make, ShellCheck, gitleaks, sqlfluff, actionlint, and shfmt were missing. The tooling quality report should therefore treat missing ShellCheck or SQLFluff as `skipped` unless `--allow-install` is explicit.
+The first local inventory found required tools present, but optional Docker, make, ShellCheck, gitleaks, sqlfluff, actionlint, and shfmt were missing. The tooling quality report should therefore treat missing ShellCheck, SQLFluff, or actionlint as `skipped` unless `--allow-install` is explicit.
 
 The first useful signal from this gate was not theoretical: ShellCheck and the LF guard both surfaced CRLF bytes in Ubuntu-targeted shell scripts. Treat that as a follow-up cleanup slice with reviewable line-ending policy, not as an automatic broad rewrite.

--- a/schemas/ops/tooling-quality-report.v1.schema.json
+++ b/schemas/ops/tooling-quality-report.v1.schema.json
@@ -7,7 +7,7 @@
   "properties": {
     "schema": { "const": "studiobrain-ops-tooling-quality-report.v1" },
     "generatedAt": { "type": "string", "format": "date-time" },
-    "mode": { "enum": ["all", "shell-lf", "shellcheck", "powershell", "sqlfluff"] },
+    "mode": { "enum": ["all", "shell-lf", "shellcheck", "powershell", "sqlfluff", "actionlint"] },
     "allowInstall": { "type": "boolean" },
     "status": { "enum": ["pass", "warn", "fail"] },
     "summary": {
@@ -26,7 +26,7 @@
         "type": "object",
         "required": ["id", "status", "tool", "checkedFiles", "findings"],
         "properties": {
-          "id": { "enum": ["shell-lf", "shellcheck", "powershell", "sqlfluff"] },
+          "id": { "enum": ["shell-lf", "shellcheck", "powershell", "sqlfluff", "actionlint"] },
           "status": { "enum": ["pass", "warn", "fail", "skipped"] },
           "tool": { "type": "string" },
           "checkedFiles": { "type": "integer", "minimum": 0 },

--- a/scripts/ops/installed_tool_inventory.mjs
+++ b/scripts/ops/installed_tool_inventory.mjs
@@ -233,6 +233,7 @@ function effectivityFromToolingReport(report) {
   assign("pwsh", sections.find((section) => section.id === "powershell"));
   assign("powershell", sections.find((section) => section.id === "powershell"));
   assign("sqlfluff", sections.find((section) => section.id === "sqlfluff"));
+  assign("actionlint", sections.find((section) => section.id === "actionlint"));
   byTool.uv = runnerEffectivity("uv", sections.find((section) => section.id === "sqlfluff"));
   byTool.npx = runnerEffectivity("npx", sections.find((section) => section.id === "shellcheck"));
   return byTool;

--- a/scripts/ops/installed_tool_inventory.test.mjs
+++ b/scripts/ops/installed_tool_inventory.test.mjs
@@ -22,7 +22,8 @@ test("effectivityFromToolingReport maps findings to tool usefulness", () => {
     sections: [
       { id: "shell-lf", status: "fail", findings: [{ code: "CRLF" }, { code: "CRLF" }] },
       { id: "shellcheck", status: "warn", findings: [{ code: "SC1017" }] },
-      { id: "sqlfluff", status: "pass", findings: [] }
+      { id: "sqlfluff", status: "pass", findings: [] },
+      { id: "actionlint", status: "warn", findings: [{ code: "expression" }] }
     ]
   });
 
@@ -30,6 +31,8 @@ test("effectivityFromToolingReport maps findings to tool usefulness", () => {
   assert.equal(effectivity.node.promotionState, "candidate");
   assert.equal(effectivity.shellcheck.actionableFindings, 1);
   assert.equal(effectivity.sqlfluff.promotionState, "report_only");
+  assert.equal(effectivity.actionlint.actionableFindings, 1);
+  assert.equal(effectivity.actionlint.promotionState, "candidate");
   assert.equal(effectivity.uv.observed, true);
   assert.equal(effectivity.uv.actionableFindings, 0);
   assert.equal(effectivity.npx.actionableFindings, 0);

--- a/scripts/ops/tooling_quality_report.mjs
+++ b/scripts/ops/tooling_quality_report.mjs
@@ -8,7 +8,7 @@ import { fileURLToPath } from "node:url";
 const __filename = fileURLToPath(import.meta.url);
 const REPO_ROOT = resolve(dirname(__filename), "..", "..");
 const DEFAULT_OUTPUT_DIR = resolve(REPO_ROOT, "output", "ops", "tooling-quality");
-const MODES = new Set(["all", "shell-lf", "shellcheck", "powershell", "sqlfluff"]);
+const MODES = new Set(["all", "shell-lf", "shellcheck", "powershell", "sqlfluff", "actionlint"]);
 
 function usage() {
   return `Studio Brain ops tooling quality report
@@ -17,7 +17,7 @@ Usage:
   node scripts/ops/tooling_quality_report.mjs [--mode all] [--json] [--write]
 
 Options:
-  --mode <mode>       all, shell-lf, shellcheck, powershell, sqlfluff. Default: all.
+  --mode <mode>       all, shell-lf, shellcheck, powershell, sqlfluff, actionlint. Default: all.
   --json              Print JSON to stdout.
   --write             Write JSON and Markdown artifacts under output/ops/tooling-quality.
   --output-dir <path> Artifact directory.
@@ -322,6 +322,61 @@ function sqlfluffReport(options) {
   };
 }
 
+function parseActionlintOutput(output) {
+  const findings = [];
+  for (const line of clean(output).split(/\r?\n/)) {
+    const match = /^(.+?):(\d+):(\d+):\s+(.+?)(?:\s+\[([^\]]+)])?$/.exec(line.trim());
+    if (!match) continue;
+    findings.push({
+      file: match[1],
+      line: Number(match[2]),
+      column: Number(match[3]),
+      code: match[5] || "actionlint",
+      message: match[4]
+    });
+    if (findings.length >= 200) break;
+  }
+  return findings;
+}
+
+function actionlintReport(options) {
+  const files = limited(gitFiles((file) => /^\.github\/workflows\/.+\.ya?ml$/i.test(file)), options.limit);
+  if (files.length === 0) return { id: "actionlint", status: "pass", tool: "actionlint", checkedFiles: 0, findings: [] };
+  let command = "";
+  let args = [];
+  let tool = "actionlint";
+  if (commandExists("actionlint")) {
+    command = commandExecutable("actionlint");
+    args = files;
+  } else if (options.allowInstall && commandExists("go")) {
+    command = commandExecutable("go");
+    args = ["run", "github.com/rhysd/actionlint/cmd/actionlint@latest", ...files];
+    tool = "go run actionlint";
+  } else {
+    return {
+      id: "actionlint",
+      status: "skipped",
+      tool: "actionlint",
+      checkedFiles: 0,
+      findings: [{ code: "tool_missing", message: "actionlint is not installed; rerun with --allow-install to use go run actionlint when Go is available." }]
+    };
+  }
+  const result = run(command, args, { timeoutMs: 120_000, maxOutput: 40_000 });
+  const findings = parseActionlintOutput(`${result.stdout}\n${result.stderr}`);
+  if (!result.ok && findings.length === 0) {
+    findings.push({ code: "actionlint_failed", message: result.error || `actionlint exited ${result.status} without parseable findings` });
+  }
+  return {
+    id: "actionlint",
+    status: findings.length > 0 ? "warn" : "pass",
+    tool,
+    checkedFiles: files.length,
+    command: result.command,
+    findings,
+    ...(result.ok || findings.length > 0 ? {} : { outputPreview: (result.stdout || result.stderr).slice(0, 12000) })
+  };
+}
+
 function statusFromSections(sections) {
   if (sections.some((section) => section.status === "fail")) return "fail";
   if (sections.some((section) => section.status === "warn" || section.status === "skipped")) return "warn";
@@ -372,6 +427,7 @@ function buildReport(options) {
   if (options.mode === "all" || options.mode === "shellcheck") sections.push(shellcheckReport(options));
   if (options.mode === "all" || options.mode === "powershell") sections.push(powershellSyntaxReport(options));
   if (options.mode === "all" || options.mode === "sqlfluff") sections.push(sqlfluffReport(options));
+  if (options.mode === "all" || options.mode === "actionlint") sections.push(actionlintReport(options));
   const summary = {
     checkedFiles: sections.reduce((sum, section) => sum + section.checkedFiles, 0),
     findings: sections.reduce((sum, section) => sum + section.findings.length, 0),
@@ -408,6 +464,7 @@ export {
   buildReport,
   main,
   parseArgs,
+  parseActionlintOutput,
   parseShellCheckJson,
   statusFromSections
 };

--- a/scripts/ops/tooling_quality_report.test.mjs
+++ b/scripts/ops/tooling_quality_report.test.mjs
@@ -6,6 +6,7 @@ import { resolve } from "node:path";
 import {
   buildReport,
   parseArgs,
+  parseActionlintOutput,
   parseShellCheckJson,
   statusFromSections
 } from "./tooling_quality_report.mjs";
@@ -35,12 +36,26 @@ function assertReportContract(report) {
 }
 
 test("parseArgs accepts explicit modes and allow-install flag", () => {
-  const options = parseArgs(["--mode", "shellcheck", "--allow-install", "--limit=2", "--json"]);
+  const options = parseArgs(["--mode", "actionlint", "--allow-install", "--limit=2", "--json"]);
 
-  assert.equal(options.mode, "shellcheck");
+  assert.equal(options.mode, "actionlint");
   assert.equal(options.allowInstall, true);
   assert.equal(options.limit, 2);
   assert.equal(options.json, true);
+});
+
+test("parseActionlintOutput extracts structured workflow findings", () => {
+  const findings = parseActionlintOutput(".github/workflows/ci.yml:12:7: property \"foo\" is not defined [expression]");
+
+  assert.deepEqual(findings, [
+    {
+      file: ".github/workflows/ci.yml",
+      line: 12,
+      column: 7,
+      code: "expression",
+      message: "property \"foo\" is not defined"
+    }
+  ]);
 });
 
 test("parseShellCheckJson extracts structured findings", () => {


### PR DESCRIPTION
## Summary
- add report-only actionlint mode to the ops tooling quality report
- parse actionlint file/line/column/rule findings into structured output
- map actionlint sections into installed-tool effectivity and schema validation
- add a Makefile wrapper and docs for optional allow-install behavior

## Evidence
- Local actionlint mode currently reports skipped because actionlint and Go are not installed, which is expected and explicit.
- Full tooling-quality all mode now includes actionlint alongside shell LF, shellcheck, PowerShell parse, and SQLFluff.

## Testing
- node --check scripts/ops/tooling_quality_report.mjs
- node --test scripts/ops/tooling_quality_report.test.mjs scripts/ops/installed_tool_inventory.test.mjs scripts/ops/validate_ops_artifacts.test.mjs
- node scripts/ops/tooling_quality_report.mjs --mode actionlint --json --write
- node scripts/ops/tooling_quality_report.mjs --mode all --json --write
- node scripts/ops/installed_tool_inventory.mjs --json --write
- node scripts/ops/validate_ops_artifacts.mjs --json --write
- bash scripts/ops/ops_ci_validate.sh
- git diff --check

## Risk
Low. Report-only tooling expansion; no workflow mutation, package installation, host action, Docker action, DB action, restart, or cleanup.

## Rollback
Revert this commit to remove actionlint mode/schema/docs. Existing tooling quality modes remain available.

## Follow-ups
- Add Docker Compose rendered-config validation as a skipped-when-Docker-missing report-only gate.
- Consider installing actionlint/Go only if the next five-slice usefulness audit shows enough workflow risk to justify it.