### PR TITLE
[ops] Summarize work-packet outcomes

### DIFF
--- a/docs/ops/admin-effectivity-loop.md
+++ b/docs/ops/admin-effectivity-loop.md
@@ -107,7 +107,7 @@ Work packets should steer from fresh evidence only. Missing, invalid, stale, or 
 Tooling findings export is included in work-packet evidence as `fresh-tooling-findings`; issue-ready validator tasks are tagged `signalClass=issue_ready_task` so agents can pick them up without scraping terminal output.
 When the export contains task entries, the work-packet generator also emits them as normal `ops-wp-*` packets with scoped write sets and validator-focused acceptance criteria.
 Packets are sorted by priority first, then readiness, so a ready P1 diagnostic/tooling task is visible before an approval-gated P1 cleanup task.
-PR readiness packets include the latest wave runner packet window and top work-packet titles so reviewers can tell whether a PR was prepared from the default three-packet view or a widened slice window. When `--packet-id <ops-wp-id>` is supplied, the readiness packet also includes a ready-to-run `--record-outcome` command for the work-packet outcome ledger.
+PR readiness packets include the latest wave runner packet window and top work-packet titles so reviewers can tell whether a PR was prepared from the default three-packet view or a widened slice window. When `--packet-id <ops-wp-id>` is supplied, the readiness packet also includes a ready-to-run `--record-outcome` command for the work-packet outcome ledger. Work-packet reports summarize that ledger by outcome, useful/stale rates, latest outcome by packet, and stale/misleading or blocked packet IDs.
 
 ## Scoring
 

--- a/schemas/ops/ops-work-packet-report.v1.schema.json
+++ b/schemas/ops/ops-work-packet-report.v1.schema.json
@@ -63,9 +63,15 @@
       "type": "object",
       "required": [
         "total",
+        "uniquePackets",
         "helpful",
+        "helpfulRate",
         "staleOrMisleading",
+        "staleOrMisleadingRate",
         "blocked",
+        "staleOrMisleadingPackets",
+        "blockedPackets",
+        "latestByPacket",
         "byOutcome",
         "recent",
         "latest"
@@ -79,13 +85,34 @@
           "type": "integer",
           "minimum": 0
         },
+        "uniquePackets": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "helpfulRate": {
+          "type": "number",
+          "minimum": 0
+        },
         "staleOrMisleading": {
           "type": "integer",
+          "minimum": 0
+        },
+        "staleOrMisleadingRate": {
+          "type": "number",
           "minimum": 0
         },
         "blocked": {
           "type": "integer",
           "minimum": 0
+        },
+        "staleOrMisleadingPackets": {
+          "type": "array"
+        },
+        "blockedPackets": {
+          "type": "array"
+        },
+        "latestByPacket": {
+          "type": "array"
         },
         "byOutcome": {
           "type": "object"

--- a/scripts/studiobrain-ops-work-packet.mjs
+++ b/scripts/studiobrain-ops-work-packet.mjs
@@ -494,13 +494,28 @@ function buildOutcomeSummary(outcomes) {
   const staleOrMisleading = valid.filter((entry) => ["stale", "misleading"].includes(entry.outcome));
   const byOutcome = Object.fromEntries(Array.from(VALID_OUTCOMES).map((outcome) => [outcome, 0]));
   for (const entry of valid) byOutcome[entry.outcome] += 1;
+  const latestByPacket = new Map();
+  for (const entry of valid) {
+    const packetId = clean(entry.packetId);
+    if (packetId) latestByPacket.set(packetId, entry);
+  }
+  const latestPacketOutcomes = Array.from(latestByPacket.values());
+  const staleOrMisleadingPackets = latestPacketOutcomes.filter((entry) => ["stale", "misleading"].includes(clean(entry.outcome)));
+  const blockedPackets = latestPacketOutcomes.filter((entry) => clean(entry.outcome) === "blocked");
   const recent = valid.slice(-10);
+  const rate = (count) => (valid.length > 0 ? Number((count / valid.length).toFixed(3)) : 0);
   return {
     total: valid.length,
+    uniquePackets: latestByPacket.size,
     byOutcome,
     helpful: helpful.length,
+    helpfulRate: rate(helpful.length),
     staleOrMisleading: staleOrMisleading.length,
+    staleOrMisleadingRate: rate(staleOrMisleading.length),
     blocked: valid.filter((entry) => entry.outcome === "blocked").length,
+    staleOrMisleadingPackets,
+    blockedPackets,
+    latestByPacket: latestPacketOutcomes.slice(-10),
     recent,
     latest: recent,
   };

--- a/scripts/studiobrain-ops-work-packet.test.mjs
+++ b/scripts/studiobrain-ops-work-packet.test.mjs
@@ -528,7 +528,7 @@ test("outcome ledger summaries expose by-outcome and recent receipts", () => {
       "--outcomes",
       outcomes,
     ]));
-    const report = silenceStdout(() => runOpsWorkPacket([
+    silenceStdout(() => runOpsWorkPacket([
       "--record-outcome",
       "ops-wp-test",
       "--outcome",
@@ -538,14 +538,31 @@ test("outcome ledger summaries expose by-outcome and recent receipts", () => {
       "--outcomes",
       outcomes,
     ]));
+    const report = silenceStdout(() => runOpsWorkPacket([
+      "--record-outcome",
+      "ops-wp-other",
+      "--outcome",
+      "blocked",
+      "--notes",
+      "needs approval",
+      "--outcomes",
+      outcomes,
+    ]));
 
-    assert.equal(report.outcomeSummary.total, 2);
+    assert.equal(report.outcomeSummary.total, 3);
+    assert.equal(report.outcomeSummary.uniquePackets, 2);
     assert.equal(report.outcomeSummary.byOutcome.helpful, 1);
     assert.equal(report.outcomeSummary.byOutcome.stale, 1);
+    assert.equal(report.outcomeSummary.byOutcome.blocked, 1);
     assert.equal(report.outcomeSummary.helpful, 1);
+    assert.equal(report.outcomeSummary.helpfulRate, 0.333);
     assert.equal(report.outcomeSummary.staleOrMisleading, 1);
-    assert.equal(report.outcomeSummary.recent.length, 2);
-    assert.equal(report.outcomeSummary.latest.length, 2);
+    assert.equal(report.outcomeSummary.staleOrMisleadingRate, 0.333);
+    assert.equal(report.outcomeSummary.staleOrMisleadingPackets[0].packetId, "ops-wp-test");
+    assert.equal(report.outcomeSummary.blockedPackets[0].packetId, "ops-wp-other");
+    assert.equal(report.outcomeSummary.latestByPacket.length, 2);
+    assert.equal(report.outcomeSummary.recent.length, 3);
+    assert.equal(report.outcomeSummary.latest.length, 3);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- Expand work-packet outcome summaries with unique packet counts, helpful/stale rates, latest outcome by packet, and stale/misleading or blocked packet lists.
- Keep existing outcome ledger behavior intact while making packet usefulness auditable without raw JSONL inspection.
- Document the outcome summary fields and add regression coverage.

## Evidence
- Slice recorded as slice-20260507-069.
- Outcome ledger test covers helpful -> stale for one packet and blocked for another.
- Final artifact validation passed 11/11.

## Files Changed
- scripts/studiobrain-ops-work-packet.mjs
- scripts/studiobrain-ops-work-packet.test.mjs
- schemas/ops/ops-work-packet-report.v1.schema.json
- docs/ops/admin-effectivity-loop.md

## Testing Performed
- node --check scripts/studiobrain-ops-work-packet.mjs
- node --test scripts/studiobrain-ops-work-packet.test.mjs
- node scripts/studiobrain-ops-work-packet.mjs --json --write --max-packets 8
- node scripts/ops/validate_ops_artifacts.mjs --json --write
- bash scripts/ops/ops_ci_validate.sh
- git diff --check

## Risk Level
Low. This only changes read-only reporting over an ignored outcome JSONL ledger.

## Rollback Instructions
Revert this commit to restore the prior outcome summary shape.

## Follow-up Tickets
- Feed outcome health into admin effectivity audits.
- Add stale/misleading packet warning thresholds for packet generators.