### PR TITLE
[ops] Allow wider wave packet windows

### DIFF
--- a/docs/ops/admin-effectivity-loop.md
+++ b/docs/ops/admin-effectivity-loop.md
@@ -94,10 +94,11 @@ Run the ordered safe wave when refreshing dependent latest artifacts:
 node scripts/ops/ops_wave_runner.mjs --json --write
 node scripts/ops/ops_wave_runner.mjs --dry-run --json --write
 node scripts/ops/ops_wave_runner.mjs --allow-tool-install --json --write
+node scripts/ops/ops_wave_runner.mjs --max-packets 8 --json --write
 ```
 
-The wave runner executes read-only checks in dependency order: preflight, tooling quality, tooling findings export, tool inventory, admin effectivity audit, work packet generation, preliminary artifact schema validation, PR readiness packet generation, then final artifact schema validation. Use it when a downstream command consumes a `*-latest.json` artifact from an upstream command.
-The default run does not install or fetch missing optional validators. Use `--allow-tool-install` only on a tooling lane where ephemeral runners such as `npx` or `uv tool run` are acceptable; the mode still writes only under `output/ops`.
+The wave runner executes read-only checks in dependency order: preflight, tooling quality, tooling findings export, tool inventory, tool-install recommendation refresh, admin effectivity audit, work packet generation, preliminary artifact schema validation, PR readiness packet generation, then final artifact schema validation. Use it when a downstream command consumes a `*-latest.json` artifact from an upstream command.
+The default run does not install or fetch missing optional validators. Use `--allow-tool-install` only on a tooling lane where ephemeral runners such as `npx` or `uv tool run` are acceptable; the mode still writes only under `output/ops`. Use `--max-packets <n>` when the default three-packet window hides lower-priority ready work behind approval-gated P0/P1 tasks.
 Tooling findings export converts fresh `tooling-quality` findings into GitHub-copy-ready cleanup tasks, keeping validator output from becoming a one-off terminal observation.
 The effectivity audit compares tool inventory sources against the start of the selected slice window, so validators run during the wave are not falsely marked stale just because the slice ledger is appended after validation completes.
 

--- a/scripts/ops/ops_wave_runner.mjs
+++ b/scripts/ops/ops_wave_runner.mjs
@@ -8,6 +8,7 @@ import { fileURLToPath } from "node:url";
 const __filename = fileURLToPath(import.meta.url);
 const REPO_ROOT = resolve(dirname(__filename), "..", "..");
 const DEFAULT_OUTPUT_DIR = resolve(REPO_ROOT, "output", "ops", "waves");
+const DEFAULT_WORK_PACKET_MAX_PACKETS = 3;
 
 const STEP_DEFINITIONS = [
   {
@@ -42,7 +43,7 @@ const STEP_DEFINITIONS = [
   },
   {
     id: "work-packet",
-    command: [process.execPath, "scripts/studiobrain-ops-work-packet.mjs", "--json", "--write", "--max-packets", "3"],
+    command: [process.execPath, "scripts/studiobrain-ops-work-packet.mjs", "--json", "--write"],
     expectedArtifacts: ["output/ops/swarm/latest-work-packet.json"],
   },
   {
@@ -90,6 +91,7 @@ Options:
   --steps <a,b,c>         Restrict to step ids.
   --skip <id>             Skip one step; repeatable.
   --allow-tool-install    Allow tooling-quality to use its ephemeral validator runners.
+  --max-packets <n>       Number of work packets to generate. Default: ${DEFAULT_WORK_PACKET_MAX_PACKETS}.
 `;
 }
 
@@ -113,6 +115,7 @@ function parseArgs(argv) {
     outputDir: DEFAULT_OUTPUT_DIR,
     steps: [],
     skip: [],
+    maxPackets: DEFAULT_WORK_PACKET_MAX_PACKETS,
   };
   for (let index = 0; index < argv.length; index += 1) {
     const arg = clean(argv[index]);
@@ -141,6 +144,7 @@ function parseArgs(argv) {
       ["--run-id", "runId"],
       ["--output-dir", "outputDir"],
       ["--steps", "steps"],
+      ["--max-packets", "maxPackets"],
     ];
     let consumed = false;
     for (const [flag, key] of mappings) {
@@ -161,6 +165,7 @@ function parseArgs(argv) {
     throw new Error(`Unknown argument: ${arg}`);
   }
   options.outputDir = resolve(REPO_ROOT, options.outputDir);
+  options.maxPackets = Math.max(1, Number(options.maxPackets) || DEFAULT_WORK_PACKET_MAX_PACKETS);
   options.runId ||= `ops-wave-${nowIso().replace(/[-:]/g, "").replace(/\.\d+Z$/, "Z")}`;
   return options;
 }
@@ -173,9 +178,9 @@ function buildWavePlan(options = {}) {
   return STEP_DEFINITIONS
     .filter((step) => (only.size === 0 || only.has(step.id)) && !skip.has(step.id))
     .map((step, index) => {
-      const command = step.id === "tooling-quality" && options.allowToolInstall
-        ? [...step.command, "--allow-install"]
-        : step.command;
+      let command = step.command;
+      if (step.id === "tooling-quality" && options.allowToolInstall) command = [...command, "--allow-install"];
+      if (step.id === "work-packet") command = [...command, "--max-packets", String(options.maxPackets || DEFAULT_WORK_PACKET_MAX_PACKETS)];
       return {
         ...step,
         command,

--- a/scripts/ops/ops_wave_runner.test.mjs
+++ b/scripts/ops/ops_wave_runner.test.mjs
@@ -32,6 +32,14 @@ test("buildWavePlan only enables ephemeral validator runners when requested", ()
   assert.equal(installPlan[0].commandText.includes("--allow-install"), true);
 });
 
+test("buildWavePlan lets callers widen the work-packet window", () => {
+  const defaultPlan = buildWavePlan({ steps: ["work-packet"] });
+  const widenedPlan = buildWavePlan({ steps: ["work-packet"], maxPackets: 12 });
+
+  assert.match(defaultPlan[0].commandText, /--max-packets 3$/);
+  assert.match(widenedPlan[0].commandText, /--max-packets 12$/);
+});
+
 test("buildWavePlan exports tooling findings after tooling quality", () => {
   const plan = buildWavePlan();
   const qualityIndex = plan.findIndex((step) => step.id === "tooling-quality");


### PR DESCRIPTION
## Summary
- Add --max-packets <n> to the ops wave runner and pass it through to work-packet generation.
- Keep the default window at 3 packets while allowing wider report windows when ready tooling work is hidden behind P0/P1 gates.
- Document the option and add coverage for the generated work-packet command.

## Evidence
- Slice recorded as slice-20260507-066.
- Dry-run with --max-packets 8 shows 
ode scripts/studiobrain-ops-work-packet.mjs --json --write --max-packets 8.
- Admin effectivity audit for slices 062-066 passed with usefulness 0.886, verification 1.0, no-op rate 0.

## Files Changed
- scripts/ops/ops_wave_runner.mjs
- scripts/ops/ops_wave_runner.test.mjs
- docs/ops/admin-effectivity-loop.md

## Testing Performed
- node --check scripts/ops/ops_wave_runner.mjs
- node --test scripts/ops/ops_wave_runner.test.mjs
- node scripts/ops/ops_wave_runner.mjs --dry-run --json --max-packets 8
- node scripts/ops/ops_wave_runner.mjs --allow-tool-install --max-packets 8 --json --write
- node scripts/ops/admin_effectivity_audit.mjs --json --write --slice-run-id admin-infra-20260507 --run-id admin-effectivity-slice-066
- bash scripts/ops/ops_ci_validate.sh
- git diff --check

## Risk Level
Low. This only changes a read-only report window size option; default behavior remains three packets.

## Rollback Instructions
Revert this commit to restore the hardcoded three-packet wave window.

## Follow-up Tickets
- Add packet outcome promotion so widened packets can be marked used/helpful/stale.
- Include packet window details in PR readiness packets.