### PR TITLE
[ops] Validate PR readiness after wave generation

### DIFF
--- a/docs/ops/admin-effectivity-loop.md
+++ b/docs/ops/admin-effectivity-loop.md
@@ -95,7 +95,7 @@ node scripts/ops/ops_wave_runner.mjs --json --write
 node scripts/ops/ops_wave_runner.mjs --dry-run --json --write
 ```
 
-The wave runner executes read-only checks in dependency order: preflight, tooling quality, tool inventory, admin effectivity audit, work packet generation, artifact schema validation, then PR readiness packet generation. Use it when a downstream command consumes a `*-latest.json` artifact from an upstream command.
+The wave runner executes read-only checks in dependency order: preflight, tooling quality, tool inventory, admin effectivity audit, work packet generation, preliminary artifact schema validation, PR readiness packet generation, then final artifact schema validation. Use it when a downstream command consumes a `*-latest.json` artifact from an upstream command.
 
 Work packets should steer from fresh evidence only. Missing, invalid, stale, or invalid-timestamp latest artifacts stay visible in `freshEvidence`, but they are excluded from packet `sourceSignals`. Tool inventory coverage gaps are kept as `signalClass=coverage_gap` so missing validators remain visible without being treated as actionable defect evidence. Tool-install recommendations are tracked as a separate fresh source and use `signalClass=tool_install_recommendation` only when the recommendation artifact has install-now candidates; approval-required tools remain evidence for planning, not automatic installation.
 

--- a/scripts/ops/ops_wave_runner.mjs
+++ b/scripts/ops/ops_wave_runner.mjs
@@ -36,7 +36,7 @@ const STEP_DEFINITIONS = [
     expectedArtifacts: ["output/ops/swarm/latest-work-packet.json"],
   },
   {
-    id: "artifact-validation",
+    id: "artifact-validation-pre",
     command: [process.execPath, "scripts/ops/validate_ops_artifacts.mjs", "--json", "--write"],
     expectedArtifacts: ["output/ops/artifact-validation/artifact-schema-validation-latest.json"],
   },
@@ -44,6 +44,11 @@ const STEP_DEFINITIONS = [
     id: "pr-readiness",
     command: [process.execPath, "scripts/ops/pr_readiness_packet.mjs", "--json", "--write"],
     expectedArtifacts: ["output/ops/pr-readiness/pr-readiness-latest.md"],
+  },
+  {
+    id: "artifact-validation",
+    command: [process.execPath, "scripts/ops/validate_ops_artifacts.mjs", "--json", "--write"],
+    expectedArtifacts: ["output/ops/artifact-validation/artifact-schema-validation-latest.json"],
   },
 ];
 

--- a/scripts/ops/ops_wave_runner.test.mjs
+++ b/scripts/ops/ops_wave_runner.test.mjs
@@ -11,13 +11,16 @@ test("buildWavePlan keeps dependent ops steps ordered", () => {
   assert.ok(plan[0].commandText.includes("swarm_lane_preflight.mjs"));
 });
 
-test("buildWavePlan runs PR readiness after artifact validation by default", () => {
+test("buildWavePlan runs PR readiness between preflight validation and final validation", () => {
   const plan = buildWavePlan();
+  const preArtifactIndex = plan.findIndex((step) => step.id === "artifact-validation-pre");
   const artifactIndex = plan.findIndex((step) => step.id === "artifact-validation");
   const readinessIndex = plan.findIndex((step) => step.id === "pr-readiness");
 
+  assert.ok(preArtifactIndex >= 0);
   assert.ok(artifactIndex >= 0);
-  assert.ok(readinessIndex > artifactIndex);
+  assert.ok(readinessIndex > preArtifactIndex);
+  assert.ok(artifactIndex > readinessIndex);
   assert.ok(plan[readinessIndex].commandText.includes("pr_readiness_packet.mjs"));
 });
 


### PR DESCRIPTION
## Summary
- Split wave-runner artifact validation into preliminary and final passes.
- Generate PR readiness after the preliminary validation, then run final artifact validation against the freshly written readiness packet.
- Update the effectivity-loop docs and ordering tests.

## Evidence
- Slice recorded as slice-20260507-058.
- Default wave order is now artifact-validation-pre -> pr-readiness -> artifact-validation.
- Final artifact validation validates the current pr-readiness-latest.json.

## Files Changed
- scripts/ops/ops_wave_runner.mjs
- scripts/ops/ops_wave_runner.test.mjs
- docs/ops/admin-effectivity-loop.md

## Testing Performed
- node --check scripts/ops/ops_wave_runner.mjs
- node --test scripts/ops/ops_wave_runner.test.mjs
- node scripts/ops/ops_wave_runner.mjs --dry-run --json --write
- node scripts/ops/ops_wave_runner.mjs --json --write
- node scripts/ops/validate_ops_artifacts.mjs --json --write
- bash scripts/ops/ops_ci_validate.sh
- git diff --check

## Risk Level
Low. This only changes read-only wave ordering and documentation.

## Rollback Instructions
Revert this commit to restore the prior single artifact-validation pass before PR readiness.