### PR TITLE
[ops] Feed effectivity evidence lanes into work packets

### DIFF
--- a/schemas/ops/ops-work-packet.v1.schema.json
+++ b/schemas/ops/ops-work-packet.v1.schema.json
@@ -38,7 +38,7 @@
     },
     "evidenceSummary": {
       "type": "object",
-      "required": ["risks", "backlogItems", "effectivityNextSafeSlices", "remainingApprovalGates", "freshSources", "staleSources", "toolPromotionCandidates", "toolActionableFindings", "toolCoverageGaps", "toolInstallRecommendations", "toolInstallApprovalRequired", "toolInstallNowCandidates", "swarmPreflightStatus", "swarmPreflightOutsideScope", "swarmPreflightProblems"],
+      "required": ["risks", "backlogItems", "effectivityNextSafeSlices", "remainingApprovalGates", "freshSources", "staleSources", "toolPromotionCandidates", "toolActionableFindings", "toolCoverageGaps", "toolInstallRecommendations", "toolInstallApprovalRequired", "toolInstallNowCandidates", "effectivityEvidenceLanes", "effectivityApprovalRequiredLanes", "effectivityHighSeverityLanes", "swarmPreflightStatus", "swarmPreflightOutsideScope", "swarmPreflightProblems"],
       "properties": {
         "risks": { "type": "number", "minimum": 0 },
         "backlogItems": { "type": "number", "minimum": 0 },
@@ -52,6 +52,9 @@
         "toolInstallRecommendations": { "type": ["number", "null"], "minimum": 0 },
         "toolInstallApprovalRequired": { "type": ["number", "null"], "minimum": 0 },
         "toolInstallNowCandidates": { "type": ["number", "null"], "minimum": 0 },
+        "effectivityEvidenceLanes": { "type": ["number", "null"], "minimum": 0 },
+        "effectivityApprovalRequiredLanes": { "type": ["number", "null"], "minimum": 0 },
+        "effectivityHighSeverityLanes": { "type": ["number", "null"], "minimum": 0 },
         "swarmPreflightStatus": { "type": "string" },
         "swarmPreflightOutsideScope": { "type": ["number", "null"], "minimum": 0 },
         "swarmPreflightProblems": { "type": ["number", "null"], "minimum": 0 }

--- a/scripts/studiobrain-ops-work-packet.mjs
+++ b/scripts/studiobrain-ops-work-packet.mjs
@@ -355,6 +355,10 @@ function freshSourceSignals(freshEvidence) {
 }
 
 function signalClassForSource(source) {
+  if (source.source === "fresh-admin-audit") {
+    if ((source.summary?.approvalRequiredEvidenceLanes || 0) > 0) return "approval_gate";
+    if ((source.summary?.highSeverityEvidenceLanes || 0) > 0) return "evidence_gap";
+  }
   if (source.source === "fresh-tool-inventory" && (source.summary?.coverageGaps || 0) > 0) return "coverage_gap";
   if (source.source === "fresh-tool-install-recommendations") {
     if ((source.summary?.installNowCandidates || 0) > 0) return "tool_install_recommendation";
@@ -454,6 +458,7 @@ function summarizeFreshEvidence(inputs = {}, options = {}) {
     generatedAt: "",
     summary,
   });
+  const effectivityEvidenceLanes = effectivityLanesFromAdminAudit(adminAudit);
   return {
     adminAudit: adminAudit && adminAudit.status !== "invalid_json"
       ? applyFreshness({
@@ -465,6 +470,16 @@ function summarizeFreshEvidence(inputs = {}, options = {}) {
             sliceWindow: adminAudit.sliceWindow || null,
             scores: adminAudit.scores || null,
             privilegedEvidence: adminAudit.sections?.effectivityReport?.report?.sections?.privilegedEvidence?.status || "",
+            effectivityEvidenceLanes: effectivityEvidenceLanes.length,
+            approvalRequiredEvidenceLanes: effectivityEvidenceLanes.filter((lane) => lane.approvalRequired).length,
+            highSeverityEvidenceLanes: effectivityEvidenceLanes.filter((lane) => clean(lane.severity) === "high").length,
+            topEvidenceLanes: effectivityEvidenceLanes.slice(0, 5).map((lane) => ({
+              id: clean(lane.id),
+              status: clean(lane.status),
+              severity: clean(lane.severity),
+              approvalRequired: Boolean(lane.approvalRequired),
+              safeNextStep: clean(lane.safeNextStep),
+            })),
           },
         }, options)
       : unavailable(
@@ -567,6 +582,11 @@ function summarizeFreshEvidence(inputs = {}, options = {}) {
   };
 }
 
+function effectivityLanesFromAdminAudit(adminAudit) {
+  const lanes = adminAudit?.sections?.effectivityReport?.report?.evidenceLanes;
+  return Array.isArray(lanes) ? lanes : [];
+}
+
 export function buildOpsWorkPacket(inputs = {}, options = {}) {
   const risks = parseRiskRegister(inputs.riskMarkdown || "");
   const backlog = parseBacklog(inputs.backlogMarkdown || "");
@@ -625,6 +645,9 @@ export function buildOpsWorkPacket(inputs = {}, options = {}) {
       toolInstallRecommendations: freshEvidence.toolInstallRecommendations.summary.recommendations ?? null,
       toolInstallApprovalRequired: freshEvidence.toolInstallRecommendations.summary.approvalRequired ?? null,
       toolInstallNowCandidates: freshEvidence.toolInstallRecommendations.summary.installNowCandidates ?? null,
+      effectivityEvidenceLanes: freshEvidence.adminAudit.summary.effectivityEvidenceLanes ?? null,
+      effectivityApprovalRequiredLanes: freshEvidence.adminAudit.summary.approvalRequiredEvidenceLanes ?? null,
+      effectivityHighSeverityLanes: freshEvidence.adminAudit.summary.highSeverityEvidenceLanes ?? null,
       swarmPreflightStatus: freshEvidence.swarmPreflight.status,
       swarmPreflightOutsideScope: freshEvidence.swarmPreflight.summary.outsideScope ?? null,
       swarmPreflightProblems: freshEvidence.swarmPreflight.summary.problems ?? null,

--- a/scripts/studiobrain-ops-work-packet.test.mjs
+++ b/scripts/studiobrain-ops-work-packet.test.mjs
@@ -128,6 +128,22 @@ const freshInputs = {
           sections: {
             privilegedEvidence: { status: "sudo_unavailable" },
           },
+          evidenceLanes: [
+            {
+              id: "backup_confidence",
+              status: "warn",
+              severity: "high",
+              approvalRequired: false,
+              safeNextStep: "Refresh backup evidence before backup changes.",
+            },
+            {
+              id: "privileged_evidence",
+              status: "sudo_unavailable",
+              severity: "medium",
+              approvalRequired: true,
+              safeNextStep: "Use the approval-gated privileged capture path.",
+            },
+          ],
         },
       },
     },
@@ -227,6 +243,9 @@ test("buildOpsWorkPacket creates bounded read-only packets from docs evidence", 
   assert.equal(report.evidenceSummary.toolInstallRecommendations, 7);
   assert.equal(report.evidenceSummary.toolInstallApprovalRequired, 1);
   assert.equal(report.evidenceSummary.toolInstallNowCandidates, 2);
+  assert.equal(report.evidenceSummary.effectivityEvidenceLanes, 2);
+  assert.equal(report.evidenceSummary.effectivityApprovalRequiredLanes, 1);
+  assert.equal(report.evidenceSummary.effectivityHighSeverityLanes, 1);
   assert.equal(report.evidenceSummary.swarmPreflightStatus, "pass");
   assert.equal(report.evidenceSummary.swarmPreflightOutsideScope, 0);
   assert.equal(report.freshEvidence.adminAudit.status, "pass");
@@ -235,6 +254,9 @@ test("buildOpsWorkPacket creates bounded read-only packets from docs evidence", 
   assert.ok(report.packets.every((packet) => packet.packetId.startsWith("ops-wp-")));
   assert.ok(report.packets.every((packet) => packet.constraints.readOnlyFirst));
   assert.ok(report.packets[0].sourceSignals.some((signal) => signal.source === "fresh-admin-audit"));
+  const adminSignal = report.packets[0].sourceSignals.find((signal) => signal.source === "fresh-admin-audit");
+  assert.equal(adminSignal.signalClass, "approval_gate");
+  assert.equal(adminSignal.summary.topEvidenceLanes.length, 2);
   assert.ok(report.packets[0].sourceSignals.some((signal) => signal.source === "fresh-tool-inventory"));
   assert.ok(report.packets[0].sourceSignals.some((signal) => signal.source === "fresh-tool-inventory" && signal.signalClass === "coverage_gap"));
   assert.ok(report.packets[0].sourceSignals.some((signal) => signal.source === "fresh-tool-install-recommendations"));


### PR DESCRIPTION
## Summary
- Include admin-audit effectivity evidence lane counts in generated work-packet summaries.
- Carry top evidence lanes into fresh-admin-audit source signals.
- Classify admin-audit source signals as approval_gate or evidence_gap when lanes require approval or are high severity.

## Evidence
- Slice recorded as slice-20260507-056.
- Latest work packet reports effectivityEvidenceLanes=4, effectivityApprovalRequiredLanes=1, effectivityHighSeverityLanes=1.
- Generated packet source signals include backup_confidence and privileged_evidence lane details without scraping Markdown.

## Files Changed
- scripts/studiobrain-ops-work-packet.mjs
- scripts/studiobrain-ops-work-packet.test.mjs
- schemas/ops/ops-work-packet.v1.schema.json

## Testing Performed
- node --check scripts/studiobrain-ops-work-packet.mjs
- node --test scripts/studiobrain-ops-work-packet.test.mjs
- node scripts/studiobrain-ops-work-packet.mjs --json --write --max-packets 3
- node scripts/ops/validate_ops_artifacts.mjs --json --write
- bash scripts/ops/ops_ci_validate.sh
- git diff --check

## Risk Level
Low. This only enriches read-only packet metadata and schema expectations.

## Rollback Instructions
Revert commit ce65981b and regenerate ignored output/ops/swarm artifacts if local latest packets were written with the new fields.