### PR TITLE
[ops] Feed tooling findings into work packets

### DIFF
--- a/docs/ops/admin-effectivity-loop.md
+++ b/docs/ops/admin-effectivity-loop.md
@@ -102,6 +102,7 @@ Tooling findings export converts fresh `tooling-quality` findings into GitHub-co
 The effectivity audit compares tool inventory sources against the start of the selected slice window, so validators run during the wave are not falsely marked stale just because the slice ledger is appended after validation completes.
 
 Work packets should steer from fresh evidence only. Missing, invalid, stale, or invalid-timestamp latest artifacts stay visible in `freshEvidence`, but they are excluded from packet `sourceSignals`. Tool inventory coverage gaps are kept as `signalClass=coverage_gap` so missing validators remain visible without being treated as actionable defect evidence. Tool-install recommendations are tracked as a separate fresh source and use `signalClass=tool_install_recommendation` only when the recommendation artifact has install-now candidates; approval-required tools remain evidence for planning, not automatic installation.
+Tooling findings export is included in work-packet evidence as `fresh-tooling-findings`; issue-ready validator tasks are tagged `signalClass=issue_ready_task` so agents can pick them up without scraping terminal output.
 
 ## Scoring
 

--- a/schemas/ops/ops-work-packet.v1.schema.json
+++ b/schemas/ops/ops-work-packet.v1.schema.json
@@ -11,7 +11,7 @@
     "purpose": { "type": "string" },
     "sources": {
       "type": "object",
-      "required": ["riskRegister", "backlog", "effectivity", "adminAudit", "sliceLedger", "toolInventory", "toolInstallRecommendations", "swarmPreflight"],
+      "required": ["riskRegister", "backlog", "effectivity", "adminAudit", "sliceLedger", "toolInventory", "toolInstallRecommendations", "toolingFindings", "swarmPreflight"],
       "properties": {
         "riskRegister": { "type": "string" },
         "backlog": { "type": "string" },
@@ -20,6 +20,7 @@
         "sliceLedger": { "type": "string" },
         "toolInventory": { "type": "string" },
         "toolInstallRecommendations": { "type": "string" },
+        "toolingFindings": { "type": "string" },
         "swarmPreflight": { "type": "string" }
       },
       "additionalProperties": false
@@ -38,7 +39,7 @@
     },
     "evidenceSummary": {
       "type": "object",
-      "required": ["risks", "backlogItems", "effectivityNextSafeSlices", "remainingApprovalGates", "freshSources", "staleSources", "toolPromotionCandidates", "toolActionableFindings", "toolCoverageGaps", "toolInstallRecommendations", "toolInstallApprovalRequired", "toolInstallNowCandidates", "effectivityEvidenceLanes", "effectivityApprovalRequiredLanes", "effectivityHighSeverityLanes", "swarmPreflightStatus", "swarmPreflightOutsideScope", "swarmPreflightProblems"],
+      "required": ["risks", "backlogItems", "effectivityNextSafeSlices", "remainingApprovalGates", "freshSources", "staleSources", "toolPromotionCandidates", "toolActionableFindings", "toolCoverageGaps", "toolInstallRecommendations", "toolInstallApprovalRequired", "toolInstallNowCandidates", "toolingFindings", "toolingActionableFindings", "toolingIssueReadyTasks", "effectivityEvidenceLanes", "effectivityApprovalRequiredLanes", "effectivityHighSeverityLanes", "swarmPreflightStatus", "swarmPreflightOutsideScope", "swarmPreflightProblems"],
       "properties": {
         "risks": { "type": "number", "minimum": 0 },
         "backlogItems": { "type": "number", "minimum": 0 },
@@ -52,6 +53,9 @@
         "toolInstallRecommendations": { "type": ["number", "null"], "minimum": 0 },
         "toolInstallApprovalRequired": { "type": ["number", "null"], "minimum": 0 },
         "toolInstallNowCandidates": { "type": ["number", "null"], "minimum": 0 },
+        "toolingFindings": { "type": ["number", "null"], "minimum": 0 },
+        "toolingActionableFindings": { "type": ["number", "null"], "minimum": 0 },
+        "toolingIssueReadyTasks": { "type": ["number", "null"], "minimum": 0 },
         "effectivityEvidenceLanes": { "type": ["number", "null"], "minimum": 0 },
         "effectivityApprovalRequiredLanes": { "type": ["number", "null"], "minimum": 0 },
         "effectivityHighSeverityLanes": { "type": ["number", "null"], "minimum": 0 },
@@ -63,7 +67,7 @@
     },
     "freshEvidence": {
       "type": "object",
-      "required": ["adminAudit", "sliceLedger", "toolInventory", "toolInstallRecommendations", "swarmPreflight"],
+      "required": ["adminAudit", "sliceLedger", "toolInventory", "toolInstallRecommendations", "toolingFindings", "swarmPreflight"],
       "additionalProperties": true
     },
     "packets": {

--- a/scripts/studiobrain-ops-work-packet.mjs
+++ b/scripts/studiobrain-ops-work-packet.mjs
@@ -21,6 +21,7 @@ const DEFAULT_ADMIN_AUDIT = resolve(REPO_ROOT, "output", "ops", "effectivity", "
 const DEFAULT_SLICE_LEDGER = resolve(REPO_ROOT, "output", "ops", "effectivity", "slice-ledger-latest.json");
 const DEFAULT_TOOL_INVENTORY = resolve(REPO_ROOT, "output", "ops", "effectivity", "installed-tool-inventory-latest.json");
 const DEFAULT_TOOL_INSTALL_RECOMMENDATIONS = resolve(REPO_ROOT, "output", "ops", "effectivity", "tool-install-recommendations-latest.json");
+const DEFAULT_TOOLING_FINDINGS = resolve(REPO_ROOT, "output", "ops", "tooling-quality", "tooling-findings-latest.json");
 const DEFAULT_SWARM_PREFLIGHT = resolve(REPO_ROOT, "output", "ops", "swarm-lane-preflight", "swarm-lane-preflight-latest.json");
 const VALID_OUTCOMES = new Set([
   "used",
@@ -341,6 +342,7 @@ function freshSourceSignals(freshEvidence) {
     freshEvidence.sliceLedger,
     freshEvidence.toolInventory,
     freshEvidence.toolInstallRecommendations,
+    freshEvidence.toolingFindings,
     freshEvidence.swarmPreflight,
   ]
     .filter((source) => source && !["missing", "invalid_json", "invalid_timestamp", "stale"].includes(source.status))
@@ -363,6 +365,10 @@ function signalClassForSource(source) {
   if (source.source === "fresh-tool-install-recommendations") {
     if ((source.summary?.installNowCandidates || 0) > 0) return "tool_install_recommendation";
     if ((source.summary?.approvalRequired || 0) > 0) return "approval_gate";
+  }
+  if (source.source === "fresh-tooling-findings") {
+    if ((source.summary?.issueReadyTasks || 0) > 0) return "issue_ready_task";
+    if ((source.summary?.coverageGaps || 0) > 0) return "coverage_gap";
   }
   return "fresh";
 }
@@ -450,6 +456,7 @@ function summarizeFreshEvidence(inputs = {}, options = {}) {
   const sliceLedger = inputs.sliceLedger || null;
   const toolInventory = inputs.toolInventory || null;
   const toolInstallRecommendations = inputs.toolInstallRecommendations || null;
+  const toolingFindings = inputs.toolingFindings || null;
   const swarmPreflight = inputs.swarmPreflight || null;
   const unavailable = (source, path, status = "missing", summary = {}) => ({
     source,
@@ -555,6 +562,34 @@ function summarizeFreshEvidence(inputs = {}, options = {}) {
           toolInstallRecommendations?.status || "missing",
           toolInstallRecommendations?.parseError ? { parseError: toolInstallRecommendations.parseError } : {},
         ),
+    toolingFindings: toolingFindings && toolingFindings.status !== "invalid_json"
+      ? applyFreshness({
+          source: "fresh-tooling-findings",
+          path: inputs.toolingFindingsPath || "output/ops/tooling-quality/tooling-findings-latest.json",
+          status: clean(toolingFindings.status) || "unknown",
+          generatedAt: clean(toolingFindings.generatedAt),
+          summary: {
+            findings: toolingFindings.summary?.findings ?? null,
+            actionableFindings: toolingFindings.summary?.actionableFindings ?? null,
+            coverageGaps: toolingFindings.summary?.coverageGaps ?? null,
+            issueReadyTasks: toolingFindings.summary?.issueReadyTasks ?? null,
+            topTasks: Array.isArray(toolingFindings.tasks)
+              ? toolingFindings.tasks.slice(0, 3).map((task) => ({
+                  title: clean(task.title),
+                  priority: clean(task.priority),
+                  approvalRequired: Boolean(task.approvalRequired),
+                  suggestedBranchName: clean(task.suggestedBranchName),
+                  suggestedPrTitle: clean(task.suggestedPrTitle),
+                }))
+              : [],
+          },
+        }, options)
+      : unavailable(
+          "fresh-tooling-findings",
+          inputs.toolingFindingsPath || "output/ops/tooling-quality/tooling-findings-latest.json",
+          toolingFindings?.status || "missing",
+          toolingFindings?.parseError ? { parseError: toolingFindings.parseError } : {},
+        ),
     swarmPreflight: swarmPreflight && swarmPreflight.status !== "invalid_json"
       ? applyFreshness({
           source: "fresh-swarm-preflight",
@@ -600,6 +635,7 @@ export function buildOpsWorkPacket(inputs = {}, options = {}) {
     freshEvidence.sliceLedger,
     freshEvidence.toolInventory,
     freshEvidence.toolInstallRecommendations,
+    freshEvidence.toolingFindings,
     freshEvidence.swarmPreflight,
   ];
   const freshSources = freshEvidenceSources.filter((source) => !["missing", "invalid_json", "invalid_timestamp", "stale"].includes(source.status));
@@ -623,6 +659,7 @@ export function buildOpsWorkPacket(inputs = {}, options = {}) {
       sliceLedger: freshEvidence.sliceLedger.path,
       toolInventory: freshEvidence.toolInventory.path,
       toolInstallRecommendations: freshEvidence.toolInstallRecommendations.path,
+      toolingFindings: freshEvidence.toolingFindings.path,
       swarmPreflight: freshEvidence.swarmPreflight.path,
     },
     constraints: {
@@ -645,6 +682,9 @@ export function buildOpsWorkPacket(inputs = {}, options = {}) {
       toolInstallRecommendations: freshEvidence.toolInstallRecommendations.summary.recommendations ?? null,
       toolInstallApprovalRequired: freshEvidence.toolInstallRecommendations.summary.approvalRequired ?? null,
       toolInstallNowCandidates: freshEvidence.toolInstallRecommendations.summary.installNowCandidates ?? null,
+      toolingFindings: freshEvidence.toolingFindings.summary.findings ?? null,
+      toolingActionableFindings: freshEvidence.toolingFindings.summary.actionableFindings ?? null,
+      toolingIssueReadyTasks: freshEvidence.toolingFindings.summary.issueReadyTasks ?? null,
       effectivityEvidenceLanes: freshEvidence.adminAudit.summary.effectivityEvidenceLanes ?? null,
       effectivityApprovalRequiredLanes: freshEvidence.adminAudit.summary.approvalRequiredEvidenceLanes ?? null,
       effectivityHighSeverityLanes: freshEvidence.adminAudit.summary.highSeverityEvidenceLanes ?? null,
@@ -670,6 +710,7 @@ function parseArgs(argv) {
     sliceLedger: DEFAULT_SLICE_LEDGER,
     toolInventory: DEFAULT_TOOL_INVENTORY,
     toolInstallRecommendations: DEFAULT_TOOL_INSTALL_RECOMMENDATIONS,
+    toolingFindings: DEFAULT_TOOLING_FINDINGS,
     swarmPreflight: DEFAULT_SWARM_PREFLIGHT,
     maxAgeHours: 24,
     maxPackets: 8,
@@ -713,6 +754,7 @@ function parseArgs(argv) {
       "--slice-ledger": "sliceLedger",
       "--tool-inventory": "toolInventory",
       "--tool-install-recommendations": "toolInstallRecommendations",
+      "--tooling-findings": "toolingFindings",
       "--swarm-preflight": "swarmPreflight",
       "--record-outcome": "recordOutcome",
       "--outcome": "outcome",
@@ -724,7 +766,7 @@ function parseArgs(argv) {
     for (const [flag, key] of Object.entries(stringOptions)) {
       const value = read(flag);
       if (value !== null) {
-        args[key] = key === "outputRoot" || key === "artifact" || key === "latest" || key === "outcomes" || key === "adminAudit" || key === "sliceLedger" || key === "toolInventory" || key === "toolInstallRecommendations" || key === "swarmPreflight"
+        args[key] = key === "outputRoot" || key === "artifact" || key === "latest" || key === "outcomes" || key === "adminAudit" || key === "sliceLedger" || key === "toolInventory" || key === "toolInstallRecommendations" || key === "toolingFindings" || key === "swarmPreflight"
           ? resolve(REPO_ROOT, value)
           : value;
         matched = true;
@@ -768,6 +810,7 @@ function printUsage() {
       "  --slice-ledger <path>   Default: output/ops/effectivity/slice-ledger-latest.json.",
       "  --tool-inventory <path> Default: output/ops/effectivity/installed-tool-inventory-latest.json.",
       "  --tool-install-recommendations <path> Default: output/ops/effectivity/tool-install-recommendations-latest.json.",
+      "  --tooling-findings <path> Default: output/ops/tooling-quality/tooling-findings-latest.json.",
       "  --swarm-preflight <path> Default: output/ops/swarm-lane-preflight/swarm-lane-preflight-latest.json.",
       "  --max-age-hours <n>     Warn when fresh-input artifacts are older than this. Default: 24.",
       "  --max-packets <n>       Default: 8.",
@@ -829,11 +872,13 @@ export function runOpsWorkPacket(rawArgs = process.argv.slice(2)) {
       sliceLedger: readJsonIfExists(options.sliceLedger),
       toolInventory: readJsonIfExists(options.toolInventory),
       toolInstallRecommendations: readJsonIfExists(options.toolInstallRecommendations),
+      toolingFindings: readJsonIfExists(options.toolingFindings),
       swarmPreflight: readJsonIfExists(options.swarmPreflight),
       adminAuditPath: toRepoRelative(options.adminAudit),
       sliceLedgerPath: toRepoRelative(options.sliceLedger),
       toolInventoryPath: toRepoRelative(options.toolInventory),
       toolInstallRecommendationsPath: toRepoRelative(options.toolInstallRecommendations),
+      toolingFindingsPath: toRepoRelative(options.toolingFindings),
       swarmPreflightPath: toRepoRelative(options.swarmPreflight),
     },
     {

--- a/scripts/studiobrain-ops-work-packet.test.mjs
+++ b/scripts/studiobrain-ops-work-packet.test.mjs
@@ -196,6 +196,28 @@ const freshInputs = {
       },
     ],
   },
+  toolingFindings: {
+    schema: "studiobrain-ops-tooling-findings-export.v1",
+    generatedAt: "2026-05-07T08:45:53.000Z",
+    status: "warn",
+    readOnly: true,
+    summary: {
+      sections: 6,
+      findings: 6,
+      actionableFindings: 4,
+      coverageGaps: 2,
+      issueReadyTasks: 2,
+    },
+    tasks: [
+      {
+        title: "[ops-tooling] Review shellcheck findings",
+        priority: "P1",
+        approvalRequired: false,
+        suggestedBranchName: "codex/ops-tooling-shellcheck-findings",
+        suggestedPrTitle: "[ops] Address shellcheck tooling findings",
+      },
+    ],
+  },
   swarmPreflight: {
     schema: "studiobrain-swarm-lane-preflight.v1",
     generatedAt: "2026-05-07T08:46:12.000Z",
@@ -215,6 +237,7 @@ const freshInputs = {
   sliceLedgerPath: "output/ops/effectivity/slice-ledger-latest.json",
   toolInventoryPath: "output/ops/effectivity/installed-tool-inventory-latest.json",
   toolInstallRecommendationsPath: "output/ops/effectivity/tool-install-recommendations-latest.json",
+  toolingFindingsPath: "output/ops/tooling-quality/tooling-findings-latest.json",
   swarmPreflightPath: "output/ops/swarm-lane-preflight/swarm-lane-preflight-latest.json",
 };
 
@@ -235,7 +258,7 @@ test("buildOpsWorkPacket creates bounded read-only packets from docs evidence", 
   assert.equal(report.constraints.noServiceRestart, true);
   assert.equal(report.evidenceSummary.risks, 2);
   assert.equal(report.evidenceSummary.backlogItems, 2);
-  assert.equal(report.evidenceSummary.freshSources, 5);
+  assert.equal(report.evidenceSummary.freshSources, 6);
   assert.equal(report.evidenceSummary.staleSources, 0);
   assert.equal(report.evidenceSummary.toolPromotionCandidates, 0);
   assert.equal(report.evidenceSummary.toolActionableFindings, 0);
@@ -243,6 +266,9 @@ test("buildOpsWorkPacket creates bounded read-only packets from docs evidence", 
   assert.equal(report.evidenceSummary.toolInstallRecommendations, 7);
   assert.equal(report.evidenceSummary.toolInstallApprovalRequired, 1);
   assert.equal(report.evidenceSummary.toolInstallNowCandidates, 2);
+  assert.equal(report.evidenceSummary.toolingFindings, 6);
+  assert.equal(report.evidenceSummary.toolingActionableFindings, 4);
+  assert.equal(report.evidenceSummary.toolingIssueReadyTasks, 2);
   assert.equal(report.evidenceSummary.effectivityEvidenceLanes, 2);
   assert.equal(report.evidenceSummary.effectivityApprovalRequiredLanes, 1);
   assert.equal(report.evidenceSummary.effectivityHighSeverityLanes, 1);
@@ -264,6 +290,9 @@ test("buildOpsWorkPacket creates bounded read-only packets from docs evidence", 
   const installSignal = report.packets[0].sourceSignals.find((signal) => signal.source === "fresh-tool-install-recommendations");
   assert.equal(installSignal.summary.approvalRequired, 1);
   assert.equal(installSignal.summary.topRecommendations.some((item) => Object.hasOwn(item, "installCommand")), false);
+  const toolingFindingsSignal = report.packets[0].sourceSignals.find((signal) => signal.source === "fresh-tooling-findings");
+  assert.equal(toolingFindingsSignal.signalClass, "issue_ready_task");
+  assert.equal(toolingFindingsSignal.summary.issueReadyTasks, 2);
   assert.ok(report.packets[0].sourceSignals.some((signal) => signal.source === "fresh-swarm-preflight"));
   assert.equal(report.packets[0].priority, "P0");
   assert.ok(report.packets[0].humanGate.includes("PostgreSQL dump"));
@@ -277,6 +306,7 @@ test("summarizeFreshEvidence degrades when ignored artifacts are missing", () =>
   assert.equal(fresh.sliceLedger.status, "missing");
   assert.equal(fresh.toolInventory.status, "missing");
   assert.equal(fresh.toolInstallRecommendations.status, "missing");
+  assert.equal(fresh.toolingFindings.status, "missing");
   assert.equal(fresh.swarmPreflight.status, "missing");
 });
 
@@ -290,6 +320,7 @@ test("summarizeFreshEvidence does not count invalid JSON as fresh", () => {
       sliceLedger: freshInputs.sliceLedger,
       toolInventory: { status: "invalid_json", parseError: "bad tools" },
       toolInstallRecommendations: { status: "invalid_json", parseError: "bad tool install recommendations" },
+      toolingFindings: { status: "invalid_json", parseError: "bad tooling findings" },
     },
     { maxPackets: 1 },
   );
@@ -299,9 +330,11 @@ test("summarizeFreshEvidence does not count invalid JSON as fresh", () => {
   assert.equal(report.freshEvidence.adminAudit.status, "invalid_json");
   assert.equal(report.freshEvidence.toolInventory.summary.parseError, "bad tools");
   assert.equal(report.freshEvidence.toolInstallRecommendations.summary.parseError, "bad tool install recommendations");
+  assert.equal(report.freshEvidence.toolingFindings.summary.parseError, "bad tooling findings");
   assert.equal(report.packets[0].sourceSignals.some((signal) => signal.source === "fresh-admin-audit"), false);
   assert.equal(report.packets[0].sourceSignals.some((signal) => signal.source === "fresh-tool-inventory"), false);
   assert.equal(report.packets[0].sourceSignals.some((signal) => signal.source === "fresh-tool-install-recommendations"), false);
+  assert.equal(report.packets[0].sourceSignals.some((signal) => signal.source === "fresh-tooling-findings"), false);
 });
 
 test("workPacketReportStatus warns when falling back to static docs only", () => {
@@ -384,7 +417,7 @@ test("workPacketReportStatus warns when fresh evidence is stale", () => {
   );
 
   assert.equal(stale.evidenceSummary.freshSources, 0);
-  assert.equal(stale.evidenceSummary.staleSources, 5);
+  assert.equal(stale.evidenceSummary.staleSources, 6);
   assert.equal(stale.freshEvidence.adminAudit.status, "stale");
   assert.equal(stale.freshEvidence.adminAudit.sourceStatus, "pass");
   assert.equal(stale.freshEvidence.adminAudit.freshness.stale, true);


### PR DESCRIPTION
## Summary
- Add tooling-findings export as a fresh work-packet evidence source.
- Surface tooling finding counts and issue-ready task counts in evidenceSummary.
- Tag tooling-findings source signals as issue_ready_task or coverage_gap for downstream agents.

## Evidence
- Slice recorded as slice-20260507-062.
- Work packet output now includes sources.toolingFindings and freshEvidence.toolingFindings.
- Artifact schema validation passes 11/11 with the expanded work-packet schema.

## Files Changed
- scripts/studiobrain-ops-work-packet.mjs
- scripts/studiobrain-ops-work-packet.test.mjs
- schemas/ops/ops-work-packet.v1.schema.json
- docs/ops/admin-effectivity-loop.md

## Testing Performed
- node --check scripts/studiobrain-ops-work-packet.mjs
- node --test scripts/studiobrain-ops-work-packet.test.mjs
- node scripts/studiobrain-ops-work-packet.mjs --json --write --max-packets 3
- node scripts/ops/validate_ops_artifacts.mjs --json --write
- bash scripts/ops/ops_ci_validate.sh
- git diff --check

## Risk Level
Low. This is report-only packet metadata and schema/test coverage; no host, service, Docker, or database mutation.

## Rollback Instructions
Revert this commit to remove tooling-findings from work-packet evidence.