### PR TITLE
[ops] Validate artifact freshness and latest targets

### DIFF
--- a/schemas/ops/artifact-schema-validation.v1.schema.json
+++ b/schemas/ops/artifact-schema-validation.v1.schema.json
@@ -38,6 +38,7 @@
       "required": [
         "checks",
         "passed",
+        "warned",
         "missing",
         "failed"
       ],
@@ -47,6 +48,10 @@
           "minimum": 0
         },
         "passed": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "warned": {
           "type": "integer",
           "minimum": 0
         },
@@ -70,7 +75,8 @@
           "artifact",
           "schema",
           "status",
-          "errors"
+          "errors",
+          "warnings"
         ],
         "properties": {
           "id": {
@@ -95,6 +101,26 @@
             "items": {
               "type": "string"
             }
+          },
+          "warnings": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "generatedAt": {
+            "type": "string"
+          },
+          "ageHours": {
+            "type": ["number", "null"],
+            "minimum": 0
+          },
+          "maxAgeHours": {
+            "type": "number",
+            "minimum": 0
+          },
+          "referencedArtifact": {
+            "type": "string"
           }
         },
         "additionalProperties": false

--- a/scripts/ops/validate_ops_artifacts.mjs
+++ b/scripts/ops/validate_ops_artifacts.mjs
@@ -66,6 +66,7 @@ Options:
   --write                   Write timestamped and latest reports under output/ops/artifact-validation.
   --output-dir <path>       Default: output/ops/artifact-validation.
   --artifact <id:path:schema>  Validate an additional artifact/schema pair.
+  --max-age-hours <number>  Warn when generatedAt is older than this. Default: 24.
 `;
 }
 
@@ -108,6 +109,7 @@ function parseArgs(argv) {
     write: false,
     outputDir: DEFAULT_OUTPUT_DIR,
     artifacts: [...DEFAULT_ARTIFACTS],
+    maxAgeHours: 24,
   };
 
   for (let index = 0; index < argv.length; index += 1) {
@@ -136,6 +138,12 @@ function parseArgs(argv) {
       if (!id || !artifactPath || !schemaPath) throw new Error("--artifact must use id:path:schema.");
       options.artifacts.push({ id, artifact: artifactPath, schema: schemaPath });
       index = artifact.nextIndex;
+      continue;
+    }
+    const maxAgeHours = readFlagValue(argv, index, "--max-age-hours");
+    if (maxAgeHours.matched) {
+      options.maxAgeHours = Math.max(0, Number(maxAgeHours.value) || 0);
+      index = maxAgeHours.nextIndex;
       continue;
     }
     throw new Error(`Unknown argument: ${arg}`);
@@ -214,7 +222,31 @@ function validateJsonSchema(value, schema, path = "$") {
   return errors;
 }
 
-function validateArtifact(definition) {
+function generatedAtWarning(artifact, options = {}) {
+  const generatedAt = clean(artifact?.generatedAt);
+  if (!generatedAt) return { generatedAt: "", ageHours: null, warnings: [] };
+  const generatedMs = Date.parse(generatedAt);
+  const nowMs = Date.parse(clean(options.now) || nowIso());
+  if (Number.isNaN(generatedMs) || Number.isNaN(nowMs)) return { generatedAt, ageHours: null, warnings: [] };
+  const ageHours = Number(Math.max(0, (nowMs - generatedMs) / 3_600_000).toFixed(2));
+  const maxAgeHours = Number(options.maxAgeHours ?? 24);
+  const warnings = maxAgeHours > 0 && ageHours > maxAgeHours
+    ? [`generatedAt is stale: ageHours=${ageHours}, maxAgeHours=${maxAgeHours}`]
+    : [];
+  return { generatedAt, ageHours, warnings };
+}
+
+function referencedArtifactErrors(artifact) {
+  const artifactPath = clean(artifact?.artifactPath);
+  if (!artifactPath) return { referencedArtifact: "", errors: [] };
+  const resolved = resolve(REPO_ROOT, artifactPath);
+  return {
+    referencedArtifact: repoRelative(resolved),
+    errors: existsSync(resolved) ? [] : [`artifactPath points to a missing artifact: ${repoRelative(resolved)}`]
+  };
+}
+
+function validateArtifact(definition, options = {}) {
   const artifactPath = resolve(REPO_ROOT, definition.artifact);
   const schemaPath = resolve(REPO_ROOT, definition.schema);
   const check = {
@@ -223,6 +255,7 @@ function validateArtifact(definition) {
     schema: repoRelative(schemaPath),
     status: "missing",
     errors: [],
+    warnings: [],
   };
 
   if (!existsSync(schemaPath)) {
@@ -236,23 +269,38 @@ function validateArtifact(definition) {
     const artifact = readJson(artifactPath);
     const schema = readJson(schemaPath);
     const errors = validateJsonSchema(artifact, schema);
-    return { ...check, status: errors.length ? "fail" : "pass", errors };
+    const freshness = generatedAtWarning(artifact, options);
+    const referenced = referencedArtifactErrors(artifact);
+    const allErrors = [...errors, ...referenced.errors];
+    const warnings = freshness.warnings;
+    return {
+      ...check,
+      status: allErrors.length ? "fail" : warnings.length ? "warn" : "pass",
+      errors: allErrors,
+      warnings,
+      generatedAt: freshness.generatedAt,
+      ageHours: freshness.ageHours,
+      maxAgeHours: Number(options.maxAgeHours ?? 24),
+      referencedArtifact: referenced.referencedArtifact,
+    };
   } catch (error) {
     return {
       ...check,
       status: "fail",
       errors: [error instanceof Error ? error.message : String(error)],
+      warnings: [],
     };
   }
 }
 
 function buildReport(options = {}) {
   const generatedAt = nowIso();
-  const checks = options.artifacts.map(validateArtifact);
+  const checks = options.artifacts.map((artifact) => validateArtifact(artifact, { maxAgeHours: options.maxAgeHours, now: options.now || generatedAt }));
   const failed = checks.filter((check) => check.status === "fail").length;
   const missing = checks.filter((check) => check.status === "missing").length;
+  const warned = checks.filter((check) => check.status === "warn").length;
   const passed = checks.filter((check) => check.status === "pass").length;
-  const status = failed > 0 ? "fail" : missing > 0 ? "warn" : "pass";
+  const status = failed > 0 ? "fail" : missing > 0 || warned > 0 ? "warn" : "pass";
   const runId = `ops-artifact-validation-${generatedAt.replace(/[-:]/g, "").replace(/\.\d+Z$/, "Z")}`;
   return {
     schema: "studiobrain-ops-artifact-schema-validation.v1",
@@ -263,6 +311,7 @@ function buildReport(options = {}) {
     summary: {
       checks: checks.length,
       passed,
+      warned,
       missing,
       failed,
     },

--- a/scripts/ops/validate_ops_artifacts.test.mjs
+++ b/scripts/ops/validate_ops_artifacts.test.mjs
@@ -46,9 +46,74 @@ test("buildReport treats missing artifacts as warnings and schema mismatch as fa
     const fail = buildReport({ artifacts: [{ id: "invalid", artifact: invalidPath, schema: schemaPath }] });
 
     assert.equal(warn.status, "warn");
+    assert.equal(warn.summary.warned, 0);
     assert.equal(pass.status, "pass");
     assert.equal(fail.status, "fail");
     assert.ok(fail.checks[0].errors.some((error) => error.includes("expected const")));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("buildReport warns when an artifact is schema-valid but stale", () => {
+  const dir = mkdtempSync(join(tmpdir(), "ops-artifact-stale-"));
+  try {
+    const schemaPath = join(dir, "schema.json");
+    const stalePath = join(dir, "stale.json");
+    writeFileSync(schemaPath, JSON.stringify({
+      type: "object",
+      required: ["schema", "generatedAt"],
+      properties: {
+        schema: { const: "artifact.v1" },
+        generatedAt: { type: "string", format: "date-time" }
+      },
+      additionalProperties: false,
+    }));
+    writeFileSync(stalePath, JSON.stringify({ schema: "artifact.v1", generatedAt: "2026-05-07T08:00:00.000Z" }));
+
+    const report = buildReport({
+      artifacts: [{ id: "stale", artifact: stalePath, schema: schemaPath }],
+      now: "2026-05-07T12:00:00.000Z",
+      maxAgeHours: 1
+    });
+
+    assert.equal(report.status, "warn");
+    assert.equal(report.summary.warned, 1);
+    assert.ok(report.checks[0].warnings.some((warning) => warning.includes("generatedAt is stale")));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("buildReport fails when latest artifactPath points nowhere", () => {
+  const dir = mkdtempSync(join(tmpdir(), "ops-artifact-latest-"));
+  try {
+    const schemaPath = join(dir, "schema.json");
+    const latestPath = join(dir, "latest.json");
+    writeFileSync(schemaPath, JSON.stringify({
+      type: "object",
+      required: ["schema", "generatedAt", "artifactPath"],
+      properties: {
+        schema: { const: "artifact.v1" },
+        generatedAt: { type: "string", format: "date-time" },
+        artifactPath: { type: "string" }
+      },
+      additionalProperties: false,
+    }));
+    writeFileSync(latestPath, JSON.stringify({
+      schema: "artifact.v1",
+      generatedAt: "2026-05-07T12:00:00.000Z",
+      artifactPath: "output/ops/missing-timestamped-artifact.json"
+    }));
+
+    const report = buildReport({
+      artifacts: [{ id: "latest", artifact: latestPath, schema: schemaPath }],
+      now: "2026-05-07T12:00:00.000Z",
+      maxAgeHours: 24
+    });
+
+    assert.equal(report.status, "fail");
+    assert.ok(report.checks[0].errors.some((error) => error.includes("artifactPath points to a missing artifact")));
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- Extends ops artifact validation with `--max-age-hours` freshness warnings for schema-valid but stale artifacts.
- Fails validation when a latest artifact's `artifactPath` points to a missing timestamped artifact.
- Updates the artifact validation schema and tests for warning counts, freshness metadata, and referenced artifact checks.

## Evidence
- Slice recorded as `slice-20260507-046` in the local effectivity ledger.
- Latest validation report showed 9/9 checks passing with `warned=0`, `missing=0`, and `failed=0` after bootstrap.
- Five-slice summary for slices 042-046: usefulness `0.882`, verification `1`, no-op rate `0`, next audit at slice 050.

## Files Changed
- `scripts/ops/validate_ops_artifacts.mjs`
- `scripts/ops/validate_ops_artifacts.test.mjs`
- `schemas/ops/artifact-schema-validation.v1.schema.json`

## Testing Performed
- `node --check scripts/ops/validate_ops_artifacts.mjs`
- `node --test scripts/ops/validate_ops_artifacts.test.mjs`
- `node scripts/ops/validate_ops_artifacts.mjs --json --write`
- `bash scripts/ops/ops_ci_validate.sh`
- `git diff --check`

## Risk Level
Low. This is read-only validation/reporting logic. It can turn stale or broken latest artifacts into warnings/failures, which may require regenerating artifacts before downstream automation trusts them.

## Rollback Instructions
Revert this commit to restore schema-only artifact validation without freshness or referenced-artifact checks. Regenerate `output/ops/artifact-validation/artifact-schema-validation-latest.json` afterward if local ignored outputs were produced with the newer shape.

## Follow-up Tickets
- Feed artifact freshness warnings into work-packet summaries and PR readiness packets.
- Decide whether selected artifact classes need stricter or looser max-age thresholds.