### PR TITLE
[ops] Audit tooling source freshness

### DIFF
--- a/docs/ops/admin-effectivity-loop.md
+++ b/docs/ops/admin-effectivity-loop.md
@@ -105,7 +105,7 @@ Work packets should steer from fresh evidence only. Missing, invalid, stale, or 
 - `verification`: passing command checks divided by total recorded command checks.
 - `noOpRate`: share of rows with no changed file, artifact, command evidence, or an explicit no-op status.
 - `blockedLaneClarity`: blocked slices with a fixed blocker class and safe next step.
-- `toolInventoryFreshness`: 1 when the inventory command can run; 0 when unavailable.
+- `toolInventoryFreshness`: 1 when the inventory command can run and both the inventory and its upstream tooling-quality source are fresh enough for the selected slice window; 0 when unavailable, stale, invalid, or older than the audited slices.
 
 The audit fails if required tools are missing or a slice failed. It warns when no slices are recorded, no-op rate is high, or the underlying ops effectivity report cannot run.
 

--- a/schemas/ops/admin-effectivity-audit.v1.schema.json
+++ b/schemas/ops/admin-effectivity-audit.v1.schema.json
@@ -36,6 +36,7 @@
       "properties": {
         "sliceLedger": { "type": "object" },
         "installedTools": { "type": "object" },
+        "installedToolsFreshness": { "type": "object" },
         "effectivityReport": { "type": "object" }
       },
       "additionalProperties": true

--- a/scripts/ops/admin_effectivity_audit.mjs
+++ b/scripts/ops/admin_effectivity_audit.mjs
@@ -179,6 +179,11 @@ function rowTimestamp(row) {
   return Date.parse(clean(row.completedAt) || clean(row.startedAt)) || 0;
 }
 
+function latestRowIso(rows) {
+  const timestamp = rows.reduce((latest, row) => Math.max(latest, rowTimestamp(row)), 0);
+  return timestamp > 0 ? new Date(timestamp).toISOString() : "";
+}
+
 function sliceSequence(row) {
   const match = clean(row.sliceId).match(/-(\d+)$/);
   return match ? Number(match[1]) : null;
@@ -209,6 +214,47 @@ function tryEffectivityReport() {
   const result = runJson("bash", ["scripts/ops/effectivity_report.sh", "--json", "--no-write"]);
   if (!result.ok) return { ok: false, status: "unavailable", reason: result.error, report: null };
   return { ok: true, status: result.json?.status || "ok", reason: "", report: summarizeEffectivityReport(result.json) };
+}
+
+function sourceFreshness(generatedAt, options = {}) {
+  const generated = Date.parse(clean(generatedAt));
+  const now = Date.parse(clean(options.now) || nowIso());
+  const minGeneratedAt = clean(options.minGeneratedAt);
+  const minGenerated = minGeneratedAt ? Date.parse(minGeneratedAt) : 0;
+  const maxAgeHours = Number(options.maxAgeHours ?? 24);
+  if (!clean(generatedAt)) return { status: "missing", score: 0, generatedAt: "", ageHours: null, minGeneratedAt, maxAgeHours };
+  if (Number.isNaN(generated) || Number.isNaN(now) || (minGeneratedAt && Number.isNaN(minGenerated))) {
+    return { status: "invalid_timestamp", score: 0, generatedAt: clean(generatedAt), ageHours: null, minGeneratedAt, maxAgeHours };
+  }
+  const ageHours = Number(Math.max(0, (now - generated) / 3_600_000).toFixed(2));
+  if (minGenerated && generated < minGenerated) {
+    return { status: "older_than_slice_window", score: 0, generatedAt: clean(generatedAt), ageHours, minGeneratedAt, maxAgeHours };
+  }
+  if (maxAgeHours > 0 && ageHours > maxAgeHours) {
+    return { status: "stale", score: 0, generatedAt: clean(generatedAt), ageHours, minGeneratedAt, maxAgeHours };
+  }
+  return { status: "fresh", score: 1, generatedAt: clean(generatedAt), ageHours, minGeneratedAt, maxAgeHours };
+}
+
+function buildInstalledToolsFreshness(toolInventory, options = {}) {
+  if (!toolInventory?.schema) {
+    return {
+      status: "unavailable",
+      score: 0,
+      inventory: sourceFreshness("", options),
+      toolingQuality: sourceFreshness("", options)
+    };
+  }
+  const inventory = sourceFreshness(toolInventory.generatedAt, options);
+  const toolingQuality = sourceFreshness(toolInventory.effectivitySource?.generatedAt, options);
+  const score = inventory.score === 1 && toolingQuality.score === 1 ? 1 : 0;
+  return {
+    status: score === 1 ? "fresh" : "stale_source",
+    score,
+    inventory,
+    toolingQuality,
+    effectivitySourceStatus: clean(toolInventory.effectivitySource?.status) || "unknown"
+  };
 }
 
 function summarizeEffectivityReport(report) {
@@ -253,7 +299,12 @@ function buildAudit(options) {
   const sliceSummary = summarizeSlices(selectedRows);
   const toolInventory = runJson(process.execPath, ["scripts/ops/installed_tool_inventory.mjs", "--json"]);
   const effectivityReport = tryEffectivityReport();
-  const toolFreshness = toolInventory.ok ? 1 : 0;
+  const installedToolsFreshness = buildInstalledToolsFreshness(toolInventory.json, {
+    now: generatedAt,
+    minGeneratedAt: latestRowIso(selectedRows),
+    maxAgeHours: 24
+  });
+  const toolFreshness = toolInventory.ok ? installedToolsFreshness.score : 0;
   const missingRequired = Number(toolInventory.json?.summary?.missingRequired) || 0;
   const usefulness = sliceSummary.count > 0 ? sliceSummary.usefulness : 0;
   const scores = {
@@ -265,7 +316,7 @@ function buildAudit(options) {
   };
   const status = missingRequired > 0 || sliceSummary.failed > 0
     ? "fail"
-    : sliceSummary.count === 0 || sliceSummary.noOpRate > 0.4 || !effectivityReport.ok
+    : sliceSummary.count === 0 || sliceSummary.noOpRate > 0.4 || !effectivityReport.ok || toolFreshness < 1
       ? "warn"
       : "pass";
   return {
@@ -289,6 +340,7 @@ function buildAudit(options) {
         rows: selectedRows
       },
       installedTools: toolInventory.ok ? toolInventory.json : { status: "unavailable", error: toolInventory.error },
+      installedToolsFreshness,
       effectivityReport
     },
     missionControl: {
@@ -337,6 +389,8 @@ function markdown(audit) {
     `- Missing required: ${audit.sections.installedTools.summary?.missingRequired ?? "unknown"}`,
     `- Missing optional: ${audit.sections.installedTools.summary?.missingOptional ?? "unknown"}`,
     `- Shadowed: ${audit.sections.installedTools.summary?.shadowed ?? "unknown"}`,
+    `- Freshness status: ${audit.sections.installedToolsFreshness?.status ?? "unknown"}`,
+    `- Tooling quality source freshness: ${audit.sections.installedToolsFreshness?.toolingQuality?.status ?? "unknown"}`,
     "",
     "## Slice Rows",
     ""
@@ -360,16 +414,30 @@ function writeArtifacts(options, audit) {
   return { jsonPath, markdownPath };
 }
 
-try {
-  const options = parseArgs(process.argv.slice(2));
-  const audit = buildAudit(options);
-  const artifacts = options.write ? writeArtifacts(options, audit) : null;
-  if (options.json || !options.write) {
-    process.stdout.write(`${JSON.stringify(artifacts ? { ...audit, artifacts } : audit, null, 2)}\n`);
-  } else {
-    process.stdout.write(`admin effectivity audit: ${audit.status}, slices=${audit.sliceWindow.count}, usefulness=${audit.scores.usefulness}\n`);
+function main(argv = process.argv.slice(2)) {
+  try {
+    const options = parseArgs(argv);
+    const audit = buildAudit(options);
+    const artifacts = options.write ? writeArtifacts(options, audit) : null;
+    if (options.json || !options.write) {
+      process.stdout.write(`${JSON.stringify(artifacts ? { ...audit, artifacts } : audit, null, 2)}\n`);
+    } else {
+      process.stdout.write(`admin effectivity audit: ${audit.status}, slices=${audit.sliceWindow.count}, usefulness=${audit.scores.usefulness}\n`);
+    }
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exit(1);
   }
-} catch (error) {
-  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
-  process.exit(1);
+}
+
+export {
+  buildAudit,
+  buildInstalledToolsFreshness,
+  main,
+  parseArgs,
+  sourceFreshness
+};
+
+if (process.argv[1] && resolve(process.argv[1]) === __filename) {
+  main();
 }

--- a/scripts/ops/admin_effectivity_audit.test.mjs
+++ b/scripts/ops/admin_effectivity_audit.test.mjs
@@ -1,0 +1,63 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  buildInstalledToolsFreshness,
+  sourceFreshness
+} from "./admin_effectivity_audit.mjs";
+
+test("sourceFreshness rejects sources older than the selected slice window", () => {
+  const result = sourceFreshness("2026-05-07T10:00:00.000Z", {
+    now: "2026-05-07T11:00:00.000Z",
+    minGeneratedAt: "2026-05-07T10:30:00.000Z",
+    maxAgeHours: 24
+  });
+
+  assert.equal(result.status, "older_than_slice_window");
+  assert.equal(result.score, 0);
+});
+
+test("sourceFreshness accepts fresh sources inside the max age", () => {
+  const result = sourceFreshness("2026-05-07T10:45:00.000Z", {
+    now: "2026-05-07T11:00:00.000Z",
+    minGeneratedAt: "2026-05-07T10:30:00.000Z",
+    maxAgeHours: 24
+  });
+
+  assert.equal(result.status, "fresh");
+  assert.equal(result.score, 1);
+});
+
+test("buildInstalledToolsFreshness requires both inventory and tooling source freshness", () => {
+  const stale = buildInstalledToolsFreshness({
+    schema: "studiobrain-installed-tool-inventory.v1",
+    generatedAt: "2026-05-07T11:00:00.000Z",
+    effectivitySource: {
+      generatedAt: "2026-05-07T09:00:00.000Z",
+      status: "warn"
+    }
+  }, {
+    now: "2026-05-07T11:05:00.000Z",
+    minGeneratedAt: "2026-05-07T10:30:00.000Z"
+  });
+
+  assert.equal(stale.status, "stale_source");
+  assert.equal(stale.score, 0);
+  assert.equal(stale.inventory.status, "fresh");
+  assert.equal(stale.toolingQuality.status, "older_than_slice_window");
+
+  const fresh = buildInstalledToolsFreshness({
+    schema: "studiobrain-installed-tool-inventory.v1",
+    generatedAt: "2026-05-07T11:00:00.000Z",
+    effectivitySource: {
+      generatedAt: "2026-05-07T10:45:00.000Z",
+      status: "warn"
+    }
+  }, {
+    now: "2026-05-07T11:05:00.000Z",
+    minGeneratedAt: "2026-05-07T10:30:00.000Z"
+  });
+
+  assert.equal(fresh.status, "fresh");
+  assert.equal(fresh.score, 1);
+});

--- a/scripts/ops/ops_ci_validate.sh
+++ b/scripts/ops/ops_ci_validate.sh
@@ -43,6 +43,7 @@ check_file "scripts/ops/validate_ops_artifacts.mjs"
 check_file "scripts/ops/swarm_lane_preflight.mjs"
 check_file "scripts/ops/ops_wave_runner.mjs"
 check_file "scripts/ops/slice_ledger.mjs"
+check_file "scripts/ops/admin_effectivity_audit.mjs"
 check_file "scripts/ops/tooling_quality_report.mjs"
 check_file "scripts/ops/installed_tool_inventory.mjs"
 check_file "scripts/ops/tool_install_recommendations.mjs"
@@ -67,6 +68,7 @@ for script in \
   "scripts/ops/swarm_lane_preflight.mjs" \
   "scripts/ops/ops_wave_runner.mjs" \
   "scripts/ops/slice_ledger.mjs" \
+  "scripts/ops/admin_effectivity_audit.mjs" \
   "scripts/ops/tooling_quality_report.mjs" \
   "scripts/ops/installed_tool_inventory.mjs" \
   "scripts/ops/tool_install_recommendations.mjs"; do
@@ -100,6 +102,12 @@ if node --test "${REPO_ROOT}/scripts/ops/slice_ledger.test.mjs" >"${OUT_DIR}/sli
   pass "node --test scripts/ops/slice_ledger.test.mjs"
 else
   fail "node --test scripts/ops/slice_ledger.test.mjs"
+fi
+
+if node --test "${REPO_ROOT}/scripts/ops/admin_effectivity_audit.test.mjs" >"${OUT_DIR}/admin-effectivity-audit.test.out" 2>&1; then
+  pass "node --test scripts/ops/admin_effectivity_audit.test.mjs"
+else
+  fail "node --test scripts/ops/admin_effectivity_audit.test.mjs"
 fi
 
 if node --test "${REPO_ROOT}/scripts/ops/tooling_quality_report.test.mjs" >"${OUT_DIR}/tooling-quality-report.test.out" 2>&1; then


### PR DESCRIPTION
## Summary
- make admin effectivity audit validate installed-tool inventory freshness and its upstream tooling-quality source freshness
- compare both timestamps against the selected slice window so stale latest artifacts cannot silently pass
- add focused admin_effectivity_audit tests and include them in ops CI

## Evidence
- after recording slice 45 and refreshing tooling/inventory, the five-slice audit for slices 41-45 passed with usefulness=0.88, verification=1.0, noOpRate=0, toolInventoryFreshness=1
- installedToolsFreshness now shows inventory/toolingQuality source freshness and minGeneratedAt from the slice window

## Testing
- node --check scripts/ops/admin_effectivity_audit.mjs
- node --test scripts/ops/admin_effectivity_audit.test.mjs scripts/ops/validate_ops_artifacts.test.mjs
- node scripts/ops/tooling_quality_report.mjs --mode all --json --write
- node scripts/ops/installed_tool_inventory.mjs --json --write
- node scripts/ops/admin_effectivity_audit.mjs --json --write --slice-run-id admin-infra-20260507
- node scripts/ops/validate_ops_artifacts.mjs --json --write
- bash scripts/ops/ops_ci_validate.sh
- git diff --check

## Risk
Low. Audit/report semantics only; no host, Docker, database, package, or service mutation.

## Rollback
Revert commit 4f788bb5 to restore prior admin effectivity freshness behavior.

## Follow-up
Apply generatedAt age/latest consistency checks in artifact validation so schema-valid stale artifacts warn before downstream tools consume them.