### PR TITLE
[ops] Add compose config tooling quality mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ OPS_SWARM_LANE ?= tooling
 OPS_SWARM_BASE ?= origin/main
 OPS_SWARM_PREFLIGHT_FLAGS ?=
 
-.PHONY: ops-check ops-inventory ops-postgres-review ops-postgres-sql ops-postgres-top-queries ops-postgres-query-tasks ops-postgres-growth-snapshot ops-postgres-autovacuum-stats ops-postgres-roles-extensions ops-docker-review ops-docker-posture ops-capacity ops-import-pressure ops-cleanup-candidates ops-backup-evidence ops-postgres-backup-artifacts ops-restore-prereq ops-redis-minio-backup-evidence ops-ubuntu-review ops-host-failed-unit-trends ops-package-posture ops-time-sync ops-network-review ops-host-drift ops-systemd-drift ops-portal-bridge-review ops-app-review ops-dependency-review ops-idle-worker-effectivity ops-effectivity-report ops-slice-ledger ops-tool-inventory ops-admin-effectivity-audit ops-tooling-quality ops-shell-lf-guard ops-shellcheck-report ops-powershell-syntax ops-sql-parse-report ops-actionlint-report ops-validate-artifacts ops-swarm-lane-preflight ops-wave-runner ops-privileged-evidence-read ops-privileged-evidence-capture ops-privileged-evidence-capture-smoke ops-work-packet ops-incident-bundle ops-incident-bundle-v2 ops-ci-validate ops-post-deploy-verify ops-docs ops-backlog ops-report
+.PHONY: ops-check ops-inventory ops-postgres-review ops-postgres-sql ops-postgres-top-queries ops-postgres-query-tasks ops-postgres-growth-snapshot ops-postgres-autovacuum-stats ops-postgres-roles-extensions ops-docker-review ops-docker-posture ops-capacity ops-import-pressure ops-cleanup-candidates ops-backup-evidence ops-postgres-backup-artifacts ops-restore-prereq ops-redis-minio-backup-evidence ops-ubuntu-review ops-host-failed-unit-trends ops-package-posture ops-time-sync ops-network-review ops-host-drift ops-systemd-drift ops-portal-bridge-review ops-app-review ops-dependency-review ops-idle-worker-effectivity ops-effectivity-report ops-slice-ledger ops-tool-inventory ops-admin-effectivity-audit ops-tooling-quality ops-shell-lf-guard ops-shellcheck-report ops-powershell-syntax ops-sql-parse-report ops-actionlint-report ops-compose-config-report ops-validate-artifacts ops-swarm-lane-preflight ops-wave-runner ops-privileged-evidence-read ops-privileged-evidence-capture ops-privileged-evidence-capture-smoke ops-work-packet ops-incident-bundle ops-incident-bundle-v2 ops-ci-validate ops-post-deploy-verify ops-docs ops-backlog ops-report
 
 ops-check: ops-inventory ops-docker-review ops-capacity ops-cleanup-candidates ops-backup-evidence ops-ubuntu-review ops-network-review ops-host-drift ops-systemd-drift ops-portal-bridge-review ops-app-review
 
@@ -141,6 +141,9 @@ ops-sql-parse-report:
 
 ops-actionlint-report:
 	node scripts/ops/tooling_quality_report.mjs --mode actionlint --write $(OPS_TOOLING_QUALITY_FLAGS)
+
+ops-compose-config-report:
+	node scripts/ops/tooling_quality_report.mjs --mode compose-config --write $(OPS_TOOLING_QUALITY_FLAGS)
 
 ops-validate-artifacts:
 	node scripts/ops/validate_ops_artifacts.mjs --write

--- a/docs/ops/tooling-quality-gates.md
+++ b/docs/ops/tooling-quality-gates.md
@@ -24,6 +24,7 @@ The Makefile wrapper keeps installs off by default. Use `make ops-tooling-qualit
 - `powershell`: parses tracked `.ps1` files with `pwsh` or Windows PowerShell.
 - `sqlfluff`: runs PostgreSQL parser checks when `sqlfluff` is installed. With `--allow-install`, it can use `uv tool run --from sqlfluff`.
 - `actionlint`: validates tracked GitHub Actions workflow YAML when `actionlint` is installed. With `--allow-install`, it can use `go run github.com/rhysd/actionlint/cmd/actionlint@latest` if Go is available.
+- `compose-config`: renders tracked Docker Compose files with `docker compose config --quiet` when Docker is installed. This validates configuration only; it does not pull images, start services, restart containers, prune artifacts, or contact the Docker daemon for lifecycle changes.
 
 ## Promotion Rule
 
@@ -36,6 +37,6 @@ Keep new validators report-only until they prove useful over about five slices:
 
 ## Current Expected Findings
 
-The first local inventory found required tools present, but optional Docker, make, ShellCheck, gitleaks, sqlfluff, actionlint, and shfmt were missing. The tooling quality report should therefore treat missing ShellCheck, SQLFluff, or actionlint as `skipped` unless `--allow-install` is explicit.
+The first local inventory found required tools present, but optional Docker, make, ShellCheck, gitleaks, sqlfluff, actionlint, and shfmt were missing. The tooling quality report should therefore treat missing Docker/Compose, ShellCheck, SQLFluff, or actionlint as `skipped` unless a useful local install path is explicit.
 
 The first useful signal from this gate was not theoretical: ShellCheck and the LF guard both surfaced CRLF bytes in Ubuntu-targeted shell scripts. Treat that as a follow-up cleanup slice with reviewable line-ending policy, not as an automatic broad rewrite.

--- a/schemas/ops/tooling-quality-report.v1.schema.json
+++ b/schemas/ops/tooling-quality-report.v1.schema.json
@@ -7,7 +7,7 @@
   "properties": {
     "schema": { "const": "studiobrain-ops-tooling-quality-report.v1" },
     "generatedAt": { "type": "string", "format": "date-time" },
-    "mode": { "enum": ["all", "shell-lf", "shellcheck", "powershell", "sqlfluff", "actionlint"] },
+    "mode": { "enum": ["all", "shell-lf", "shellcheck", "powershell", "sqlfluff", "actionlint", "compose-config"] },
     "allowInstall": { "type": "boolean" },
     "status": { "enum": ["pass", "warn", "fail"] },
     "summary": {
@@ -26,7 +26,7 @@
         "type": "object",
         "required": ["id", "status", "tool", "checkedFiles", "findings"],
         "properties": {
-          "id": { "enum": ["shell-lf", "shellcheck", "powershell", "sqlfluff", "actionlint"] },
+          "id": { "enum": ["shell-lf", "shellcheck", "powershell", "sqlfluff", "actionlint", "compose-config"] },
           "status": { "enum": ["pass", "warn", "fail", "skipped"] },
           "tool": { "type": "string" },
           "checkedFiles": { "type": "integer", "minimum": 0 },

--- a/scripts/ops/installed_tool_inventory.mjs
+++ b/scripts/ops/installed_tool_inventory.mjs
@@ -234,6 +234,7 @@ function effectivityFromToolingReport(report) {
   assign("powershell", sections.find((section) => section.id === "powershell"));
   assign("sqlfluff", sections.find((section) => section.id === "sqlfluff"));
   assign("actionlint", sections.find((section) => section.id === "actionlint"));
+  assign("docker", sections.find((section) => section.id === "compose-config"));
   byTool.uv = runnerEffectivity("uv", sections.find((section) => section.id === "sqlfluff"));
   byTool.npx = runnerEffectivity("npx", sections.find((section) => section.id === "shellcheck"));
   return byTool;

--- a/scripts/ops/installed_tool_inventory.test.mjs
+++ b/scripts/ops/installed_tool_inventory.test.mjs
@@ -23,7 +23,8 @@ test("effectivityFromToolingReport maps findings to tool usefulness", () => {
       { id: "shell-lf", status: "fail", findings: [{ code: "CRLF" }, { code: "CRLF" }] },
       { id: "shellcheck", status: "warn", findings: [{ code: "SC1017" }] },
       { id: "sqlfluff", status: "pass", findings: [] },
-      { id: "actionlint", status: "warn", findings: [{ code: "expression" }] }
+      { id: "actionlint", status: "warn", findings: [{ code: "expression" }] },
+      { id: "compose-config", status: "warn", findings: [{ code: "compose_config_failed" }] }
     ]
   });
 
@@ -33,6 +34,8 @@ test("effectivityFromToolingReport maps findings to tool usefulness", () => {
   assert.equal(effectivity.sqlfluff.promotionState, "report_only");
   assert.equal(effectivity.actionlint.actionableFindings, 1);
   assert.equal(effectivity.actionlint.promotionState, "candidate");
+  assert.equal(effectivity.docker.actionableFindings, 1);
+  assert.equal(effectivity.docker.promotionState, "candidate");
   assert.equal(effectivity.uv.observed, true);
   assert.equal(effectivity.uv.actionableFindings, 0);
   assert.equal(effectivity.npx.actionableFindings, 0);

--- a/scripts/ops/ops_ci_validate.sh
+++ b/scripts/ops/ops_ci_validate.sh
@@ -43,6 +43,8 @@ check_file "scripts/ops/validate_ops_artifacts.mjs"
 check_file "scripts/ops/swarm_lane_preflight.mjs"
 check_file "scripts/ops/ops_wave_runner.mjs"
 check_file "scripts/ops/slice_ledger.mjs"
+check_file "scripts/ops/tooling_quality_report.mjs"
+check_file "scripts/ops/installed_tool_inventory.mjs"
 check_file "docs/ops/17-pr-readiness-packet-template.md"
 check_file "docs/ops/18-release-verification.md"
 
@@ -63,7 +65,9 @@ for script in \
   "scripts/ops/validate_ops_artifacts.mjs" \
   "scripts/ops/swarm_lane_preflight.mjs" \
   "scripts/ops/ops_wave_runner.mjs" \
-  "scripts/ops/slice_ledger.mjs"; do
+  "scripts/ops/slice_ledger.mjs" \
+  "scripts/ops/tooling_quality_report.mjs" \
+  "scripts/ops/installed_tool_inventory.mjs"; do
   if [ -f "${REPO_ROOT}/${script}" ] && node --check "${REPO_ROOT}/${script}" >/dev/null; then
     pass "node --check ${script}"
   else
@@ -94,6 +98,18 @@ if node --test "${REPO_ROOT}/scripts/ops/slice_ledger.test.mjs" >"${OUT_DIR}/sli
   pass "node --test scripts/ops/slice_ledger.test.mjs"
 else
   fail "node --test scripts/ops/slice_ledger.test.mjs"
+fi
+
+if node --test "${REPO_ROOT}/scripts/ops/tooling_quality_report.test.mjs" >"${OUT_DIR}/tooling-quality-report.test.out" 2>&1; then
+  pass "node --test scripts/ops/tooling_quality_report.test.mjs"
+else
+  fail "node --test scripts/ops/tooling_quality_report.test.mjs"
+fi
+
+if node --test "${REPO_ROOT}/scripts/ops/installed_tool_inventory.test.mjs" >"${OUT_DIR}/installed-tool-inventory.test.out" 2>&1; then
+  pass "node --test scripts/ops/installed_tool_inventory.test.mjs"
+else
+  fail "node --test scripts/ops/installed_tool_inventory.test.mjs"
 fi
 
 section "Swarm Lane Preflight Smoke"

--- a/scripts/ops/tooling_quality_report.mjs
+++ b/scripts/ops/tooling_quality_report.mjs
@@ -8,7 +8,7 @@ import { fileURLToPath } from "node:url";
 const __filename = fileURLToPath(import.meta.url);
 const REPO_ROOT = resolve(dirname(__filename), "..", "..");
 const DEFAULT_OUTPUT_DIR = resolve(REPO_ROOT, "output", "ops", "tooling-quality");
-const MODES = new Set(["all", "shell-lf", "shellcheck", "powershell", "sqlfluff", "actionlint"]);
+const MODES = new Set(["all", "shell-lf", "shellcheck", "powershell", "sqlfluff", "actionlint", "compose-config"]);
 
 function usage() {
   return `Studio Brain ops tooling quality report
@@ -17,7 +17,7 @@ Usage:
   node scripts/ops/tooling_quality_report.mjs [--mode all] [--json] [--write]
 
 Options:
-  --mode <mode>       all, shell-lf, shellcheck, powershell, sqlfluff, actionlint. Default: all.
+  --mode <mode>       all, shell-lf, shellcheck, powershell, sqlfluff, actionlint, compose-config. Default: all.
   --json              Print JSON to stdout.
   --write             Write JSON and Markdown artifacts under output/ops/tooling-quality.
   --output-dir <path> Artifact directory.
@@ -377,6 +377,39 @@ function actionlintReport(options) {
   };
 }
 
+function composeConfigReport(options) {
+  const files = limited(gitFiles((file) => /(^|\/)(docker-compose|compose)(\.[^/]+)?\.ya?ml$/i.test(file)), options.limit);
+  if (files.length === 0) return { id: "compose-config", status: "pass", tool: "docker compose", checkedFiles: 0, findings: [] };
+  if (!commandExists("docker")) {
+    return {
+      id: "compose-config",
+      status: "skipped",
+      tool: "docker compose",
+      checkedFiles: 0,
+      findings: [{ code: "tool_missing", message: `docker is not installed; ${files.length} compose file(s) were not rendered.` }]
+    };
+  }
+  const command = commandExecutable("docker");
+  const findings = [];
+  for (const file of files) {
+    const result = run(command, ["compose", "-f", file, "config", "--quiet"], { timeoutMs: 60_000, maxOutput: 12_000 });
+    if (!result.ok) {
+      findings.push({
+        file,
+        code: "compose_config_failed",
+        message: result.stderr || result.stdout || result.error || "docker compose config failed."
+      });
+    }
+  }
+  return {
+    id: "compose-config",
+    status: findings.length > 0 ? "warn" : "pass",
+    tool: "docker compose config --quiet",
+    checkedFiles: files.length,
+    findings
+  };
+}
+
 function statusFromSections(sections) {
   if (sections.some((section) => section.status === "fail")) return "fail";
   if (sections.some((section) => section.status === "warn" || section.status === "skipped")) return "warn";
@@ -428,6 +461,7 @@ function buildReport(options) {
   if (options.mode === "all" || options.mode === "powershell") sections.push(powershellSyntaxReport(options));
   if (options.mode === "all" || options.mode === "sqlfluff") sections.push(sqlfluffReport(options));
   if (options.mode === "all" || options.mode === "actionlint") sections.push(actionlintReport(options));
+  if (options.mode === "all" || options.mode === "compose-config") sections.push(composeConfigReport(options));
   const summary = {
     checkedFiles: sections.reduce((sum, section) => sum + section.checkedFiles, 0),
     findings: sections.reduce((sum, section) => sum + section.findings.length, 0),

--- a/scripts/ops/tooling_quality_report.test.mjs
+++ b/scripts/ops/tooling_quality_report.test.mjs
@@ -36,9 +36,9 @@ function assertReportContract(report) {
 }
 
 test("parseArgs accepts explicit modes and allow-install flag", () => {
-  const options = parseArgs(["--mode", "actionlint", "--allow-install", "--limit=2", "--json"]);
+  const options = parseArgs(["--mode", "compose-config", "--allow-install", "--limit=2", "--json"]);
 
-  assert.equal(options.mode, "actionlint");
+  assert.equal(options.mode, "compose-config");
   assert.equal(options.allowInstall, true);
   assert.equal(options.limit, 2);
   assert.equal(options.json, true);
@@ -102,4 +102,21 @@ test("buildReport emits the documented tooling quality schema", () => {
   assert.equal(report.mode, "shell-lf");
   assert.equal(report.sections.length, 1);
   assert.equal(report.sections[0].id, "shell-lf");
+});
+
+test("buildReport emits a compose config section without starting services", () => {
+  const report = buildReport({
+    mode: "compose-config",
+    json: true,
+    write: false,
+    outputDir: resolve("output/ops/tooling-quality"),
+    allowInstall: false,
+    limit: 1
+  });
+
+  assertReportContract(report);
+  assert.equal(report.mode, "compose-config");
+  assert.equal(report.sections.length, 1);
+  assert.equal(report.sections[0].id, "compose-config");
+  assert.equal(report.sections[0].tool.includes("docker compose"), true);
 });


### PR DESCRIPTION
## Summary
- add report-only Docker Compose rendered-config validation to the ops tooling quality report
- expose compose-config through Makefile, schema, docs, installed-tool effectivity, and ops CI validation
- keep missing Docker explicit as a skipped/tool_missing evidence lane instead of claiming coverage

## Evidence
- local report found 3 tracked compose files but Docker is not installed here, so compose validation is skipped with tool_missing
- slice ledger slice-20260507-040 recorded the warning and safe next step
- five-slice admin effectivity audit passed: usefulness 0.854, verification 1.0, no-op rate 0

## Testing
- node --check scripts/ops/tooling_quality_report.mjs
- node --test scripts/ops/tooling_quality_report.test.mjs scripts/ops/installed_tool_inventory.test.mjs scripts/ops/validate_ops_artifacts.test.mjs
- node scripts/ops/tooling_quality_report.mjs --mode compose-config --json --write
- node scripts/ops/tooling_quality_report.mjs --mode all --json --write
- node scripts/ops/installed_tool_inventory.mjs --json --write
- node scripts/ops/validate_ops_artifacts.mjs --json --write
- bash scripts/ops/ops_ci_validate.sh
- git diff --check

## Risk
Low. Read-only validation only; does not start, restart, pull, prune, or mutate Docker resources.

## Rollback
Revert commit 152f7998 to remove the compose-config mode and Makefile wrapper.

## Follow-up
- run this report on a Docker-capable lane or install Docker only after confirming the report materially improves ops effectiveness
- keep compose-config report-only until it catches real compose defects with tolerable noise