### PR TITLE
[ops] Validate PR readiness packets as ops artifacts

### DIFF
--- a/schemas/ops/pr-readiness-packet.v1.schema.json
+++ b/schemas/ops/pr-readiness-packet.v1.schema.json
@@ -1,0 +1,136 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://studio-brain.local/schemas/ops/pr-readiness-packet.v1.schema.json",
+  "title": "Studio Brain Ops PR Readiness Packet v1",
+  "type": "object",
+  "required": [
+    "schema",
+    "generatedAt",
+    "readOnly",
+    "pr",
+    "owner",
+    "sliceIds",
+    "scope",
+    "evidence",
+    "warnings",
+    "status",
+    "rollback"
+  ],
+  "properties": {
+    "schema": { "const": "studiobrain-ops-pr-readiness-packet.v1" },
+    "generatedAt": { "type": "string", "format": "date-time" },
+    "readOnly": { "const": true },
+    "pr": { "type": "string" },
+    "owner": { "type": "string" },
+    "sliceIds": { "type": "string" },
+    "scope": {
+      "type": "object",
+      "required": ["branch", "base", "head", "changedFiles", "dirtyFiles", "nonScope"],
+      "properties": {
+        "branch": { "type": "string" },
+        "base": { "type": "string" },
+        "head": { "type": "string" },
+        "changedFiles": { "type": "array", "items": { "type": "string" } },
+        "dirtyFiles": { "type": "array", "items": { "type": "string" } },
+        "nonScope": { "type": "array", "items": { "type": "string" } }
+      },
+      "additionalProperties": false
+    },
+    "evidence": {
+      "type": "object",
+      "required": ["artifactValidation", "workPacket", "sliceLedger", "toolInstall"],
+      "properties": {
+        "artifactValidation": {
+          "type": "object",
+          "required": ["status", "generatedAt", "checks", "passed", "warned", "failed", "missing", "problems"],
+          "properties": {
+            "status": { "type": "string" },
+            "generatedAt": { "type": "string" },
+            "checks": { "type": "number", "minimum": 0 },
+            "passed": { "type": "number", "minimum": 0 },
+            "warned": { "type": "number", "minimum": 0 },
+            "failed": { "type": "number", "minimum": 0 },
+            "missing": { "type": "number", "minimum": 0 },
+            "problems": { "type": "array", "items": { "type": "string" } }
+          },
+          "additionalProperties": false
+        },
+        "workPacket": {
+          "type": "object",
+          "required": ["status", "generatedAt", "packets", "freshSources", "staleSources", "topPacket", "humanGates"],
+          "properties": {
+            "status": { "type": "string" },
+            "generatedAt": { "type": "string" },
+            "packets": { "type": "number", "minimum": 0 },
+            "freshSources": { "type": ["number", "null"], "minimum": 0 },
+            "staleSources": { "type": ["number", "null"], "minimum": 0 },
+            "topPacket": { "type": "string" },
+            "humanGates": { "type": "number", "minimum": 0 },
+            "toolInstallNowCandidates": { "type": ["number", "null"], "minimum": 0 },
+            "toolInstallApprovalRequired": { "type": ["number", "null"], "minimum": 0 },
+            "parseError": { "type": "string" }
+          },
+          "additionalProperties": false
+        },
+        "sliceLedger": {
+          "type": "object",
+          "required": ["status", "generatedAt", "window", "verification", "usefulness", "commandFailures"],
+          "properties": {
+            "status": { "type": "string" },
+            "generatedAt": { "type": "string" },
+            "window": {
+              "type": ["object", "null"],
+              "required": ["count", "from", "to"],
+              "properties": {
+                "count": { "type": "number", "minimum": 0 },
+                "from": { "type": "string" },
+                "to": { "type": "string" }
+              },
+              "additionalProperties": false
+            },
+            "verification": { "type": ["number", "null"], "minimum": 0 },
+            "usefulness": { "type": ["number", "null"], "minimum": 0 },
+            "commandFailures": { "type": ["number", "null"], "minimum": 0 },
+            "parseError": { "type": "string" }
+          },
+          "additionalProperties": false
+        },
+        "toolInstall": {
+          "type": "object",
+          "required": ["status", "generatedAt", "recommendations", "installNowCandidates", "approvalRequired", "topRecommendations"],
+          "properties": {
+            "status": { "type": "string" },
+            "generatedAt": { "type": "string" },
+            "recommendations": { "type": "number", "minimum": 0 },
+            "installNowCandidates": { "type": "number", "minimum": 0 },
+            "approvalRequired": { "type": "number", "minimum": 0 },
+            "topRecommendations": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": ["tool", "priority", "acquisitionClass", "validationCommand", "approvalRequired"],
+                "properties": {
+                  "tool": { "type": "string" },
+                  "priority": { "type": "string" },
+                  "acquisitionClass": { "type": "string" },
+                  "validationCommand": { "type": "string" },
+                  "approvalRequired": { "type": "boolean" }
+                },
+                "additionalProperties": false
+              }
+            },
+            "parseError": { "type": "string" }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "warnings": { "type": "array", "items": { "type": "string" } },
+    "status": { "enum": ["pass", "warn", "fail"] },
+    "rollback": { "type": "string" },
+    "artifactPath": { "type": "string" },
+    "markdownPath": { "type": "string" }
+  },
+  "additionalProperties": false
+}

--- a/scripts/ops/pr_readiness_packet.test.mjs
+++ b/scripts/ops/pr_readiness_packet.test.mjs
@@ -1,7 +1,9 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 
 import { buildPrReadinessPacket, renderMarkdown } from "./pr_readiness_packet.mjs";
+import { validateJsonSchema } from "./validate_ops_artifacts.mjs";
 
 const gitState = {
   base: "origin/main",
@@ -84,6 +86,16 @@ test("buildPrReadinessPacket summarizes current evidence without executable inst
   assert.match(markdown, /shellcheck/);
   assert.doesNotMatch(markdown, /do not copy this/);
   assert.doesNotMatch(markdown, /do not install Docker/);
+});
+
+test("buildPrReadinessPacket stays compatible with its JSON schema", () => {
+  const packet = buildPrReadinessPacket(
+    { gitState, artifactValidation, workPacket, sliceLedger, toolInstallRecommendations },
+    { generatedAt: "2026-05-07T12:10:00.000Z", pr: "#123", sliceIds: "slice-046,slice-047" },
+  );
+  const schema = JSON.parse(readFileSync("schemas/ops/pr-readiness-packet.v1.schema.json", "utf8"));
+
+  assert.deepEqual(validateJsonSchema(packet, schema), []);
 });
 
 test("buildPrReadinessPacket fails on failing artifact validation", () => {

--- a/scripts/ops/validate_ops_artifacts.mjs
+++ b/scripts/ops/validate_ops_artifacts.mjs
@@ -49,6 +49,11 @@ const DEFAULT_ARTIFACTS = [
     schema: "schemas/ops/ops-wave-runner.v1.schema.json",
   },
   {
+    id: "pr-readiness-packet",
+    artifact: "output/ops/pr-readiness/pr-readiness-latest.json",
+    schema: "schemas/ops/pr-readiness-packet.v1.schema.json",
+  },
+  {
     id: "artifact-schema-validation",
     artifact: "output/ops/artifact-validation/artifact-schema-validation-latest.json",
     schema: "schemas/ops/artifact-schema-validation.v1.schema.json",


### PR DESCRIPTION
## Summary
- Add a JSON schema for generated ops PR readiness packets.
- Register pr-readiness-latest.json in the default artifact validation checklist.
- Add schema compatibility coverage for generated PR readiness packets.

## Evidence
- Slice recorded as slice-20260507-053.
- Artifact validation now reports 10 checks, 10 passed, 0 warned, 0 missing, 0 failed.
- PR readiness latest artifact validates against schemas/ops/pr-readiness-packet.v1.schema.json.

## Files Changed
- schemas/ops/pr-readiness-packet.v1.schema.json
- scripts/ops/validate_ops_artifacts.mjs
- scripts/ops/pr_readiness_packet.test.mjs

## Testing Performed
- node --check scripts/ops/validate_ops_artifacts.mjs
- node --test scripts/ops/pr_readiness_packet.test.mjs scripts/ops/validate_ops_artifacts.test.mjs
- node scripts/ops/pr_readiness_packet.mjs --json --write --base codex/ops-swarm-preflight-recommendation-wave2 --pr #625 --slice-ids slice-20260507-053
- node scripts/ops/validate_ops_artifacts.mjs --json --write
- bash scripts/ops/ops_ci_validate.sh
- git diff --check

## Risk Level
Low. This only expands read-only validation coverage and test/schema metadata.

## Rollback Instructions
Revert commit 789faf8c and regenerate ignored output/ops artifacts if local latest outputs referenced the new schema.