### PR TITLE
[ops] Surface effectivity lanes in PR readiness

### DIFF
--- a/schemas/ops/pr-readiness-packet.v1.schema.json
+++ b/schemas/ops/pr-readiness-packet.v1.schema.json
@@ -57,7 +57,7 @@
         },
         "workPacket": {
           "type": "object",
-          "required": ["status", "generatedAt", "packets", "freshSources", "staleSources", "topPacket", "humanGates"],
+          "required": ["status", "generatedAt", "packets", "freshSources", "staleSources", "topPacket", "humanGates", "effectivityEvidenceLanes", "effectivityApprovalRequiredLanes", "effectivityHighSeverityLanes"],
           "properties": {
             "status": { "type": "string" },
             "generatedAt": { "type": "string" },
@@ -68,6 +68,9 @@
             "humanGates": { "type": "number", "minimum": 0 },
             "toolInstallNowCandidates": { "type": ["number", "null"], "minimum": 0 },
             "toolInstallApprovalRequired": { "type": ["number", "null"], "minimum": 0 },
+            "effectivityEvidenceLanes": { "type": ["number", "null"], "minimum": 0 },
+            "effectivityApprovalRequiredLanes": { "type": ["number", "null"], "minimum": 0 },
+            "effectivityHighSeverityLanes": { "type": ["number", "null"], "minimum": 0 },
             "parseError": { "type": "string" }
           },
           "additionalProperties": false

--- a/scripts/ops/pr_readiness_packet.mjs
+++ b/scripts/ops/pr_readiness_packet.mjs
@@ -86,8 +86,8 @@ function summarizeArtifactValidation(report) {
 }
 
 function summarizeWorkPacket(packet) {
-  if (!packet) return { status: "missing", generatedAt: "", packets: 0, freshSources: 0, staleSources: 0, topPacket: "", humanGates: 0 };
-  if (packet.status === "invalid_json") return { status: "invalid_json", generatedAt: "", packets: 0, freshSources: 0, staleSources: 0, topPacket: "", humanGates: 0, parseError: packet.parseError || "" };
+  if (!packet) return { status: "missing", generatedAt: "", packets: 0, freshSources: 0, staleSources: 0, topPacket: "", humanGates: 0, effectivityEvidenceLanes: null, effectivityApprovalRequiredLanes: null, effectivityHighSeverityLanes: null };
+  if (packet.status === "invalid_json") return { status: "invalid_json", generatedAt: "", packets: 0, freshSources: 0, staleSources: 0, topPacket: "", humanGates: 0, effectivityEvidenceLanes: null, effectivityApprovalRequiredLanes: null, effectivityHighSeverityLanes: null, parseError: packet.parseError || "" };
   const packets = Array.isArray(packet.packets) ? packet.packets : [];
   return {
     status: packets.length > 0 ? "present" : "empty",
@@ -99,6 +99,9 @@ function summarizeWorkPacket(packet) {
     humanGates: packets.filter((entry) => clean(entry.humanGate)).length,
     toolInstallNowCandidates: packet.evidenceSummary?.toolInstallNowCandidates ?? null,
     toolInstallApprovalRequired: packet.evidenceSummary?.toolInstallApprovalRequired ?? null,
+    effectivityEvidenceLanes: packet.evidenceSummary?.effectivityEvidenceLanes ?? null,
+    effectivityApprovalRequiredLanes: packet.evidenceSummary?.effectivityApprovalRequiredLanes ?? null,
+    effectivityHighSeverityLanes: packet.evidenceSummary?.effectivityHighSeverityLanes ?? null,
   };
 }
 
@@ -228,7 +231,7 @@ ${dirtyFiles}
 | --- | --- | --- |
 | Artifact validation | ${packet.evidence.artifactValidation.status} | checks=${packet.evidence.artifactValidation.checks}, warned=${packet.evidence.artifactValidation.warned}, missing=${packet.evidence.artifactValidation.missing}, failed=${packet.evidence.artifactValidation.failed} |
 | Slice ledger | ${packet.evidence.sliceLedger.status} | window=${packet.evidence.sliceLedger.window?.from || ""}..${packet.evidence.sliceLedger.window?.to || ""}, verification=${packet.evidence.sliceLedger.verification ?? ""}, usefulness=${packet.evidence.sliceLedger.usefulness ?? ""} |
-| Work packet | ${packet.evidence.workPacket.status} | packets=${packet.evidence.workPacket.packets}, freshSources=${packet.evidence.workPacket.freshSources ?? ""}, staleSources=${packet.evidence.workPacket.staleSources ?? ""}, top="${packet.evidence.workPacket.topPacket}" |
+| Work packet | ${packet.evidence.workPacket.status} | packets=${packet.evidence.workPacket.packets}, freshSources=${packet.evidence.workPacket.freshSources ?? ""}, staleSources=${packet.evidence.workPacket.staleSources ?? ""}, lanes=${packet.evidence.workPacket.effectivityEvidenceLanes ?? ""}, approvalLanes=${packet.evidence.workPacket.effectivityApprovalRequiredLanes ?? ""}, highLanes=${packet.evidence.workPacket.effectivityHighSeverityLanes ?? ""}, top="${packet.evidence.workPacket.topPacket}" |
 | Tool install recommendations | ${packet.evidence.toolInstall.status} | recommendations=${packet.evidence.toolInstall.recommendations}, installNow=${packet.evidence.toolInstall.installNowCandidates}, approvalRequired=${packet.evidence.toolInstall.approvalRequired} |
 
 ## Tool Recommendation Summary

--- a/scripts/ops/pr_readiness_packet.test.mjs
+++ b/scripts/ops/pr_readiness_packet.test.mjs
@@ -29,6 +29,9 @@ const workPacket = {
     staleSources: 0,
     toolInstallNowCandidates: 2,
     toolInstallApprovalRequired: 1,
+    effectivityEvidenceLanes: 4,
+    effectivityApprovalRequiredLanes: 1,
+    effectivityHighSeverityLanes: 1,
   },
   packets: [{ title: "[ops] Refresh evidence", humanGate: "" }],
 };
@@ -77,12 +80,17 @@ test("buildPrReadinessPacket summarizes current evidence without executable inst
   assert.equal(packet.status, "warn");
   assert.equal(packet.evidence.artifactValidation.status, "pass");
   assert.equal(packet.evidence.workPacket.freshSources, 5);
+  assert.equal(packet.evidence.workPacket.effectivityEvidenceLanes, 4);
+  assert.equal(packet.evidence.workPacket.effectivityApprovalRequiredLanes, 1);
+  assert.equal(packet.evidence.workPacket.effectivityHighSeverityLanes, 1);
   assert.equal(packet.evidence.toolInstall.installNowCandidates, 2);
   assert.equal(packet.evidence.toolInstall.approvalRequired, 1);
   assert.ok(packet.warnings.some((warning) => warning.includes("require approval")));
 
   const markdown = renderMarkdown(packet);
   assert.match(markdown, /Tool Recommendation Summary/);
+  assert.match(markdown, /lanes=4/);
+  assert.match(markdown, /approvalLanes=1/);
   assert.match(markdown, /shellcheck/);
   assert.doesNotMatch(markdown, /do not copy this/);
   assert.doesNotMatch(markdown, /do not install Docker/);


### PR DESCRIPTION
## Summary
- Add effectivity evidence-lane counts to PR readiness work-packet evidence.
- Update the PR readiness schema to require those counts.
- Show lane, approval-lane, and high-severity-lane counts in the readiness Markdown evidence table.

## Evidence
- Slice recorded as slice-20260507-057.
- Latest PR readiness packet includes effectivityEvidenceLanes=4, effectivityApprovalRequiredLanes=1, effectivityHighSeverityLanes=1.
- Artifact validation rerun after packet write passed 10/10 checks.

## Files Changed
- scripts/ops/pr_readiness_packet.mjs
- scripts/ops/pr_readiness_packet.test.mjs
- schemas/ops/pr-readiness-packet.v1.schema.json

## Testing Performed
- node --check scripts/ops/pr_readiness_packet.mjs
- node --test scripts/ops/pr_readiness_packet.test.mjs
- node scripts/ops/pr_readiness_packet.mjs --json --write --base codex/ops-work-packet-effectivity-lanes-wave2 --pr #628 --slice-ids slice-20260507-057
- node scripts/ops/validate_ops_artifacts.mjs --json --write
- bash scripts/ops/ops_ci_validate.sh
- git diff --check

## Risk Level
Low. This only enriches read-only review packet metadata and schema expectations.

## Rollback Instructions
Revert commit 4f07a27e and regenerate ignored output/ops/pr-readiness artifacts if local latest files used the new fields.