### PR TITLE
[ops] Add PR readiness outcome hints

### DIFF
--- a/docs/ops/admin-effectivity-loop.md
+++ b/docs/ops/admin-effectivity-loop.md
@@ -107,7 +107,7 @@ Work packets should steer from fresh evidence only. Missing, invalid, stale, or 
 Tooling findings export is included in work-packet evidence as `fresh-tooling-findings`; issue-ready validator tasks are tagged `signalClass=issue_ready_task` so agents can pick them up without scraping terminal output.
 When the export contains task entries, the work-packet generator also emits them as normal `ops-wp-*` packets with scoped write sets and validator-focused acceptance criteria.
 Packets are sorted by priority first, then readiness, so a ready P1 diagnostic/tooling task is visible before an approval-gated P1 cleanup task.
-PR readiness packets include the latest wave runner packet window and top work-packet titles so reviewers can tell whether a PR was prepared from the default three-packet view or a widened slice window.
+PR readiness packets include the latest wave runner packet window and top work-packet titles so reviewers can tell whether a PR was prepared from the default three-packet view or a widened slice window. When `--packet-id <ops-wp-id>` is supplied, the readiness packet also includes a ready-to-run `--record-outcome` command for the work-packet outcome ledger.
 
 ## Scoring
 

--- a/schemas/ops/pr-readiness-packet.v1.schema.json
+++ b/schemas/ops/pr-readiness-packet.v1.schema.json
@@ -10,6 +10,7 @@
     "pr",
     "owner",
     "sliceIds",
+    "outcomeLedger",
     "scope",
     "evidence",
     "warnings",
@@ -23,6 +24,16 @@
     "pr": { "type": "string" },
     "owner": { "type": "string" },
     "sliceIds": { "type": "string" },
+    "outcomeLedger": {
+      "type": "object",
+      "required": ["packetId", "suggestedPacketIds", "recordCommand"],
+      "properties": {
+        "packetId": { "type": "string" },
+        "suggestedPacketIds": { "type": "array", "items": { "type": "string" } },
+        "recordCommand": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
     "scope": {
       "type": "object",
       "required": ["branch", "base", "head", "changedFiles", "dirtyFiles", "nonScope"],
@@ -84,8 +95,9 @@
               "type": "array",
               "items": {
                 "type": "object",
-                "required": ["title", "status", "priority"],
+                "required": ["packetId", "title", "status", "priority"],
                 "properties": {
+                  "packetId": { "type": "string" },
                   "title": { "type": "string" },
                   "status": { "type": "string" },
                   "priority": { "type": "string" }

--- a/scripts/ops/pr_readiness_packet.mjs
+++ b/scripts/ops/pr_readiness_packet.mjs
@@ -100,6 +100,7 @@ function summarizeWorkPacket(packet) {
     readyPackets: packets.filter((entry) => clean(entry.status) === "ready").length,
     approvalGatedPackets: packets.filter((entry) => clean(entry.status) === "approval_gated").length,
     topPackets: packets.slice(0, 5).map((entry) => ({
+      packetId: clean(entry.packetId),
       title: clean(entry.title),
       status: clean(entry.status),
       priority: clean(entry.priority),
@@ -110,6 +111,22 @@ function summarizeWorkPacket(packet) {
     effectivityEvidenceLanes: packet.evidenceSummary?.effectivityEvidenceLanes ?? null,
     effectivityApprovalRequiredLanes: packet.evidenceSummary?.effectivityApprovalRequiredLanes ?? null,
     effectivityHighSeverityLanes: packet.evidenceSummary?.effectivityHighSeverityLanes ?? null,
+  };
+}
+
+function buildOutcomeLedger(options = {}, evidence = {}) {
+  const packetId = clean(options.packetId);
+  const pr = clean(options.pr);
+  const suggestedPacketIds = Array.isArray(evidence.workPacket?.topPackets)
+    ? evidence.workPacket.topPackets.map((packet) => clean(packet.packetId)).filter(Boolean)
+    : [];
+  const notes = pr ? `PR ${pr} used this packet` : "PR readiness used this packet";
+  return {
+    packetId,
+    suggestedPacketIds,
+    recordCommand: packetId
+      ? `node scripts/studiobrain-ops-work-packet.mjs --record-outcome ${packetId} --outcome used --notes "${notes}"`
+      : "",
   };
 }
 
@@ -212,6 +229,7 @@ export function buildPrReadinessPacket(inputs = {}, options = {}) {
     pr: clean(options.pr),
     owner: clean(options.owner) || "Codex",
     sliceIds: clean(options.sliceIds),
+    outcomeLedger: buildOutcomeLedger(options, evidence),
     scope: {
       branch: gitState.branch,
       base: gitState.base,
@@ -239,8 +257,11 @@ function renderMarkdown(packet) {
     .map((item) => `- ${item.priority} ${item.tool}: ${item.acquisitionClass}; validate with \`${item.validationCommand}\`; approvalRequired=${item.approvalRequired}`)
     .join("\n") || "- None recorded.";
   const topPackets = packet.evidence.workPacket.topPackets
-    .map((item) => `- ${item.priority || "P?"} ${item.status || "unknown"}: ${item.title}`)
+    .map((item) => `- ${item.priority || "P?"} ${item.status || "unknown"} ${item.packetId || ""}: ${item.title}`)
     .join("\n") || "- None recorded.";
+  const outcomeCommand = packet.outcomeLedger.recordCommand
+    ? `\`${packet.outcomeLedger.recordCommand}\``
+    : "Pass `--packet-id <ops-wp-id>` to include a ready-to-run outcome command.";
   const warnings = packet.warnings.map((warning) => `- ${warning}`).join("\n") || "- None.";
   const changedFiles = packet.scope.changedFiles.slice(0, 20).map((file) => `- ${file}`).join("\n") || "- None detected from base.";
   const dirtyFiles = packet.scope.dirtyFiles.map((file) => `- ${file}`).join("\n") || "- Clean.";
@@ -280,6 +301,12 @@ ${dirtyFiles}
 
 ${topPackets}
 
+## Outcome Ledger
+
+- Packet ID: ${packet.outcomeLedger.packetId || ""}
+- Suggested packet IDs: ${packet.outcomeLedger.suggestedPacketIds.join(", ") || "none"}
+- Record command: ${outcomeCommand}
+
 ## Tool Recommendation Summary
 
 ${topRecommendations}
@@ -310,6 +337,7 @@ function parseArgs(argv) {
     pr: "",
     owner: "Codex",
     sliceIds: "",
+    packetId: "",
     artifactValidation: DEFAULT_ARTIFACT_VALIDATION,
     waveRunner: DEFAULT_WAVE_RUNNER,
     workPacket: DEFAULT_WORK_PACKET,
@@ -347,6 +375,7 @@ function parseArgs(argv) {
       "--pr": "pr",
       "--owner": "owner",
       "--slice-ids": "sliceIds",
+      "--packet-id": "packetId",
       "--artifact-validation": "artifactValidation",
       "--wave-runner": "waveRunner",
       "--work-packet": "workPacket",
@@ -379,6 +408,7 @@ Options:
   --base <ref>                         Default: origin/main.
   --pr <id-or-url>                     Optional PR number or URL.
   --slice-ids <ids>                    Optional slice id list.
+  --packet-id <ops-wp-id>              Optional work packet id used by this PR.
   --artifact-validation <path>         Default: output/ops/artifact-validation/artifact-schema-validation-latest.json.
   --wave-runner <path>                 Default: output/ops/waves/ops-wave-runner-latest.json.
   --work-packet <path>                 Default: output/ops/swarm/latest-work-packet.json.

--- a/scripts/ops/pr_readiness_packet.test.mjs
+++ b/scripts/ops/pr_readiness_packet.test.mjs
@@ -34,8 +34,8 @@ const workPacket = {
     effectivityHighSeverityLanes: 1,
   },
   packets: [
-    { title: "[ops] Refresh evidence", status: "ready", priority: "P1", humanGate: "" },
-    { title: "[backup] Restore drill", status: "approval_gated", priority: "P0", humanGate: "human approval" },
+    { packetId: "ops-wp-ready", title: "[ops] Refresh evidence", status: "ready", priority: "P1", humanGate: "" },
+    { packetId: "ops-wp-gated", title: "[backup] Restore drill", status: "approval_gated", priority: "P0", humanGate: "human approval" },
   ],
 };
 
@@ -89,7 +89,7 @@ const toolInstallRecommendations = {
 test("buildPrReadinessPacket summarizes current evidence without executable install commands", () => {
   const packet = buildPrReadinessPacket(
     { gitState, artifactValidation, waveRunner, workPacket, sliceLedger, toolInstallRecommendations },
-    { generatedAt: "2026-05-07T12:10:00.000Z", pr: "#123", sliceIds: "slice-046,slice-047" },
+    { generatedAt: "2026-05-07T12:10:00.000Z", pr: "#123", sliceIds: "slice-046,slice-047", packetId: "ops-wp-ready" },
   );
 
   assert.equal(packet.schema, "studiobrain-ops-pr-readiness-packet.v1");
@@ -100,6 +100,9 @@ test("buildPrReadinessPacket summarizes current evidence without executable inst
   assert.equal(packet.evidence.workPacket.freshSources, 5);
   assert.equal(packet.evidence.workPacket.readyPackets, 1);
   assert.equal(packet.evidence.workPacket.approvalGatedPackets, 1);
+  assert.equal(packet.outcomeLedger.packetId, "ops-wp-ready");
+  assert.ok(packet.outcomeLedger.suggestedPacketIds.includes("ops-wp-gated"));
+  assert.match(packet.outcomeLedger.recordCommand, /--record-outcome ops-wp-ready/);
   assert.equal(packet.evidence.workPacket.effectivityEvidenceLanes, 4);
   assert.equal(packet.evidence.workPacket.effectivityApprovalRequiredLanes, 1);
   assert.equal(packet.evidence.workPacket.effectivityHighSeverityLanes, 1);
@@ -110,6 +113,9 @@ test("buildPrReadinessPacket summarizes current evidence without executable inst
   const markdown = renderMarkdown(packet);
   assert.match(markdown, /Tool Recommendation Summary/);
   assert.match(markdown, /Work Packet Window/);
+  assert.match(markdown, /Outcome Ledger/);
+  assert.match(markdown, /ops-wp-ready/);
+  assert.match(markdown, /--record-outcome ops-wp-ready/);
   assert.match(markdown, /workPacketMaxPackets=8/);
   assert.match(markdown, /ready=1/);
   assert.match(markdown, /approvalGated=1/);
@@ -142,7 +148,7 @@ test("buildPrReadinessPacket warns when dry-run wave evidence mismatches packet 
 test("buildPrReadinessPacket stays compatible with its JSON schema", () => {
   const packet = buildPrReadinessPacket(
     { gitState, artifactValidation, waveRunner, workPacket, sliceLedger, toolInstallRecommendations },
-    { generatedAt: "2026-05-07T12:10:00.000Z", pr: "#123", sliceIds: "slice-046,slice-047" },
+    { generatedAt: "2026-05-07T12:10:00.000Z", pr: "#123", sliceIds: "slice-046,slice-047", packetId: "ops-wp-ready" },
   );
   const schema = JSON.parse(readFileSync("schemas/ops/pr-readiness-packet.v1.schema.json", "utf8"));
 


### PR DESCRIPTION
## Summary
- Add optional --packet-id support to PR readiness packets.
- Include top work-packet IDs and a ready-to-run studiobrain-ops-work-packet --record-outcome command in JSON/Markdown readiness output.
- Keep install commands omitted; readiness still exposes only validation and outcome-recording commands.

## Evidence
- Slice recorded as slice-20260507-068.
- Generated readiness packet includes outcomeLedger.packetId, suggested packet IDs, and ecordCommand.
- Final artifact validation passed 11/11.

## Files Changed
- scripts/ops/pr_readiness_packet.mjs
- scripts/ops/pr_readiness_packet.test.mjs
- schemas/ops/pr-readiness-packet.v1.schema.json
- docs/ops/admin-effectivity-loop.md

## Testing Performed
- node --check scripts/ops/pr_readiness_packet.mjs
- node --test scripts/ops/pr_readiness_packet.test.mjs
- node scripts/ops/pr_readiness_packet.mjs --json --write --packet-id ops-wp-ready --pr #638
- node scripts/ops/validate_ops_artifacts.mjs --json --write
- bash scripts/ops/ops_ci_validate.sh
- git diff --check

## Risk Level
Low. This adds reporting metadata and a non-executed command hint only.

## Rollback Instructions
Revert this commit to remove outcome hints from PR readiness packets.

## Follow-up Tickets
- Add an outcome summary report that identifies stale/misleading packets.
- Add an optional PR creation wrapper that records packet outcomes automatically after a PR exists.