### PR TITLE
[ops] Feed tool install recommendations into work packets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ OPS_SWARM_LANE ?= tooling
 OPS_SWARM_BASE ?= origin/main
 OPS_SWARM_PREFLIGHT_FLAGS ?=
 
-.PHONY: ops-check ops-inventory ops-postgres-review ops-postgres-sql ops-postgres-top-queries ops-postgres-query-tasks ops-postgres-growth-snapshot ops-postgres-autovacuum-stats ops-postgres-roles-extensions ops-docker-review ops-docker-posture ops-capacity ops-import-pressure ops-cleanup-candidates ops-backup-evidence ops-postgres-backup-artifacts ops-restore-prereq ops-redis-minio-backup-evidence ops-ubuntu-review ops-host-failed-unit-trends ops-package-posture ops-time-sync ops-network-review ops-host-drift ops-systemd-drift ops-portal-bridge-review ops-app-review ops-dependency-review ops-idle-worker-effectivity ops-effectivity-report ops-slice-ledger ops-tool-inventory ops-tool-install-plan ops-admin-effectivity-audit ops-tooling-quality ops-shell-lf-guard ops-shellcheck-report ops-powershell-syntax ops-sql-parse-report ops-actionlint-report ops-compose-config-report ops-validate-artifacts ops-swarm-lane-preflight ops-wave-runner ops-privileged-evidence-read ops-privileged-evidence-capture ops-privileged-evidence-capture-smoke ops-work-packet ops-incident-bundle ops-incident-bundle-v2 ops-ci-validate ops-post-deploy-verify ops-docs ops-backlog ops-report
+.PHONY: ops-check ops-inventory ops-postgres-review ops-postgres-sql ops-postgres-top-queries ops-postgres-query-tasks ops-postgres-growth-snapshot ops-postgres-autovacuum-stats ops-postgres-roles-extensions ops-docker-review ops-docker-posture ops-capacity ops-import-pressure ops-cleanup-candidates ops-backup-evidence ops-postgres-backup-artifacts ops-restore-prereq ops-redis-minio-backup-evidence ops-ubuntu-review ops-host-failed-unit-trends ops-package-posture ops-time-sync ops-network-review ops-host-drift ops-systemd-drift ops-portal-bridge-review ops-app-review ops-dependency-review ops-idle-worker-effectivity ops-effectivity-report ops-slice-ledger ops-tool-inventory ops-tool-install-plan ops-admin-effectivity-audit ops-tooling-quality ops-shell-lf-guard ops-shellcheck-report ops-powershell-syntax ops-sql-parse-report ops-actionlint-report ops-compose-config-report ops-validate-artifacts ops-swarm-lane-preflight ops-wave-runner ops-privileged-evidence-read ops-privileged-evidence-capture ops-privileged-evidence-capture-smoke ops-work-packet ops-pr-readiness-packet ops-incident-bundle ops-incident-bundle-v2 ops-ci-validate ops-post-deploy-verify ops-docs ops-backlog ops-report
 
 ops-check: ops-inventory ops-docker-review ops-capacity ops-cleanup-candidates ops-backup-evidence ops-ubuntu-review ops-network-review ops-host-drift ops-systemd-drift ops-portal-bridge-review ops-app-review
 
@@ -168,6 +168,9 @@ ops-privileged-evidence-capture-smoke:
 
 ops-work-packet:
 	node ./scripts/studiobrain-ops-work-packet.mjs --write
+
+ops-pr-readiness-packet:
+	node ./scripts/ops/pr_readiness_packet.mjs --write
 
 ops-incident-bundle:
 	bash scripts/ops/incident_bundle.sh

--- a/docs/ops/17-pr-readiness-packet-template.md
+++ b/docs/ops/17-pr-readiness-packet-template.md
@@ -21,6 +21,7 @@ Use this packet before opening or merging ops PRs that touch Studio Brain eviden
 | --- | --- | --- | --- |
 | Shell syntax | `bash -n scripts/ops/incident_bundle_v2.sh scripts/ops/ops_ci_validate.sh scripts/ops/post_deploy_verify.sh` | passes | |
 | Ops script validation | `bash scripts/ops/ops_ci_validate.sh` | passes and writes `output/ops/ci-validate` | |
+| Generated readiness packet | `node scripts/ops/pr_readiness_packet.mjs --json --write` | writes `output/ops/pr-readiness/pr-readiness-latest.md` and omits install commands | |
 | Redacted incident bundle v2 | `INCIDENT_INCLUDE_LOGS=0 INCIDENT_INCLUDE_POST_DEPLOY=0 bash scripts/ops/incident_bundle_v2.sh output/ops/incidents-v2/pr-smoke` | writes `summary.json` and redacted reports | |
 | Post-deploy verification help | `bash scripts/ops/post_deploy_verify.sh --help` | documents safe flags and env vars | |
 | Docs review | Review `docs/ops/18-release-verification.md` | release verifier covers Studio Brain health/ready, Mission Control health/admin DOM, harness, and idle-worker audit | |

--- a/docs/ops/admin-effectivity-loop.md
+++ b/docs/ops/admin-effectivity-loop.md
@@ -97,7 +97,7 @@ node scripts/ops/ops_wave_runner.mjs --dry-run --json --write
 
 The wave runner executes read-only checks in dependency order: preflight, tooling quality, tool inventory, admin effectivity audit, work packet generation, then artifact schema validation. Use it when a downstream command consumes a `*-latest.json` artifact from an upstream command.
 
-Work packets should steer from fresh evidence only. Missing, invalid, stale, or invalid-timestamp latest artifacts stay visible in `freshEvidence`, but they are excluded from packet `sourceSignals`. Tool inventory coverage gaps are kept as `signalClass=coverage_gap` so missing validators remain visible without being treated as actionable defect evidence.
+Work packets should steer from fresh evidence only. Missing, invalid, stale, or invalid-timestamp latest artifacts stay visible in `freshEvidence`, but they are excluded from packet `sourceSignals`. Tool inventory coverage gaps are kept as `signalClass=coverage_gap` so missing validators remain visible without being treated as actionable defect evidence. Tool-install recommendations are tracked as a separate fresh source and use `signalClass=tool_install_recommendation` only when the recommendation artifact has install-now candidates; approval-required tools remain evidence for planning, not automatic installation.
 
 ## Scoring
 

--- a/schemas/ops/ops-work-packet.v1.schema.json
+++ b/schemas/ops/ops-work-packet.v1.schema.json
@@ -11,7 +11,7 @@
     "purpose": { "type": "string" },
     "sources": {
       "type": "object",
-      "required": ["riskRegister", "backlog", "effectivity", "adminAudit", "sliceLedger", "toolInventory", "swarmPreflight"],
+      "required": ["riskRegister", "backlog", "effectivity", "adminAudit", "sliceLedger", "toolInventory", "toolInstallRecommendations", "swarmPreflight"],
       "properties": {
         "riskRegister": { "type": "string" },
         "backlog": { "type": "string" },
@@ -19,6 +19,7 @@
         "adminAudit": { "type": "string" },
         "sliceLedger": { "type": "string" },
         "toolInventory": { "type": "string" },
+        "toolInstallRecommendations": { "type": "string" },
         "swarmPreflight": { "type": "string" }
       },
       "additionalProperties": false
@@ -37,7 +38,7 @@
     },
     "evidenceSummary": {
       "type": "object",
-      "required": ["risks", "backlogItems", "effectivityNextSafeSlices", "remainingApprovalGates", "freshSources", "staleSources", "toolPromotionCandidates", "toolActionableFindings", "toolCoverageGaps", "swarmPreflightStatus", "swarmPreflightOutsideScope", "swarmPreflightProblems"],
+      "required": ["risks", "backlogItems", "effectivityNextSafeSlices", "remainingApprovalGates", "freshSources", "staleSources", "toolPromotionCandidates", "toolActionableFindings", "toolCoverageGaps", "toolInstallRecommendations", "toolInstallApprovalRequired", "toolInstallNowCandidates", "swarmPreflightStatus", "swarmPreflightOutsideScope", "swarmPreflightProblems"],
       "properties": {
         "risks": { "type": "number", "minimum": 0 },
         "backlogItems": { "type": "number", "minimum": 0 },
@@ -48,6 +49,9 @@
         "toolPromotionCandidates": { "type": ["number", "null"], "minimum": 0 },
         "toolActionableFindings": { "type": ["number", "null"], "minimum": 0 },
         "toolCoverageGaps": { "type": ["number", "null"], "minimum": 0 },
+        "toolInstallRecommendations": { "type": ["number", "null"], "minimum": 0 },
+        "toolInstallApprovalRequired": { "type": ["number", "null"], "minimum": 0 },
+        "toolInstallNowCandidates": { "type": ["number", "null"], "minimum": 0 },
         "swarmPreflightStatus": { "type": "string" },
         "swarmPreflightOutsideScope": { "type": ["number", "null"], "minimum": 0 },
         "swarmPreflightProblems": { "type": ["number", "null"], "minimum": 0 }
@@ -56,7 +60,7 @@
     },
     "freshEvidence": {
       "type": "object",
-      "required": ["adminAudit", "sliceLedger", "toolInventory", "swarmPreflight"],
+      "required": ["adminAudit", "sliceLedger", "toolInventory", "toolInstallRecommendations", "swarmPreflight"],
       "additionalProperties": true
     },
     "packets": {

--- a/scripts/ops/ops_ci_validate.sh
+++ b/scripts/ops/ops_ci_validate.sh
@@ -47,6 +47,7 @@ check_file "scripts/ops/admin_effectivity_audit.mjs"
 check_file "scripts/ops/tooling_quality_report.mjs"
 check_file "scripts/ops/installed_tool_inventory.mjs"
 check_file "scripts/ops/tool_install_recommendations.mjs"
+check_file "scripts/ops/pr_readiness_packet.mjs"
 check_file "docs/ops/17-pr-readiness-packet-template.md"
 check_file "docs/ops/18-release-verification.md"
 
@@ -71,7 +72,8 @@ for script in \
   "scripts/ops/admin_effectivity_audit.mjs" \
   "scripts/ops/tooling_quality_report.mjs" \
   "scripts/ops/installed_tool_inventory.mjs" \
-  "scripts/ops/tool_install_recommendations.mjs"; do
+  "scripts/ops/tool_install_recommendations.mjs" \
+  "scripts/ops/pr_readiness_packet.mjs"; do
   if [ -f "${REPO_ROOT}/${script}" ] && node --check "${REPO_ROOT}/${script}" >/dev/null; then
     pass "node --check ${script}"
   else
@@ -128,6 +130,12 @@ else
   fail "node --test scripts/ops/tool_install_recommendations.test.mjs"
 fi
 
+if node --test "${REPO_ROOT}/scripts/ops/pr_readiness_packet.test.mjs" >"${OUT_DIR}/pr-readiness-packet.test.out" 2>&1; then
+  pass "node --test scripts/ops/pr_readiness_packet.test.mjs"
+else
+  fail "node --test scripts/ops/pr_readiness_packet.test.mjs"
+fi
+
 section "Swarm Lane Preflight Smoke"
 if node "${REPO_ROOT}/scripts/ops/swarm_lane_preflight.mjs" --lane tooling --base origin/main --json --write >"${OUT_DIR}/swarm-lane-preflight.json"; then
   pass "swarm_lane_preflight tooling smoke"
@@ -160,6 +168,13 @@ if node "${REPO_ROOT}/scripts/ops/validate_ops_artifacts.mjs" --json --write >"$
   pass "validate_ops_artifacts schema smoke"
 else
   fail "validate_ops_artifacts schema smoke"
+fi
+
+section "PR Readiness Packet Smoke"
+if node "${REPO_ROOT}/scripts/ops/pr_readiness_packet.mjs" --json --write >"${OUT_DIR}/pr-readiness-packet.json"; then
+  pass "pr_readiness_packet smoke"
+else
+  fail "pr_readiness_packet smoke"
 fi
 
 section "Docs Contract"

--- a/scripts/ops/pr_readiness_packet.mjs
+++ b/scripts/ops/pr_readiness_packet.mjs
@@ -1,0 +1,387 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const REPO_ROOT = resolve(dirname(__filename), "..", "..");
+const DEFAULT_OUTPUT_DIR = resolve(REPO_ROOT, "output", "ops", "pr-readiness");
+const DEFAULT_ARTIFACT_VALIDATION = resolve(REPO_ROOT, "output", "ops", "artifact-validation", "artifact-schema-validation-latest.json");
+const DEFAULT_WORK_PACKET = resolve(REPO_ROOT, "output", "ops", "swarm", "latest-work-packet.json");
+const DEFAULT_SLICE_LEDGER = resolve(REPO_ROOT, "output", "ops", "effectivity", "slice-ledger-latest.json");
+const DEFAULT_TOOL_INSTALL_RECOMMENDATIONS = resolve(REPO_ROOT, "output", "ops", "effectivity", "tool-install-recommendations-latest.json");
+
+function clean(value) {
+  return String(value ?? "").replace(/\r/g, "").trim();
+}
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function repoRelative(path) {
+  const raw = clean(path);
+  if (!raw) return "";
+  return relative(REPO_ROOT, resolve(REPO_ROOT, raw)).replace(/\\/g, "/");
+}
+
+function readJsonIfExists(path) {
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch (error) {
+    return {
+      schema: "invalid-json",
+      status: "invalid_json",
+      parseError: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+function gitLines(args, fallback = []) {
+  try {
+    return execFileSync("git", args, { cwd: REPO_ROOT, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] })
+      .split(/\r?\n/)
+      .map(clean)
+      .filter(Boolean);
+  } catch {
+    return fallback;
+  }
+}
+
+function firstLine(args, fallback = "") {
+  return gitLines(args, [fallback])[0] || fallback;
+}
+
+function collectGitState(options = {}) {
+  const base = clean(options.base) || "origin/main";
+  const branch = clean(options.branch) || firstLine(["rev-parse", "--abbrev-ref", "HEAD"], "unknown");
+  return {
+    base,
+    branch,
+    head: firstLine(["rev-parse", "--short", "HEAD"], ""),
+    changedFiles: gitLines(["diff", "--name-only", `${base}...HEAD`]),
+    dirtyFiles: gitLines(["status", "--short"]),
+  };
+}
+
+function summarizeArtifactValidation(report) {
+  if (!report) return { status: "missing", checks: 0, passed: 0, warned: 0, failed: 0, missing: 0, generatedAt: "", problems: ["artifact validation report is missing"] };
+  if (report.status === "invalid_json") return { status: "invalid_json", checks: 0, passed: 0, warned: 0, failed: 1, missing: 0, generatedAt: "", problems: [report.parseError || "artifact validation JSON is invalid"] };
+  const failing = Array.isArray(report.checks)
+    ? report.checks.filter((check) => ["fail", "missing", "warn"].includes(clean(check.status))).map((check) => `${check.id}: ${check.status}`)
+    : [];
+  return {
+    status: clean(report.status) || "unknown",
+    generatedAt: clean(report.generatedAt),
+    checks: report.summary?.checks ?? 0,
+    passed: report.summary?.passed ?? 0,
+    warned: report.summary?.warned ?? 0,
+    failed: report.summary?.failed ?? 0,
+    missing: report.summary?.missing ?? 0,
+    problems: failing,
+  };
+}
+
+function summarizeWorkPacket(packet) {
+  if (!packet) return { status: "missing", generatedAt: "", packets: 0, freshSources: 0, staleSources: 0, topPacket: "", humanGates: 0 };
+  if (packet.status === "invalid_json") return { status: "invalid_json", generatedAt: "", packets: 0, freshSources: 0, staleSources: 0, topPacket: "", humanGates: 0, parseError: packet.parseError || "" };
+  const packets = Array.isArray(packet.packets) ? packet.packets : [];
+  return {
+    status: packets.length > 0 ? "present" : "empty",
+    generatedAt: clean(packet.generatedAt),
+    packets: packets.length,
+    freshSources: packet.evidenceSummary?.freshSources ?? null,
+    staleSources: packet.evidenceSummary?.staleSources ?? null,
+    topPacket: clean(packets[0]?.title),
+    humanGates: packets.filter((entry) => clean(entry.humanGate)).length,
+    toolInstallNowCandidates: packet.evidenceSummary?.toolInstallNowCandidates ?? null,
+    toolInstallApprovalRequired: packet.evidenceSummary?.toolInstallApprovalRequired ?? null,
+  };
+}
+
+function summarizeSliceLedger(summary) {
+  if (!summary) return { status: "missing", generatedAt: "", window: null, verification: null, usefulness: null, commandFailures: null };
+  if (summary.status === "invalid_json") return { status: "invalid_json", generatedAt: "", window: null, verification: null, usefulness: null, commandFailures: null, parseError: summary.parseError || "" };
+  return {
+    status: (summary.counts?.failed ?? 0) > 0 || (summary.counts?.commandFailures ?? 0) > 0 ? "fail" : "present",
+    generatedAt: clean(summary.generatedAt),
+    window: summary.window || null,
+    verification: summary.scores?.verification ?? null,
+    usefulness: summary.scores?.usefulness ?? null,
+    commandFailures: summary.counts?.commandFailures ?? null,
+  };
+}
+
+function summarizeToolInstall(report) {
+  if (!report) return { status: "missing", generatedAt: "", recommendations: 0, installNowCandidates: 0, approvalRequired: 0, topRecommendations: [] };
+  if (report.status === "invalid_json") return { status: "invalid_json", generatedAt: "", recommendations: 0, installNowCandidates: 0, approvalRequired: 0, topRecommendations: [], parseError: report.parseError || "" };
+  return {
+    status: clean(report.status) || "unknown",
+    generatedAt: clean(report.generatedAt),
+    recommendations: report.summary?.recommendations ?? 0,
+    installNowCandidates: report.summary?.installNowCandidates ?? 0,
+    approvalRequired: report.summary?.approvalRequired ?? 0,
+    topRecommendations: Array.isArray(report.recommendations)
+      ? report.recommendations.slice(0, 3).map((item) => ({
+          tool: clean(item.tool),
+          priority: clean(item.priority),
+          acquisitionClass: clean(item.acquisitionClass),
+          validationCommand: clean(item.validationCommand),
+          approvalRequired: Boolean(item.approvalRequired),
+        }))
+      : [],
+  };
+}
+
+function readinessStatus(packet) {
+  if (packet.evidence.artifactValidation.status === "fail" || packet.evidence.artifactValidation.status === "invalid_json") return "fail";
+  if (packet.evidence.sliceLedger.status === "fail") return "fail";
+  if (packet.warnings.length > 0) return "warn";
+  return "pass";
+}
+
+function buildWarnings({ gitState, evidence }) {
+  const warnings = [];
+  if (gitState.dirtyFiles.length > 0) warnings.push(`${gitState.dirtyFiles.length} dirty file(s) in local worktree`);
+  if (evidence.artifactValidation.status === "missing") warnings.push("artifact validation report is missing");
+  if (evidence.artifactValidation.warned > 0 || evidence.artifactValidation.missing > 0) warnings.push("artifact validation has warnings or missing artifacts");
+  if (evidence.workPacket.status === "missing") warnings.push("work-packet latest artifact is missing");
+  if ((evidence.workPacket.staleSources ?? 0) > 0) warnings.push("work packet has stale evidence sources");
+  if ((evidence.toolInstall.approvalRequired ?? 0) > 0) warnings.push(`${evidence.toolInstall.approvalRequired} tool recommendation(s) require approval before use`);
+  return warnings;
+}
+
+export function buildPrReadinessPacket(inputs = {}, options = {}) {
+  const generatedAt = options.generatedAt || nowIso();
+  const gitState = inputs.gitState || collectGitState(options);
+  const evidence = {
+    artifactValidation: summarizeArtifactValidation(inputs.artifactValidation),
+    workPacket: summarizeWorkPacket(inputs.workPacket),
+    sliceLedger: summarizeSliceLedger(inputs.sliceLedger),
+    toolInstall: summarizeToolInstall(inputs.toolInstallRecommendations),
+  };
+  const warnings = buildWarnings({ gitState, evidence });
+  const packet = {
+    schema: "studiobrain-ops-pr-readiness-packet.v1",
+    generatedAt,
+    readOnly: true,
+    pr: clean(options.pr),
+    owner: clean(options.owner) || "Codex",
+    sliceIds: clean(options.sliceIds),
+    scope: {
+      branch: gitState.branch,
+      base: gitState.base,
+      head: gitState.head,
+      changedFiles: gitState.changedFiles,
+      dirtyFiles: gitState.dirtyFiles,
+      nonScope: [
+        "no service restarts",
+        "no deploys",
+        "no package upgrades",
+        "no firewall, SSH, sudoers, systemd, Docker, PostgreSQL, or secret changes",
+      ],
+    },
+    evidence,
+    warnings,
+    status: "pass",
+    rollback: "Revert the PR commit(s), then regenerate ignored output/ops artifacts if a local latest file used the reverted schema.",
+  };
+  packet.status = readinessStatus(packet);
+  return packet;
+}
+
+function renderMarkdown(packet) {
+  const topRecommendations = packet.evidence.toolInstall.topRecommendations
+    .map((item) => `- ${item.priority} ${item.tool}: ${item.acquisitionClass}; validate with \`${item.validationCommand}\`; approvalRequired=${item.approvalRequired}`)
+    .join("\n") || "- None recorded.";
+  const warnings = packet.warnings.map((warning) => `- ${warning}`).join("\n") || "- None.";
+  const changedFiles = packet.scope.changedFiles.slice(0, 20).map((file) => `- ${file}`).join("\n") || "- None detected from base.";
+  const dirtyFiles = packet.scope.dirtyFiles.map((file) => `- ${file}`).join("\n") || "- Clean.";
+  return `# Ops PR Readiness Packet
+
+Generated: ${packet.generatedAt}
+Status: ${packet.status}
+
+## Scope
+
+- PR: ${packet.pr || ""}
+- Branch: ${packet.scope.branch}
+- Base: ${packet.scope.base}
+- Head: ${packet.scope.head}
+- Owner: ${packet.owner}
+- Slice IDs: ${packet.sliceIds || ""}
+
+### Changed Files
+
+${changedFiles}
+
+### Dirty Files
+
+${dirtyFiles}
+
+## Evidence
+
+| Check | Status | Detail |
+| --- | --- | --- |
+| Artifact validation | ${packet.evidence.artifactValidation.status} | checks=${packet.evidence.artifactValidation.checks}, warned=${packet.evidence.artifactValidation.warned}, missing=${packet.evidence.artifactValidation.missing}, failed=${packet.evidence.artifactValidation.failed} |
+| Slice ledger | ${packet.evidence.sliceLedger.status} | window=${packet.evidence.sliceLedger.window?.from || ""}..${packet.evidence.sliceLedger.window?.to || ""}, verification=${packet.evidence.sliceLedger.verification ?? ""}, usefulness=${packet.evidence.sliceLedger.usefulness ?? ""} |
+| Work packet | ${packet.evidence.workPacket.status} | packets=${packet.evidence.workPacket.packets}, freshSources=${packet.evidence.workPacket.freshSources ?? ""}, staleSources=${packet.evidence.workPacket.staleSources ?? ""}, top="${packet.evidence.workPacket.topPacket}" |
+| Tool install recommendations | ${packet.evidence.toolInstall.status} | recommendations=${packet.evidence.toolInstall.recommendations}, installNow=${packet.evidence.toolInstall.installNowCandidates}, approvalRequired=${packet.evidence.toolInstall.approvalRequired} |
+
+## Tool Recommendation Summary
+
+${topRecommendations}
+
+## Warnings
+
+${warnings}
+
+## Safety
+
+- Read-only packet generation only.
+- Generated outputs stay under ignored \`output/ops/pr-readiness\`.
+- Tool recommendations expose validation commands only; install commands are intentionally omitted.
+
+## Rollback
+
+${packet.rollback}
+`;
+}
+
+function parseArgs(argv) {
+  const options = {
+    json: false,
+    write: false,
+    outputDir: DEFAULT_OUTPUT_DIR,
+    base: "origin/main",
+    branch: "",
+    pr: "",
+    owner: "Codex",
+    sliceIds: "",
+    artifactValidation: DEFAULT_ARTIFACT_VALIDATION,
+    workPacket: DEFAULT_WORK_PACKET,
+    sliceLedger: DEFAULT_SLICE_LEDGER,
+    toolInstallRecommendations: DEFAULT_TOOL_INSTALL_RECOMMENDATIONS,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = clean(argv[index]);
+    if (arg === "--help" || arg === "-h") {
+      printUsage();
+      process.exit(0);
+    }
+    if (arg === "--json") {
+      options.json = true;
+      continue;
+    }
+    if (arg === "--write") {
+      options.write = true;
+      continue;
+    }
+    const next = clean(argv[index + 1]);
+    const read = (flag) => {
+      if (arg === flag) {
+        if (!next) throw new Error(`${flag} requires a value.`);
+        index += 1;
+        return next;
+      }
+      if (arg.startsWith(`${flag}=`)) return arg.slice(flag.length + 1);
+      return null;
+    };
+    const flags = {
+      "--output-dir": "outputDir",
+      "--base": "base",
+      "--branch": "branch",
+      "--pr": "pr",
+      "--owner": "owner",
+      "--slice-ids": "sliceIds",
+      "--artifact-validation": "artifactValidation",
+      "--work-packet": "workPacket",
+      "--slice-ledger": "sliceLedger",
+      "--tool-install-recommendations": "toolInstallRecommendations",
+    };
+    let matched = false;
+    for (const [flag, key] of Object.entries(flags)) {
+      const value = read(flag);
+      if (value === null) continue;
+      options[key] = ["outputDir", "artifactValidation", "workPacket", "sliceLedger", "toolInstallRecommendations"].includes(key)
+        ? resolve(REPO_ROOT, value)
+        : value;
+      matched = true;
+      break;
+    }
+    if (matched) continue;
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+  return options;
+}
+
+function printUsage() {
+  process.stdout.write(`Studio Brain ops PR readiness packet
+
+Usage:
+  node scripts/ops/pr_readiness_packet.mjs --write [--json]
+
+Options:
+  --base <ref>                         Default: origin/main.
+  --pr <id-or-url>                     Optional PR number or URL.
+  --slice-ids <ids>                    Optional slice id list.
+  --artifact-validation <path>         Default: output/ops/artifact-validation/artifact-schema-validation-latest.json.
+  --work-packet <path>                 Default: output/ops/swarm/latest-work-packet.json.
+  --slice-ledger <path>                Default: output/ops/effectivity/slice-ledger-latest.json.
+  --tool-install-recommendations <path> Default: output/ops/effectivity/tool-install-recommendations-latest.json.
+`);
+}
+
+function writeOutputs(packet, outputDir) {
+  mkdirSync(outputDir, { recursive: true });
+  const stamp = packet.generatedAt.replace(/[-:]/g, "").replace(/\.\d+Z$/, "Z");
+  const jsonPath = resolve(outputDir, `pr-readiness-${stamp}.json`);
+  const markdownPath = resolve(outputDir, `pr-readiness-${stamp}.md`);
+  const latestJson = resolve(outputDir, "pr-readiness-latest.json");
+  const latestMarkdown = resolve(outputDir, "pr-readiness-latest.md");
+  writeFileSync(jsonPath, `${JSON.stringify(packet, null, 2)}\n`, "utf8");
+  writeFileSync(markdownPath, renderMarkdown(packet), "utf8");
+  writeFileSync(latestJson, `${JSON.stringify({ ...packet, artifactPath: repoRelative(jsonPath), markdownPath: repoRelative(markdownPath) }, null, 2)}\n`, "utf8");
+  writeFileSync(latestMarkdown, renderMarkdown({ ...packet, artifactPath: repoRelative(jsonPath), markdownPath: repoRelative(markdownPath) }), "utf8");
+  return {
+    jsonPath: repoRelative(jsonPath),
+    markdownPath: repoRelative(markdownPath),
+    latestJson: repoRelative(latestJson),
+    latestMarkdown: repoRelative(latestMarkdown),
+  };
+}
+
+function run(rawArgs = process.argv.slice(2)) {
+  const options = parseArgs(rawArgs);
+  const packet = buildPrReadinessPacket({
+    artifactValidation: readJsonIfExists(options.artifactValidation),
+    workPacket: readJsonIfExists(options.workPacket),
+    sliceLedger: readJsonIfExists(options.sliceLedger),
+    toolInstallRecommendations: readJsonIfExists(options.toolInstallRecommendations),
+  }, options);
+  const report = {
+    ...packet,
+    artifacts: options.write ? writeOutputs(packet, options.outputDir) : null,
+  };
+  if (options.json) process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  else {
+    process.stdout.write(`ops PR readiness: ${packet.status}\n`);
+    if (options.write) process.stdout.write(`artifact: ${report.artifacts.latestMarkdown}\n`);
+  }
+  if (packet.status === "fail") process.exitCode = 1;
+  return report;
+}
+
+export { renderMarkdown };
+
+if (process.argv[1] && resolve(process.argv[1]) === __filename) {
+  try {
+    run();
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.stack || error.message : String(error)}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/ops/pr_readiness_packet.test.mjs
+++ b/scripts/ops/pr_readiness_packet.test.mjs
@@ -1,0 +1,118 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { buildPrReadinessPacket, renderMarkdown } from "./pr_readiness_packet.mjs";
+
+const gitState = {
+  base: "origin/main",
+  branch: "codex/ops-test",
+  head: "abc1234",
+  changedFiles: ["scripts/ops/example.mjs"],
+  dirtyFiles: [],
+};
+
+const artifactValidation = {
+  schema: "studiobrain-ops-artifact-schema-validation.v1",
+  generatedAt: "2026-05-07T12:00:00.000Z",
+  status: "pass",
+  summary: { checks: 4, passed: 4, warned: 0, missing: 0, failed: 0 },
+  checks: [],
+};
+
+const workPacket = {
+  schema: "studiobrain-ops-work-packet.v1",
+  generatedAt: "2026-05-07T12:01:00.000Z",
+  evidenceSummary: {
+    freshSources: 5,
+    staleSources: 0,
+    toolInstallNowCandidates: 2,
+    toolInstallApprovalRequired: 1,
+  },
+  packets: [{ title: "[ops] Refresh evidence", humanGate: "" }],
+};
+
+const sliceLedger = {
+  schema: "studiobrain-admin-slice-ledger-summary.v1",
+  generatedAt: "2026-05-07T12:02:00.000Z",
+  window: { from: "slice-046", to: "slice-047", count: 2 },
+  counts: { failed: 0, commandFailures: 0 },
+  scores: { usefulness: 0.88, verification: 1 },
+};
+
+const toolInstallRecommendations = {
+  schema: "studiobrain-ops-tool-install-recommendations.v1",
+  generatedAt: "2026-05-07T12:03:00.000Z",
+  status: "warn",
+  summary: { recommendations: 7, installNowCandidates: 2, approvalRequired: 1 },
+  recommendations: [
+    {
+      tool: "shellcheck",
+      priority: "P1",
+      acquisitionClass: "ephemeral-runner",
+      validationCommand: "node scripts/ops/tooling_quality_report.mjs --mode shellcheck --allow-install --json --write",
+      installCommand: "do not copy this into readiness markdown",
+      approvalRequired: false,
+    },
+    {
+      tool: "docker",
+      priority: "P2",
+      acquisitionClass: "remote-lane",
+      validationCommand: "node scripts/ops/tooling_quality_report.mjs --mode compose-config --json --write",
+      installCommand: "do not install Docker from a packet",
+      approvalRequired: true,
+    },
+  ],
+};
+
+test("buildPrReadinessPacket summarizes current evidence without executable install commands", () => {
+  const packet = buildPrReadinessPacket(
+    { gitState, artifactValidation, workPacket, sliceLedger, toolInstallRecommendations },
+    { generatedAt: "2026-05-07T12:10:00.000Z", pr: "#123", sliceIds: "slice-046,slice-047" },
+  );
+
+  assert.equal(packet.schema, "studiobrain-ops-pr-readiness-packet.v1");
+  assert.equal(packet.readOnly, true);
+  assert.equal(packet.status, "warn");
+  assert.equal(packet.evidence.artifactValidation.status, "pass");
+  assert.equal(packet.evidence.workPacket.freshSources, 5);
+  assert.equal(packet.evidence.toolInstall.installNowCandidates, 2);
+  assert.equal(packet.evidence.toolInstall.approvalRequired, 1);
+  assert.ok(packet.warnings.some((warning) => warning.includes("require approval")));
+
+  const markdown = renderMarkdown(packet);
+  assert.match(markdown, /Tool Recommendation Summary/);
+  assert.match(markdown, /shellcheck/);
+  assert.doesNotMatch(markdown, /do not copy this/);
+  assert.doesNotMatch(markdown, /do not install Docker/);
+});
+
+test("buildPrReadinessPacket fails on failing artifact validation", () => {
+  const packet = buildPrReadinessPacket({
+    gitState,
+    artifactValidation: {
+      ...artifactValidation,
+      status: "fail",
+      summary: { checks: 4, passed: 3, warned: 0, missing: 0, failed: 1 },
+      checks: [{ id: "work-packet", status: "fail" }],
+    },
+    workPacket,
+    sliceLedger,
+    toolInstallRecommendations: { ...toolInstallRecommendations, summary: { recommendations: 1, installNowCandidates: 0, approvalRequired: 0 } },
+  });
+
+  assert.equal(packet.status, "fail");
+  assert.deepEqual(packet.evidence.artifactValidation.problems, ["work-packet: fail"]);
+});
+
+test("buildPrReadinessPacket warns on dirty local state", () => {
+  const packet = buildPrReadinessPacket({
+    gitState: { ...gitState, dirtyFiles: [" M scripts/ops/example.mjs"] },
+    artifactValidation,
+    workPacket,
+    sliceLedger,
+    toolInstallRecommendations: { ...toolInstallRecommendations, summary: { recommendations: 1, installNowCandidates: 0, approvalRequired: 0 } },
+  });
+
+  assert.equal(packet.status, "warn");
+  assert.ok(packet.warnings.some((warning) => warning.includes("dirty file")));
+});

--- a/scripts/studiobrain-ops-work-packet.mjs
+++ b/scripts/studiobrain-ops-work-packet.mjs
@@ -20,6 +20,7 @@ const DEFAULT_EFFECTIVITY_DOC = resolve(REPO_ROOT, "docs", "ops", "16-effectivit
 const DEFAULT_ADMIN_AUDIT = resolve(REPO_ROOT, "output", "ops", "effectivity", "admin-effectivity-audit-latest.json");
 const DEFAULT_SLICE_LEDGER = resolve(REPO_ROOT, "output", "ops", "effectivity", "slice-ledger-latest.json");
 const DEFAULT_TOOL_INVENTORY = resolve(REPO_ROOT, "output", "ops", "effectivity", "installed-tool-inventory-latest.json");
+const DEFAULT_TOOL_INSTALL_RECOMMENDATIONS = resolve(REPO_ROOT, "output", "ops", "effectivity", "tool-install-recommendations-latest.json");
 const DEFAULT_SWARM_PREFLIGHT = resolve(REPO_ROOT, "output", "ops", "swarm-lane-preflight", "swarm-lane-preflight-latest.json");
 const VALID_OUTCOMES = new Set([
   "used",
@@ -335,16 +336,31 @@ function makePacket(backlogItem, risk, effectivity, freshEvidence) {
 
 function freshSourceSignals(freshEvidence) {
   if (!freshEvidence) return [];
-  return [freshEvidence.adminAudit, freshEvidence.sliceLedger, freshEvidence.toolInventory, freshEvidence.swarmPreflight]
+  return [
+    freshEvidence.adminAudit,
+    freshEvidence.sliceLedger,
+    freshEvidence.toolInventory,
+    freshEvidence.toolInstallRecommendations,
+    freshEvidence.swarmPreflight,
+  ]
     .filter((source) => source && !["missing", "invalid_json", "invalid_timestamp", "stale"].includes(source.status))
     .map((source) => ({
       source: source.source,
       path: source.path,
       status: source.status,
       generatedAt: source.generatedAt || "",
-      signalClass: source.source === "fresh-tool-inventory" && (source.summary?.coverageGaps || 0) > 0 ? "coverage_gap" : "fresh",
+      signalClass: signalClassForSource(source),
       summary: source.summary,
     }));
+}
+
+function signalClassForSource(source) {
+  if (source.source === "fresh-tool-inventory" && (source.summary?.coverageGaps || 0) > 0) return "coverage_gap";
+  if (source.source === "fresh-tool-install-recommendations") {
+    if ((source.summary?.installNowCandidates || 0) > 0) return "tool_install_recommendation";
+    if ((source.summary?.approvalRequired || 0) > 0) return "approval_gate";
+  }
+  return "fresh";
 }
 
 function collectAcceptanceFallback(body) {
@@ -429,6 +445,7 @@ function summarizeFreshEvidence(inputs = {}, options = {}) {
   const adminAudit = inputs.adminAudit || null;
   const sliceLedger = inputs.sliceLedger || null;
   const toolInventory = inputs.toolInventory || null;
+  const toolInstallRecommendations = inputs.toolInstallRecommendations || null;
   const swarmPreflight = inputs.swarmPreflight || null;
   const unavailable = (source, path, status = "missing", summary = {}) => ({
     source,
@@ -494,6 +511,34 @@ function summarizeFreshEvidence(inputs = {}, options = {}) {
           inputs.toolInventoryPath || "output/ops/effectivity/installed-tool-inventory-latest.json",
           toolInventory?.status || "missing",
           toolInventory?.parseError ? { parseError: toolInventory.parseError } : {},
+      ),
+    toolInstallRecommendations: toolInstallRecommendations && toolInstallRecommendations.status !== "invalid_json"
+      ? applyFreshness({
+          source: "fresh-tool-install-recommendations",
+          path: inputs.toolInstallRecommendationsPath || "output/ops/effectivity/tool-install-recommendations-latest.json",
+          status: clean(toolInstallRecommendations.status) || "unknown",
+          generatedAt: clean(toolInstallRecommendations.generatedAt),
+          summary: {
+            recommendations: toolInstallRecommendations.summary?.recommendations ?? null,
+            coverageGaps: toolInstallRecommendations.summary?.coverageGaps ?? null,
+            approvalRequired: toolInstallRecommendations.summary?.approvalRequired ?? null,
+            installNowCandidates: toolInstallRecommendations.summary?.installNowCandidates ?? null,
+            topRecommendations: Array.isArray(toolInstallRecommendations.recommendations)
+              ? toolInstallRecommendations.recommendations.slice(0, 3).map((item) => ({
+                  tool: clean(item.tool),
+                  priority: clean(item.priority),
+                  acquisitionClass: clean(item.acquisitionClass),
+                  validationCommand: clean(item.validationCommand),
+                  approvalRequired: Boolean(item.approvalRequired),
+                }))
+              : [],
+          },
+        }, options)
+      : unavailable(
+          "fresh-tool-install-recommendations",
+          inputs.toolInstallRecommendationsPath || "output/ops/effectivity/tool-install-recommendations-latest.json",
+          toolInstallRecommendations?.status || "missing",
+          toolInstallRecommendations?.parseError ? { parseError: toolInstallRecommendations.parseError } : {},
         ),
     swarmPreflight: swarmPreflight && swarmPreflight.status !== "invalid_json"
       ? applyFreshness({
@@ -530,7 +575,13 @@ export function buildOpsWorkPacket(inputs = {}, options = {}) {
     maxAgeHours: options.maxAgeHours,
     now: options.now || options.generatedAt,
   });
-  const freshEvidenceSources = [freshEvidence.adminAudit, freshEvidence.sliceLedger, freshEvidence.toolInventory, freshEvidence.swarmPreflight];
+  const freshEvidenceSources = [
+    freshEvidence.adminAudit,
+    freshEvidence.sliceLedger,
+    freshEvidence.toolInventory,
+    freshEvidence.toolInstallRecommendations,
+    freshEvidence.swarmPreflight,
+  ];
   const freshSources = freshEvidenceSources.filter((source) => !["missing", "invalid_json", "invalid_timestamp", "stale"].includes(source.status));
   const staleSources = freshEvidenceSources.filter((source) => ["invalid_timestamp", "stale"].includes(source.status));
   const packets = backlog
@@ -551,6 +602,7 @@ export function buildOpsWorkPacket(inputs = {}, options = {}) {
       adminAudit: freshEvidence.adminAudit.path,
       sliceLedger: freshEvidence.sliceLedger.path,
       toolInventory: freshEvidence.toolInventory.path,
+      toolInstallRecommendations: freshEvidence.toolInstallRecommendations.path,
       swarmPreflight: freshEvidence.swarmPreflight.path,
     },
     constraints: {
@@ -570,6 +622,9 @@ export function buildOpsWorkPacket(inputs = {}, options = {}) {
       toolPromotionCandidates: freshEvidence.toolInventory.summary.promotionCandidates ?? null,
       toolActionableFindings: freshEvidence.toolInventory.summary.actionableFindings ?? null,
       toolCoverageGaps: freshEvidence.toolInventory.summary.coverageGaps ?? null,
+      toolInstallRecommendations: freshEvidence.toolInstallRecommendations.summary.recommendations ?? null,
+      toolInstallApprovalRequired: freshEvidence.toolInstallRecommendations.summary.approvalRequired ?? null,
+      toolInstallNowCandidates: freshEvidence.toolInstallRecommendations.summary.installNowCandidates ?? null,
       swarmPreflightStatus: freshEvidence.swarmPreflight.status,
       swarmPreflightOutsideScope: freshEvidence.swarmPreflight.summary.outsideScope ?? null,
       swarmPreflightProblems: freshEvidence.swarmPreflight.summary.problems ?? null,
@@ -591,6 +646,7 @@ function parseArgs(argv) {
     adminAudit: DEFAULT_ADMIN_AUDIT,
     sliceLedger: DEFAULT_SLICE_LEDGER,
     toolInventory: DEFAULT_TOOL_INVENTORY,
+    toolInstallRecommendations: DEFAULT_TOOL_INSTALL_RECOMMENDATIONS,
     swarmPreflight: DEFAULT_SWARM_PREFLIGHT,
     maxAgeHours: 24,
     maxPackets: 8,
@@ -633,6 +689,7 @@ function parseArgs(argv) {
       "--admin-audit": "adminAudit",
       "--slice-ledger": "sliceLedger",
       "--tool-inventory": "toolInventory",
+      "--tool-install-recommendations": "toolInstallRecommendations",
       "--swarm-preflight": "swarmPreflight",
       "--record-outcome": "recordOutcome",
       "--outcome": "outcome",
@@ -644,7 +701,7 @@ function parseArgs(argv) {
     for (const [flag, key] of Object.entries(stringOptions)) {
       const value = read(flag);
       if (value !== null) {
-        args[key] = key === "outputRoot" || key === "artifact" || key === "latest" || key === "outcomes" || key === "adminAudit" || key === "sliceLedger" || key === "toolInventory" || key === "swarmPreflight"
+        args[key] = key === "outputRoot" || key === "artifact" || key === "latest" || key === "outcomes" || key === "adminAudit" || key === "sliceLedger" || key === "toolInventory" || key === "toolInstallRecommendations" || key === "swarmPreflight"
           ? resolve(REPO_ROOT, value)
           : value;
         matched = true;
@@ -687,6 +744,7 @@ function printUsage() {
       "  --admin-audit <path>    Default: output/ops/effectivity/admin-effectivity-audit-latest.json.",
       "  --slice-ledger <path>   Default: output/ops/effectivity/slice-ledger-latest.json.",
       "  --tool-inventory <path> Default: output/ops/effectivity/installed-tool-inventory-latest.json.",
+      "  --tool-install-recommendations <path> Default: output/ops/effectivity/tool-install-recommendations-latest.json.",
       "  --swarm-preflight <path> Default: output/ops/swarm-lane-preflight/swarm-lane-preflight-latest.json.",
       "  --max-age-hours <n>     Warn when fresh-input artifacts are older than this. Default: 24.",
       "  --max-packets <n>       Default: 8.",
@@ -747,10 +805,12 @@ export function runOpsWorkPacket(rawArgs = process.argv.slice(2)) {
       adminAudit: readJsonIfExists(options.adminAudit),
       sliceLedger: readJsonIfExists(options.sliceLedger),
       toolInventory: readJsonIfExists(options.toolInventory),
+      toolInstallRecommendations: readJsonIfExists(options.toolInstallRecommendations),
       swarmPreflight: readJsonIfExists(options.swarmPreflight),
       adminAuditPath: toRepoRelative(options.adminAudit),
       sliceLedgerPath: toRepoRelative(options.sliceLedger),
       toolInventoryPath: toRepoRelative(options.toolInventory),
+      toolInstallRecommendationsPath: toRepoRelative(options.toolInstallRecommendations),
       swarmPreflightPath: toRepoRelative(options.swarmPreflight),
     },
     {

--- a/scripts/studiobrain-ops-work-packet.test.mjs
+++ b/scripts/studiobrain-ops-work-packet.test.mjs
@@ -152,6 +152,34 @@ const freshInputs = {
       promotionCandidates: 0,
     },
   },
+  toolInstallRecommendations: {
+    schema: "studiobrain-ops-tool-install-recommendations.v1",
+    generatedAt: "2026-05-07T08:45:52.000Z",
+    status: "warn",
+    readOnly: true,
+    summary: {
+      recommendations: 7,
+      coverageGaps: 4,
+      approvalRequired: 1,
+      installNowCandidates: 2,
+    },
+    recommendations: [
+      {
+        tool: "shellcheck",
+        priority: "P1",
+        acquisitionClass: "ephemeral-runner",
+        validationCommand: "node scripts/ops/tooling_quality_report.mjs --mode shellcheck --allow-install --json --write",
+        approvalRequired: false,
+      },
+      {
+        tool: "docker",
+        priority: "P2",
+        acquisitionClass: "remote-lane",
+        validationCommand: "node scripts/ops/tooling_quality_report.mjs --mode compose-config --json --write",
+        approvalRequired: true,
+      },
+    ],
+  },
   swarmPreflight: {
     schema: "studiobrain-swarm-lane-preflight.v1",
     generatedAt: "2026-05-07T08:46:12.000Z",
@@ -170,6 +198,7 @@ const freshInputs = {
   adminAuditPath: "output/ops/effectivity/admin-effectivity-audit-latest.json",
   sliceLedgerPath: "output/ops/effectivity/slice-ledger-latest.json",
   toolInventoryPath: "output/ops/effectivity/installed-tool-inventory-latest.json",
+  toolInstallRecommendationsPath: "output/ops/effectivity/tool-install-recommendations-latest.json",
   swarmPreflightPath: "output/ops/swarm-lane-preflight/swarm-lane-preflight-latest.json",
 };
 
@@ -190,11 +219,14 @@ test("buildOpsWorkPacket creates bounded read-only packets from docs evidence", 
   assert.equal(report.constraints.noServiceRestart, true);
   assert.equal(report.evidenceSummary.risks, 2);
   assert.equal(report.evidenceSummary.backlogItems, 2);
-  assert.equal(report.evidenceSummary.freshSources, 4);
+  assert.equal(report.evidenceSummary.freshSources, 5);
   assert.equal(report.evidenceSummary.staleSources, 0);
   assert.equal(report.evidenceSummary.toolPromotionCandidates, 0);
   assert.equal(report.evidenceSummary.toolActionableFindings, 0);
   assert.equal(report.evidenceSummary.toolCoverageGaps, 4);
+  assert.equal(report.evidenceSummary.toolInstallRecommendations, 7);
+  assert.equal(report.evidenceSummary.toolInstallApprovalRequired, 1);
+  assert.equal(report.evidenceSummary.toolInstallNowCandidates, 2);
   assert.equal(report.evidenceSummary.swarmPreflightStatus, "pass");
   assert.equal(report.evidenceSummary.swarmPreflightOutsideScope, 0);
   assert.equal(report.freshEvidence.adminAudit.status, "pass");
@@ -205,6 +237,11 @@ test("buildOpsWorkPacket creates bounded read-only packets from docs evidence", 
   assert.ok(report.packets[0].sourceSignals.some((signal) => signal.source === "fresh-admin-audit"));
   assert.ok(report.packets[0].sourceSignals.some((signal) => signal.source === "fresh-tool-inventory"));
   assert.ok(report.packets[0].sourceSignals.some((signal) => signal.source === "fresh-tool-inventory" && signal.signalClass === "coverage_gap"));
+  assert.ok(report.packets[0].sourceSignals.some((signal) => signal.source === "fresh-tool-install-recommendations"));
+  assert.ok(report.packets[0].sourceSignals.some((signal) => signal.source === "fresh-tool-install-recommendations" && signal.signalClass === "tool_install_recommendation"));
+  const installSignal = report.packets[0].sourceSignals.find((signal) => signal.source === "fresh-tool-install-recommendations");
+  assert.equal(installSignal.summary.approvalRequired, 1);
+  assert.equal(installSignal.summary.topRecommendations.some((item) => Object.hasOwn(item, "installCommand")), false);
   assert.ok(report.packets[0].sourceSignals.some((signal) => signal.source === "fresh-swarm-preflight"));
   assert.equal(report.packets[0].priority, "P0");
   assert.ok(report.packets[0].humanGate.includes("PostgreSQL dump"));
@@ -217,6 +254,7 @@ test("summarizeFreshEvidence degrades when ignored artifacts are missing", () =>
   assert.equal(fresh.adminAudit.status, "missing");
   assert.equal(fresh.sliceLedger.status, "missing");
   assert.equal(fresh.toolInventory.status, "missing");
+  assert.equal(fresh.toolInstallRecommendations.status, "missing");
   assert.equal(fresh.swarmPreflight.status, "missing");
 });
 
@@ -229,6 +267,7 @@ test("summarizeFreshEvidence does not count invalid JSON as fresh", () => {
       adminAudit: { status: "invalid_json", parseError: "bad admin" },
       sliceLedger: freshInputs.sliceLedger,
       toolInventory: { status: "invalid_json", parseError: "bad tools" },
+      toolInstallRecommendations: { status: "invalid_json", parseError: "bad tool install recommendations" },
     },
     { maxPackets: 1 },
   );
@@ -237,8 +276,10 @@ test("summarizeFreshEvidence does not count invalid JSON as fresh", () => {
   assert.equal(report.evidenceSummary.staleSources, 0);
   assert.equal(report.freshEvidence.adminAudit.status, "invalid_json");
   assert.equal(report.freshEvidence.toolInventory.summary.parseError, "bad tools");
+  assert.equal(report.freshEvidence.toolInstallRecommendations.summary.parseError, "bad tool install recommendations");
   assert.equal(report.packets[0].sourceSignals.some((signal) => signal.source === "fresh-admin-audit"), false);
   assert.equal(report.packets[0].sourceSignals.some((signal) => signal.source === "fresh-tool-inventory"), false);
+  assert.equal(report.packets[0].sourceSignals.some((signal) => signal.source === "fresh-tool-install-recommendations"), false);
 });
 
 test("workPacketReportStatus warns when falling back to static docs only", () => {
@@ -321,7 +362,7 @@ test("workPacketReportStatus warns when fresh evidence is stale", () => {
   );
 
   assert.equal(stale.evidenceSummary.freshSources, 0);
-  assert.equal(stale.evidenceSummary.staleSources, 4);
+  assert.equal(stale.evidenceSummary.staleSources, 5);
   assert.equal(stale.freshEvidence.adminAudit.status, "stale");
   assert.equal(stale.freshEvidence.adminAudit.sourceStatus, "pass");
   assert.equal(stale.freshEvidence.adminAudit.freshness.stale, true);


### PR DESCRIPTION
## Summary
- Adds `tool-install-recommendations-latest.json` as a first-class fresh-evidence source for ops work packets.
- Exposes recommendation, install-now, and approval-required counts in the work-packet evidence summary.
- Emits `signalClass=tool_install_recommendation` for fresh recommendation evidence while keeping install commands out of source signals.
- Documents that approval-required tools remain planning evidence, not automatic installation.

## Evidence
- Slice recorded as `slice-20260507-047` in the local effectivity ledger.
- Generated work packet showed 5 fresh sources, 7 tool recommendations, 2 install-now candidates, and 1 approval-required tool lane.
- Source signal includes ShellCheck/SQLFluff validation commands but omits `installCommand`.

## Files Changed
- `scripts/studiobrain-ops-work-packet.mjs`
- `scripts/studiobrain-ops-work-packet.test.mjs`
- `schemas/ops/ops-work-packet.v1.schema.json`
- `docs/ops/admin-effectivity-loop.md`

## Testing Performed
- `node --check scripts/studiobrain-ops-work-packet.mjs`
- `node --test scripts/studiobrain-ops-work-packet.test.mjs scripts/ops/validate_ops_artifacts.test.mjs`
- `node scripts/studiobrain-ops-work-packet.mjs --json --write --max-packets 1`
- `node scripts/ops/validate_ops_artifacts.mjs --json --write`
- `bash scripts/ops/ops_ci_validate.sh`
- `git diff --check`

## Risk Level
Low. This is read-only evidence plumbing and schema/test/doc coverage. It may make downstream work-packet consumers see a new `toolInstallRecommendations` source and additional evidence summary fields.

## Rollback Instructions
Revert this commit to remove the tool-install recommendation source from work packets. Regenerate ignored `output/ops/swarm/latest-work-packet.json` if local artifacts were written with the newer packet shape.

## Follow-up Tickets
- Refresh swarm preflight after the branch is clean so work-packet warnings are not caused by intentional uncommitted slice files.
- Add PR-readiness packet support for tool-install recommendation summaries.