### PR TITLE
[ops] Acknowledge audit slices in ledger cadence

### DIFF
--- a/schemas/ops/slice-ledger-summary.v1.schema.json
+++ b/schemas/ops/slice-ledger-summary.v1.schema.json
@@ -44,7 +44,8 @@
         "countedSlices": { "type": "number", "minimum": 0 },
         "slicesSinceLastAudit": { "type": "number", "minimum": 0 },
         "auditDue": { "type": "boolean" },
-        "nextAuditAt": { "type": "number", "minimum": 1 }
+        "nextAuditAt": { "type": "number", "minimum": 1 },
+        "lastAuditSliceId": { "type": ["string", "null"] }
       },
       "additionalProperties": false
     },

--- a/scripts/ops/slice_ledger.mjs
+++ b/scripts/ops/slice_ledger.mjs
@@ -304,18 +304,37 @@ function selectRecentRows(rows, last, runId = "") {
   return orderedRows(rows, runId).slice(-last);
 }
 
+function isAuditRow(row) {
+  const title = clean(row.title).toLowerCase();
+  if (title.includes("effectivity audit") || title.includes("admin effectivity audit")) return true;
+  return Array.isArray(row.commands) && row.commands.some((command) => clean(command.command).includes("admin_effectivity_audit.mjs"));
+}
+
 function auditCadence(rows, interval = 5) {
   const countable = rows.filter((row) => row.status !== "noop" && !row.noOp?.detected);
   const total = countable.length;
-  const remainder = total % interval;
-  const slicesSinceLastAudit = total === 0 ? 0 : remainder === 0 ? interval : remainder;
-  const auditDue = total > 0 && remainder === 0;
+  const lastAuditIndex = countable.findLastIndex(isAuditRow);
+  const lastAuditSliceId = lastAuditIndex >= 0 ? countable[lastAuditIndex]?.sliceId || null : null;
+  const slicesSinceLastAudit = lastAuditIndex >= 0
+    ? total - lastAuditIndex - 1
+    : total === 0
+      ? 0
+      : total % interval === 0
+        ? interval
+        : total % interval;
+  const auditDue = total > 0 && slicesSinceLastAudit >= interval;
+  const nextAuditAt = lastAuditIndex >= 0
+    ? total + (interval - slicesSinceLastAudit)
+    : auditDue
+      ? total
+      : total + (interval - slicesSinceLastAudit);
   return {
     interval,
     countedSlices: total,
     slicesSinceLastAudit,
     auditDue,
-    nextAuditAt: auditDue ? total : total + (interval - slicesSinceLastAudit)
+    nextAuditAt,
+    lastAuditSliceId
   };
 }
 

--- a/scripts/ops/slice_ledger.test.mjs
+++ b/scripts/ops/slice_ledger.test.mjs
@@ -29,6 +29,7 @@ test("auditCadence is due every five countable slices", () => {
     slicesSinceLastAudit: 0,
     auditDue: false,
     nextAuditAt: 5,
+    lastAuditSliceId: null,
   });
   assert.equal(auditCadence([1, 2, 3, 4].map(row), 5).auditDue, false);
   assert.equal(auditCadence([1, 2, 3, 4].map(row), 5).slicesSinceLastAudit, 4);
@@ -41,6 +42,21 @@ test("auditCadence ignores no-op rows", () => {
 
   assert.equal(cadence.countedSlices, 5);
   assert.equal(cadence.auditDue, true);
+});
+
+test("auditCadence treats effectivity audit rows as cadence acknowledgements", () => {
+  const audit = row(5);
+  audit.title = "Run five-slice admin effectivity audit";
+  audit.commands = [{ command: "node scripts/ops/admin_effectivity_audit.mjs --json --write", status: "pass" }];
+  const acknowledged = auditCadence([row(1), row(2), row(3), row(4), audit], 5);
+  const nextSlice = auditCadence([row(1), row(2), row(3), row(4), audit, row(6)], 5);
+
+  assert.equal(acknowledged.auditDue, false);
+  assert.equal(acknowledged.slicesSinceLastAudit, 0);
+  assert.equal(acknowledged.lastAuditSliceId, "slice-20260507-005");
+  assert.equal(acknowledged.nextAuditAt, 10);
+  assert.equal(nextSlice.slicesSinceLastAudit, 1);
+  assert.equal(nextSlice.nextAuditAt, 10);
 });
 
 test("summarize filters cadence by run id while preserving natural slice order", () => {


### PR DESCRIPTION
## Summary
- Treat effectivity audit rows as cadence acknowledgements in slice ledger summaries.
- Add lastAuditSliceId to audit cadence output.
- Prevent auditDue from staying true immediately after the audit slice has been recorded.

## Evidence
- Slice recorded as slice-20260507-051.
- Latest summary after slice 051: countedSlices=51, slicesSinceLastAudit=1, auditDue=false, nextAuditAt=55, lastAuditSliceId=slice-20260507-050.

## Files Changed
- scripts/ops/slice_ledger.mjs
- scripts/ops/slice_ledger.test.mjs
- schemas/ops/slice-ledger-summary.v1.schema.json

## Testing Performed
- node --check scripts/ops/slice_ledger.mjs
- node --test scripts/ops/slice_ledger.test.mjs scripts/ops/validate_ops_artifacts.test.mjs
- node scripts/ops/slice_ledger.mjs --summary --last 5 --run-id admin-infra-20260507 --json
- node scripts/ops/validate_ops_artifacts.mjs --json --write
- bash scripts/ops/ops_ci_validate.sh
- git diff --check

## Risk Level
Low. This only changes local read-only cadence reporting and schema metadata.

## Rollback Instructions
Revert commit ddcc231e to restore the previous every-fifth-row auditDue behavior.