### PR TITLE
[ops] Include PR readiness in wave runner

### DIFF
--- a/docs/ops/admin-effectivity-loop.md
+++ b/docs/ops/admin-effectivity-loop.md
@@ -95,7 +95,7 @@ node scripts/ops/ops_wave_runner.mjs --json --write
 node scripts/ops/ops_wave_runner.mjs --dry-run --json --write
 ```
 
-The wave runner executes read-only checks in dependency order: preflight, tooling quality, tool inventory, admin effectivity audit, work packet generation, then artifact schema validation. Use it when a downstream command consumes a `*-latest.json` artifact from an upstream command.
+The wave runner executes read-only checks in dependency order: preflight, tooling quality, tool inventory, admin effectivity audit, work packet generation, artifact schema validation, then PR readiness packet generation. Use it when a downstream command consumes a `*-latest.json` artifact from an upstream command.
 
 Work packets should steer from fresh evidence only. Missing, invalid, stale, or invalid-timestamp latest artifacts stay visible in `freshEvidence`, but they are excluded from packet `sourceSignals`. Tool inventory coverage gaps are kept as `signalClass=coverage_gap` so missing validators remain visible without being treated as actionable defect evidence. Tool-install recommendations are tracked as a separate fresh source and use `signalClass=tool_install_recommendation` only when the recommendation artifact has install-now candidates; approval-required tools remain evidence for planning, not automatic installation.
 

--- a/scripts/ops/ops_wave_runner.mjs
+++ b/scripts/ops/ops_wave_runner.mjs
@@ -40,6 +40,11 @@ const STEP_DEFINITIONS = [
     command: [process.execPath, "scripts/ops/validate_ops_artifacts.mjs", "--json", "--write"],
     expectedArtifacts: ["output/ops/artifact-validation/artifact-schema-validation-latest.json"],
   },
+  {
+    id: "pr-readiness",
+    command: [process.execPath, "scripts/ops/pr_readiness_packet.mjs", "--json", "--write"],
+    expectedArtifacts: ["output/ops/pr-readiness/pr-readiness-latest.md"],
+  },
 ];
 
 function clean(value) {
@@ -246,7 +251,7 @@ function runWave(options = {}, runner = defaultRunner) {
       ? "Inspect the failed receipt before running downstream dependent steps."
       : status === "planned"
         ? "Run without --dry-run to refresh ordered ops artifacts."
-        : "Use the latest work packet and artifact validation report for the next safe slice.",
+        : "Use the latest work packet, artifact validation report, and PR readiness packet for the next safe slice.",
   };
 }
 

--- a/scripts/ops/ops_wave_runner.test.mjs
+++ b/scripts/ops/ops_wave_runner.test.mjs
@@ -11,6 +11,16 @@ test("buildWavePlan keeps dependent ops steps ordered", () => {
   assert.ok(plan[0].commandText.includes("swarm_lane_preflight.mjs"));
 });
 
+test("buildWavePlan runs PR readiness after artifact validation by default", () => {
+  const plan = buildWavePlan();
+  const artifactIndex = plan.findIndex((step) => step.id === "artifact-validation");
+  const readinessIndex = plan.findIndex((step) => step.id === "pr-readiness");
+
+  assert.ok(artifactIndex >= 0);
+  assert.ok(readinessIndex > artifactIndex);
+  assert.ok(plan[readinessIndex].commandText.includes("pr_readiness_packet.mjs"));
+});
+
 test("runWave dry-run records skipped receipts without executing", () => {
   const manifest = runWave({ dryRun: true, runId: "unit-wave", steps: ["swarm-preflight", "work-packet"] }, () => {
     throw new Error("runner should not execute in dry-run mode");


### PR DESCRIPTION
## Summary
- Adds `pr-readiness` as the final default step in the safe ops wave runner.
- Ensures the ordered refresh path ends with a reviewer-facing PR readiness packet after work-packet and artifact-validation outputs are current.
- Updates tests and loop docs for the new dependency order.

## Evidence
- Slice recorded as `slice-20260507-049`.
- Wave plan now ends with `pr-readiness` after `artifact-validation`.
- Five-slice ledger window slices 045-049: usefulness `0.882`, verification `1`, no-op rate `0`, next audit at slice 050.

## Files Changed
- `scripts/ops/ops_wave_runner.mjs`
- `scripts/ops/ops_wave_runner.test.mjs`
- `docs/ops/admin-effectivity-loop.md`

## Testing Performed
- `node --check scripts/ops/ops_wave_runner.mjs`
- `node --test scripts/ops/ops_wave_runner.test.mjs scripts/ops/pr_readiness_packet.test.mjs`
- `node scripts/ops/ops_wave_runner.mjs --dry-run --json --write`
- `bash scripts/ops/ops_ci_validate.sh`
- `git diff --check`

## Risk Level
Low. This changes read-only local artifact refresh ordering. The default wave runner may now return `warn` when the readiness packet sees approval-required tool recommendations, but it still exits non-failing unless a step fails.

## Rollback Instructions
Revert this commit to remove the PR readiness step from the default wave runner. `node scripts/ops/pr_readiness_packet.mjs --write` remains independently runnable from the previous PR.

## Follow-up Tickets
- Run the slice-050 admin effectivity audit and inspect usefulness/no-op/tool freshness before the next wave.