### PR TITLE
[ops] Emit tooling findings as work packets

### DIFF
--- a/docs/ops/admin-effectivity-loop.md
+++ b/docs/ops/admin-effectivity-loop.md
@@ -103,6 +103,7 @@ The effectivity audit compares tool inventory sources against the start of the s
 
 Work packets should steer from fresh evidence only. Missing, invalid, stale, or invalid-timestamp latest artifacts stay visible in `freshEvidence`, but they are excluded from packet `sourceSignals`. Tool inventory coverage gaps are kept as `signalClass=coverage_gap` so missing validators remain visible without being treated as actionable defect evidence. Tool-install recommendations are tracked as a separate fresh source and use `signalClass=tool_install_recommendation` only when the recommendation artifact has install-now candidates; approval-required tools remain evidence for planning, not automatic installation.
 Tooling findings export is included in work-packet evidence as `fresh-tooling-findings`; issue-ready validator tasks are tagged `signalClass=issue_ready_task` so agents can pick them up without scraping terminal output.
+When the export contains task entries, the work-packet generator also emits them as normal `ops-wp-*` packets with scoped write sets and validator-focused acceptance criteria.
 
 ## Scoring
 

--- a/scripts/studiobrain-ops-work-packet.mjs
+++ b/scripts/studiobrain-ops-work-packet.mjs
@@ -335,6 +335,64 @@ function makePacket(backlogItem, risk, effectivity, freshEvidence) {
   };
 }
 
+function makeToolingFindingPacket(task, freshEvidence) {
+  const title = clean(task.title);
+  const priority = clean(task.priority) || "P2";
+  const packetKey = ["tooling-finding", title, clean(task.suggestedBranchName), clean(task.suggestedPrTitle)].join("|");
+  return {
+    packetId: `ops-wp-${stableHash(packetKey)}`,
+    title,
+    status: task.approvalRequired ? "approval_gated" : "ready",
+    priority,
+    priorityRank: priorityRank(priority),
+    risk: "low for scoped code cleanup",
+    recommendedOwner: clean(task.owner) || "Codex",
+    sourceSignals: [
+      freshEvidence?.toolingFindings
+        ? {
+            source: freshEvidence.toolingFindings.source,
+            path: freshEvidence.toolingFindings.path,
+            status: freshEvidence.toolingFindings.status,
+            generatedAt: freshEvidence.toolingFindings.generatedAt || "",
+            signalClass: signalClassForSource(freshEvidence.toolingFindings),
+            summary: freshEvidence.toolingFindings.summary,
+          }
+        : null,
+      {
+        source: "tooling-findings-task",
+        title,
+        evidence: Array.isArray(task.evidence) ? task.evidence : [],
+        files: Array.isArray(task.files) ? task.files : [],
+      },
+    ].filter(Boolean),
+    why: clean(task.problem) || "Issue-ready tooling finding from the latest report-only validator output.",
+    safeNextStep: clean(task.proposedFix) || "Make the smallest safe fix and rerun the targeted validator.",
+    suggestedBranchName: clean(task.suggestedBranchName),
+    suggestedPrTitle: clean(task.suggestedPrTitle),
+    verification: Array.isArray(task.acceptanceCriteria) && task.acceptanceCriteria.length > 0
+      ? task.acceptanceCriteria.map(clean)
+      : [
+          "Rerun the targeted validator and confirm the finding is gone or documented as intentional.",
+          "Confirm no generated artifact includes secrets, tokens, keys, or raw environment values.",
+        ],
+    humanGate: task.approvalRequired ? "Tooling finding task requires human approval before execution." : "",
+    constraints: {
+      readOnlyFirst: true,
+      noSecrets: true,
+      noServiceRestart: true,
+      noDataMutation: true,
+      writeScope: Array.isArray(task.files) && task.files.length > 0 ? task.files.map(clean) : ["scripts/"],
+    },
+  };
+}
+
+function toolingFindingPackets(toolingFindings, freshEvidence) {
+  if (!Array.isArray(toolingFindings?.tasks)) return [];
+  return toolingFindings.tasks
+    .filter((task) => clean(task.title))
+    .map((task) => makeToolingFindingPacket(task, freshEvidence));
+}
+
 function freshSourceSignals(freshEvidence) {
   if (!freshEvidence) return [];
   return [
@@ -640,9 +698,13 @@ export function buildOpsWorkPacket(inputs = {}, options = {}) {
   ];
   const freshSources = freshEvidenceSources.filter((source) => !["missing", "invalid_json", "invalid_timestamp", "stale"].includes(source.status));
   const staleSources = freshEvidenceSources.filter((source) => ["invalid_timestamp", "stale"].includes(source.status));
-  const packets = backlog
+  const backlogPackets = backlog
     .filter((item) => priorityRank(item.priority) <= 2)
-    .map((item) => makePacket(item, matchingRisk(item, risks), effectivity, freshEvidence))
+    .map((item) => makePacket(item, matchingRisk(item, risks), effectivity, freshEvidence));
+  const packets = [
+    ...backlogPackets,
+    ...toolingFindingPackets(inputs.toolingFindings, freshEvidence),
+  ]
     .sort((left, right) => left.priorityRank - right.priorityRank || left.title.localeCompare(right.title))
     .slice(0, Number(options.maxPackets || 8));
 

--- a/scripts/studiobrain-ops-work-packet.test.mjs
+++ b/scripts/studiobrain-ops-work-packet.test.mjs
@@ -297,6 +297,10 @@ test("buildOpsWorkPacket creates bounded read-only packets from docs evidence", 
   assert.equal(report.packets[0].priority, "P0");
   assert.ok(report.packets[0].humanGate.includes("PostgreSQL dump"));
   assert.ok(report.packets[0].safeNextStep.includes("restore-prerequisite"));
+  const toolingPacket = report.packets.find((packet) => packet.title === "[ops-tooling] Review shellcheck findings");
+  assert.equal(toolingPacket.status, "ready");
+  assert.ok(toolingPacket.sourceSignals.some((signal) => signal.source === "tooling-findings-task"));
+  assert.equal(toolingPacket.suggestedBranchName, "codex/ops-tooling-shellcheck-findings");
 });
 
 test("summarizeFreshEvidence degrades when ignored artifacts are missing", () => {


### PR DESCRIPTION
## Summary
- Turn issue-ready tooling finding tasks into first-class ops-wp packets.
- Preserve scoped write sets, suggested branches/PRs, and validator acceptance criteria from the findings export.
- Document that work-packet generation emits tooling tasks when available.

## Evidence
- Slice recorded as slice-20260507-063.
- Unit coverage now asserts a shellcheck findings task becomes a ready work packet.
- Generated work packets remain schema-valid and artifact validation passes.

## Files Changed
- scripts/studiobrain-ops-work-packet.mjs
- scripts/studiobrain-ops-work-packet.test.mjs
- docs/ops/admin-effectivity-loop.md

## Testing Performed
- node --check scripts/studiobrain-ops-work-packet.mjs
- node --test scripts/studiobrain-ops-work-packet.test.mjs
- node scripts/studiobrain-ops-work-packet.mjs --json --write --max-packets 6
- node scripts/ops/validate_ops_artifacts.mjs --json --write
- bash scripts/ops/ops_ci_validate.sh
- git diff --check

## Risk Level
Low. This is report-only packet generation and does not mutate host, Docker, database, service, package, or firewall state.

## Rollback Instructions
Revert this commit to return tooling findings to source-signal-only evidence.