### PR TITLE
[ops] Separate tooling coverage gaps from findings

### DIFF
--- a/docs/ops/tooling-quality-gates.md
+++ b/docs/ops/tooling-quality-gates.md
@@ -46,3 +46,5 @@ The first local inventory found required tools present, but optional Docker, mak
 The first useful signal from this gate was not theoretical: ShellCheck and the LF guard both surfaced CRLF bytes in Ubuntu-targeted shell scripts. Treat that as a follow-up cleanup slice with reviewable line-ending policy, not as an automatic broad rewrite.
 
 Use `tool-install-recommendations-latest.json` as the install decision surface. It can recommend ephemeral report-only runs for tools such as ShellCheck or SQLFluff, while classifying Docker as a host/remote-lane gap and unmodeled tools such as gitleaks or shfmt as not yet justified.
+
+The tooling quality summary uses `findings`/`actionableFindings` for defect-like rows and `coverageGaps` for missing validators. `rawFindings` remains available for row accounting, but it should not be used as the defect count.

--- a/schemas/ops/tooling-quality-report.v1.schema.json
+++ b/schemas/ops/tooling-quality-report.v1.schema.json
@@ -12,10 +12,13 @@
     "status": { "enum": ["pass", "warn", "fail"] },
     "summary": {
       "type": "object",
-      "required": ["checkedFiles", "findings", "skipped"],
+      "required": ["checkedFiles", "findings", "actionableFindings", "coverageGaps", "rawFindings", "skipped"],
       "properties": {
         "checkedFiles": { "type": "integer", "minimum": 0 },
         "findings": { "type": "integer", "minimum": 0 },
+        "actionableFindings": { "type": "integer", "minimum": 0 },
+        "coverageGaps": { "type": "integer", "minimum": 0 },
+        "rawFindings": { "type": "integer", "minimum": 0 },
         "skipped": { "type": "integer", "minimum": 0 }
       },
       "additionalProperties": false
@@ -24,12 +27,15 @@
       "type": "array",
       "items": {
         "type": "object",
-        "required": ["id", "status", "tool", "checkedFiles", "findings"],
+        "required": ["id", "status", "tool", "checkedFiles", "findings", "actionableFindings", "coverageGaps", "rawFindings"],
         "properties": {
           "id": { "enum": ["shell-lf", "shellcheck", "powershell", "sqlfluff", "actionlint", "compose-config"] },
           "status": { "enum": ["pass", "warn", "fail", "skipped"] },
           "tool": { "type": "string" },
           "checkedFiles": { "type": "integer", "minimum": 0 },
+          "actionableFindings": { "type": "integer", "minimum": 0 },
+          "coverageGaps": { "type": "integer", "minimum": 0 },
+          "rawFindings": { "type": "integer", "minimum": 0 },
           "command": { "type": "string" },
           "outputPreview": { "type": "string" },
           "findings": {

--- a/scripts/ops/installed_tool_inventory.mjs
+++ b/scripts/ops/installed_tool_inventory.mjs
@@ -215,8 +215,12 @@ function effectivityFromToolingReport(report) {
   const assign = (toolName, section) => {
     if (!section) return;
     const findings = Array.isArray(section.findings) ? section.findings : [];
-    const coverageGaps = findings.filter((finding) => finding?.code === "tool_missing").length;
-    const actionableFindings = findings.length - coverageGaps;
+    const coverageGaps = Number.isInteger(section.coverageGaps)
+      ? section.coverageGaps
+      : findings.filter((finding) => finding?.code === "tool_missing").length;
+    const actionableFindings = Number.isInteger(section.actionableFindings)
+      ? section.actionableFindings
+      : findings.length - coverageGaps;
     byTool[toolName] = {
       observed: true,
       actionableFindings,

--- a/scripts/ops/tooling_quality_report.mjs
+++ b/scripts/ops/tooling_quality_report.mjs
@@ -416,6 +416,21 @@ function statusFromSections(sections) {
   return "pass";
 }
 
+function findingCounts(findings = []) {
+  const rows = Array.isArray(findings) ? findings : [];
+  const coverageGaps = rows.filter((finding) => finding?.code === "tool_missing").length;
+  return {
+    rawFindings: rows.length,
+    coverageGaps,
+    actionableFindings: rows.length - coverageGaps
+  };
+}
+
+function annotateSection(section) {
+  const counts = findingCounts(section.findings);
+  return { ...section, ...counts };
+}
+
 function markdown(report) {
   const lines = [
     "# Studio Brain Ops Tooling Quality Report",
@@ -428,12 +443,24 @@ function markdown(report) {
     "## Summary",
     "",
     `- Checked files: ${report.summary.checkedFiles}`,
-    `- Findings: ${report.summary.findings}`,
+    `- Actionable findings: ${report.summary.actionableFindings}`,
+    `- Coverage gaps: ${report.summary.coverageGaps}`,
+    `- Raw finding rows: ${report.summary.rawFindings}`,
     `- Skipped sections: ${report.summary.skipped}`,
     ""
   ];
   for (const section of report.sections) {
-    lines.push(`## ${section.id}`, "", `- Status: ${section.status}`, `- Tool: ${section.tool}`, `- Checked files: ${section.checkedFiles}`, `- Findings: ${section.findings.length}`, "");
+    lines.push(
+      `## ${section.id}`,
+      "",
+      `- Status: ${section.status}`,
+      `- Tool: ${section.tool}`,
+      `- Checked files: ${section.checkedFiles}`,
+      `- Actionable findings: ${section.actionableFindings}`,
+      `- Coverage gaps: ${section.coverageGaps}`,
+      `- Raw finding rows: ${section.rawFindings}`,
+      ""
+    );
     for (const finding of section.findings.slice(0, 20)) {
       lines.push(`- ${finding.file ? `${finding.file}: ` : ""}${finding.code}: ${clean(finding.message)}`);
     }
@@ -462,19 +489,23 @@ function buildReport(options) {
   if (options.mode === "all" || options.mode === "sqlfluff") sections.push(sqlfluffReport(options));
   if (options.mode === "all" || options.mode === "actionlint") sections.push(actionlintReport(options));
   if (options.mode === "all" || options.mode === "compose-config") sections.push(composeConfigReport(options));
+  const annotatedSections = sections.map(annotateSection);
   const summary = {
-    checkedFiles: sections.reduce((sum, section) => sum + section.checkedFiles, 0),
-    findings: sections.reduce((sum, section) => sum + section.findings.length, 0),
-    skipped: sections.filter((section) => section.status === "skipped").length
+    checkedFiles: annotatedSections.reduce((sum, section) => sum + section.checkedFiles, 0),
+    findings: annotatedSections.reduce((sum, section) => sum + section.actionableFindings, 0),
+    actionableFindings: annotatedSections.reduce((sum, section) => sum + section.actionableFindings, 0),
+    coverageGaps: annotatedSections.reduce((sum, section) => sum + section.coverageGaps, 0),
+    rawFindings: annotatedSections.reduce((sum, section) => sum + section.rawFindings, 0),
+    skipped: annotatedSections.filter((section) => section.status === "skipped").length
   };
   return {
     schema: "studiobrain-ops-tooling-quality-report.v1",
     generatedAt: nowIso(),
     mode: options.mode,
     allowInstall: options.allowInstall,
-    status: statusFromSections(sections),
+    status: statusFromSections(annotatedSections),
     summary,
-    sections
+    sections: annotatedSections
   };
 }
 
@@ -495,7 +526,9 @@ function main(argv = process.argv.slice(2)) {
 }
 
 export {
+  annotateSection,
   buildReport,
+  findingCounts,
   main,
   parseArgs,
   parseActionlintOutput,

--- a/scripts/ops/tooling_quality_report.test.mjs
+++ b/scripts/ops/tooling_quality_report.test.mjs
@@ -4,7 +4,9 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
 import {
+  annotateSection,
   buildReport,
+  findingCounts,
   parseArgs,
   parseActionlintOutput,
   parseShellCheckJson,
@@ -21,12 +23,18 @@ function assertReportContract(report) {
   assert.equal(typeof report.allowInstall, "boolean");
   assert.equal(typeof report.summary.checkedFiles, "number");
   assert.equal(typeof report.summary.findings, "number");
+  assert.equal(typeof report.summary.actionableFindings, "number");
+  assert.equal(typeof report.summary.coverageGaps, "number");
+  assert.equal(typeof report.summary.rawFindings, "number");
   assert.equal(typeof report.summary.skipped, "number");
   for (const section of report.sections) {
     assert.ok(schema.properties.sections.items.properties.id.enum.includes(section.id));
     assert.ok(schema.properties.sections.items.properties.status.enum.includes(section.status));
     assert.equal(typeof section.tool, "string");
     assert.equal(typeof section.checkedFiles, "number");
+    assert.equal(typeof section.actionableFindings, "number");
+    assert.equal(typeof section.coverageGaps, "number");
+    assert.equal(typeof section.rawFindings, "number");
     assert.ok(Array.isArray(section.findings));
     for (const finding of section.findings) {
       assert.equal(typeof finding.code, "string");
@@ -86,6 +94,31 @@ test("statusFromSections preserves worst section state", () => {
   assert.equal(statusFromSections([{ status: "pass" }, { status: "warn" }]), "warn");
   assert.equal(statusFromSections([{ status: "warn" }, { status: "fail" }]), "fail");
   assert.equal(statusFromSections([{ status: "pass" }]), "pass");
+});
+
+test("findingCounts treats missing tools as coverage gaps, not actionable findings", () => {
+  assert.deepEqual(findingCounts([
+    { code: "tool_missing", message: "missing" },
+    { code: "parse_error", message: "bad" }
+  ]), {
+    rawFindings: 2,
+    coverageGaps: 1,
+    actionableFindings: 1
+  });
+});
+
+test("annotateSection adds explicit finding classes", () => {
+  const section = annotateSection({
+    id: "shellcheck",
+    status: "skipped",
+    tool: "shellcheck",
+    checkedFiles: 0,
+    findings: [{ code: "tool_missing", message: "missing" }]
+  });
+
+  assert.equal(section.rawFindings, 1);
+  assert.equal(section.coverageGaps, 1);
+  assert.equal(section.actionableFindings, 0);
 });
 
 test("buildReport emits the documented tooling quality schema", () => {


### PR DESCRIPTION
## Summary
- make tooling-quality summaries distinguish actionable findings from missing-validator coverage gaps
- add per-section actionableFindings, coverageGaps, and rawFindings counts
- update installed-tool inventory to consume explicit counts when present

## Evidence
- latest tooling report now emits findings=0/actionableFindings=0/coverageGaps=4/rawFindings=4
- missing Docker/ShellCheck/SQLFluff/actionlint remain visible without being summarized as defects

## Testing
- node --check scripts/ops/tooling_quality_report.mjs
- node --check scripts/ops/installed_tool_inventory.mjs
- node --test scripts/ops/tooling_quality_report.test.mjs scripts/ops/installed_tool_inventory.test.mjs scripts/ops/validate_ops_artifacts.test.mjs
- node scripts/ops/tooling_quality_report.mjs --mode all --json --write
- node scripts/ops/installed_tool_inventory.mjs --json --write
- node scripts/ops/tool_install_recommendations.mjs --json --write
- node scripts/ops/validate_ops_artifacts.mjs --json --write
- bash scripts/ops/ops_ci_validate.sh
- git diff --check

## Risk
Low. Reporting semantics only; no host, Docker, database, package, or service changes.

## Rollback
Revert commit 84121adb to restore the prior tooling-quality summary semantics.

## Follow-up
Use coverageGaps/actionableFindings in audit freshness and work-packet steering instead of raw finding rows.