### PR TITLE
[ops] Add opt-in wave validator installs

### DIFF
--- a/docs/ops/admin-effectivity-loop.md
+++ b/docs/ops/admin-effectivity-loop.md
@@ -93,9 +93,11 @@ Run the ordered safe wave when refreshing dependent latest artifacts:
 ```bash
 node scripts/ops/ops_wave_runner.mjs --json --write
 node scripts/ops/ops_wave_runner.mjs --dry-run --json --write
+node scripts/ops/ops_wave_runner.mjs --allow-tool-install --json --write
 ```
 
 The wave runner executes read-only checks in dependency order: preflight, tooling quality, tool inventory, admin effectivity audit, work packet generation, preliminary artifact schema validation, PR readiness packet generation, then final artifact schema validation. Use it when a downstream command consumes a `*-latest.json` artifact from an upstream command.
+The default run does not install or fetch missing optional validators. Use `--allow-tool-install` only on a tooling lane where ephemeral runners such as `npx` or `uv tool run` are acceptable; the mode still writes only under `output/ops`.
 
 Work packets should steer from fresh evidence only. Missing, invalid, stale, or invalid-timestamp latest artifacts stay visible in `freshEvidence`, but they are excluded from packet `sourceSignals`. Tool inventory coverage gaps are kept as `signalClass=coverage_gap` so missing validators remain visible without being treated as actionable defect evidence. Tool-install recommendations are tracked as a separate fresh source and use `signalClass=tool_install_recommendation` only when the recommendation artifact has install-now candidates; approval-required tools remain evidence for planning, not automatic installation.
 

--- a/scripts/ops/ops_wave_runner.mjs
+++ b/scripts/ops/ops_wave_runner.mjs
@@ -79,6 +79,7 @@ Options:
   --run-id <id>           Default: generated from current UTC time.
   --steps <a,b,c>         Restrict to step ids.
   --skip <id>             Skip one step; repeatable.
+  --allow-tool-install    Allow tooling-quality to use its ephemeral validator runners.
 `;
 }
 
@@ -97,6 +98,7 @@ function parseArgs(argv) {
     json: false,
     write: false,
     dryRun: false,
+    allowToolInstall: false,
     runId: "",
     outputDir: DEFAULT_OUTPUT_DIR,
     steps: [],
@@ -119,6 +121,10 @@ function parseArgs(argv) {
     }
     if (arg === "--dry-run") {
       options.dryRun = true;
+      continue;
+    }
+    if (arg === "--allow-tool-install") {
+      options.allowToolInstall = true;
       continue;
     }
     const mappings = [
@@ -156,11 +162,17 @@ function buildWavePlan(options = {}) {
   if (unknown.length > 0) throw new Error(`Unknown step id(s): ${Array.from(new Set(unknown)).join(", ")}`);
   return STEP_DEFINITIONS
     .filter((step) => (only.size === 0 || only.has(step.id)) && !skip.has(step.id))
-    .map((step, index) => ({
-      ...step,
-      order: index + 1,
-      commandText: step.command.map((part, partIndex) => (partIndex === 0 && part === process.execPath ? "node" : part)).join(" "),
-    }));
+    .map((step, index) => {
+      const command = step.id === "tooling-quality" && options.allowToolInstall
+        ? [...step.command, "--allow-install"]
+        : step.command;
+      return {
+        ...step,
+        command,
+        order: index + 1,
+        commandText: command.map((part, partIndex) => (partIndex === 0 && part === process.execPath ? "node" : part)).join(" "),
+      };
+    });
 }
 
 function parseJsonObject(stdout) {

--- a/scripts/ops/ops_wave_runner.test.mjs
+++ b/scripts/ops/ops_wave_runner.test.mjs
@@ -24,6 +24,14 @@ test("buildWavePlan runs PR readiness between preflight validation and final val
   assert.ok(plan[readinessIndex].commandText.includes("pr_readiness_packet.mjs"));
 });
 
+test("buildWavePlan only enables ephemeral validator runners when requested", () => {
+  const defaultPlan = buildWavePlan({ steps: ["tooling-quality"] });
+  const installPlan = buildWavePlan({ steps: ["tooling-quality"], allowToolInstall: true });
+
+  assert.equal(defaultPlan[0].commandText.includes("--allow-install"), false);
+  assert.equal(installPlan[0].commandText.includes("--allow-install"), true);
+});
+
 test("runWave dry-run records skipped receipts without executing", () => {
   const manifest = runWave({ dryRun: true, runId: "unit-wave", steps: ["swarm-preflight", "work-packet"] }, () => {
     throw new Error("runner should not execute in dry-run mode");


### PR DESCRIPTION
## Summary
- Add an explicit --allow-tool-install option to the ops wave runner.
- Keep the default wave conservative, but allow approved tooling lanes to pass --allow-install through to tooling-quality.
- Document the opt-in mode and test that defaults do not fetch optional validators.

## Evidence
- Slice recorded as slice-20260507-059.
- Dry run shows tooling-quality command includes --allow-install only when the new flag is present.
- Opt-in execution ran npx shellcheck and uv sqlfluff, turning missing-tool coverage gaps into actionable findings.

## Files Changed
- scripts/ops/ops_wave_runner.mjs
- scripts/ops/ops_wave_runner.test.mjs
- docs/ops/admin-effectivity-loop.md

## Testing Performed
- node --check scripts/ops/ops_wave_runner.mjs
- node --test scripts/ops/ops_wave_runner.test.mjs
- node scripts/ops/ops_wave_runner.mjs --steps tooling-quality --allow-tool-install --dry-run --json
- node scripts/ops/ops_wave_runner.mjs --steps tooling-quality --allow-tool-install --json --write
- node scripts/ops/validate_ops_artifacts.mjs --json --write
- bash scripts/ops/ops_ci_validate.sh
- git diff --check

## Risk Level
Low. The new behavior is opt-in and limited to read-only tooling-quality validators; default wave behavior is unchanged.

## Rollback Instructions
Revert this commit to remove the opt-in flag and return to the prior runner interface.