### PR TITLE
[ops] Export tooling findings as issue-ready tasks

### DIFF
--- a/docs/ops/admin-effectivity-loop.md
+++ b/docs/ops/admin-effectivity-loop.md
@@ -96,8 +96,9 @@ node scripts/ops/ops_wave_runner.mjs --dry-run --json --write
 node scripts/ops/ops_wave_runner.mjs --allow-tool-install --json --write
 ```
 
-The wave runner executes read-only checks in dependency order: preflight, tooling quality, tool inventory, admin effectivity audit, work packet generation, preliminary artifact schema validation, PR readiness packet generation, then final artifact schema validation. Use it when a downstream command consumes a `*-latest.json` artifact from an upstream command.
+The wave runner executes read-only checks in dependency order: preflight, tooling quality, tooling findings export, tool inventory, admin effectivity audit, work packet generation, preliminary artifact schema validation, PR readiness packet generation, then final artifact schema validation. Use it when a downstream command consumes a `*-latest.json` artifact from an upstream command.
 The default run does not install or fetch missing optional validators. Use `--allow-tool-install` only on a tooling lane where ephemeral runners such as `npx` or `uv tool run` are acceptable; the mode still writes only under `output/ops`.
+Tooling findings export converts fresh `tooling-quality` findings into GitHub-copy-ready cleanup tasks, keeping validator output from becoming a one-off terminal observation.
 
 Work packets should steer from fresh evidence only. Missing, invalid, stale, or invalid-timestamp latest artifacts stay visible in `freshEvidence`, but they are excluded from packet `sourceSignals`. Tool inventory coverage gaps are kept as `signalClass=coverage_gap` so missing validators remain visible without being treated as actionable defect evidence. Tool-install recommendations are tracked as a separate fresh source and use `signalClass=tool_install_recommendation` only when the recommendation artifact has install-now candidates; approval-required tools remain evidence for planning, not automatic installation.
 

--- a/schemas/ops/tooling-findings-export.v1.schema.json
+++ b/schemas/ops/tooling-findings-export.v1.schema.json
@@ -1,0 +1,103 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://studio-brain.local/schemas/ops/tooling-findings-export.v1.schema.json",
+  "title": "Studio Brain Ops Tooling Findings Export v1",
+  "type": "object",
+  "required": [
+    "schema",
+    "generatedAt",
+    "status",
+    "readOnly",
+    "source",
+    "summary",
+    "findings",
+    "tasks"
+  ],
+  "properties": {
+    "schema": { "const": "studiobrain-ops-tooling-findings-export.v1" },
+    "generatedAt": { "type": "string", "format": "date-time" },
+    "status": { "enum": ["pass", "warn", "fail"] },
+    "readOnly": { "const": true },
+    "artifactPath": { "type": "string" },
+    "markdownPath": { "type": "string" },
+    "source": {
+      "type": "object",
+      "required": ["toolingReportPath", "toolingReportGeneratedAt", "toolingReportStatus"],
+      "properties": {
+        "toolingReportPath": { "type": "string" },
+        "toolingReportGeneratedAt": { "type": ["string", "null"] },
+        "toolingReportStatus": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "summary": {
+      "type": "object",
+      "required": ["sections", "findings", "actionableFindings", "coverageGaps", "issueReadyTasks"],
+      "properties": {
+        "sections": { "type": "number", "minimum": 0 },
+        "findings": { "type": "number", "minimum": 0 },
+        "actionableFindings": { "type": "number", "minimum": 0 },
+        "coverageGaps": { "type": "number", "minimum": 0 },
+        "issueReadyTasks": { "type": "number", "minimum": 0 }
+      },
+      "additionalProperties": false
+    },
+    "findings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["toolId", "tool", "file", "line", "column", "code", "severity", "message", "coverageGap"],
+        "properties": {
+          "toolId": { "type": "string" },
+          "tool": { "type": "string" },
+          "file": { "type": "string" },
+          "line": { "type": ["number", "null"] },
+          "column": { "type": ["number", "null"] },
+          "code": { "type": "string" },
+          "severity": { "type": "string" },
+          "message": { "type": "string" },
+          "coverageGap": { "type": "boolean" }
+        },
+        "additionalProperties": false
+      }
+    },
+    "tasks": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "labels",
+          "priority",
+          "owner",
+          "approvalRequired",
+          "problem",
+          "evidence",
+          "proposedFix",
+          "acceptanceCriteria",
+          "safetyNotes",
+          "suggestedBranchName",
+          "suggestedPrTitle",
+          "files"
+        ],
+        "properties": {
+          "title": { "type": "string" },
+          "labels": { "type": "array", "items": { "type": "string" } },
+          "priority": { "enum": ["P0", "P1", "P2", "P3"] },
+          "owner": { "type": "string" },
+          "approvalRequired": { "type": "boolean" },
+          "problem": { "type": "string" },
+          "evidence": { "type": "array", "items": { "type": "string" } },
+          "proposedFix": { "type": "string" },
+          "acceptanceCriteria": { "type": "array", "items": { "type": "string" } },
+          "safetyNotes": { "type": "array", "items": { "type": "string" } },
+          "suggestedBranchName": { "type": "string" },
+          "suggestedPrTitle": { "type": "string" },
+          "files": { "type": "array", "items": { "type": "string" } }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/scripts/ops/ops_ci_validate.sh
+++ b/scripts/ops/ops_ci_validate.sh
@@ -45,6 +45,7 @@ check_file "scripts/ops/ops_wave_runner.mjs"
 check_file "scripts/ops/slice_ledger.mjs"
 check_file "scripts/ops/admin_effectivity_audit.mjs"
 check_file "scripts/ops/tooling_quality_report.mjs"
+check_file "scripts/ops/tooling_findings_export.mjs"
 check_file "scripts/ops/installed_tool_inventory.mjs"
 check_file "scripts/ops/tool_install_recommendations.mjs"
 check_file "scripts/ops/pr_readiness_packet.mjs"
@@ -71,6 +72,7 @@ for script in \
   "scripts/ops/slice_ledger.mjs" \
   "scripts/ops/admin_effectivity_audit.mjs" \
   "scripts/ops/tooling_quality_report.mjs" \
+  "scripts/ops/tooling_findings_export.mjs" \
   "scripts/ops/installed_tool_inventory.mjs" \
   "scripts/ops/tool_install_recommendations.mjs" \
   "scripts/ops/pr_readiness_packet.mjs"; do
@@ -118,6 +120,12 @@ else
   fail "node --test scripts/ops/tooling_quality_report.test.mjs"
 fi
 
+if node --test "${REPO_ROOT}/scripts/ops/tooling_findings_export.test.mjs" >"${OUT_DIR}/tooling-findings-export.test.out" 2>&1; then
+  pass "node --test scripts/ops/tooling_findings_export.test.mjs"
+else
+  fail "node --test scripts/ops/tooling_findings_export.test.mjs"
+fi
+
 if node --test "${REPO_ROOT}/scripts/ops/installed_tool_inventory.test.mjs" >"${OUT_DIR}/installed-tool-inventory.test.out" 2>&1; then
   pass "node --test scripts/ops/installed_tool_inventory.test.mjs"
 else
@@ -161,6 +169,13 @@ if node "${REPO_ROOT}/scripts/ops/tool_install_recommendations.mjs" --json --wri
   pass "tool_install_recommendations smoke"
 else
   fail "tool_install_recommendations smoke"
+fi
+
+section "Tooling Findings Export Smoke"
+if node "${REPO_ROOT}/scripts/ops/tooling_findings_export.mjs" --json --write >"${OUT_DIR}/tooling-findings-export.json"; then
+  pass "tooling_findings_export smoke"
+else
+  fail "tooling_findings_export smoke"
 fi
 
 section "Artifact Schema Smoke"

--- a/scripts/ops/ops_wave_runner.mjs
+++ b/scripts/ops/ops_wave_runner.mjs
@@ -21,6 +21,11 @@ const STEP_DEFINITIONS = [
     expectedArtifacts: ["output/ops/tooling-quality/tooling-quality-latest.json"],
   },
   {
+    id: "tooling-findings",
+    command: [process.execPath, "scripts/ops/tooling_findings_export.mjs", "--json", "--write"],
+    expectedArtifacts: ["output/ops/tooling-quality/tooling-findings-latest.json"],
+  },
+  {
     id: "tool-inventory",
     command: [process.execPath, "scripts/ops/installed_tool_inventory.mjs", "--json", "--write"],
     expectedArtifacts: ["output/ops/effectivity/installed-tool-inventory-latest.json"],

--- a/scripts/ops/ops_wave_runner.test.mjs
+++ b/scripts/ops/ops_wave_runner.test.mjs
@@ -32,6 +32,16 @@ test("buildWavePlan only enables ephemeral validator runners when requested", ()
   assert.equal(installPlan[0].commandText.includes("--allow-install"), true);
 });
 
+test("buildWavePlan exports tooling findings after tooling quality", () => {
+  const plan = buildWavePlan();
+  const qualityIndex = plan.findIndex((step) => step.id === "tooling-quality");
+  const findingsIndex = plan.findIndex((step) => step.id === "tooling-findings");
+
+  assert.ok(qualityIndex >= 0);
+  assert.ok(findingsIndex > qualityIndex);
+  assert.ok(plan[findingsIndex].commandText.includes("tooling_findings_export.mjs"));
+});
+
 test("runWave dry-run records skipped receipts without executing", () => {
   const manifest = runWave({ dryRun: true, runId: "unit-wave", steps: ["swarm-preflight", "work-packet"] }, () => {
     throw new Error("runner should not execute in dry-run mode");

--- a/scripts/ops/tooling_findings_export.mjs
+++ b/scripts/ops/tooling_findings_export.mjs
@@ -1,0 +1,277 @@
+#!/usr/bin/env node
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const REPO_ROOT = resolve(dirname(__filename), "..", "..");
+const DEFAULT_OUTPUT_DIR = resolve(REPO_ROOT, "output", "ops", "tooling-quality");
+const DEFAULT_TOOLING_REPORT = resolve(DEFAULT_OUTPUT_DIR, "tooling-quality-latest.json");
+
+function usage() {
+  return `Studio Brain ops tooling findings export
+
+Usage:
+  node scripts/ops/tooling_findings_export.mjs [--json] [--write]
+
+Options:
+  --json                Print JSON.
+  --write               Write timestamped/latest JSON and Markdown artifacts.
+  --tooling-report <p>  Tooling-quality report. Default: output/ops/tooling-quality/tooling-quality-latest.json.
+  --output-dir <path>   Artifact directory. Default: output/ops/tooling-quality.
+`;
+}
+
+function clean(value) {
+  return String(value ?? "").replace(/\r/g, "").trim();
+}
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function resolveRepoPath(path) {
+  return resolve(REPO_ROOT, clean(path));
+}
+
+function repoRelative(path) {
+  return relative(REPO_ROOT, resolve(path)).replace(/\\/g, "/");
+}
+
+function readJson(path) {
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function parseArgs(argv) {
+  const options = {
+    json: false,
+    write: false,
+    toolingReport: DEFAULT_TOOLING_REPORT,
+    outputDir: DEFAULT_OUTPUT_DIR,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = clean(argv[index]);
+    if (arg === "--help" || arg === "-h") {
+      process.stdout.write(usage());
+      process.exit(0);
+    }
+    if (arg === "--json") {
+      options.json = true;
+      continue;
+    }
+    if (arg === "--write") {
+      options.write = true;
+      continue;
+    }
+    if (arg === "--tooling-report") {
+      options.toolingReport = resolveRepoPath(argv[++index]);
+      continue;
+    }
+    if (arg.startsWith("--tooling-report=")) {
+      options.toolingReport = resolveRepoPath(arg.slice("--tooling-report=".length));
+      continue;
+    }
+    if (arg === "--output-dir") {
+      options.outputDir = resolveRepoPath(argv[++index]);
+      continue;
+    }
+    if (arg.startsWith("--output-dir=")) {
+      options.outputDir = resolveRepoPath(arg.slice("--output-dir=".length));
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+  return options;
+}
+
+function sectionsFrom(report) {
+  if (Array.isArray(report?.sections)) return report.sections;
+  if (Array.isArray(report?.checks)) return report.checks;
+  return [];
+}
+
+function isCoverageGap(finding) {
+  const code = clean(finding?.code).toLowerCase();
+  const message = clean(finding?.message).toLowerCase();
+  return code === "tool_missing" || message.includes("not installed");
+}
+
+function normalizeFinding(section, finding) {
+  const location = {
+    file: clean(finding?.file),
+    line: Number.isInteger(finding?.line) ? finding.line : null,
+    column: Number.isInteger(finding?.column) ? finding.column : null,
+  };
+  return {
+    toolId: clean(section?.id),
+    tool: clean(section?.tool) || clean(section?.id),
+    file: location.file,
+    line: location.line,
+    column: location.column,
+    code: clean(finding?.code) || clean(section?.id) || "tooling",
+    severity: clean(finding?.severity) || "warning",
+    message: clean(finding?.message),
+    coverageGap: isCoverageGap(finding),
+  };
+}
+
+function findingEvidence(finding) {
+  const loc = finding.file
+    ? `${finding.file}${finding.line ? `:${finding.line}` : ""}${finding.column ? `:${finding.column}` : ""}`
+    : finding.tool;
+  return `${loc} ${finding.code}: ${finding.message}`.trim();
+}
+
+function taskFor(section, findings) {
+  const toolId = clean(section.id);
+  const files = Array.from(new Set(findings.map((finding) => finding.file).filter(Boolean)));
+  return {
+    title: `[ops-tooling] Review ${toolId} findings`,
+    labels: ["ops", "reliability", "cleanup"],
+    priority: findings.some((finding) => finding.code === "SC2115") ? "P1" : "P2",
+    owner: "Codex",
+    approvalRequired: false,
+    problem: `${toolId} produced ${findings.length} actionable finding(s) in the latest tooling-quality report.`,
+    evidence: findings.map(findingEvidence),
+    proposedFix: "Review the finding(s), make the smallest safe code/doc change, and rerun the targeted validator.",
+    acceptanceCriteria: [
+      "The targeted validator no longer reports the finding, or the finding is documented as an intentional false positive.",
+      "The fix is covered by existing focused tests or a small new regression test when behavior changes.",
+      "No generated ops artifact prints secrets, tokens, or raw environment values.",
+    ],
+    safetyNotes: [
+      "Report-only task; no host, Docker, database, package, or firewall mutation is implied.",
+      "Rollback is a normal git revert of the small fixing PR.",
+    ],
+    suggestedBranchName: `codex/ops-tooling-${toolId}-findings`,
+    suggestedPrTitle: `[ops] Address ${toolId} tooling findings`,
+    files,
+  };
+}
+
+function buildReport(options = {}) {
+  const generatedAt = nowIso();
+  const reportPath = options.toolingReport || DEFAULT_TOOLING_REPORT;
+  const sourceReport = options.reportObject || readJson(reportPath);
+  const sections = sectionsFrom(sourceReport);
+  const findings = sections.flatMap((section) =>
+    (Array.isArray(section.findings) ? section.findings : []).map((finding) => normalizeFinding(section, finding)));
+  const actionable = findings.filter((finding) => !finding.coverageGap);
+  const coverageGaps = findings.filter((finding) => finding.coverageGap);
+  const tasks = sections
+    .map((section) => {
+      const sectionFindings = actionable.filter((finding) => finding.toolId === clean(section.id));
+      return sectionFindings.length ? taskFor(section, sectionFindings) : null;
+    })
+    .filter(Boolean);
+  const status = sourceReport ? (actionable.length || coverageGaps.length ? "warn" : "pass") : "warn";
+  return {
+    schema: "studiobrain-ops-tooling-findings-export.v1",
+    generatedAt,
+    status,
+    readOnly: true,
+    source: {
+      toolingReportPath: repoRelative(reportPath),
+      toolingReportGeneratedAt: sourceReport?.generatedAt || null,
+      toolingReportStatus: sourceReport?.status || "unavailable",
+    },
+    summary: {
+      sections: sections.length,
+      findings: findings.length,
+      actionableFindings: actionable.length,
+      coverageGaps: coverageGaps.length,
+      issueReadyTasks: tasks.length,
+    },
+    findings,
+    tasks,
+  };
+}
+
+function renderMarkdown(report) {
+  const lines = [
+    "# Studio Brain Tooling Findings Export",
+    "",
+    `Generated: ${report.generatedAt}`,
+    `Status: ${report.status}`,
+    `Source: ${report.source.toolingReportPath}`,
+    "",
+    "## Summary",
+    "",
+    `- Findings: ${report.summary.findings}`,
+    `- Actionable findings: ${report.summary.actionableFindings}`,
+    `- Coverage gaps: ${report.summary.coverageGaps}`,
+    `- Issue-ready tasks: ${report.summary.issueReadyTasks}`,
+    "",
+  ];
+  if (report.tasks.length === 0) {
+    lines.push("No issue-ready tooling findings were found.", "");
+    return `${lines.join("\n")}\n`;
+  }
+  lines.push("## Issue-Ready Tasks", "");
+  for (const task of report.tasks) {
+    lines.push(`### ${task.title}`, "");
+    lines.push("Labels: " + task.labels.join(", "));
+    lines.push(`Priority: ${task.priority}`);
+    lines.push(`Owner: ${task.owner}`);
+    lines.push(`Approval required: ${task.approvalRequired ? "yes" : "no"}`, "");
+    lines.push("## Problem", task.problem, "");
+    lines.push("## Evidence");
+    for (const item of task.evidence) lines.push(`- ${item}`);
+    lines.push("", "## Proposed Fix", task.proposedFix, "");
+    lines.push("## Acceptance Criteria");
+    for (const item of task.acceptanceCriteria) lines.push(`- ${item}`);
+    lines.push("", "## Safety Notes");
+    for (const item of task.safetyNotes) lines.push(`- ${item}`);
+    lines.push("", `Suggested branch: \`${task.suggestedBranchName}\``);
+    lines.push(`Suggested PR: \`${task.suggestedPrTitle}\``, "");
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+function writeArtifact(path, content) {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, content, "utf8");
+}
+
+function run(rawArgs = process.argv.slice(2)) {
+  const options = parseArgs(rawArgs);
+  const report = buildReport(options);
+  const stamp = report.generatedAt.replace(/[-:]/g, "").replace(/\.\d+Z$/, "Z");
+  const jsonPath = resolve(options.outputDir, `tooling-findings-${stamp}.json`);
+  const markdownPath = resolve(options.outputDir, `tooling-findings-${stamp}.md`);
+  const latestJson = resolve(options.outputDir, "tooling-findings-latest.json");
+  const latestMarkdown = resolve(options.outputDir, "tooling-findings-latest.md");
+  if (options.write) {
+    writeArtifact(jsonPath, `${JSON.stringify(report, null, 2)}\n`);
+    writeArtifact(markdownPath, renderMarkdown(report));
+    writeArtifact(latestJson, `${JSON.stringify({ ...report, artifactPath: repoRelative(jsonPath), markdownPath: repoRelative(markdownPath) }, null, 2)}\n`);
+    writeArtifact(latestMarkdown, renderMarkdown(report));
+  }
+  const output = options.write
+    ? { ...report, artifacts: { jsonPath: repoRelative(jsonPath), latestPath: repoRelative(latestJson), markdownPath: repoRelative(markdownPath), latestMarkdownPath: repoRelative(latestMarkdown) } }
+    : report;
+  if (options.json) process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
+  else {
+    process.stdout.write(`tooling findings export: ${report.status}\n`);
+    process.stdout.write(`tasks: ${report.summary.issueReadyTasks}\n`);
+    if (options.write) process.stdout.write(`artifact: ${repoRelative(jsonPath)}\n`);
+  }
+  return output;
+}
+
+export { buildReport, normalizeFinding, renderMarkdown };
+
+if (process.argv[1] && resolve(process.argv[1]) === __filename) {
+  try {
+    run();
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.stack || error.message : String(error)}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/ops/tooling_findings_export.test.mjs
+++ b/scripts/ops/tooling_findings_export.test.mjs
@@ -1,0 +1,72 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { buildReport, normalizeFinding, renderMarkdown } from "./tooling_findings_export.mjs";
+
+test("normalizeFinding marks missing tools as coverage gaps", () => {
+  const finding = normalizeFinding(
+    { id: "actionlint", tool: "actionlint" },
+    { code: "tool_missing", message: "actionlint is not installed." },
+  );
+
+  assert.equal(finding.coverageGap, true);
+  assert.equal(finding.toolId, "actionlint");
+});
+
+test("buildReport converts actionable findings into issue-ready tasks", () => {
+  const report = buildReport({
+    toolingReport: "output/ops/tooling-quality/tooling-quality-latest.json",
+    reportObject: {
+      schema: "studiobrain-ops-tooling-quality-report.v1",
+      generatedAt: "2026-05-07T00:00:00.000Z",
+      status: "warn",
+      sections: [
+        {
+          id: "shellcheck",
+          tool: "npx shellcheck",
+          findings: [
+            {
+              file: "scripts/ops/example.sh",
+              line: 7,
+              column: 3,
+              code: "SC2155",
+              severity: "warning",
+              message: "Declare and assign separately.",
+            },
+          ],
+        },
+        {
+          id: "actionlint",
+          tool: "actionlint",
+          findings: [{ code: "tool_missing", message: "actionlint is not installed." }],
+        },
+      ],
+    },
+  });
+
+  assert.equal(report.status, "warn");
+  assert.equal(report.summary.findings, 2);
+  assert.equal(report.summary.actionableFindings, 1);
+  assert.equal(report.summary.coverageGaps, 1);
+  assert.equal(report.summary.issueReadyTasks, 1);
+  assert.equal(report.tasks[0].title, "[ops-tooling] Review shellcheck findings");
+});
+
+test("renderMarkdown emits GitHub-copy-ready task sections", () => {
+  const report = buildReport({
+    reportObject: {
+      sections: [
+        {
+          id: "sqlfluff",
+          tool: "uv sqlfluff",
+          findings: [{ file: "scripts/ops/review.sql", code: "parse_error", message: "SQL parse failed." }],
+        },
+      ],
+    },
+  });
+  const markdown = renderMarkdown(report);
+
+  assert.match(markdown, /## Problem/);
+  assert.match(markdown, /## Acceptance Criteria/);
+  assert.match(markdown, /scripts\/ops\/review\.sql parse_error/);
+});

--- a/scripts/ops/validate_ops_artifacts.mjs
+++ b/scripts/ops/validate_ops_artifacts.mjs
@@ -14,6 +14,11 @@ const DEFAULT_ARTIFACTS = [
     schema: "schemas/ops/tooling-quality-report.v1.schema.json",
   },
   {
+    id: "tooling-findings-export",
+    artifact: "output/ops/tooling-quality/tooling-findings-latest.json",
+    schema: "schemas/ops/tooling-findings-export.v1.schema.json",
+  },
+  {
     id: "installed-tool-inventory",
     artifact: "output/ops/effectivity/installed-tool-inventory-latest.json",
     schema: "schemas/ops/installed-tool-inventory.v1.schema.json",


### PR DESCRIPTION
## Summary
- Add a tooling findings exporter that converts tooling-quality findings into JSON and GitHub-copy-ready Markdown tasks.
- Include the exporter in the ordered wave runner after tooling-quality.
- Add schema validation and local CI coverage for the new artifact.

## Evidence
- Slice recorded as slice-20260507-060.
- Latest exporter output produced 2 issue-ready tasks from 4 actionable findings and separated 2 coverage gaps.
- Artifact validation now checks 11/11 latest ops artifacts.

## Files Changed
- scripts/ops/tooling_findings_export.mjs
- scripts/ops/tooling_findings_export.test.mjs
- schemas/ops/tooling-findings-export.v1.schema.json
- scripts/ops/validate_ops_artifacts.mjs
- scripts/ops/ops_wave_runner.mjs
- scripts/ops/ops_wave_runner.test.mjs
- scripts/ops/ops_ci_validate.sh
- docs/ops/admin-effectivity-loop.md

## Testing Performed
- node --check scripts/ops/tooling_findings_export.mjs
- node --test scripts/ops/tooling_findings_export.test.mjs
- node --test scripts/ops/ops_wave_runner.test.mjs
- node --test scripts/ops/validate_ops_artifacts.test.mjs
- node scripts/ops/tooling_findings_export.mjs --json --write
- node scripts/ops/ops_wave_runner.mjs --json --write
- node scripts/ops/validate_ops_artifacts.mjs --json --write
- bash scripts/ops/ops_ci_validate.sh
- git diff --check

## Risk Level
Low. This is report-only ops tooling that writes generated artifacts under output/ops and does not mutate host, Docker, database, package, or firewall state.

## Rollback Instructions
Revert this commit to remove the exporter and the wave/schema/CI references.