### PR TITLE
[ops] Classify missing validators as coverage gaps

### DIFF
--- a/docs/ops/tooling-quality-gates.md
+++ b/docs/ops/tooling-quality-gates.md
@@ -32,8 +32,9 @@ Keep new validators report-only until they prove useful over about five slices:
 
 1. Count actionable findings fixed.
 2. Count false positives or style-only noise.
-3. Record whether the check prevented a broken script, failed CI run, unsafe recommendation, or operator confusion.
-4. Promote to required only after it catches real defects with tolerable noise.
+3. Count coverage gaps separately when a validator is missing; a missing tool is useful evidence, but it is not a caught defect and should not claim minutes saved.
+4. Record whether the check prevented a broken script, failed CI run, unsafe recommendation, or operator confusion.
+5. Promote to required only after it catches real defects with tolerable noise.
 
 ## Current Expected Findings
 

--- a/schemas/ops/installed-tool-inventory.v1.schema.json
+++ b/schemas/ops/installed-tool-inventory.v1.schema.json
@@ -16,6 +16,7 @@
         "missingOptional": { "type": "integer", "minimum": 0 },
         "shadowed": { "type": "integer", "minimum": 0 },
         "actionableFindings": { "type": "integer", "minimum": 0 },
+        "coverageGaps": { "type": "integer", "minimum": 0 },
         "falsePositiveCount": { "type": "integer", "minimum": 0 },
         "minutesSaved": { "type": "integer", "minimum": 0 },
         "promotionCandidates": { "type": "integer", "minimum": 0 }
@@ -59,9 +60,10 @@
             "properties": {
               "observed": { "type": "boolean" },
               "actionableFindings": { "type": "integer", "minimum": 0 },
+              "coverageGaps": { "type": "integer", "minimum": 0 },
               "falsePositiveCount": { "type": "integer", "minimum": 0 },
               "minutesSaved": { "type": "integer", "minimum": 0 },
-              "promotionState": { "enum": ["required", "optional_missing", "not_observed", "candidate", "report_only"] },
+              "promotionState": { "enum": ["required", "optional_missing", "not_observed", "candidate", "report_only", "coverage_gap"] },
               "evidence": { "type": "array", "items": { "type": "string" } }
             },
             "additionalProperties": false

--- a/scripts/ops/installed_tool_inventory.mjs
+++ b/scripts/ops/installed_tool_inventory.mjs
@@ -201,6 +201,7 @@ function defaultToolEffectivity(status, required) {
   return {
     observed: false,
     actionableFindings: 0,
+    coverageGaps: 0,
     falsePositiveCount: 0,
     minutesSaved: 0,
     promotionState: required ? "required" : status === "missing_optional" ? "optional_missing" : "not_observed",
@@ -213,14 +214,19 @@ function effectivityFromToolingReport(report) {
   const byTool = {};
   const assign = (toolName, section) => {
     if (!section) return;
-    const actionableFindings = Array.isArray(section.findings) ? section.findings.length : 0;
+    const findings = Array.isArray(section.findings) ? section.findings : [];
+    const coverageGaps = findings.filter((finding) => finding?.code === "tool_missing").length;
+    const actionableFindings = findings.length - coverageGaps;
     byTool[toolName] = {
       observed: true,
       actionableFindings,
+      coverageGaps,
       falsePositiveCount: 0,
       minutesSaved: actionableFindings > 0 ? Math.min(30, actionableFindings) : 0,
-      promotionState: section.status === "skipped"
-        ? "optional_missing"
+      promotionState: coverageGaps > 0 && actionableFindings === 0
+        ? "coverage_gap"
+        : section.status === "skipped"
+          ? "optional_missing"
         : actionableFindings > 0
           ? "candidate"
           : "report_only",
@@ -245,6 +251,7 @@ function runnerEffectivity(toolName, section) {
   return {
     observed: true,
     actionableFindings: 0,
+    coverageGaps: 0,
     falsePositiveCount: 0,
     minutesSaved: 0,
     promotionState: section.status === "skipped" ? "optional_missing" : "report_only",
@@ -262,6 +269,7 @@ function buildInventory(options = {}) {
     missingOptional: tools.filter((tool) => tool.status === "missing_optional").length,
     shadowed: tools.filter((tool) => tool.status === "shadowed").length,
     actionableFindings: tools.reduce((sum, tool) => sum + (tool.effectivity?.actionableFindings || 0), 0),
+    coverageGaps: tools.reduce((sum, tool) => sum + (tool.effectivity?.coverageGaps || 0), 0),
     falsePositiveCount: tools.reduce((sum, tool) => sum + (tool.effectivity?.falsePositiveCount || 0), 0),
     minutesSaved: tools.reduce((sum, tool) => sum + (tool.effectivity?.minutesSaved || 0), 0),
     promotionCandidates: tools.filter((tool) => tool.effectivity?.promotionState === "candidate").length

--- a/scripts/ops/installed_tool_inventory.test.mjs
+++ b/scripts/ops/installed_tool_inventory.test.mjs
@@ -29,6 +29,7 @@ test("effectivityFromToolingReport maps findings to tool usefulness", () => {
   });
 
   assert.equal(effectivity.node.actionableFindings, 2);
+  assert.equal(effectivity.node.coverageGaps, 0);
   assert.equal(effectivity.node.promotionState, "candidate");
   assert.equal(effectivity.shellcheck.actionableFindings, 1);
   assert.equal(effectivity.sqlfluff.promotionState, "report_only");
@@ -41,11 +42,33 @@ test("effectivityFromToolingReport maps findings to tool usefulness", () => {
   assert.equal(effectivity.npx.actionableFindings, 0);
 });
 
+test("effectivityFromToolingReport treats missing tools as coverage gaps, not findings", () => {
+  const effectivity = effectivityFromToolingReport({
+    schema: "studiobrain-ops-tooling-quality-report.v1",
+    generatedAt: "2026-05-07T08:00:00.000Z",
+    status: "warn",
+    sections: [
+      { id: "shellcheck", status: "skipped", findings: [{ code: "tool_missing" }] },
+      { id: "compose-config", status: "skipped", findings: [{ code: "tool_missing" }] }
+    ]
+  });
+
+  assert.equal(effectivity.shellcheck.actionableFindings, 0);
+  assert.equal(effectivity.shellcheck.coverageGaps, 1);
+  assert.equal(effectivity.shellcheck.minutesSaved, 0);
+  assert.equal(effectivity.shellcheck.promotionState, "coverage_gap");
+  assert.equal(effectivity.docker.actionableFindings, 0);
+  assert.equal(effectivity.docker.coverageGaps, 1);
+  assert.equal(effectivity.docker.minutesSaved, 0);
+  assert.equal(effectivity.docker.promotionState, "coverage_gap");
+});
+
 test("buildInventory includes effectivity summary even when tooling report is missing", () => {
   const inventory = buildInventory({ toolingReport: "output/ops/tooling-quality/missing.json" });
 
   assert.equal(inventory.schema, "studiobrain-installed-tool-inventory.v1");
   assert.equal(inventory.effectivitySource.status, "unavailable");
   assert.equal(typeof inventory.summary.actionableFindings, "number");
+  assert.equal(typeof inventory.summary.coverageGaps, "number");
   assert.ok(inventory.tools.every((tool) => tool.effectivity));
 });


### PR DESCRIPTION
## Summary
- separate missing optional validators from actionable tooling findings
- add coverageGaps to installed-tool inventory summaries and per-tool effectivity
- keep missing tools from claiming minutes saved or promotion-candidate status

## Evidence
- latest inventory now reports actionableFindings=0, coverageGaps=4, minutesSaved=0 for missing validators
- this keeps shellcheck/sqlfluff/actionlint/docker absence visible without overstating effectiveness

## Testing
- node --check scripts/ops/installed_tool_inventory.mjs
- node --test scripts/ops/installed_tool_inventory.test.mjs scripts/ops/validate_ops_artifacts.test.mjs
- node scripts/ops/installed_tool_inventory.mjs --json --write
- node scripts/ops/validate_ops_artifacts.mjs --json --write
- bash scripts/ops/ops_ci_validate.sh
- git diff --check

## Risk
Low. Report/schema semantics only; no host, Docker, or database mutations.

## Rollback
Revert commit 1e884903 to restore the prior installed-tool effectivity accounting.

## Follow-up
Use coverageGaps to recommend installs only when a validator has a concrete report path and expected benefit.