### PR TITLE
[ops] Feed tool coverage gaps into work packets

### DIFF
--- a/docs/ops/admin-effectivity-loop.md
+++ b/docs/ops/admin-effectivity-loop.md
@@ -97,6 +97,8 @@ node scripts/ops/ops_wave_runner.mjs --dry-run --json --write
 
 The wave runner executes read-only checks in dependency order: preflight, tooling quality, tool inventory, admin effectivity audit, work packet generation, then artifact schema validation. Use it when a downstream command consumes a `*-latest.json` artifact from an upstream command.
 
+Work packets should steer from fresh evidence only. Missing, invalid, stale, or invalid-timestamp latest artifacts stay visible in `freshEvidence`, but they are excluded from packet `sourceSignals`. Tool inventory coverage gaps are kept as `signalClass=coverage_gap` so missing validators remain visible without being treated as actionable defect evidence.
+
 ## Scoring
 
 - `usefulness`: average slice usefulness score, 0 to 1.

--- a/schemas/ops/ops-work-packet.v1.schema.json
+++ b/schemas/ops/ops-work-packet.v1.schema.json
@@ -37,7 +37,7 @@
     },
     "evidenceSummary": {
       "type": "object",
-      "required": ["risks", "backlogItems", "effectivityNextSafeSlices", "remainingApprovalGates", "freshSources", "staleSources", "toolPromotionCandidates", "toolActionableFindings", "swarmPreflightStatus", "swarmPreflightOutsideScope", "swarmPreflightProblems"],
+      "required": ["risks", "backlogItems", "effectivityNextSafeSlices", "remainingApprovalGates", "freshSources", "staleSources", "toolPromotionCandidates", "toolActionableFindings", "toolCoverageGaps", "swarmPreflightStatus", "swarmPreflightOutsideScope", "swarmPreflightProblems"],
       "properties": {
         "risks": { "type": "number", "minimum": 0 },
         "backlogItems": { "type": "number", "minimum": 0 },
@@ -47,6 +47,7 @@
         "staleSources": { "type": "number", "minimum": 0 },
         "toolPromotionCandidates": { "type": ["number", "null"], "minimum": 0 },
         "toolActionableFindings": { "type": ["number", "null"], "minimum": 0 },
+        "toolCoverageGaps": { "type": ["number", "null"], "minimum": 0 },
         "swarmPreflightStatus": { "type": "string" },
         "swarmPreflightOutsideScope": { "type": ["number", "null"], "minimum": 0 },
         "swarmPreflightProblems": { "type": ["number", "null"], "minimum": 0 }

--- a/scripts/studiobrain-ops-work-packet.mjs
+++ b/scripts/studiobrain-ops-work-packet.mjs
@@ -336,12 +336,13 @@ function makePacket(backlogItem, risk, effectivity, freshEvidence) {
 function freshSourceSignals(freshEvidence) {
   if (!freshEvidence) return [];
   return [freshEvidence.adminAudit, freshEvidence.sliceLedger, freshEvidence.toolInventory, freshEvidence.swarmPreflight]
-    .filter((source) => source && source.status !== "missing")
+    .filter((source) => source && !["missing", "invalid_json", "invalid_timestamp", "stale"].includes(source.status))
     .map((source) => ({
       source: source.source,
       path: source.path,
       status: source.status,
       generatedAt: source.generatedAt || "",
+      signalClass: source.source === "fresh-tool-inventory" && (source.summary?.coverageGaps || 0) > 0 ? "coverage_gap" : "fresh",
       summary: source.summary,
     }));
 }
@@ -484,6 +485,7 @@ function summarizeFreshEvidence(inputs = {}, options = {}) {
             missingRequired: toolInventory.summary?.missingRequired ?? null,
             missingOptional: toolInventory.summary?.missingOptional ?? null,
             actionableFindings: toolInventory.summary?.actionableFindings ?? null,
+            coverageGaps: toolInventory.summary?.coverageGaps ?? null,
             promotionCandidates: toolInventory.summary?.promotionCandidates ?? null,
           },
         }, options)
@@ -567,6 +569,7 @@ export function buildOpsWorkPacket(inputs = {}, options = {}) {
       staleSources: staleSources.length,
       toolPromotionCandidates: freshEvidence.toolInventory.summary.promotionCandidates ?? null,
       toolActionableFindings: freshEvidence.toolInventory.summary.actionableFindings ?? null,
+      toolCoverageGaps: freshEvidence.toolInventory.summary.coverageGaps ?? null,
       swarmPreflightStatus: freshEvidence.swarmPreflight.status,
       swarmPreflightOutsideScope: freshEvidence.swarmPreflight.summary.outsideScope ?? null,
       swarmPreflightProblems: freshEvidence.swarmPreflight.summary.problems ?? null,

--- a/scripts/studiobrain-ops-work-packet.test.mjs
+++ b/scripts/studiobrain-ops-work-packet.test.mjs
@@ -147,8 +147,9 @@ const freshInputs = {
       installed: 13,
       missingRequired: 0,
       missingOptional: 7,
-      actionableFindings: 4,
-      promotionCandidates: 2,
+      actionableFindings: 0,
+      coverageGaps: 4,
+      promotionCandidates: 0,
     },
   },
   swarmPreflight: {
@@ -191,7 +192,9 @@ test("buildOpsWorkPacket creates bounded read-only packets from docs evidence", 
   assert.equal(report.evidenceSummary.backlogItems, 2);
   assert.equal(report.evidenceSummary.freshSources, 4);
   assert.equal(report.evidenceSummary.staleSources, 0);
-  assert.equal(report.evidenceSummary.toolPromotionCandidates, 2);
+  assert.equal(report.evidenceSummary.toolPromotionCandidates, 0);
+  assert.equal(report.evidenceSummary.toolActionableFindings, 0);
+  assert.equal(report.evidenceSummary.toolCoverageGaps, 4);
   assert.equal(report.evidenceSummary.swarmPreflightStatus, "pass");
   assert.equal(report.evidenceSummary.swarmPreflightOutsideScope, 0);
   assert.equal(report.freshEvidence.adminAudit.status, "pass");
@@ -201,6 +204,7 @@ test("buildOpsWorkPacket creates bounded read-only packets from docs evidence", 
   assert.ok(report.packets.every((packet) => packet.constraints.readOnlyFirst));
   assert.ok(report.packets[0].sourceSignals.some((signal) => signal.source === "fresh-admin-audit"));
   assert.ok(report.packets[0].sourceSignals.some((signal) => signal.source === "fresh-tool-inventory"));
+  assert.ok(report.packets[0].sourceSignals.some((signal) => signal.source === "fresh-tool-inventory" && signal.signalClass === "coverage_gap"));
   assert.ok(report.packets[0].sourceSignals.some((signal) => signal.source === "fresh-swarm-preflight"));
   assert.equal(report.packets[0].priority, "P0");
   assert.ok(report.packets[0].humanGate.includes("PostgreSQL dump"));
@@ -233,7 +237,8 @@ test("summarizeFreshEvidence does not count invalid JSON as fresh", () => {
   assert.equal(report.evidenceSummary.staleSources, 0);
   assert.equal(report.freshEvidence.adminAudit.status, "invalid_json");
   assert.equal(report.freshEvidence.toolInventory.summary.parseError, "bad tools");
-  assert.equal(report.packets[0].sourceSignals.some((signal) => signal.source === "fresh-admin-audit"), true);
+  assert.equal(report.packets[0].sourceSignals.some((signal) => signal.source === "fresh-admin-audit"), false);
+  assert.equal(report.packets[0].sourceSignals.some((signal) => signal.source === "fresh-tool-inventory"), false);
 });
 
 test("workPacketReportStatus warns when falling back to static docs only", () => {


### PR DESCRIPTION
## Summary
- expose toolCoverageGaps in ops work-packet evidence summaries
- mark fresh tool inventory source signals as signalClass=coverage_gap when missing validators are present
- exclude missing, invalid_json, invalid_timestamp, and stale latest artifacts from packet sourceSignals while keeping them visible in freshEvidence

## Evidence
- generated packet now shows toolCoverageGaps=4 and fresh-tool-inventory signalClass=coverage_gap
- invalid admin/tool evidence is no longer attached as steering sourceSignals in tests

## Testing
- node --check scripts/studiobrain-ops-work-packet.mjs
- node --test scripts/studiobrain-ops-work-packet.test.mjs scripts/ops/validate_ops_artifacts.test.mjs
- node scripts/studiobrain-ops-work-packet.mjs --json --write --max-packets 1
- node scripts/ops/validate_ops_artifacts.mjs --json --write
- bash scripts/ops/ops_ci_validate.sh
- git diff --check

## Risk
Low. Work-packet/report semantics only; no production, host, Docker, DB, package, or service mutation.

## Rollback
Revert commit 9bbfb949 to restore the prior work-packet source signal behavior.

## Follow-up
Use the same freshness/degraded-source policy in admin effectivity audit and artifact validation.