### PR TITLE
[ops] Prefer ready work packets within priority

### DIFF
--- a/docs/ops/admin-effectivity-loop.md
+++ b/docs/ops/admin-effectivity-loop.md
@@ -104,6 +104,7 @@ The effectivity audit compares tool inventory sources against the start of the s
 Work packets should steer from fresh evidence only. Missing, invalid, stale, or invalid-timestamp latest artifacts stay visible in `freshEvidence`, but they are excluded from packet `sourceSignals`. Tool inventory coverage gaps are kept as `signalClass=coverage_gap` so missing validators remain visible without being treated as actionable defect evidence. Tool-install recommendations are tracked as a separate fresh source and use `signalClass=tool_install_recommendation` only when the recommendation artifact has install-now candidates; approval-required tools remain evidence for planning, not automatic installation.
 Tooling findings export is included in work-packet evidence as `fresh-tooling-findings`; issue-ready validator tasks are tagged `signalClass=issue_ready_task` so agents can pick them up without scraping terminal output.
 When the export contains task entries, the work-packet generator also emits them as normal `ops-wp-*` packets with scoped write sets and validator-focused acceptance criteria.
+Packets are sorted by priority first, then readiness, so a ready P1 diagnostic/tooling task is visible before an approval-gated P1 cleanup task.
 
 ## Scoring
 

--- a/scripts/studiobrain-ops-work-packet.mjs
+++ b/scripts/studiobrain-ops-work-packet.mjs
@@ -393,6 +393,16 @@ function toolingFindingPackets(toolingFindings, freshEvidence) {
     .map((task) => makeToolingFindingPacket(task, freshEvidence));
 }
 
+function packetReadinessRank(packet) {
+  return clean(packet.status) === "ready" ? 0 : 1;
+}
+
+function comparePackets(left, right) {
+  return left.priorityRank - right.priorityRank
+    || packetReadinessRank(left) - packetReadinessRank(right)
+    || left.title.localeCompare(right.title);
+}
+
 function freshSourceSignals(freshEvidence) {
   if (!freshEvidence) return [];
   return [
@@ -705,7 +715,7 @@ export function buildOpsWorkPacket(inputs = {}, options = {}) {
     ...backlogPackets,
     ...toolingFindingPackets(inputs.toolingFindings, freshEvidence),
   ]
-    .sort((left, right) => left.priorityRank - right.priorityRank || left.title.localeCompare(right.title))
+    .sort(comparePackets)
     .slice(0, Number(options.maxPackets || 8));
 
   return {
@@ -981,7 +991,7 @@ export function runOpsWorkPacket(rawArgs = process.argv.slice(2)) {
   return report;
 }
 
-export { summarizeFreshEvidence, workPacketReportStatus };
+export { comparePackets, summarizeFreshEvidence, workPacketReportStatus };
 
 if (process.argv[1] && resolve(process.argv[1]) === __filename) {
   try {

--- a/scripts/studiobrain-ops-work-packet.test.mjs
+++ b/scripts/studiobrain-ops-work-packet.test.mjs
@@ -4,7 +4,7 @@ import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
-import { buildOpsWorkPacket, runOpsWorkPacket, summarizeFreshEvidence, workPacketReportStatus } from "./studiobrain-ops-work-packet.mjs";
+import { buildOpsWorkPacket, comparePackets, runOpsWorkPacket, summarizeFreshEvidence, workPacketReportStatus } from "./studiobrain-ops-work-packet.mjs";
 
 const packetSchema = JSON.parse(readFileSync(resolve("schemas/ops/ops-work-packet.v1.schema.json"), "utf8"));
 const reportSchema = JSON.parse(readFileSync(resolve("schemas/ops/ops-work-packet-report.v1.schema.json"), "utf8"));
@@ -312,6 +312,15 @@ test("summarizeFreshEvidence degrades when ignored artifacts are missing", () =>
   assert.equal(fresh.toolInstallRecommendations.status, "missing");
   assert.equal(fresh.toolingFindings.status, "missing");
   assert.equal(fresh.swarmPreflight.status, "missing");
+});
+
+test("comparePackets prefers ready packets within the same priority", () => {
+  const packets = [
+    { title: "[cleanup] Approval-gated cleanup", priorityRank: 1, status: "approval_gated" },
+    { title: "[ops-tooling] Ready shellcheck task", priorityRank: 1, status: "ready" },
+  ].sort(comparePackets);
+
+  assert.equal(packets[0].title, "[ops-tooling] Ready shellcheck task");
 });
 
 test("summarizeFreshEvidence does not count invalid JSON as fresh", () => {


### PR DESCRIPTION
## Summary
- Sort work packets by priority, then readiness, then title.
- Keep ready P1 diagnostic/tooling packets visible ahead of same-priority approval-gated cleanup work.
- Document the packet ordering rule.

## Evidence
- Slice recorded as slice-20260507-064.
- Opt-in validator wave produced 4 actionable findings, 2 issue-ready tooling tasks, and live packets with fresh-tooling-findings:issue_ready_task.
- Unit coverage asserts ready packets sort before approval-gated packets within the same priority.

## Files Changed
- scripts/studiobrain-ops-work-packet.mjs
- scripts/studiobrain-ops-work-packet.test.mjs
- docs/ops/admin-effectivity-loop.md

## Testing Performed
- node --check scripts/studiobrain-ops-work-packet.mjs
- node --test scripts/studiobrain-ops-work-packet.test.mjs
- node scripts/ops/ops_wave_runner.mjs --allow-tool-install --json --write
- node scripts/studiobrain-ops-work-packet.mjs --json --write --max-packets 3
- node scripts/ops/validate_ops_artifacts.mjs --json --write
- bash scripts/ops/ops_ci_validate.sh
- git diff --check

## Risk Level
Low. This only changes packet ordering in report-only generated artifacts.

## Rollback Instructions
Revert this commit to sort packets by priority and title only.