### PR TITLE
[ops] Refresh packet outcomes in wave runner

### DIFF
--- a/docs/ops/admin-effectivity-loop.md
+++ b/docs/ops/admin-effectivity-loop.md
@@ -97,7 +97,7 @@ node scripts/ops/ops_wave_runner.mjs --allow-tool-install --json --write
 node scripts/ops/ops_wave_runner.mjs --max-packets 8 --json --write
 ```
 
-The wave runner executes read-only checks in dependency order: preflight, tooling quality, tooling findings export, tool inventory, tool-install recommendation refresh, admin effectivity audit, work packet generation, preliminary artifact schema validation, PR readiness packet generation, then final artifact schema validation. Use it when a downstream command consumes a `*-latest.json` artifact from an upstream command.
+The wave runner executes read-only checks in dependency order: preflight, tooling quality, tooling findings export, tool inventory, tool-install recommendation refresh, admin effectivity audit, work packet generation, packet outcome report generation, preliminary artifact schema validation, PR readiness packet generation, then final artifact schema validation. Use it when a downstream command consumes a `*-latest.json` artifact from an upstream command.
 The default run does not install or fetch missing optional validators. Use `--allow-tool-install` only on a tooling lane where ephemeral runners such as `npx` or `uv tool run` are acceptable; the mode still writes only under `output/ops`. Use `--max-packets <n>` when the default three-packet window hides lower-priority ready work behind approval-gated P0/P1 tasks.
 Dry-run wave artifacts are timestamped only and do not replace `ops-wave-runner-latest.json`; latest is reserved for executable wave evidence.
 Tooling findings export converts fresh `tooling-quality` findings into GitHub-copy-ready cleanup tasks, keeping validator output from becoming a one-off terminal observation.

--- a/scripts/ops/ops_wave_runner.mjs
+++ b/scripts/ops/ops_wave_runner.mjs
@@ -47,6 +47,11 @@ const STEP_DEFINITIONS = [
     expectedArtifacts: ["output/ops/swarm/latest-work-packet.json"],
   },
   {
+    id: "packet-outcome-report",
+    command: [process.execPath, "scripts/ops/packet_outcome_report.mjs", "--json", "--write"],
+    expectedArtifacts: ["output/ops/swarm/packet-outcome-report-latest.json"],
+  },
+  {
     id: "artifact-validation-pre",
     command: [process.execPath, "scripts/ops/validate_ops_artifacts.mjs", "--json", "--write"],
     expectedArtifacts: ["output/ops/artifact-validation/artifact-schema-validation-latest.json"],

--- a/scripts/ops/ops_wave_runner.test.mjs
+++ b/scripts/ops/ops_wave_runner.test.mjs
@@ -44,6 +44,18 @@ test("buildWavePlan lets callers widen the work-packet window", () => {
   assert.match(widenedPlan[0].commandText, /--max-packets 12$/);
 });
 
+test("buildWavePlan refreshes packet outcome report after work packets", () => {
+  const plan = buildWavePlan();
+  const workPacketIndex = plan.findIndex((step) => step.id === "work-packet");
+  const outcomeIndex = plan.findIndex((step) => step.id === "packet-outcome-report");
+  const validationIndex = plan.findIndex((step) => step.id === "artifact-validation-pre");
+
+  assert.ok(workPacketIndex >= 0);
+  assert.ok(outcomeIndex > workPacketIndex);
+  assert.ok(validationIndex > outcomeIndex);
+  assert.ok(plan[outcomeIndex].commandText.includes("packet_outcome_report.mjs"));
+});
+
 test("buildWavePlan exports tooling findings after tooling quality", () => {
   const plan = buildWavePlan();
   const qualityIndex = plan.findIndex((step) => step.id === "tooling-quality");


### PR DESCRIPTION
## Summary
- Add packet outcome report refresh to the ops wave runner immediately after work-packet generation.
- Keep preliminary artifact validation after the outcome report so the new latest artifact is validated in the same wave.
- Document the updated dependency order.

## Evidence
- Slice recorded as slice-20260507-074.
- Dry-run plan shows `work-packet -> packet-outcome-report -> artifact-validation-pre`.
- Executed the three-step wave; work-packet warned from current advisory state, packet outcome report and artifact validation passed.

## Files Changed
- scripts/ops/ops_wave_runner.mjs
- scripts/ops/ops_wave_runner.test.mjs
- docs/ops/admin-effectivity-loop.md

## Testing Performed
- node --check scripts/ops/ops_wave_runner.mjs
- node --test scripts/ops/ops_wave_runner.test.mjs
- node scripts/ops/ops_wave_runner.mjs --dry-run --json --steps work-packet,packet-outcome-report,artifact-validation-pre
- node scripts/ops/ops_wave_runner.mjs --steps work-packet,packet-outcome-report,artifact-validation-pre --max-packets 8 --json --write
- node scripts/ops/validate_ops_artifacts.mjs --json --write
- bash scripts/ops/ops_ci_validate.sh
- git diff --check

## Risk Level
Low. Adds one read-only reporting step to the local ops wave runner.

## Rollback Instructions
Revert this commit to remove the packet outcome report step from wave runner execution.

## Follow-up Tickets
- Run the next five-slice admin effectivity audit after slice 075.
- Add outcome reset guidance when packet IDs churn heavily between evidence generations.