### PR TITLE
[ops] Audit work-packet outcome health

### DIFF
--- a/docs/ops/admin-effectivity-loop.md
+++ b/docs/ops/admin-effectivity-loop.md
@@ -107,7 +107,7 @@ Work packets should steer from fresh evidence only. Missing, invalid, stale, or 
 Tooling findings export is included in work-packet evidence as `fresh-tooling-findings`; issue-ready validator tasks are tagged `signalClass=issue_ready_task` so agents can pick them up without scraping terminal output.
 When the export contains task entries, the work-packet generator also emits them as normal `ops-wp-*` packets with scoped write sets and validator-focused acceptance criteria.
 Packets are sorted by priority first, then readiness, so a ready P1 diagnostic/tooling task is visible before an approval-gated P1 cleanup task.
-PR readiness packets include the latest wave runner packet window and top work-packet titles so reviewers can tell whether a PR was prepared from the default three-packet view or a widened slice window. When `--packet-id <ops-wp-id>` is supplied, the readiness packet also includes a ready-to-run `--record-outcome` command for the work-packet outcome ledger. Work-packet reports summarize that ledger by outcome, useful/stale rates, latest outcome by packet, and stale/misleading or blocked packet IDs.
+PR readiness packets include the latest wave runner packet window and top work-packet titles so reviewers can tell whether a PR was prepared from the default three-packet view or a widened slice window. When `--packet-id <ops-wp-id>` is supplied, the readiness packet also includes a ready-to-run `--record-outcome` command for the work-packet outcome ledger. Work-packet reports summarize that ledger by outcome, useful/stale rates, latest outcome by packet, and stale/misleading or blocked packet IDs. The admin effectivity audit reads the latest work-packet report and carries that outcome health into the five-slice audit, warning when mature packet outcomes show stale/misleading or blocked work.
 
 ## Scoring
 
@@ -116,8 +116,9 @@ PR readiness packets include the latest wave runner packet window and top work-p
 - `noOpRate`: share of rows with no changed file, artifact, command evidence, or an explicit no-op status.
 - `blockedLaneClarity`: blocked slices with a fixed blocker class and safe next step.
 - `toolInventoryFreshness`: 1 when the inventory command can run and both the inventory and its upstream tooling-quality source are fresh enough for the selected slice window; 0 when unavailable, stale, invalid, or older than the audited slices.
+- `workPacketOutcomeHealth`: 1 when the latest work-packet report is fresh and its outcome ledger is clean or still warming up; 0.4 when mature outcomes show too many stale/misleading packets; 0.6 when blocked packet outcomes need triage.
 
-The audit fails if required tools are missing or a slice failed. It warns when no slices are recorded, no-op rate is high, or the underlying ops effectivity report cannot run.
+The audit fails if required tools are missing or a slice failed. It warns when no slices are recorded, no-op rate is high, the underlying ops effectivity report cannot run, or the latest work-packet outcome health is degraded.
 
 ## Blocker Classes
 

--- a/schemas/ops/admin-effectivity-audit.v1.schema.json
+++ b/schemas/ops/admin-effectivity-audit.v1.schema.json
@@ -21,13 +21,14 @@
     },
     "scores": {
       "type": "object",
-      "required": ["usefulness", "verification", "noOpRate", "blockedLaneClarity", "toolInventoryFreshness"],
+      "required": ["usefulness", "verification", "noOpRate", "blockedLaneClarity", "toolInventoryFreshness", "workPacketOutcomeHealth"],
       "properties": {
         "usefulness": { "type": "number", "minimum": 0, "maximum": 1 },
         "verification": { "type": "number", "minimum": 0, "maximum": 1 },
         "noOpRate": { "type": "number", "minimum": 0, "maximum": 1 },
         "blockedLaneClarity": { "type": "number", "minimum": 0, "maximum": 1 },
-        "toolInventoryFreshness": { "type": "number", "minimum": 0, "maximum": 1 }
+        "toolInventoryFreshness": { "type": "number", "minimum": 0, "maximum": 1 },
+        "workPacketOutcomeHealth": { "type": "number", "minimum": 0, "maximum": 1 }
       },
       "additionalProperties": false
     },
@@ -37,6 +38,7 @@
         "sliceLedger": { "type": "object" },
         "installedTools": { "type": "object" },
         "installedToolsFreshness": { "type": "object" },
+        "workPacketOutcome": { "type": "object" },
         "effectivityReport": { "type": "object" }
       },
       "additionalProperties": true

--- a/scripts/ops/admin_effectivity_audit.mjs
+++ b/scripts/ops/admin_effectivity_audit.mjs
@@ -9,6 +9,7 @@ const __filename = fileURLToPath(import.meta.url);
 const REPO_ROOT = resolve(dirname(__filename), "..", "..");
 const DEFAULT_OUTPUT_DIR = resolve(REPO_ROOT, "output", "ops", "effectivity");
 const DEFAULT_LEDGER = resolve(DEFAULT_OUTPUT_DIR, "slice-ledger.jsonl");
+const DEFAULT_WORK_PACKET = resolve(REPO_ROOT, "output", "ops", "swarm", "latest-work-packet.json");
 
 function usage() {
   return `Studio Brain administrator effectivity audit
@@ -21,6 +22,7 @@ Options:
   --write             Write timestamped JSON and Markdown artifacts.
   --output-dir <path> Artifact directory. Default: output/ops/effectivity.
   --ledger <path>     Slice ledger path. Default: output/ops/effectivity/slice-ledger.jsonl.
+  --work-packet <path> Latest work-packet report. Default: output/ops/swarm/latest-work-packet.json.
   --last <number>     Slice window. Default: 5.
   --slice-run-id <id> Filter slice ledger rows by run id before selecting the window.
   --run-id <id>       Stable run id. Default: admin-effectivity timestamp.
@@ -72,6 +74,7 @@ function parseArgs(argv) {
     write: false,
     outputDir: DEFAULT_OUTPUT_DIR,
     ledger: DEFAULT_LEDGER,
+    workPacket: DEFAULT_WORK_PACKET,
     last: 5,
     sliceRunId: "",
     runId: ""
@@ -93,6 +96,7 @@ function parseArgs(argv) {
     const mappings = [
       ["--output-dir", "outputDir"],
       ["--ledger", "ledger"],
+      ["--work-packet", "workPacket"],
       ["--last", "last"],
       ["--slice-run-id", "sliceRunId"],
       ["--run-id", "runId"]
@@ -111,8 +115,20 @@ function parseArgs(argv) {
   }
   options.outputDir = resolve(REPO_ROOT, options.outputDir);
   options.ledger = resolve(REPO_ROOT, options.ledger);
+  options.workPacket = resolve(REPO_ROOT, options.workPacket);
   options.last = Math.max(1, Number(options.last) || 5);
   return options;
+}
+
+function readJsonIfExists(path) {
+  if (!existsSync(path)) {
+    return { ok: false, status: "missing", error: `${repoRelative(path)} missing`, json: null };
+  }
+  try {
+    return { ok: true, status: "present", error: "", json: JSON.parse(readFileSync(path, "utf8")) };
+  } catch (error) {
+    return { ok: false, status: "invalid", error: error.message, json: null };
+  }
 }
 
 function runJson(command, args) {
@@ -257,6 +273,67 @@ function buildInstalledToolsFreshness(toolInventory, options = {}) {
     inventory,
     toolingQuality,
     effectivitySourceStatus: clean(toolInventory.effectivitySource?.status) || "unknown"
+  };
+}
+
+function summarizeWorkPacketOutcome(workPacket, options = {}) {
+  const sourcePath = repoRelative(options.path || DEFAULT_WORK_PACKET);
+  if (!workPacket?.schema) {
+    return {
+      status: "unavailable",
+      score: 0,
+      sourcePath,
+      generatedAt: "",
+      freshness: sourceFreshness("", options),
+      maturity: "missing",
+      warnings: ["latest work-packet artifact missing or invalid"],
+      outcomeSummary: null
+    };
+  }
+
+  const freshness = sourceFreshness(workPacket.generatedAt, options);
+  const summary = workPacket.outcomeSummary || {};
+  const total = Number(summary.total) || 0;
+  const staleOrMisleadingRate = Number(summary.staleOrMisleadingRate) || 0;
+  const staleOrMisleadingPackets = Array.isArray(summary.staleOrMisleadingPackets) ? summary.staleOrMisleadingPackets : [];
+  const blockedPackets = Array.isArray(summary.blockedPackets) ? summary.blockedPackets : [];
+  const warnings = [];
+  if (freshness.score < 1) warnings.push(`work-packet freshness=${freshness.status}`);
+  if (total >= 3 && staleOrMisleadingRate > 0.25) warnings.push(`staleOrMisleadingRate=${staleOrMisleadingRate}`);
+  if (blockedPackets.length > 0) warnings.push(`blockedPackets=${blockedPackets.length}`);
+
+  const score = freshness.score < 1
+    ? 0
+    : warnings.length === 0
+      ? 1
+      : total >= 3 && staleOrMisleadingRate > 0.25
+        ? 0.4
+        : 0.6;
+  return {
+    status: warnings.length === 0 ? "pass" : "warn",
+    score,
+    sourcePath,
+    generatedAt: clean(workPacket.generatedAt),
+    freshness,
+    maturity: total >= 3 ? "evidence_ready" : "warming_up",
+    warnings,
+    outcomeSummary: {
+      total,
+      uniquePackets: Number(summary.uniquePackets) || 0,
+      helpfulRate: Number(summary.helpfulRate) || 0,
+      staleOrMisleadingRate,
+      staleOrMisleadingPackets: staleOrMisleadingPackets.map((packet) => ({
+        packetId: clean(packet.packetId),
+        outcome: clean(packet.outcome),
+        reason: clean(packet.reason)
+      })),
+      blockedPackets: blockedPackets.map((packet) => ({
+        packetId: clean(packet.packetId),
+        outcome: clean(packet.outcome),
+        reason: clean(packet.reason),
+        blockerClass: clean(packet.blockerClass)
+      }))
+    }
   };
 }
 
@@ -412,10 +489,17 @@ function buildAudit(options) {
   const sliceSummary = summarizeSlices(selectedRows);
   const toolInventory = runJson(process.execPath, ["scripts/ops/installed_tool_inventory.mjs", "--json"]);
   const effectivityReport = tryEffectivityReport();
+  const workPacketRead = readJsonIfExists(options.workPacket);
   const installedToolsFreshness = buildInstalledToolsFreshness(toolInventory.json, {
     now: generatedAt,
     minGeneratedAt: earliestRowIso(selectedRows),
     maxAgeHours: 24
+  });
+  const workPacketOutcome = summarizeWorkPacketOutcome(workPacketRead.json, {
+    now: generatedAt,
+    minGeneratedAt: earliestRowIso(selectedRows),
+    maxAgeHours: 24,
+    path: options.workPacket
   });
   const toolFreshness = toolInventory.ok ? installedToolsFreshness.score : 0;
   const missingRequired = Number(toolInventory.json?.summary?.missingRequired) || 0;
@@ -425,11 +509,12 @@ function buildAudit(options) {
     verification: sliceSummary.verification,
     noOpRate: sliceSummary.noOpRate,
     blockedLaneClarity: sliceSummary.blockedLaneClarity,
-    toolInventoryFreshness: toolFreshness
+    toolInventoryFreshness: toolFreshness,
+    workPacketOutcomeHealth: workPacketOutcome.score
   };
   const status = missingRequired > 0 || sliceSummary.failed > 0
     ? "fail"
-    : sliceSummary.count === 0 || sliceSummary.noOpRate > 0.4 || !effectivityReport.ok || toolFreshness < 1
+    : sliceSummary.count === 0 || sliceSummary.noOpRate > 0.4 || !effectivityReport.ok || toolFreshness < 1 || workPacketOutcome.status === "warn" || workPacketOutcome.status === "unavailable"
       ? "warn"
       : "pass";
   return {
@@ -454,6 +539,11 @@ function buildAudit(options) {
       },
       installedTools: toolInventory.ok ? toolInventory.json : { status: "unavailable", error: toolInventory.error },
       installedToolsFreshness,
+      workPacketOutcome: {
+        ...workPacketOutcome,
+        readStatus: workPacketRead.status,
+        readError: workPacketRead.error
+      },
       effectivityReport
     },
     missionControl: {
@@ -466,7 +556,8 @@ function buildAudit(options) {
           status,
           sliceCount: selectedRows.length,
           usefulness: scores.usefulness,
-          noOpRate: scores.noOpRate
+          noOpRate: scores.noOpRate,
+          workPacketOutcomeHealth: scores.workPacketOutcomeHealth
         }
       ]
     }
@@ -494,6 +585,7 @@ function markdown(audit) {
     `- No-op rate: ${audit.scores.noOpRate}`,
     `- Blocked-lane clarity: ${audit.scores.blockedLaneClarity}`,
     `- Tool inventory freshness: ${audit.scores.toolInventoryFreshness}`,
+    `- Work-packet outcome health: ${audit.scores.workPacketOutcomeHealth}`,
     "",
     "## Installed Tools",
     "",
@@ -512,6 +604,17 @@ function markdown(audit) {
     lines.push(`- ${row.sliceId}: ${row.status} - ${row.title}`);
   }
   if (audit.sections.sliceLedger.rows.length === 0) lines.push("- No slice rows recorded yet.");
+  lines.push("", "## Work-Packet Outcomes", "");
+  const outcome = audit.sections.workPacketOutcome;
+  lines.push(`- Status: ${outcome.status}`);
+  lines.push(`- Source: ${outcome.sourcePath}`);
+  lines.push(`- Maturity: ${outcome.maturity}`);
+  lines.push(`- Total outcomes: ${outcome.outcomeSummary?.total ?? 0}`);
+  lines.push(`- Helpful rate: ${outcome.outcomeSummary?.helpfulRate ?? 0}`);
+  lines.push(`- Stale/misleading rate: ${outcome.outcomeSummary?.staleOrMisleadingRate ?? 0}`);
+  if (outcome.warnings?.length) {
+    for (const warning of outcome.warnings) lines.push(`- Warning: ${warning}`);
+  }
   lines.push("", "## Effectivity Evidence Lanes", "");
   const evidenceLanes = audit.sections.effectivityReport?.report?.evidenceLanes || [];
   if (evidenceLanes.length === 0) {
@@ -559,6 +662,7 @@ export {
   buildInstalledToolsFreshness,
   main,
   parseArgs,
+  summarizeWorkPacketOutcome,
   sourceFreshness
 };
 

--- a/scripts/ops/admin_effectivity_audit.test.mjs
+++ b/scripts/ops/admin_effectivity_audit.test.mjs
@@ -5,7 +5,8 @@ import {
   buildInstalledToolsFreshness,
   classifyEffectivityLanes,
   earliestRowIso,
-  sourceFreshness
+  sourceFreshness,
+  summarizeWorkPacketOutcome
 } from "./admin_effectivity_audit.mjs";
 
 test("sourceFreshness rejects sources older than the selected slice window", () => {
@@ -100,4 +101,56 @@ test("classifyEffectivityLanes turns degraded report sections into approval-awar
   assert.equal(lanes.find((lane) => lane.id === "backup_confidence").severity, "high");
   assert.equal(lanes.find((lane) => lane.id === "privileged_evidence").approvalRequired, true);
   assert.ok(lanes.find((lane) => lane.id === "privileged_evidence").safeNextStep.includes("approval-gated"));
+});
+
+test("summarizeWorkPacketOutcome warns on stale packet outcomes after maturity threshold", () => {
+  const summary = summarizeWorkPacketOutcome({
+    schema: "studiobrain-ops-work-packet.v1",
+    generatedAt: "2026-05-07T11:00:00.000Z",
+    outcomeSummary: {
+      total: 4,
+      uniquePackets: 3,
+      helpfulRate: 0.25,
+      staleOrMisleadingRate: 0.5,
+      staleOrMisleadingPackets: [
+        { packetId: "ops-wp-1", outcome: "stale", reason: "superseded by newer host evidence" }
+      ],
+      blockedPackets: [
+        { packetId: "ops-wp-2", outcome: "blocked", reason: "sudo unavailable", blockerClass: "approval_gate" }
+      ]
+    }
+  }, {
+    now: "2026-05-07T11:05:00.000Z",
+    minGeneratedAt: "2026-05-07T10:30:00.000Z",
+    path: "output/ops/swarm/latest-work-packet.json"
+  });
+
+  assert.equal(summary.status, "warn");
+  assert.equal(summary.score, 0.4);
+  assert.equal(summary.maturity, "evidence_ready");
+  assert.deepEqual(summary.warnings, ["staleOrMisleadingRate=0.5", "blockedPackets=1"]);
+  assert.equal(summary.outcomeSummary.staleOrMisleadingPackets[0].packetId, "ops-wp-1");
+  assert.equal(summary.outcomeSummary.blockedPackets[0].blockerClass, "approval_gate");
+});
+
+test("summarizeWorkPacketOutcome treats a small clean ledger as warming up", () => {
+  const summary = summarizeWorkPacketOutcome({
+    schema: "studiobrain-ops-work-packet.v1",
+    generatedAt: "2026-05-07T11:00:00.000Z",
+    outcomeSummary: {
+      total: 1,
+      uniquePackets: 1,
+      helpfulRate: 1,
+      staleOrMisleadingRate: 0,
+      staleOrMisleadingPackets: [],
+      blockedPackets: []
+    }
+  }, {
+    now: "2026-05-07T11:05:00.000Z",
+    minGeneratedAt: "2026-05-07T10:30:00.000Z"
+  });
+
+  assert.equal(summary.status, "pass");
+  assert.equal(summary.score, 1);
+  assert.equal(summary.maturity, "warming_up");
 });


### PR DESCRIPTION
## Summary
- Add latest work-packet outcome health to the admin effectivity audit.
- Score fresh packet outcome evidence separately and warn on mature stale/misleading or blocked packet outcomes.
- Document the new score and add focused regression coverage.

## Evidence
- Slice recorded as slice-20260507-070.
- Five-slice audit over slices 065-069 passed with workPacketOutcomeHealth=1.
- Artifact schema validation passed 11/11.

## Files Changed
- scripts/ops/admin_effectivity_audit.mjs
- scripts/ops/admin_effectivity_audit.test.mjs
- schemas/ops/admin-effectivity-audit.v1.schema.json
- docs/ops/admin-effectivity-loop.md

## Testing Performed
- node --check scripts/ops/admin_effectivity_audit.mjs
- node --test scripts/ops/admin_effectivity_audit.test.mjs
- node scripts/ops/admin_effectivity_audit.mjs --json --write --slice-run-id admin-infra-20260507 --run-id admin-effectivity-slice-070
- node scripts/ops/validate_ops_artifacts.mjs --json --write
- bash scripts/ops/ops_ci_validate.sh
- git diff --check

## Risk Level
Low. This is read-only reporting over ignored ops artifacts and does not execute packet outcomes or host changes.

## Rollback Instructions
Revert this commit to remove work-packet outcome health from admin effectivity audits.

## Follow-up Tickets
- Add stale/misleading packet warning thresholds directly to work-packet report status.
- Validate PR readiness packet ids against latest suggested packet ids.