### PR TITLE
[ops] Make swarm preflight recommendations cause-specific

### DIFF
--- a/scripts/ops/swarm_lane_preflight.mjs
+++ b/scripts/ops/swarm_lane_preflight.mjs
@@ -187,6 +187,22 @@ function inspectIntegrationBase(base, git = runGit) {
   };
 }
 
+function recommendationForPreflight({ status, dirtyFiles = [], outsideScope = [], problems = [], warnings = [], integrationBase = {}, branch = "" }) {
+  if (status === "pass") return "lane is ready for scoped work";
+  if (status === "fail") {
+    if (outsideScope.length > 0) return "do not delegate this lane until out-of-scope files are moved to the owning lane or explicitly allowed";
+    if (dirtyFiles.length > 0 && problems.some((problem) => problem.includes("dirty worktree"))) {
+      return "do not delegate this lane until dirty files are committed, stashed, or intentionally accepted";
+    }
+    return "do not delegate this lane until the scope or branch issue is fixed";
+  }
+  if (dirtyFiles.length > 0) return "commit, stash, or intentionally account for dirty files before delegating";
+  if (branch === "HEAD" || branch === "main") return "switch to a normal feature branch before delegating";
+  if (integrationBase.differs) return "review the stacked base warning and confirm integration order before delegating";
+  if (warnings.length > 0) return "review warning details before delegating this lane";
+  return "review preflight warnings before delegating";
+}
+
 function buildPreflightReport(options = {}, git = runGit) {
   const generatedAt = nowIso();
   const lane = clean(options.lane || "tooling");
@@ -228,11 +244,15 @@ function buildPreflightReport(options = {}, git = runGit) {
     outsideScope,
     problems,
     warnings,
-    recommendation: status === "pass"
-      ? "lane is ready for scoped work"
-      : status === "warn"
-        ? "commit, stash, or intentionally account for dirty files before delegating"
-        : "do not delegate this lane until the scope or branch issue is fixed",
+    recommendation: recommendationForPreflight({
+      status,
+      dirtyFiles,
+      outsideScope,
+      problems,
+      warnings,
+      integrationBase,
+      branch: branch.stdout,
+    }),
   };
 }
 

--- a/scripts/ops/swarm_lane_preflight.test.mjs
+++ b/scripts/ops/swarm_lane_preflight.test.mjs
@@ -98,4 +98,19 @@ test("buildPreflightReport warns when upstream base differs from origin main", (
   assert.equal(report.status, "warn");
   assert.equal(report.integrationBase.differs, true);
   assert.ok(report.warnings.some((warning) => warning.includes("differs from origin/main")));
+  assert.equal(report.recommendation, "review the stacked base warning and confirm integration order before delegating");
+});
+
+test("buildPreflightReport keeps dirty warning recommendation specific to dirty files", () => {
+  const report = buildPreflightReport(
+    { lane: "docs", base: "origin/main" },
+    fakeGit({
+      "rev-parse --abbrev-ref HEAD": { ok: true, stdout: "codex/docs-lane", stderr: "", status: 0 },
+      "diff --name-only --no-renames origin/main...HEAD": { ok: true, stdout: "docs/ops/admin.md\n", stderr: "", status: 0 },
+      "status --short": { ok: true, stdout: " M docs/ops/admin.md\n", stderr: "", status: 0 },
+    }),
+  );
+
+  assert.equal(report.status, "warn");
+  assert.equal(report.recommendation, "commit, stash, or intentionally account for dirty files before delegating");
 });


### PR DESCRIPTION
## Summary
- Split swarm-lane preflight recommendations by the actual warning/failure cause.
- Keep dirty-worktree advice specific to dirty worktrees.
- For clean stacked branches, recommend reviewing integration order instead of cleanup.

## Evidence
- Slice recorded as slice-20260507-052.
- Stacked-base smoke now reports status=warn with recommendation: review the stacked base warning and confirm integration order before delegating.

## Files Changed
- scripts/ops/swarm_lane_preflight.mjs
- scripts/ops/swarm_lane_preflight.test.mjs

## Testing Performed
- node --check scripts/ops/swarm_lane_preflight.mjs
- node --test scripts/ops/swarm_lane_preflight.test.mjs
- node scripts/ops/swarm_lane_preflight.mjs --lane tooling --base codex/ops-ledger-audit-ack-wave2 --json
- bash scripts/ops/ops_ci_validate.sh
- git diff --check

## Risk Level
Low. This only changes read-only diagnostic recommendation text and test coverage.

## Rollback Instructions
Revert commit 2d0931c9 to restore the previous generic warning recommendation.