### PR TITLE
[ops] Add tool install recommendation planner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ OPS_SWARM_LANE ?= tooling
 OPS_SWARM_BASE ?= origin/main
 OPS_SWARM_PREFLIGHT_FLAGS ?=
 
-.PHONY: ops-check ops-inventory ops-postgres-review ops-postgres-sql ops-postgres-top-queries ops-postgres-query-tasks ops-postgres-growth-snapshot ops-postgres-autovacuum-stats ops-postgres-roles-extensions ops-docker-review ops-docker-posture ops-capacity ops-import-pressure ops-cleanup-candidates ops-backup-evidence ops-postgres-backup-artifacts ops-restore-prereq ops-redis-minio-backup-evidence ops-ubuntu-review ops-host-failed-unit-trends ops-package-posture ops-time-sync ops-network-review ops-host-drift ops-systemd-drift ops-portal-bridge-review ops-app-review ops-dependency-review ops-idle-worker-effectivity ops-effectivity-report ops-slice-ledger ops-tool-inventory ops-admin-effectivity-audit ops-tooling-quality ops-shell-lf-guard ops-shellcheck-report ops-powershell-syntax ops-sql-parse-report ops-actionlint-report ops-compose-config-report ops-validate-artifacts ops-swarm-lane-preflight ops-wave-runner ops-privileged-evidence-read ops-privileged-evidence-capture ops-privileged-evidence-capture-smoke ops-work-packet ops-incident-bundle ops-incident-bundle-v2 ops-ci-validate ops-post-deploy-verify ops-docs ops-backlog ops-report
+.PHONY: ops-check ops-inventory ops-postgres-review ops-postgres-sql ops-postgres-top-queries ops-postgres-query-tasks ops-postgres-growth-snapshot ops-postgres-autovacuum-stats ops-postgres-roles-extensions ops-docker-review ops-docker-posture ops-capacity ops-import-pressure ops-cleanup-candidates ops-backup-evidence ops-postgres-backup-artifacts ops-restore-prereq ops-redis-minio-backup-evidence ops-ubuntu-review ops-host-failed-unit-trends ops-package-posture ops-time-sync ops-network-review ops-host-drift ops-systemd-drift ops-portal-bridge-review ops-app-review ops-dependency-review ops-idle-worker-effectivity ops-effectivity-report ops-slice-ledger ops-tool-inventory ops-tool-install-plan ops-admin-effectivity-audit ops-tooling-quality ops-shell-lf-guard ops-shellcheck-report ops-powershell-syntax ops-sql-parse-report ops-actionlint-report ops-compose-config-report ops-validate-artifacts ops-swarm-lane-preflight ops-wave-runner ops-privileged-evidence-read ops-privileged-evidence-capture ops-privileged-evidence-capture-smoke ops-work-packet ops-incident-bundle ops-incident-bundle-v2 ops-ci-validate ops-post-deploy-verify ops-docs ops-backlog ops-report
 
 ops-check: ops-inventory ops-docker-review ops-capacity ops-cleanup-candidates ops-backup-evidence ops-ubuntu-review ops-network-review ops-host-drift ops-systemd-drift ops-portal-bridge-review ops-app-review
 
@@ -120,6 +120,9 @@ ops-slice-ledger:
 
 ops-tool-inventory:
 	node scripts/ops/installed_tool_inventory.mjs --write
+
+ops-tool-install-plan:
+	node scripts/ops/tool_install_recommendations.mjs --write
 
 ops-admin-effectivity-audit:
 	node scripts/ops/admin_effectivity_audit.mjs --write

--- a/docs/ops/tooling-quality-gates.md
+++ b/docs/ops/tooling-quality-gates.md
@@ -6,9 +6,12 @@ This packet turns the research swarm recommendations into read-only, auditable t
 
 ```bash
 node scripts/ops/tooling_quality_report.mjs --mode all --json --write
+node scripts/ops/installed_tool_inventory.mjs --json --write
+node scripts/ops/tool_install_recommendations.mjs --json --write
 ```
 
 The report writes ignored artifacts under `output/ops/tooling-quality/`.
+The inventory and install recommendation reports write ignored artifacts under `output/ops/effectivity/`.
 Optional validators can be exercised explicitly after a tool usefulness audit:
 
 ```bash
@@ -41,3 +44,5 @@ Keep new validators report-only until they prove useful over about five slices:
 The first local inventory found required tools present, but optional Docker, make, ShellCheck, gitleaks, sqlfluff, actionlint, and shfmt were missing. The tooling quality report should therefore treat missing Docker/Compose, ShellCheck, SQLFluff, or actionlint as `skipped` unless a useful local install path is explicit.
 
 The first useful signal from this gate was not theoretical: ShellCheck and the LF guard both surfaced CRLF bytes in Ubuntu-targeted shell scripts. Treat that as a follow-up cleanup slice with reviewable line-ending policy, not as an automatic broad rewrite.
+
+Use `tool-install-recommendations-latest.json` as the install decision surface. It can recommend ephemeral report-only runs for tools such as ShellCheck or SQLFluff, while classifying Docker as a host/remote-lane gap and unmodeled tools such as gitleaks or shfmt as not yet justified.

--- a/schemas/ops/tool-install-recommendations.v1.schema.json
+++ b/schemas/ops/tool-install-recommendations.v1.schema.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://studio-brain.local/schemas/ops/tool-install-recommendations.v1.schema.json",
+  "title": "Studio Brain Ops Tool Install Recommendations",
+  "type": "object",
+  "required": ["schema", "generatedAt", "status", "readOnly", "source", "summary", "recommendations"],
+  "properties": {
+    "schema": { "const": "studiobrain-ops-tool-install-recommendations.v1" },
+    "generatedAt": { "type": "string", "format": "date-time" },
+    "status": { "enum": ["pass", "warn", "fail"] },
+    "readOnly": { "const": true },
+    "source": {
+      "type": "object",
+      "required": ["inventoryPath", "inventoryGeneratedAt", "inventoryStatus"],
+      "properties": {
+        "inventoryPath": { "type": "string" },
+        "inventoryGeneratedAt": { "type": ["string", "null"], "format": "date-time" },
+        "inventoryStatus": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "summary": {
+      "type": "object",
+      "required": ["recommendations", "coverageGaps", "approvalRequired", "installNowCandidates"],
+      "properties": {
+        "recommendations": { "type": "integer", "minimum": 0 },
+        "coverageGaps": { "type": "integer", "minimum": 0 },
+        "approvalRequired": { "type": "integer", "minimum": 0 },
+        "installNowCandidates": { "type": "integer", "minimum": 0 }
+      },
+      "additionalProperties": false
+    },
+    "recommendations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["tool", "priority", "acquisitionClass", "currentStatus", "coverageGaps", "actionableFindings", "reason", "expectedBenefit", "validationCommand", "installCommand", "approvalRequired", "destructive", "safetyNotes"],
+        "properties": {
+          "tool": { "type": "string" },
+          "priority": { "enum": ["P0", "P1", "P2", "P3"] },
+          "acquisitionClass": { "enum": ["ephemeral-runner", "persistent-install", "remote-lane", "not-yet-justified"] },
+          "currentStatus": { "type": "string" },
+          "coverageGaps": { "type": "integer", "minimum": 0 },
+          "actionableFindings": { "type": "integer", "minimum": 0 },
+          "reason": { "type": "string" },
+          "expectedBenefit": { "type": "string" },
+          "validationCommand": { "type": "string" },
+          "installCommand": { "type": ["string", "null"] },
+          "approvalRequired": { "type": "boolean" },
+          "destructive": { "type": "boolean" },
+          "safetyNotes": { "type": "string" }
+        },
+        "additionalProperties": false
+      }
+    },
+    "artifactPath": { "type": "string" },
+    "artifacts": {
+      "type": "object",
+      "properties": {
+        "jsonPath": { "type": "string" },
+        "markdownPath": { "type": "string" }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/scripts/ops/ops_ci_validate.sh
+++ b/scripts/ops/ops_ci_validate.sh
@@ -45,6 +45,7 @@ check_file "scripts/ops/ops_wave_runner.mjs"
 check_file "scripts/ops/slice_ledger.mjs"
 check_file "scripts/ops/tooling_quality_report.mjs"
 check_file "scripts/ops/installed_tool_inventory.mjs"
+check_file "scripts/ops/tool_install_recommendations.mjs"
 check_file "docs/ops/17-pr-readiness-packet-template.md"
 check_file "docs/ops/18-release-verification.md"
 
@@ -67,7 +68,8 @@ for script in \
   "scripts/ops/ops_wave_runner.mjs" \
   "scripts/ops/slice_ledger.mjs" \
   "scripts/ops/tooling_quality_report.mjs" \
-  "scripts/ops/installed_tool_inventory.mjs"; do
+  "scripts/ops/installed_tool_inventory.mjs" \
+  "scripts/ops/tool_install_recommendations.mjs"; do
   if [ -f "${REPO_ROOT}/${script}" ] && node --check "${REPO_ROOT}/${script}" >/dev/null; then
     pass "node --check ${script}"
   else
@@ -112,6 +114,12 @@ else
   fail "node --test scripts/ops/installed_tool_inventory.test.mjs"
 fi
 
+if node --test "${REPO_ROOT}/scripts/ops/tool_install_recommendations.test.mjs" >"${OUT_DIR}/tool-install-recommendations.test.out" 2>&1; then
+  pass "node --test scripts/ops/tool_install_recommendations.test.mjs"
+else
+  fail "node --test scripts/ops/tool_install_recommendations.test.mjs"
+fi
+
 section "Swarm Lane Preflight Smoke"
 if node "${REPO_ROOT}/scripts/ops/swarm_lane_preflight.mjs" --lane tooling --base origin/main --json --write >"${OUT_DIR}/swarm-lane-preflight.json"; then
   pass "swarm_lane_preflight tooling smoke"
@@ -124,6 +132,19 @@ if node "${REPO_ROOT}/scripts/ops/ops_wave_runner.mjs" --dry-run --json --write 
   pass "ops_wave_runner dry-run smoke"
 else
   fail "ops_wave_runner dry-run smoke"
+fi
+
+section "Tool Install Recommendation Smoke"
+if node "${REPO_ROOT}/scripts/ops/installed_tool_inventory.mjs" --json --write >"${OUT_DIR}/installed-tool-inventory.json"; then
+  pass "installed_tool_inventory smoke"
+else
+  fail "installed_tool_inventory smoke"
+fi
+
+if node "${REPO_ROOT}/scripts/ops/tool_install_recommendations.mjs" --json --write >"${OUT_DIR}/tool-install-recommendations.json"; then
+  pass "tool_install_recommendations smoke"
+else
+  fail "tool_install_recommendations smoke"
 fi
 
 section "Artifact Schema Smoke"

--- a/scripts/ops/tool_install_recommendations.mjs
+++ b/scripts/ops/tool_install_recommendations.mjs
@@ -1,0 +1,328 @@
+#!/usr/bin/env node
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const REPO_ROOT = resolve(dirname(__filename), "..", "..");
+const DEFAULT_OUTPUT_DIR = resolve(REPO_ROOT, "output", "ops", "effectivity");
+const DEFAULT_INVENTORY = resolve(DEFAULT_OUTPUT_DIR, "installed-tool-inventory-latest.json");
+
+const TOOL_PLANS = {
+  shellcheck: {
+    priority: "P1",
+    acquisitionClass: "ephemeral-runner",
+    validationCommand: "node scripts/ops/tooling_quality_report.mjs --mode shellcheck --allow-install --json --write",
+    installCommand: null,
+    approvalRequired: false,
+    expectedBenefit: "Catches shell syntax and portability defects in Ubuntu-targeted ops scripts before they reach the host.",
+    safetyNotes: "Uses the existing report-only gate; no shell files are modified."
+  },
+  sqlfluff: {
+    priority: "P1",
+    acquisitionClass: "ephemeral-runner",
+    validationCommand: "node scripts/ops/tooling_quality_report.mjs --mode sqlfluff --allow-install --json --write",
+    installCommand: null,
+    approvalRequired: false,
+    expectedBenefit: "Parses PostgreSQL inspection SQL before DBA packets are shipped.",
+    safetyNotes: "Uses uv tool execution when available; no database connection or schema mutation occurs."
+  },
+  actionlint: {
+    priority: "P2",
+    acquisitionClass: "persistent-install",
+    validationCommand: "node scripts/ops/tooling_quality_report.mjs --mode actionlint --allow-install --json --write",
+    installCommand: "Install Go or actionlint on the local tooling lane, then rerun the validation command.",
+    approvalRequired: false,
+    expectedBenefit: "Finds invalid GitHub Actions workflow syntax and expressions before PR checks fail.",
+    safetyNotes: "Keep report-only until it catches real workflow defects with tolerable noise."
+  },
+  docker: {
+    priority: "P2",
+    acquisitionClass: "remote-lane",
+    validationCommand: "node scripts/ops/tooling_quality_report.mjs --mode compose-config --json --write",
+    installCommand: "Run on a Docker-capable lane or install Docker Desktop only if compose validation becomes a repeated coverage gap.",
+    approvalRequired: true,
+    expectedBenefit: "Validates rendered Docker Compose config without starting services.",
+    safetyNotes: "Do not start, restart, pull, prune, or mutate Docker resources as part of validation."
+  },
+  gitleaks: {
+    priority: "P2",
+    acquisitionClass: "not-yet-justified",
+    validationCommand: "Add a report-only gitleaks mode before installing or requiring this tool.",
+    installCommand: null,
+    approvalRequired: false,
+    expectedBenefit: "Would provide secret-exposure scanning for generated ops bundles and docs.",
+    safetyNotes: "A report mode and redaction policy should exist before promotion."
+  },
+  shfmt: {
+    priority: "P3",
+    acquisitionClass: "not-yet-justified",
+    validationCommand: "Add a report-only shfmt check before installing or requiring this tool.",
+    installCommand: null,
+    approvalRequired: false,
+    expectedBenefit: "Would normalize shell script formatting after syntax and safety gates are stable.",
+    safetyNotes: "Formatting should remain reviewable and should not mask behavioral changes."
+  },
+  make: {
+    priority: "P3",
+    acquisitionClass: "not-yet-justified",
+    validationCommand: "Use npm/bash wrappers unless Make becomes a repeated operator friction point on Windows.",
+    installCommand: null,
+    approvalRequired: false,
+    expectedBenefit: "Would make documented make ops-* commands directly runnable on this laptop.",
+    safetyNotes: "Do not require Make on Windows until the command wrappers prove repeated value."
+  }
+};
+
+function usage() {
+  return `Studio Brain ops tool install recommendations
+
+Usage:
+  node scripts/ops/tool_install_recommendations.mjs [--json] [--write]
+
+Options:
+  --json                Print JSON.
+  --write               Write timestamped/latest JSON and Markdown artifacts.
+  --inventory <path>    Installed-tool inventory. Default: output/ops/effectivity/installed-tool-inventory-latest.json.
+  --output-dir <path>   Artifact directory. Default: output/ops/effectivity.
+`;
+}
+
+function clean(value) {
+  return String(value ?? "").replace(/\r/g, "").trim();
+}
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function resolveRepoPath(path) {
+  return resolve(REPO_ROOT, clean(path));
+}
+
+function repoRelative(path) {
+  return relative(REPO_ROOT, resolve(path)).replace(/\\/g, "/");
+}
+
+function readJson(path) {
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function parseArgs(argv) {
+  const options = {
+    json: false,
+    write: false,
+    inventory: DEFAULT_INVENTORY,
+    outputDir: DEFAULT_OUTPUT_DIR
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--help" || arg === "-h") {
+      process.stdout.write(usage());
+      process.exit(0);
+    }
+    if (arg === "--json") {
+      options.json = true;
+      continue;
+    }
+    if (arg === "--write") {
+      options.write = true;
+      continue;
+    }
+    if (arg === "--inventory") {
+      options.inventory = resolveRepoPath(argv[++index]);
+      continue;
+    }
+    if (arg.startsWith("--inventory=")) {
+      options.inventory = resolveRepoPath(arg.slice("--inventory=".length));
+      continue;
+    }
+    if (arg === "--output-dir") {
+      options.outputDir = resolveRepoPath(argv[++index]);
+      continue;
+    }
+    if (arg.startsWith("--output-dir=")) {
+      options.outputDir = resolveRepoPath(arg.slice("--output-dir=".length));
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+  return options;
+}
+
+function toolPlan(tool) {
+  return TOOL_PLANS[tool.name] || {
+    priority: "P3",
+    acquisitionClass: "not-yet-justified",
+    validationCommand: "Add a report-only validator before installing or requiring this tool.",
+    installCommand: null,
+    approvalRequired: false,
+    expectedBenefit: "No concrete repeated benefit has been measured yet.",
+    safetyNotes: "Keep as observation until a coverage gap or actionable finding proves value."
+  };
+}
+
+function reasonFor(tool, plan) {
+  const effectivity = tool.effectivity || {};
+  if ((effectivity.coverageGaps || 0) > 0) {
+    return `${tool.name} has ${effectivity.coverageGaps} coverage gap(s) in the latest tooling report.`;
+  }
+  if (tool.status === "missing_optional") {
+    return `${tool.name} is missing optional tooling, but has not yet produced a measured coverage gap.`;
+  }
+  return `${tool.name} is available; keep it report-only until usefulness is measured.`;
+}
+
+function recommendationFor(tool) {
+  const effectivity = tool.effectivity || {};
+  const plan = toolPlan(tool);
+  const hasCoverageGap = (effectivity.coverageGaps || 0) > 0;
+  const missingOptional = tool.status === "missing_optional";
+  if (!hasCoverageGap && !missingOptional) return null;
+  return {
+    tool: tool.name,
+    priority: hasCoverageGap ? plan.priority : "P3",
+    acquisitionClass: plan.acquisitionClass,
+    currentStatus: tool.status,
+    coverageGaps: effectivity.coverageGaps || 0,
+    actionableFindings: effectivity.actionableFindings || 0,
+    reason: reasonFor(tool, plan),
+    expectedBenefit: plan.expectedBenefit,
+    validationCommand: plan.validationCommand,
+    installCommand: plan.installCommand,
+    approvalRequired: Boolean(plan.approvalRequired),
+    destructive: false,
+    safetyNotes: plan.safetyNotes
+  };
+}
+
+function sortRecommendations(left, right) {
+  const priority = { P0: 0, P1: 1, P2: 2, P3: 3 };
+  const classRank = { "ephemeral-runner": 0, "persistent-install": 1, "remote-lane": 2, "not-yet-justified": 3 };
+  return (priority[left.priority] - priority[right.priority])
+    || (classRank[left.acquisitionClass] - classRank[right.acquisitionClass])
+    || left.tool.localeCompare(right.tool);
+}
+
+function buildReport(options = {}) {
+  const generatedAt = nowIso();
+  const inventoryPath = options.inventory || DEFAULT_INVENTORY;
+  const inventory = options.inventoryObject || readJson(inventoryPath);
+  const tools = Array.isArray(inventory?.tools) ? inventory.tools : [];
+  const recommendations = tools
+    .map(recommendationFor)
+    .filter(Boolean)
+    .sort(sortRecommendations);
+  const coverageGapCount = recommendations.reduce((sum, item) => sum + item.coverageGaps, 0);
+  const approvalRequired = recommendations.filter((item) => item.approvalRequired).length;
+  const installNowCandidates = recommendations.filter((item) => item.acquisitionClass === "ephemeral-runner" && !item.approvalRequired && item.coverageGaps > 0).length;
+  return {
+    schema: "studiobrain-ops-tool-install-recommendations.v1",
+    generatedAt,
+    status: inventory?.schema ? (recommendations.length ? "warn" : "pass") : "warn",
+    readOnly: true,
+    source: {
+      inventoryPath: repoRelative(inventoryPath),
+      inventoryGeneratedAt: inventory?.generatedAt || null,
+      inventoryStatus: inventory?.status || "unavailable"
+    },
+    summary: {
+      recommendations: recommendations.length,
+      coverageGaps: coverageGapCount,
+      approvalRequired,
+      installNowCandidates
+    },
+    recommendations
+  };
+}
+
+function writeJson(path, value) {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+function renderMarkdown(report) {
+  const lines = [
+    "# Studio Brain Ops Tool Install Recommendations",
+    "",
+    `Generated: ${report.generatedAt}`,
+    `Status: ${report.status}`,
+    `Inventory: ${report.source.inventoryPath}`,
+    "",
+    "## Summary",
+    "",
+    `- Recommendations: ${report.summary.recommendations}`,
+    `- Coverage gaps: ${report.summary.coverageGaps}`,
+    `- Approval required: ${report.summary.approvalRequired}`,
+    `- Install-now candidates: ${report.summary.installNowCandidates}`,
+    "",
+    "## Recommendations",
+    ""
+  ];
+  if (report.recommendations.length === 0) {
+    lines.push("No missing-tool recommendations from the latest inventory.");
+  }
+  for (const item of report.recommendations) {
+    lines.push(`### ${item.priority} ${item.tool}`);
+    lines.push("");
+    lines.push(`- Class: ${item.acquisitionClass}`);
+    lines.push(`- Current status: ${item.currentStatus}`);
+    lines.push(`- Coverage gaps: ${item.coverageGaps}`);
+    lines.push(`- Actionable findings: ${item.actionableFindings}`);
+    lines.push(`- Approval required: ${item.approvalRequired ? "yes" : "no"}`);
+    lines.push(`- Reason: ${item.reason}`);
+    lines.push(`- Expected benefit: ${item.expectedBenefit}`);
+    lines.push(`- Validation command: \`${item.validationCommand}\``);
+    if (item.installCommand) lines.push(`- Install path: ${item.installCommand}`);
+    lines.push(`- Safety notes: ${item.safetyNotes}`);
+    lines.push("");
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+function writeArtifacts(report, outputDir) {
+  const timestamp = report.generatedAt.replace(/[-:]/g, "").replace(/\.\d+Z$/, "Z");
+  const jsonPath = resolve(outputDir, `tool-install-recommendations-${timestamp}.json`);
+  const markdownPath = resolve(outputDir, `tool-install-recommendations-${timestamp}.md`);
+  writeJson(jsonPath, report);
+  writeJson(resolve(outputDir, "tool-install-recommendations-latest.json"), { ...report, artifactPath: repoRelative(jsonPath) });
+  mkdirSync(dirname(markdownPath), { recursive: true });
+  writeFileSync(markdownPath, renderMarkdown(report), "utf8");
+  writeFileSync(resolve(outputDir, "tool-install-recommendations-latest.md"), renderMarkdown(report), "utf8");
+  return { jsonPath, markdownPath };
+}
+
+function main(argv = process.argv.slice(2)) {
+  try {
+    const options = parseArgs(argv);
+    const report = buildReport(options);
+    if (options.write) {
+      report.artifacts = Object.fromEntries(Object.entries(writeArtifacts(report, options.outputDir)).map(([key, value]) => [key, value]));
+    }
+    if (options.json || !options.write) {
+      process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    } else {
+      process.stdout.write(`tool install recommendations: ${report.status}, recommendations=${report.summary.recommendations}\n`);
+    }
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exit(1);
+  }
+}
+
+export {
+  buildReport,
+  main,
+  parseArgs,
+  recommendationFor
+};
+
+if (process.argv[1] && resolve(process.argv[1]) === __filename) {
+  main();
+}

--- a/scripts/ops/tool_install_recommendations.test.mjs
+++ b/scripts/ops/tool_install_recommendations.test.mjs
@@ -1,0 +1,56 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  buildReport,
+  parseArgs,
+  recommendationFor
+} from "./tool_install_recommendations.mjs";
+
+test("parseArgs accepts inventory and write flags", () => {
+  const options = parseArgs(["--json", "--write", "--inventory", "output/ops/example.json"]);
+
+  assert.equal(options.json, true);
+  assert.equal(options.write, true);
+  assert.ok(options.inventory.endsWith("output\\ops\\example.json") || options.inventory.endsWith("output/ops/example.json"));
+});
+
+test("recommendationFor turns coverage gaps into non-destructive install guidance", () => {
+  const recommendation = recommendationFor({
+    name: "shellcheck",
+    status: "missing_optional",
+    effectivity: {
+      actionableFindings: 0,
+      coverageGaps: 1
+    }
+  });
+
+  assert.equal(recommendation.tool, "shellcheck");
+  assert.equal(recommendation.priority, "P1");
+  assert.equal(recommendation.acquisitionClass, "ephemeral-runner");
+  assert.equal(recommendation.approvalRequired, false);
+  assert.equal(recommendation.destructive, false);
+  assert.match(recommendation.validationCommand, /shellcheck/);
+});
+
+test("buildReport ranks coverage gaps before unmeasured missing tools", () => {
+  const report = buildReport({
+    inventory: "output/ops/effectivity/installed-tool-inventory-latest.json",
+    inventoryObject: {
+      schema: "studiobrain-installed-tool-inventory.v1",
+      generatedAt: "2026-05-07T14:00:00.000Z",
+      status: "warn",
+      tools: [
+        { name: "shfmt", status: "missing_optional", effectivity: { actionableFindings: 0, coverageGaps: 0 } },
+        { name: "docker", status: "missing_optional", effectivity: { actionableFindings: 0, coverageGaps: 1 } },
+        { name: "shellcheck", status: "missing_optional", effectivity: { actionableFindings: 0, coverageGaps: 1 } }
+      ]
+    }
+  });
+
+  assert.equal(report.schema, "studiobrain-ops-tool-install-recommendations.v1");
+  assert.equal(report.summary.recommendations, 3);
+  assert.equal(report.summary.coverageGaps, 2);
+  assert.equal(report.summary.installNowCandidates, 1);
+  assert.deepEqual(report.recommendations.map((item) => item.tool), ["shellcheck", "docker", "shfmt"]);
+});

--- a/scripts/ops/validate_ops_artifacts.mjs
+++ b/scripts/ops/validate_ops_artifacts.mjs
@@ -19,6 +19,11 @@ const DEFAULT_ARTIFACTS = [
     schema: "schemas/ops/installed-tool-inventory.v1.schema.json",
   },
   {
+    id: "tool-install-recommendations",
+    artifact: "output/ops/effectivity/tool-install-recommendations-latest.json",
+    schema: "schemas/ops/tool-install-recommendations.v1.schema.json",
+  },
+  {
     id: "admin-effectivity-audit",
     artifact: "output/ops/effectivity/admin-effectivity-audit-latest.json",
     schema: "schemas/ops/admin-effectivity-audit.v1.schema.json",


### PR DESCRIPTION
## Summary
- add a read-only tool install recommendation report driven by installed-tool inventory coverage gaps
- rank ShellCheck and SQLFluff as ephemeral report-only candidates, Docker as approval/remote-lane, and unmodeled tools as not-yet-justified
- add schema validation, Makefile wrapper, ops CI smoke, and docs

## Evidence
- latest recommendation report: recommendations=7, coverageGaps=4, approvalRequired=1, installNowCandidates=2
- avoids broad install pass; recommendations require validation commands and safety notes

## Testing
- node --check scripts/ops/tool_install_recommendations.mjs
- node --test scripts/ops/tool_install_recommendations.test.mjs scripts/ops/validate_ops_artifacts.test.mjs
- node scripts/ops/tool_install_recommendations.mjs --json --write
- node scripts/ops/validate_ops_artifacts.mjs --json --write
- bash scripts/ops/ops_ci_validate.sh
- git diff --check

## Risk
Low. Adds read-only reporting only; no tool installation, package changes, Docker mutation, or host changes.

## Rollback
Revert commit da7c0123 to remove the recommendation planner and schema registration.

## Follow-up
Run ShellCheck and SQLFluff through existing --allow-install report-only gates, then audit whether they catch actionable defects before persistent installation.