### PR TITLE
[ops] Show packet windows in PR readiness

### DIFF
--- a/docs/ops/admin-effectivity-loop.md
+++ b/docs/ops/admin-effectivity-loop.md
@@ -99,6 +99,7 @@ node scripts/ops/ops_wave_runner.mjs --max-packets 8 --json --write
 
 The wave runner executes read-only checks in dependency order: preflight, tooling quality, tooling findings export, tool inventory, tool-install recommendation refresh, admin effectivity audit, work packet generation, preliminary artifact schema validation, PR readiness packet generation, then final artifact schema validation. Use it when a downstream command consumes a `*-latest.json` artifact from an upstream command.
 The default run does not install or fetch missing optional validators. Use `--allow-tool-install` only on a tooling lane where ephemeral runners such as `npx` or `uv tool run` are acceptable; the mode still writes only under `output/ops`. Use `--max-packets <n>` when the default three-packet window hides lower-priority ready work behind approval-gated P0/P1 tasks.
+Dry-run wave artifacts are timestamped only and do not replace `ops-wave-runner-latest.json`; latest is reserved for executable wave evidence.
 Tooling findings export converts fresh `tooling-quality` findings into GitHub-copy-ready cleanup tasks, keeping validator output from becoming a one-off terminal observation.
 The effectivity audit compares tool inventory sources against the start of the selected slice window, so validators run during the wave are not falsely marked stale just because the slice ledger is appended after validation completes.
 
@@ -106,6 +107,7 @@ Work packets should steer from fresh evidence only. Missing, invalid, stale, or 
 Tooling findings export is included in work-packet evidence as `fresh-tooling-findings`; issue-ready validator tasks are tagged `signalClass=issue_ready_task` so agents can pick them up without scraping terminal output.
 When the export contains task entries, the work-packet generator also emits them as normal `ops-wp-*` packets with scoped write sets and validator-focused acceptance criteria.
 Packets are sorted by priority first, then readiness, so a ready P1 diagnostic/tooling task is visible before an approval-gated P1 cleanup task.
+PR readiness packets include the latest wave runner packet window and top work-packet titles so reviewers can tell whether a PR was prepared from the default three-packet view or a widened slice window.
 
 ## Scoring
 

--- a/schemas/ops/pr-readiness-packet.v1.schema.json
+++ b/schemas/ops/pr-readiness-packet.v1.schema.json
@@ -38,7 +38,7 @@
     },
     "evidence": {
       "type": "object",
-      "required": ["artifactValidation", "workPacket", "sliceLedger", "toolInstall"],
+      "required": ["artifactValidation", "waveRunner", "workPacket", "sliceLedger", "toolInstall"],
       "properties": {
         "artifactValidation": {
           "type": "object",
@@ -55,9 +55,22 @@
           },
           "additionalProperties": false
         },
+        "waveRunner": {
+          "type": "object",
+          "required": ["status", "generatedAt", "runId", "workPacketMaxPackets", "workPacketCommand"],
+          "properties": {
+            "status": { "type": "string" },
+            "generatedAt": { "type": "string" },
+            "runId": { "type": "string" },
+            "workPacketMaxPackets": { "type": ["number", "null"], "minimum": 0 },
+            "workPacketCommand": { "type": "string" },
+            "parseError": { "type": "string" }
+          },
+          "additionalProperties": false
+        },
         "workPacket": {
           "type": "object",
-          "required": ["status", "generatedAt", "packets", "freshSources", "staleSources", "topPacket", "humanGates", "effectivityEvidenceLanes", "effectivityApprovalRequiredLanes", "effectivityHighSeverityLanes"],
+          "required": ["status", "generatedAt", "packets", "freshSources", "staleSources", "topPacket", "readyPackets", "approvalGatedPackets", "topPackets", "humanGates", "effectivityEvidenceLanes", "effectivityApprovalRequiredLanes", "effectivityHighSeverityLanes"],
           "properties": {
             "status": { "type": "string" },
             "generatedAt": { "type": "string" },
@@ -65,6 +78,21 @@
             "freshSources": { "type": ["number", "null"], "minimum": 0 },
             "staleSources": { "type": ["number", "null"], "minimum": 0 },
             "topPacket": { "type": "string" },
+            "readyPackets": { "type": "number", "minimum": 0 },
+            "approvalGatedPackets": { "type": "number", "minimum": 0 },
+            "topPackets": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": ["title", "status", "priority"],
+                "properties": {
+                  "title": { "type": "string" },
+                  "status": { "type": "string" },
+                  "priority": { "type": "string" }
+                },
+                "additionalProperties": false
+              }
+            },
             "humanGates": { "type": "number", "minimum": 0 },
             "toolInstallNowCandidates": { "type": ["number", "null"], "minimum": 0 },
             "toolInstallApprovalRequired": { "type": ["number", "null"], "minimum": 0 },

--- a/scripts/ops/ops_ci_validate.sh
+++ b/scripts/ops/ops_ci_validate.sh
@@ -152,7 +152,7 @@ else
 fi
 
 section "Ops Wave Runner Dry Run"
-if node "${REPO_ROOT}/scripts/ops/ops_wave_runner.mjs" --dry-run --json --write --steps swarm-preflight,work-packet,artifact-validation >"${OUT_DIR}/ops-wave-runner-dry-run.json"; then
+if node "${REPO_ROOT}/scripts/ops/ops_wave_runner.mjs" --dry-run --json --steps swarm-preflight,work-packet,artifact-validation >"${OUT_DIR}/ops-wave-runner-dry-run.json"; then
   pass "ops_wave_runner dry-run smoke"
 else
   fail "ops_wave_runner dry-run smoke"

--- a/scripts/ops/ops_wave_runner.mjs
+++ b/scripts/ops/ops_wave_runner.mjs
@@ -297,13 +297,20 @@ function run(rawArgs = process.argv.slice(2)) {
   const manifest = runWave(options);
   const artifact = resolve(options.outputDir, `${manifest.runId}.json`);
   const latest = resolve(options.outputDir, "ops-wave-runner-latest.json");
+  const shouldUpdateLatest = options.write && !options.dryRun;
   if (options.write) {
     writeJson(artifact, manifest);
-    writeJson(latest, manifest);
+    if (shouldUpdateLatest) writeJson(latest, manifest);
   }
   const report = {
     ...manifest,
-    artifacts: options.write ? { jsonPath: repoRelative(artifact), latestPath: repoRelative(latest) } : null,
+    artifacts: options.write
+      ? {
+          jsonPath: repoRelative(artifact),
+          latestPath: shouldUpdateLatest ? repoRelative(latest) : "",
+          latestUpdated: shouldUpdateLatest,
+        }
+      : null,
   };
   if (options.json) process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
   else {

--- a/scripts/ops/ops_wave_runner.test.mjs
+++ b/scripts/ops/ops_wave_runner.test.mjs
@@ -1,5 +1,9 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
 
 import { buildWavePlan, runWave } from "./ops_wave_runner.mjs";
 
@@ -70,6 +74,34 @@ test("runWave dry-run records skipped receipts without executing", () => {
   assert.equal(manifest.status, "planned");
   assert.equal(manifest.dryRun, true);
   assert.deepEqual(manifest.receipts.map((receipt) => receipt.status), ["skipped", "skipped"]);
+});
+
+test("dry-run write does not replace the latest executable wave artifact", () => {
+  const dir = mkdtempSync(join(tmpdir(), "ops-wave-runner-"));
+  try {
+    const output = execFileSync(
+      process.execPath,
+      [
+        resolve("scripts/ops/ops_wave_runner.mjs"),
+        "--dry-run",
+        "--json",
+        "--write",
+        "--output-dir",
+        dir,
+        "--steps",
+        "swarm-preflight,work-packet",
+      ],
+      { encoding: "utf8" },
+    );
+    const report = JSON.parse(output);
+
+    assert.equal(report.status, "planned");
+    assert.equal(report.artifacts.latestUpdated, false);
+    assert.equal(report.artifacts.latestPath, "");
+    assert.equal(existsSync(join(dir, "ops-wave-runner-latest.json")), false);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 test("runWave stops on failed step and keeps downstream artifacts untouched", () => {

--- a/scripts/ops/pr_readiness_packet.mjs
+++ b/scripts/ops/pr_readiness_packet.mjs
@@ -12,6 +12,7 @@ const DEFAULT_ARTIFACT_VALIDATION = resolve(REPO_ROOT, "output", "ops", "artifac
 const DEFAULT_WORK_PACKET = resolve(REPO_ROOT, "output", "ops", "swarm", "latest-work-packet.json");
 const DEFAULT_SLICE_LEDGER = resolve(REPO_ROOT, "output", "ops", "effectivity", "slice-ledger-latest.json");
 const DEFAULT_TOOL_INSTALL_RECOMMENDATIONS = resolve(REPO_ROOT, "output", "ops", "effectivity", "tool-install-recommendations-latest.json");
+const DEFAULT_WAVE_RUNNER = resolve(REPO_ROOT, "output", "ops", "waves", "ops-wave-runner-latest.json");
 
 function clean(value) {
   return String(value ?? "").replace(/\r/g, "").trim();
@@ -86,8 +87,8 @@ function summarizeArtifactValidation(report) {
 }
 
 function summarizeWorkPacket(packet) {
-  if (!packet) return { status: "missing", generatedAt: "", packets: 0, freshSources: 0, staleSources: 0, topPacket: "", humanGates: 0, effectivityEvidenceLanes: null, effectivityApprovalRequiredLanes: null, effectivityHighSeverityLanes: null };
-  if (packet.status === "invalid_json") return { status: "invalid_json", generatedAt: "", packets: 0, freshSources: 0, staleSources: 0, topPacket: "", humanGates: 0, effectivityEvidenceLanes: null, effectivityApprovalRequiredLanes: null, effectivityHighSeverityLanes: null, parseError: packet.parseError || "" };
+  if (!packet) return { status: "missing", generatedAt: "", packets: 0, freshSources: 0, staleSources: 0, topPacket: "", readyPackets: 0, approvalGatedPackets: 0, topPackets: [], humanGates: 0, effectivityEvidenceLanes: null, effectivityApprovalRequiredLanes: null, effectivityHighSeverityLanes: null };
+  if (packet.status === "invalid_json") return { status: "invalid_json", generatedAt: "", packets: 0, freshSources: 0, staleSources: 0, topPacket: "", readyPackets: 0, approvalGatedPackets: 0, topPackets: [], humanGates: 0, effectivityEvidenceLanes: null, effectivityApprovalRequiredLanes: null, effectivityHighSeverityLanes: null, parseError: packet.parseError || "" };
   const packets = Array.isArray(packet.packets) ? packet.packets : [];
   return {
     status: packets.length > 0 ? "present" : "empty",
@@ -96,12 +97,39 @@ function summarizeWorkPacket(packet) {
     freshSources: packet.evidenceSummary?.freshSources ?? null,
     staleSources: packet.evidenceSummary?.staleSources ?? null,
     topPacket: clean(packets[0]?.title),
+    readyPackets: packets.filter((entry) => clean(entry.status) === "ready").length,
+    approvalGatedPackets: packets.filter((entry) => clean(entry.status) === "approval_gated").length,
+    topPackets: packets.slice(0, 5).map((entry) => ({
+      title: clean(entry.title),
+      status: clean(entry.status),
+      priority: clean(entry.priority),
+    })),
     humanGates: packets.filter((entry) => clean(entry.humanGate)).length,
     toolInstallNowCandidates: packet.evidenceSummary?.toolInstallNowCandidates ?? null,
     toolInstallApprovalRequired: packet.evidenceSummary?.toolInstallApprovalRequired ?? null,
     effectivityEvidenceLanes: packet.evidenceSummary?.effectivityEvidenceLanes ?? null,
     effectivityApprovalRequiredLanes: packet.evidenceSummary?.effectivityApprovalRequiredLanes ?? null,
     effectivityHighSeverityLanes: packet.evidenceSummary?.effectivityHighSeverityLanes ?? null,
+  };
+}
+
+function parseMaxPackets(command) {
+  const match = clean(command).match(/--max-packets\s+(\d+)/);
+  return match ? Number(match[1]) : null;
+}
+
+function summarizeWaveRunner(report) {
+  if (!report) return { status: "missing", generatedAt: "", runId: "", workPacketMaxPackets: null, workPacketCommand: "" };
+  if (report.status === "invalid_json") return { status: "invalid_json", generatedAt: "", runId: "", workPacketMaxPackets: null, workPacketCommand: "", parseError: report.parseError || "" };
+  const workPacketStep = [...(Array.isArray(report.plan) ? report.plan : []), ...(Array.isArray(report.receipts) ? report.receipts : [])]
+    .find((step) => clean(step.id) === "work-packet");
+  const command = clean(workPacketStep?.command);
+  return {
+    status: clean(report.status) || "unknown",
+    generatedAt: clean(report.generatedAt),
+    runId: clean(report.runId),
+    workPacketMaxPackets: parseMaxPackets(command),
+    workPacketCommand: command,
   };
 }
 
@@ -151,6 +179,15 @@ function buildWarnings({ gitState, evidence }) {
   if (gitState.dirtyFiles.length > 0) warnings.push(`${gitState.dirtyFiles.length} dirty file(s) in local worktree`);
   if (evidence.artifactValidation.status === "missing") warnings.push("artifact validation report is missing");
   if (evidence.artifactValidation.warned > 0 || evidence.artifactValidation.missing > 0) warnings.push("artifact validation has warnings or missing artifacts");
+  if (evidence.waveRunner.status === "missing") warnings.push("wave runner latest artifact is missing");
+  if (evidence.waveRunner.status === "planned") warnings.push("wave runner latest artifact is a dry-run plan, not executable wave evidence");
+  if (evidence.waveRunner.workPacketMaxPackets === null) warnings.push("wave runner packet window is unknown");
+  if (
+    evidence.waveRunner.workPacketMaxPackets !== null &&
+    evidence.workPacket.packets > evidence.waveRunner.workPacketMaxPackets
+  ) {
+    warnings.push("latest work packet contains more packets than the wave runner packet window; refresh executable wave evidence");
+  }
   if (evidence.workPacket.status === "missing") warnings.push("work-packet latest artifact is missing");
   if ((evidence.workPacket.staleSources ?? 0) > 0) warnings.push("work packet has stale evidence sources");
   if ((evidence.toolInstall.approvalRequired ?? 0) > 0) warnings.push(`${evidence.toolInstall.approvalRequired} tool recommendation(s) require approval before use`);
@@ -162,6 +199,7 @@ export function buildPrReadinessPacket(inputs = {}, options = {}) {
   const gitState = inputs.gitState || collectGitState(options);
   const evidence = {
     artifactValidation: summarizeArtifactValidation(inputs.artifactValidation),
+    waveRunner: summarizeWaveRunner(inputs.waveRunner),
     workPacket: summarizeWorkPacket(inputs.workPacket),
     sliceLedger: summarizeSliceLedger(inputs.sliceLedger),
     toolInstall: summarizeToolInstall(inputs.toolInstallRecommendations),
@@ -200,6 +238,9 @@ function renderMarkdown(packet) {
   const topRecommendations = packet.evidence.toolInstall.topRecommendations
     .map((item) => `- ${item.priority} ${item.tool}: ${item.acquisitionClass}; validate with \`${item.validationCommand}\`; approvalRequired=${item.approvalRequired}`)
     .join("\n") || "- None recorded.";
+  const topPackets = packet.evidence.workPacket.topPackets
+    .map((item) => `- ${item.priority || "P?"} ${item.status || "unknown"}: ${item.title}`)
+    .join("\n") || "- None recorded.";
   const warnings = packet.warnings.map((warning) => `- ${warning}`).join("\n") || "- None.";
   const changedFiles = packet.scope.changedFiles.slice(0, 20).map((file) => `- ${file}`).join("\n") || "- None detected from base.";
   const dirtyFiles = packet.scope.dirtyFiles.map((file) => `- ${file}`).join("\n") || "- Clean.";
@@ -230,9 +271,14 @@ ${dirtyFiles}
 | Check | Status | Detail |
 | --- | --- | --- |
 | Artifact validation | ${packet.evidence.artifactValidation.status} | checks=${packet.evidence.artifactValidation.checks}, warned=${packet.evidence.artifactValidation.warned}, missing=${packet.evidence.artifactValidation.missing}, failed=${packet.evidence.artifactValidation.failed} |
+| Wave runner | ${packet.evidence.waveRunner.status} | run=${packet.evidence.waveRunner.runId}, workPacketMaxPackets=${packet.evidence.waveRunner.workPacketMaxPackets ?? ""} |
 | Slice ledger | ${packet.evidence.sliceLedger.status} | window=${packet.evidence.sliceLedger.window?.from || ""}..${packet.evidence.sliceLedger.window?.to || ""}, verification=${packet.evidence.sliceLedger.verification ?? ""}, usefulness=${packet.evidence.sliceLedger.usefulness ?? ""} |
-| Work packet | ${packet.evidence.workPacket.status} | packets=${packet.evidence.workPacket.packets}, freshSources=${packet.evidence.workPacket.freshSources ?? ""}, staleSources=${packet.evidence.workPacket.staleSources ?? ""}, lanes=${packet.evidence.workPacket.effectivityEvidenceLanes ?? ""}, approvalLanes=${packet.evidence.workPacket.effectivityApprovalRequiredLanes ?? ""}, highLanes=${packet.evidence.workPacket.effectivityHighSeverityLanes ?? ""}, top="${packet.evidence.workPacket.topPacket}" |
+| Work packet | ${packet.evidence.workPacket.status} | packets=${packet.evidence.workPacket.packets}, ready=${packet.evidence.workPacket.readyPackets}, approvalGated=${packet.evidence.workPacket.approvalGatedPackets}, freshSources=${packet.evidence.workPacket.freshSources ?? ""}, staleSources=${packet.evidence.workPacket.staleSources ?? ""}, lanes=${packet.evidence.workPacket.effectivityEvidenceLanes ?? ""}, approvalLanes=${packet.evidence.workPacket.effectivityApprovalRequiredLanes ?? ""}, highLanes=${packet.evidence.workPacket.effectivityHighSeverityLanes ?? ""}, top="${packet.evidence.workPacket.topPacket}" |
 | Tool install recommendations | ${packet.evidence.toolInstall.status} | recommendations=${packet.evidence.toolInstall.recommendations}, installNow=${packet.evidence.toolInstall.installNowCandidates}, approvalRequired=${packet.evidence.toolInstall.approvalRequired} |
+
+## Work Packet Window
+
+${topPackets}
 
 ## Tool Recommendation Summary
 
@@ -265,6 +311,7 @@ function parseArgs(argv) {
     owner: "Codex",
     sliceIds: "",
     artifactValidation: DEFAULT_ARTIFACT_VALIDATION,
+    waveRunner: DEFAULT_WAVE_RUNNER,
     workPacket: DEFAULT_WORK_PACKET,
     sliceLedger: DEFAULT_SLICE_LEDGER,
     toolInstallRecommendations: DEFAULT_TOOL_INSTALL_RECOMMENDATIONS,
@@ -301,6 +348,7 @@ function parseArgs(argv) {
       "--owner": "owner",
       "--slice-ids": "sliceIds",
       "--artifact-validation": "artifactValidation",
+      "--wave-runner": "waveRunner",
       "--work-packet": "workPacket",
       "--slice-ledger": "sliceLedger",
       "--tool-install-recommendations": "toolInstallRecommendations",
@@ -309,7 +357,7 @@ function parseArgs(argv) {
     for (const [flag, key] of Object.entries(flags)) {
       const value = read(flag);
       if (value === null) continue;
-      options[key] = ["outputDir", "artifactValidation", "workPacket", "sliceLedger", "toolInstallRecommendations"].includes(key)
+      options[key] = ["outputDir", "artifactValidation", "waveRunner", "workPacket", "sliceLedger", "toolInstallRecommendations"].includes(key)
         ? resolve(REPO_ROOT, value)
         : value;
       matched = true;
@@ -332,6 +380,7 @@ Options:
   --pr <id-or-url>                     Optional PR number or URL.
   --slice-ids <ids>                    Optional slice id list.
   --artifact-validation <path>         Default: output/ops/artifact-validation/artifact-schema-validation-latest.json.
+  --wave-runner <path>                 Default: output/ops/waves/ops-wave-runner-latest.json.
   --work-packet <path>                 Default: output/ops/swarm/latest-work-packet.json.
   --slice-ledger <path>                Default: output/ops/effectivity/slice-ledger-latest.json.
   --tool-install-recommendations <path> Default: output/ops/effectivity/tool-install-recommendations-latest.json.
@@ -360,8 +409,9 @@ function writeOutputs(packet, outputDir) {
 function run(rawArgs = process.argv.slice(2)) {
   const options = parseArgs(rawArgs);
   const packet = buildPrReadinessPacket({
-    artifactValidation: readJsonIfExists(options.artifactValidation),
-    workPacket: readJsonIfExists(options.workPacket),
+      artifactValidation: readJsonIfExists(options.artifactValidation),
+      waveRunner: readJsonIfExists(options.waveRunner),
+      workPacket: readJsonIfExists(options.workPacket),
     sliceLedger: readJsonIfExists(options.sliceLedger),
     toolInstallRecommendations: readJsonIfExists(options.toolInstallRecommendations),
   }, options);

--- a/scripts/ops/pr_readiness_packet.test.mjs
+++ b/scripts/ops/pr_readiness_packet.test.mjs
@@ -33,7 +33,24 @@ const workPacket = {
     effectivityApprovalRequiredLanes: 1,
     effectivityHighSeverityLanes: 1,
   },
-  packets: [{ title: "[ops] Refresh evidence", humanGate: "" }],
+  packets: [
+    { title: "[ops] Refresh evidence", status: "ready", priority: "P1", humanGate: "" },
+    { title: "[backup] Restore drill", status: "approval_gated", priority: "P0", humanGate: "human approval" },
+  ],
+};
+
+const waveRunner = {
+  schema: "studiobrain-ops-wave-runner.v1",
+  generatedAt: "2026-05-07T12:00:30.000Z",
+  runId: "ops-wave-test",
+  status: "warn",
+  plan: [
+    {
+      id: "work-packet",
+      command: "node scripts/studiobrain-ops-work-packet.mjs --json --write --max-packets 8",
+    },
+  ],
+  receipts: [],
 };
 
 const sliceLedger = {
@@ -71,7 +88,7 @@ const toolInstallRecommendations = {
 
 test("buildPrReadinessPacket summarizes current evidence without executable install commands", () => {
   const packet = buildPrReadinessPacket(
-    { gitState, artifactValidation, workPacket, sliceLedger, toolInstallRecommendations },
+    { gitState, artifactValidation, waveRunner, workPacket, sliceLedger, toolInstallRecommendations },
     { generatedAt: "2026-05-07T12:10:00.000Z", pr: "#123", sliceIds: "slice-046,slice-047" },
   );
 
@@ -79,7 +96,10 @@ test("buildPrReadinessPacket summarizes current evidence without executable inst
   assert.equal(packet.readOnly, true);
   assert.equal(packet.status, "warn");
   assert.equal(packet.evidence.artifactValidation.status, "pass");
+  assert.equal(packet.evidence.waveRunner.workPacketMaxPackets, 8);
   assert.equal(packet.evidence.workPacket.freshSources, 5);
+  assert.equal(packet.evidence.workPacket.readyPackets, 1);
+  assert.equal(packet.evidence.workPacket.approvalGatedPackets, 1);
   assert.equal(packet.evidence.workPacket.effectivityEvidenceLanes, 4);
   assert.equal(packet.evidence.workPacket.effectivityApprovalRequiredLanes, 1);
   assert.equal(packet.evidence.workPacket.effectivityHighSeverityLanes, 1);
@@ -89,6 +109,10 @@ test("buildPrReadinessPacket summarizes current evidence without executable inst
 
   const markdown = renderMarkdown(packet);
   assert.match(markdown, /Tool Recommendation Summary/);
+  assert.match(markdown, /Work Packet Window/);
+  assert.match(markdown, /workPacketMaxPackets=8/);
+  assert.match(markdown, /ready=1/);
+  assert.match(markdown, /approvalGated=1/);
   assert.match(markdown, /lanes=4/);
   assert.match(markdown, /approvalLanes=1/);
   assert.match(markdown, /shellcheck/);
@@ -96,9 +120,28 @@ test("buildPrReadinessPacket summarizes current evidence without executable inst
   assert.doesNotMatch(markdown, /do not install Docker/);
 });
 
+test("buildPrReadinessPacket warns when dry-run wave evidence mismatches packet count", () => {
+  const packet = buildPrReadinessPacket({
+    gitState,
+    artifactValidation,
+    waveRunner: {
+      ...waveRunner,
+      status: "planned",
+      plan: [{ id: "work-packet", command: "node scripts/studiobrain-ops-work-packet.mjs --json --write --max-packets 1" }],
+    },
+    workPacket,
+    sliceLedger,
+    toolInstallRecommendations: { ...toolInstallRecommendations, summary: { recommendations: 1, installNowCandidates: 0, approvalRequired: 0 } },
+  });
+
+  assert.equal(packet.status, "warn");
+  assert.ok(packet.warnings.some((warning) => warning.includes("dry-run plan")));
+  assert.ok(packet.warnings.some((warning) => warning.includes("more packets than the wave runner packet window")));
+});
+
 test("buildPrReadinessPacket stays compatible with its JSON schema", () => {
   const packet = buildPrReadinessPacket(
-    { gitState, artifactValidation, workPacket, sliceLedger, toolInstallRecommendations },
+    { gitState, artifactValidation, waveRunner, workPacket, sliceLedger, toolInstallRecommendations },
     { generatedAt: "2026-05-07T12:10:00.000Z", pr: "#123", sliceIds: "slice-046,slice-047" },
   );
   const schema = JSON.parse(readFileSync("schemas/ops/pr-readiness-packet.v1.schema.json", "utf8"));
@@ -115,6 +158,7 @@ test("buildPrReadinessPacket fails on failing artifact validation", () => {
       summary: { checks: 4, passed: 3, warned: 0, missing: 0, failed: 1 },
       checks: [{ id: "work-packet", status: "fail" }],
     },
+    waveRunner,
     workPacket,
     sliceLedger,
     toolInstallRecommendations: { ...toolInstallRecommendations, summary: { recommendations: 1, installNowCandidates: 0, approvalRequired: 0 } },
@@ -128,6 +172,7 @@ test("buildPrReadinessPacket warns on dirty local state", () => {
   const packet = buildPrReadinessPacket({
     gitState: { ...gitState, dirtyFiles: [" M scripts/ops/example.mjs"] },
     artifactValidation,
+    waveRunner,
     workPacket,
     sliceLedger,
     toolInstallRecommendations: { ...toolInstallRecommendations, summary: { recommendations: 1, installNowCandidates: 0, approvalRequired: 0 } },


### PR DESCRIPTION
## Summary
- Add wave-runner evidence to PR readiness packets, including the work-packet window used by the latest executable wave.
- Summarize ready vs approval-gated packet counts and the top work-packet titles in JSON and Markdown readiness output.
- Prevent dry-run wave smokes from replacing ops-wave-runner-latest.json, and warn when PR readiness sees dry-run or mismatched packet-window evidence.

## Evidence
- Slice recorded as slice-20260507-067.
- Generated PR readiness shows workPacketMaxPackets=8, ready=3, approvalGated=5, and top packet titles.
- Final artifact validation passed 11/11 after regenerating PR readiness.

## Files Changed
- scripts/ops/pr_readiness_packet.mjs
- scripts/ops/pr_readiness_packet.test.mjs
- schemas/ops/pr-readiness-packet.v1.schema.json
- scripts/ops/ops_wave_runner.mjs
- scripts/ops/ops_wave_runner.test.mjs
- scripts/ops/ops_ci_validate.sh
- docs/ops/admin-effectivity-loop.md

## Testing Performed
- node --check scripts/ops/pr_readiness_packet.mjs
- node --check scripts/ops/ops_wave_runner.mjs
- node --test scripts/ops/pr_readiness_packet.test.mjs
- node --test scripts/ops/ops_wave_runner.test.mjs
- node scripts/ops/ops_wave_runner.mjs --allow-tool-install --max-packets 8 --json --write
- node scripts/ops/pr_readiness_packet.mjs --json --write
- node scripts/ops/validate_ops_artifacts.mjs --json --write
- bash scripts/ops/ops_ci_validate.sh
- git diff --check

## Risk Level
Low. This only changes ignored artifact generation and read-only readiness reporting.

## Rollback Instructions
Revert this commit to remove wave-runner packet-window evidence from PR readiness and restore the prior CI dry-run smoke behavior.

## Follow-up Tickets
- Add packet outcome promotion when PRs are opened from work packets.
- Add a post-wave readiness refresh step if the runner should own the second-pass readiness artifact directly.