### PR TITLE
[ops] Add PR stack audit generator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ OPS_SWARM_LANE ?= tooling
 OPS_SWARM_BASE ?= origin/main
 OPS_SWARM_PREFLIGHT_FLAGS ?=
 
-.PHONY: ops-check ops-inventory ops-postgres-review ops-postgres-sql ops-postgres-top-queries ops-postgres-query-tasks ops-postgres-growth-snapshot ops-postgres-autovacuum-stats ops-postgres-roles-extensions ops-docker-review ops-docker-posture ops-capacity ops-import-pressure ops-cleanup-candidates ops-backup-evidence ops-postgres-backup-artifacts ops-restore-prereq ops-redis-minio-backup-evidence ops-ubuntu-review ops-host-failed-unit-trends ops-package-posture ops-time-sync ops-network-review ops-host-drift ops-systemd-drift ops-portal-bridge-review ops-app-review ops-dependency-review ops-idle-worker-effectivity ops-effectivity-report ops-slice-ledger ops-tool-inventory ops-tool-install-plan ops-admin-effectivity-audit ops-tooling-quality ops-shell-lf-guard ops-shellcheck-report ops-powershell-syntax ops-sql-parse-report ops-actionlint-report ops-compose-config-report ops-validate-artifacts ops-swarm-lane-preflight ops-wave-runner ops-privileged-evidence-read ops-privileged-evidence-capture ops-privileged-evidence-capture-smoke ops-work-packet ops-pr-readiness-packet ops-incident-bundle ops-incident-bundle-v2 ops-ci-validate ops-post-deploy-verify ops-docs ops-backlog ops-report
+.PHONY: ops-check ops-inventory ops-postgres-review ops-postgres-sql ops-postgres-top-queries ops-postgres-query-tasks ops-postgres-growth-snapshot ops-postgres-autovacuum-stats ops-postgres-roles-extensions ops-docker-review ops-docker-posture ops-capacity ops-import-pressure ops-cleanup-candidates ops-backup-evidence ops-postgres-backup-artifacts ops-restore-prereq ops-redis-minio-backup-evidence ops-ubuntu-review ops-host-failed-unit-trends ops-package-posture ops-time-sync ops-network-review ops-host-drift ops-systemd-drift ops-portal-bridge-review ops-app-review ops-dependency-review ops-idle-worker-effectivity ops-effectivity-report ops-slice-ledger ops-tool-inventory ops-tool-install-plan ops-admin-effectivity-audit ops-tooling-quality ops-shell-lf-guard ops-shellcheck-report ops-powershell-syntax ops-sql-parse-report ops-actionlint-report ops-compose-config-report ops-validate-artifacts ops-swarm-lane-preflight ops-wave-runner ops-privileged-evidence-read ops-privileged-evidence-capture ops-privileged-evidence-capture-smoke ops-work-packet ops-pr-stack-audit ops-pr-readiness-packet ops-incident-bundle ops-incident-bundle-v2 ops-ci-validate ops-post-deploy-verify ops-docs ops-backlog ops-report
 
 ops-check: ops-inventory ops-docker-review ops-capacity ops-cleanup-candidates ops-backup-evidence ops-ubuntu-review ops-network-review ops-host-drift ops-systemd-drift ops-portal-bridge-review ops-app-review
 
@@ -168,6 +168,9 @@ ops-privileged-evidence-capture-smoke:
 
 ops-work-packet:
 	node ./scripts/studiobrain-ops-work-packet.mjs --write
+
+ops-pr-stack-audit:
+	node ./scripts/ops/pr_stack_audit.mjs --write
 
 ops-pr-readiness-packet:
 	node ./scripts/ops/pr_readiness_packet.mjs --write

--- a/docs/ops/13-ops-pr-stack-audit.md
+++ b/docs/ops/13-ops-pr-stack-audit.md
@@ -60,6 +60,16 @@ This audit inventories current Studio Brain / ops-adjacent pull requests and sep
 
 ## Evidence Commands
 
+Reusable current audit generator:
+
+```bash
+node scripts/ops/pr_stack_audit.mjs --json --write
+```
+
+The generator writes ignored JSON and Markdown under `output/ops/pr-stack/`, classifies dependency, draft, preview-only, conflicted, behind, ops, and stacked PRs, and records detected base/head stack edges without mutating GitHub state.
+
+Raw commands used by the generator and useful for manual spot checks:
+
 ```bash
 gh pr list --repo monsoonfirepottery-byte/monsoonfire-portal --state open --limit 30 --json number,title,headRefName,isDraft,mergeStateStatus,updatedAt
 gh pr list --repo monsoonfirepottery-byte/studio-brain-mission-control --state open --limit 30 --json number,title,headRefName,isDraft,mergeStateStatus,updatedAt

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -55,6 +55,7 @@ make ops-effectivity-report
 make ops-privileged-evidence-read
 make ops-privileged-evidence-capture-smoke
 make ops-work-packet
+make ops-pr-stack-audit
 make ops-incident-bundle
 make ops-incident-bundle-v2
 make ops-ci-validate
@@ -78,6 +79,7 @@ bash scripts/ops/effectivity_report.sh
 bash scripts/ops/privileged_evidence_read.sh
 bash scripts/ops/privileged_evidence_capture.sh --smoke --output-dir output/ops/privileged-evidence
 node scripts/studiobrain-ops-work-packet.mjs --write
+node scripts/ops/pr_stack_audit.mjs --write
 bash scripts/ops/incident_bundle_v2.sh output/ops/incidents-v2/manual-smoke
 ```
 
@@ -106,4 +108,4 @@ The first ops-doctor stack is merged into `main`, including post-merge verificat
 - Node/npm audit inventory is available with `make ops-dependency-review`; findings are evidence for small dependency PRs, not approval to run `npm audit fix`.
 - network/SSH/PostgreSQL hardening is approval-gated.
 
-Use `02-kanban-backlog.md` for the next issue-ready slices, and `13-ops-pr-stack-audit.md` for current open PR triage.
+Use `02-kanban-backlog.md` for the next issue-ready slices, and `make ops-pr-stack-audit` plus `13-ops-pr-stack-audit.md` for current open PR triage.

--- a/schemas/ops/pr-stack-audit.v1.schema.json
+++ b/schemas/ops/pr-stack-audit.v1.schema.json
@@ -1,0 +1,159 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://studio-brain.local/schemas/ops/pr-stack-audit.v1.schema.json",
+  "title": "Studio Brain Ops PR Stack Audit",
+  "type": "object",
+  "required": [
+    "schema",
+    "generatedAt",
+    "runId",
+    "status",
+    "readOnly",
+    "purpose",
+    "repos",
+    "stackEdges",
+    "summary",
+    "warnings",
+    "operatorNotes"
+  ],
+  "properties": {
+    "schema": { "const": "studiobrain-ops-pr-stack-audit.v1" },
+    "generatedAt": { "type": "string" },
+    "runId": { "type": "string" },
+    "status": { "enum": ["pass", "warn", "fail"] },
+    "readOnly": { "const": true },
+    "purpose": { "type": "string" },
+    "repos": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "label", "repo", "collection", "openPullRequests", "recentlyMerged", "summary"],
+        "properties": {
+          "id": { "type": "string" },
+          "label": { "type": "string" },
+          "repo": { "type": "string" },
+          "collection": {
+            "type": "object",
+            "required": ["openStatus", "mergedStatus", "openError", "mergedError"],
+            "properties": {
+              "openStatus": { "type": "string" },
+              "mergedStatus": { "type": "string" },
+              "openError": { "type": "string" },
+              "mergedError": { "type": "string" }
+            },
+            "additionalProperties": false
+          },
+          "openPullRequests": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "repoId",
+                "number",
+                "title",
+                "url",
+                "headRefName",
+                "baseRefName",
+                "isDraft",
+                "mergeStateStatus",
+                "updatedAt",
+                "author",
+                "category",
+                "recommendedDisposition"
+              ],
+              "properties": {
+                "repoId": { "type": "string" },
+                "number": { "type": "number" },
+                "title": { "type": "string" },
+                "url": { "type": "string" },
+                "headRefName": { "type": "string" },
+                "baseRefName": { "type": "string" },
+                "isDraft": { "type": "boolean" },
+                "mergeStateStatus": { "type": "string" },
+                "updatedAt": { "type": "string" },
+                "author": { "type": "string" },
+                "category": { "type": "string" },
+                "recommendedDisposition": { "type": "string" }
+              },
+              "additionalProperties": false
+            }
+          },
+          "recentlyMerged": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["repoId", "number", "title", "url", "headRefName", "baseRefName", "mergedAt", "mergeCommit", "author"],
+              "properties": {
+                "repoId": { "type": "string" },
+                "number": { "type": "number" },
+                "title": { "type": "string" },
+                "url": { "type": "string" },
+                "headRefName": { "type": "string" },
+                "baseRefName": { "type": "string" },
+                "mergedAt": { "type": "string" },
+                "mergeCommit": { "type": "string" },
+                "author": { "type": "string" }
+              },
+              "additionalProperties": false
+            }
+          },
+          "summary": {
+            "type": "object",
+            "required": ["open", "recentlyMerged", "openLimit", "openLimitReached", "categories", "mergeStates"],
+            "properties": {
+              "open": { "type": "number", "minimum": 0 },
+              "recentlyMerged": { "type": "number", "minimum": 0 },
+              "openLimit": { "type": ["number", "null"], "minimum": 0 },
+              "openLimitReached": { "type": "boolean" },
+              "categories": {
+                "type": "object",
+                "additionalProperties": { "type": "number", "minimum": 0 }
+              },
+              "mergeStates": {
+                "type": "object",
+                "additionalProperties": { "type": "number", "minimum": 0 }
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "stackEdges": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["repoId", "basePr", "baseHead", "childPr", "childHead"],
+        "properties": {
+          "repoId": { "type": "string" },
+          "basePr": { "type": "number" },
+          "baseHead": { "type": "string" },
+          "childPr": { "type": "number" },
+          "childHead": { "type": "string" }
+        },
+        "additionalProperties": false
+      }
+    },
+    "summary": {
+      "type": "object",
+      "required": ["repos", "open", "recentlyMerged", "categories", "warnings"],
+      "properties": {
+        "repos": { "type": "number", "minimum": 0 },
+        "open": { "type": "number", "minimum": 0 },
+        "recentlyMerged": { "type": "number", "minimum": 0 },
+        "categories": {
+          "type": "object",
+          "additionalProperties": { "type": "number", "minimum": 0 }
+        },
+        "warnings": { "type": "number", "minimum": 0 }
+      },
+      "additionalProperties": false
+    },
+    "warnings": { "type": "array", "items": { "type": "string" } },
+    "operatorNotes": { "type": "array", "items": { "type": "string" } },
+    "artifactPath": { "type": "string" },
+    "markdownPath": { "type": "string" }
+  },
+  "additionalProperties": false
+}

--- a/scripts/ops/ops_ci_validate.sh
+++ b/scripts/ops/ops_ci_validate.sh
@@ -50,6 +50,7 @@ check_file "scripts/ops/installed_tool_inventory.mjs"
 check_file "scripts/ops/tool_install_recommendations.mjs"
 check_file "scripts/ops/pr_readiness_packet.mjs"
 check_file "scripts/ops/packet_outcome_report.mjs"
+check_file "scripts/ops/pr_stack_audit.mjs"
 check_file "docs/ops/17-pr-readiness-packet-template.md"
 check_file "docs/ops/18-release-verification.md"
 
@@ -77,7 +78,8 @@ for script in \
   "scripts/ops/installed_tool_inventory.mjs" \
   "scripts/ops/tool_install_recommendations.mjs" \
   "scripts/ops/pr_readiness_packet.mjs" \
-  "scripts/ops/packet_outcome_report.mjs"; do
+  "scripts/ops/packet_outcome_report.mjs" \
+  "scripts/ops/pr_stack_audit.mjs"; do
   if [ -f "${REPO_ROOT}/${script}" ] && node --check "${REPO_ROOT}/${script}" >/dev/null; then
     pass "node --check ${script}"
   else
@@ -152,6 +154,12 @@ else
   fail "node --test scripts/ops/packet_outcome_report.test.mjs"
 fi
 
+if node --test "${REPO_ROOT}/scripts/ops/pr_stack_audit.test.mjs" >"${OUT_DIR}/pr-stack-audit.test.out" 2>&1; then
+  pass "node --test scripts/ops/pr_stack_audit.test.mjs"
+else
+  fail "node --test scripts/ops/pr_stack_audit.test.mjs"
+fi
+
 section "Swarm Lane Preflight Smoke"
 if node "${REPO_ROOT}/scripts/ops/swarm_lane_preflight.mjs" --lane tooling --base origin/main --json --write >"${OUT_DIR}/swarm-lane-preflight.json"; then
   pass "swarm_lane_preflight tooling smoke"
@@ -205,6 +213,13 @@ if node "${REPO_ROOT}/scripts/ops/packet_outcome_report.mjs" --json --write >"${
   pass "packet_outcome_report smoke"
 else
   fail "packet_outcome_report smoke"
+fi
+
+section "PR Stack Audit Smoke"
+if node "${REPO_ROOT}/scripts/ops/pr_stack_audit.mjs" --json --write >"${OUT_DIR}/pr-stack-audit.json"; then
+  pass "pr_stack_audit smoke"
+else
+  fail "pr_stack_audit smoke"
 fi
 
 section "Docs Contract"

--- a/scripts/ops/pr_stack_audit.mjs
+++ b/scripts/ops/pr_stack_audit.mjs
@@ -1,0 +1,437 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const REPO_ROOT = resolve(dirname(__filename), "..", "..");
+const DEFAULT_OUTPUT_DIR = resolve(REPO_ROOT, "output", "ops", "pr-stack");
+const DEFAULT_REPOS = [
+  { id: "portal", label: "Monsoon Fire Portal", repo: "monsoonfirepottery-byte/monsoonfire-portal" },
+  { id: "mission-control", label: "Studio Brain Mission Control", repo: "monsoonfirepottery-byte/studio-brain-mission-control" },
+];
+const OPEN_FIELDS = "number,title,headRefName,baseRefName,isDraft,mergeStateStatus,updatedAt,url,author";
+const MERGED_FIELDS = "number,title,headRefName,baseRefName,mergedAt,mergeCommit,url,author";
+
+function usage() {
+  return `Studio Brain ops PR stack audit
+
+Usage:
+  node scripts/ops/pr_stack_audit.mjs [--json] [--write]
+
+Options:
+  --json                  Print JSON.
+  --write                 Write timestamped/latest JSON and Markdown artifacts.
+  --output-dir <path>     Artifact directory. Default: output/ops/pr-stack.
+  --open-limit <n>        Open PRs per repo. Default: 40.
+  --merged-limit <n>      Recently merged PRs per repo. Default: 12.
+  --repo <id=owner/name>  Add or override a repository. Repeatable.
+`;
+}
+
+function clean(value) {
+  return String(value ?? "").replace(/\r/g, "").trim();
+}
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function repoRelative(path) {
+  return relative(REPO_ROOT, resolve(path)).replace(/\\/g, "/");
+}
+
+function readFlagValue(argv, index, flag) {
+  const value = argv[index];
+  if (value === flag) {
+    if (!argv[index + 1]) throw new Error(`${flag} requires a value.`);
+    return { matched: true, value: argv[index + 1], nextIndex: index + 1 };
+  }
+  if (value.startsWith(`${flag}=`)) {
+    return { matched: true, value: value.slice(flag.length + 1), nextIndex: index };
+  }
+  return { matched: false, value: "", nextIndex: index };
+}
+
+function parseRepo(value) {
+  const text = clean(value);
+  const separator = text.indexOf("=");
+  if (separator === -1) {
+    const id = text.split("/").pop() || text;
+    return { id, label: id, repo: text };
+  }
+  const id = clean(text.slice(0, separator));
+  const repo = clean(text.slice(separator + 1));
+  return { id, label: id, repo };
+}
+
+function parseArgs(argv = process.argv.slice(2)) {
+  const options = {
+    json: false,
+    write: false,
+    outputDir: DEFAULT_OUTPUT_DIR,
+    openLimit: 40,
+    mergedLimit: 12,
+    repos: [...DEFAULT_REPOS],
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--help" || arg === "-h") {
+      process.stdout.write(usage());
+      process.exit(0);
+    }
+    if (arg === "--json") {
+      options.json = true;
+      continue;
+    }
+    if (arg === "--write") {
+      options.write = true;
+      continue;
+    }
+    const outputDir = readFlagValue(argv, index, "--output-dir");
+    if (outputDir.matched) {
+      options.outputDir = resolve(REPO_ROOT, outputDir.value);
+      index = outputDir.nextIndex;
+      continue;
+    }
+    const openLimit = readFlagValue(argv, index, "--open-limit");
+    if (openLimit.matched) {
+      options.openLimit = Number(openLimit.value);
+      index = openLimit.nextIndex;
+      continue;
+    }
+    const mergedLimit = readFlagValue(argv, index, "--merged-limit");
+    if (mergedLimit.matched) {
+      options.mergedLimit = Number(mergedLimit.value);
+      index = mergedLimit.nextIndex;
+      continue;
+    }
+    const repo = readFlagValue(argv, index, "--repo");
+    if (repo.matched) {
+      const parsed = parseRepo(repo.value);
+      options.repos = options.repos.filter((entry) => entry.id !== parsed.id).concat(parsed);
+      index = repo.nextIndex;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+  if (!Number.isFinite(options.openLimit) || options.openLimit < 1) throw new Error("--open-limit must be a positive number.");
+  if (!Number.isFinite(options.mergedLimit) || options.mergedLimit < 0) throw new Error("--merged-limit must be zero or greater.");
+  return options;
+}
+
+function readJsonFixture(path) {
+  if (!path || !existsSync(path)) return null;
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function runGhJson(args) {
+  const result = spawnSync("gh", args, { cwd: REPO_ROOT, encoding: "utf8", windowsHide: true });
+  if (result.error) {
+    return { ok: false, data: [], error: result.error.message };
+  }
+  if (result.status !== 0) {
+    return { ok: false, data: [], error: clean(result.stderr) || `gh exited ${result.status}` };
+  }
+  try {
+    return { ok: true, data: JSON.parse(result.stdout || "[]"), error: "" };
+  } catch (error) {
+    return { ok: false, data: [], error: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+function collectRepo(repoConfig, options = {}) {
+  const fixture = options.fixtures?.[repoConfig.id];
+  const openResult = fixture?.open
+    ? { ok: true, data: fixture.open, error: "" }
+    : runGhJson([
+      "pr",
+      "list",
+      "--repo",
+      repoConfig.repo,
+      "--state",
+      "open",
+      "--limit",
+      String(options.openLimit ?? 40),
+      "--json",
+      OPEN_FIELDS,
+    ]);
+  const mergedResult = fixture?.merged
+    ? { ok: true, data: fixture.merged, error: "" }
+    : runGhJson([
+      "pr",
+      "list",
+      "--repo",
+      repoConfig.repo,
+      "--state",
+      "merged",
+      "--limit",
+      String(options.mergedLimit ?? 12),
+      "--json",
+      MERGED_FIELDS,
+    ]);
+  return {
+    id: repoConfig.id,
+    label: repoConfig.label,
+    repo: repoConfig.repo,
+    openPullRequests: Array.isArray(openResult.data) ? openResult.data : [],
+    recentlyMerged: Array.isArray(mergedResult.data) ? mergedResult.data : [],
+    collection: {
+      openStatus: openResult.ok ? "pass" : "warn",
+      mergedStatus: mergedResult.ok ? "pass" : "warn",
+      openError: clean(openResult.error),
+      mergedError: clean(mergedResult.error),
+    },
+  };
+}
+
+function authorLogin(author) {
+  return clean(author?.login) || clean(author?.name);
+}
+
+function categoryFor(pr) {
+  const title = clean(pr.title).toLowerCase();
+  const head = clean(pr.headRefName).toLowerCase();
+  const base = clean(pr.baseRefName).toLowerCase();
+  const mergeState = clean(pr.mergeStateStatus).toLowerCase();
+  if (head.includes("dependabot/") || authorLogin(pr.author).toLowerCase() === "dependabot") return "dependency";
+  if (mergeState.includes("dirty")) return "conflict";
+  if (base && base !== "main") return "stacked";
+  if (pr.isDraft) {
+    if (title.includes("preview") || head.includes("preview") || title.includes("website")) return "preview_draft";
+    return "draft";
+  }
+  if (mergeState.includes("behind")) return "behind";
+  if (title.includes("[ops]") || head.includes("ops-")) return "ops";
+  return "open";
+}
+
+function dispositionFor(pr, category) {
+  if (category === "dependency") return "Rebase/update and run the scoped dependency checks before merging.";
+  if (category === "conflict") return "Do not merge until conflicts are reviewed in a clean worktree.";
+  if (category === "preview_draft") return "Preserve preview-only boundary until the owner approves production website work.";
+  if (category === "draft") return "Owner decision needed: refresh, supersede, or close before merge work.";
+  if (category === "stacked") return "Merge only after its base PR lands and checks are green.";
+  if (category === "behind") return "Refresh from main and rerun the relevant focused checks.";
+  if (category === "ops") return "Review as a normal low-risk ops PR after checks pass.";
+  return "Review scope and checks before deciding merge order.";
+}
+
+function normalizeOpenPr(pr, repoId) {
+  const category = categoryFor(pr);
+  return {
+    repoId,
+    number: Number(pr.number),
+    title: clean(pr.title),
+    url: clean(pr.url),
+    headRefName: clean(pr.headRefName),
+    baseRefName: clean(pr.baseRefName),
+    isDraft: Boolean(pr.isDraft),
+    mergeStateStatus: clean(pr.mergeStateStatus),
+    updatedAt: clean(pr.updatedAt),
+    author: authorLogin(pr.author),
+    category,
+    recommendedDisposition: dispositionFor(pr, category),
+  };
+}
+
+function normalizeMergedPr(pr, repoId) {
+  return {
+    repoId,
+    number: Number(pr.number),
+    title: clean(pr.title),
+    url: clean(pr.url),
+    headRefName: clean(pr.headRefName),
+    baseRefName: clean(pr.baseRefName),
+    mergedAt: clean(pr.mergedAt),
+    mergeCommit: clean(pr.mergeCommit?.oid || pr.mergeCommit?.abbreviatedOid || pr.mergeCommit),
+    author: authorLogin(pr.author),
+  };
+}
+
+function stackEdges(openPrs) {
+  const heads = new Map(openPrs.map((pr) => [pr.headRefName, pr]));
+  return openPrs
+    .filter((pr) => pr.baseRefName && heads.has(pr.baseRefName))
+    .map((pr) => ({
+      repoId: pr.repoId,
+      basePr: heads.get(pr.baseRefName).number,
+      baseHead: pr.baseRefName,
+      childPr: pr.number,
+      childHead: pr.headRefName,
+    }));
+}
+
+function countBy(items, field) {
+  return items.reduce((acc, item) => {
+    const key = clean(item[field]) || "unknown";
+    acc[key] = (acc[key] || 0) + 1;
+    return acc;
+  }, {});
+}
+
+function buildPrStackAudit(inputs = {}, options = {}) {
+  const generatedAt = clean(options.generatedAt) || nowIso();
+  const repos = (options.repos || DEFAULT_REPOS).map((repoConfig) => {
+    const source = inputs.repos?.find((entry) => entry.id === repoConfig.id) || collectRepo(repoConfig, options);
+    const openPullRequests = source.openPullRequests.map((pr) => normalizeOpenPr(pr, source.id));
+    const recentlyMerged = source.recentlyMerged.map((pr) => normalizeMergedPr(pr, source.id));
+    const openLimit = Number.isFinite(options.openLimit) ? options.openLimit : null;
+    return {
+      id: source.id,
+      label: source.label || repoConfig.label,
+      repo: source.repo || repoConfig.repo,
+      collection: source.collection || { openStatus: "pass", mergedStatus: "pass", openError: "", mergedError: "" },
+      openPullRequests,
+      recentlyMerged,
+      summary: {
+        open: openPullRequests.length,
+        recentlyMerged: recentlyMerged.length,
+        openLimit,
+        openLimitReached: openLimit !== null && openPullRequests.length >= openLimit,
+        categories: countBy(openPullRequests, "category"),
+        mergeStates: countBy(openPullRequests, "mergeStateStatus"),
+      },
+    };
+  });
+  const allOpen = repos.flatMap((repo) => repo.openPullRequests);
+  const allMerged = repos.flatMap((repo) => repo.recentlyMerged);
+  const collectionWarnings = repos.flatMap((repo) => [
+    repo.collection.openStatus !== "pass" ? `${repo.id} open PR collection: ${repo.collection.openError || repo.collection.openStatus}` : "",
+    repo.collection.mergedStatus !== "pass" ? `${repo.id} merged PR collection: ${repo.collection.mergedError || repo.collection.mergedStatus}` : "",
+  ].filter(Boolean));
+  const warnings = [
+    ...collectionWarnings,
+    ...repos.filter((repo) => repo.summary.openLimitReached).map((repo) => `${repo.id} open PR collection reached limit ${repo.summary.openLimit}; rerun with a larger --open-limit for a complete audit`),
+    allOpen.some((pr) => pr.category === "conflict") ? "one or more PRs have dirty/conflicted merge state" : "",
+    allOpen.some((pr) => pr.category === "dependency") ? "dependency PRs require separate scoped validation" : "",
+    allOpen.some((pr) => pr.category === "preview_draft") ? "preview-only draft PRs require owner disposition" : "",
+  ].filter(Boolean);
+  return {
+    schema: "studiobrain-ops-pr-stack-audit.v1",
+    generatedAt,
+    runId: clean(options.runId) || `ops-pr-stack-${generatedAt.replace(/[-:]/g, "").replace(/\.\d+Z$/, "Z")}`,
+    status: collectionWarnings.length || repos.some((repo) => repo.summary.openLimitReached) ? "warn" : "pass",
+    readOnly: true,
+    purpose: "Inventory open ops-adjacent PRs, stacked branches, stale drafts, and recently merged PRs without mutating GitHub state.",
+    repos,
+    stackEdges: stackEdges(allOpen),
+    summary: {
+      repos: repos.length,
+      open: allOpen.length,
+      recentlyMerged: allMerged.length,
+      categories: countBy(allOpen, "category"),
+      warnings: warnings.length,
+    },
+    warnings,
+    operatorNotes: [
+      "This report is metadata only; it does not merge, close, rebase, or rerun checks.",
+      "Treat dependency and preview-draft PRs as separate lanes from ops-doctor stack work.",
+      "Stacked PRs should merge from the bottom of their base/head chain upward.",
+    ],
+  };
+}
+
+function renderMarkdown(report) {
+  const warnings = report.warnings.map((warning) => `- ${warning}`).join("\n") || "- None.";
+  const repoSections = report.repos.map((repo) => {
+    const openRows = repo.openPullRequests.map((pr) =>
+      `| [#${pr.number}](${pr.url}) | ${pr.headRefName} | ${pr.baseRefName} | ${pr.isDraft ? "yes" : "no"} | ${pr.mergeStateStatus || ""} | ${pr.category} | ${pr.recommendedDisposition} |`,
+    ).join("\n") || "| _none_ |  |  |  |  |  |  |";
+    const mergedRows = repo.recentlyMerged.slice(0, 8).map((pr) =>
+      `| [#${pr.number}](${pr.url}) | ${pr.title} | ${pr.mergeCommit || ""} | ${pr.mergedAt || ""} |`,
+    ).join("\n") || "| _none_ |  |  |  |";
+    return `## ${repo.label}
+
+- Repo: \`${repo.repo}\`
+- Open PRs: ${repo.summary.open}
+- Recently merged captured: ${repo.summary.recentlyMerged}
+- Open limit reached: ${repo.summary.openLimitReached}
+- Collection: open=${repo.collection.openStatus}, merged=${repo.collection.mergedStatus}
+
+### Open PRs
+
+| PR | Head | Base | Draft | Merge state | Category | Recommended disposition |
+| --- | --- | --- | --- | --- | --- | --- |
+${openRows}
+
+### Recently Merged
+
+| PR | Title | Merge commit | Merged at |
+| --- | --- | --- | --- |
+${mergedRows}
+`;
+  }).join("\n");
+  const edges = report.stackEdges.map((edge) =>
+    `- ${edge.repoId}: #${edge.basePr} (${edge.baseHead}) -> #${edge.childPr} (${edge.childHead})`,
+  ).join("\n") || "- None detected.";
+  return `# Ops PR Stack Audit
+
+Generated: ${report.generatedAt}
+Status: ${report.status}
+Run ID: ${report.runId}
+
+## Summary
+
+- Repos: ${report.summary.repos}
+- Open PRs: ${report.summary.open}
+- Recently merged captured: ${report.summary.recentlyMerged}
+- Categories: ${JSON.stringify(report.summary.categories)}
+
+## Warnings
+
+${warnings}
+
+## Stacked Edges
+
+${edges}
+
+${repoSections}
+## Notes
+
+${report.operatorNotes.map((note) => `- ${note}`).join("\n")}
+`;
+}
+
+function writeArtifacts(options, report) {
+  mkdirSync(options.outputDir, { recursive: true });
+  const jsonPath = resolve(options.outputDir, `${report.runId}.json`);
+  const markdownPath = resolve(options.outputDir, `${report.runId}.md`);
+  const latestJson = resolve(options.outputDir, "pr-stack-audit-latest.json");
+  const latestMarkdown = resolve(options.outputDir, "pr-stack-audit-latest.md");
+  writeFileSync(jsonPath, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+  writeFileSync(markdownPath, renderMarkdown(report), "utf8");
+  writeFileSync(latestJson, `${JSON.stringify({ ...report, artifactPath: repoRelative(jsonPath), markdownPath: repoRelative(markdownPath) }, null, 2)}\n`, "utf8");
+  writeFileSync(latestMarkdown, renderMarkdown(report), "utf8");
+  return {
+    jsonPath: repoRelative(jsonPath),
+    markdownPath: repoRelative(markdownPath),
+    latestJson: repoRelative(latestJson),
+    latestMarkdown: repoRelative(latestMarkdown),
+  };
+}
+
+function run(rawArgs = process.argv.slice(2)) {
+  const options = parseArgs(rawArgs);
+  const report = buildPrStackAudit({}, options);
+  const artifacts = options.write ? writeArtifacts(options, report) : null;
+  if (options.json) process.stdout.write(`${JSON.stringify({ ...report, artifacts }, null, 2)}\n`);
+  else {
+    process.stdout.write(`ops PR stack audit: ${report.status}, open=${report.summary.open}\n`);
+    if (artifacts) process.stdout.write(`artifact: ${artifacts.latestMarkdown}\n`);
+  }
+  return { ...report, artifacts };
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === __filename) {
+  try {
+    run();
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  }
+}
+
+export { buildPrStackAudit, renderMarkdown };

--- a/scripts/ops/pr_stack_audit.test.mjs
+++ b/scripts/ops/pr_stack_audit.test.mjs
@@ -1,0 +1,127 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import { buildPrStackAudit, renderMarkdown } from "./pr_stack_audit.mjs";
+import { validateJsonSchema } from "./validate_ops_artifacts.mjs";
+
+const repos = [
+  { id: "portal", label: "Portal", repo: "owner/portal" },
+  { id: "mission-control", label: "Mission Control", repo: "owner/mission-control" },
+];
+
+const fixture = {
+  repos: [
+    {
+      id: "portal",
+      label: "Portal",
+      repo: "owner/portal",
+      collection: { openStatus: "pass", mergedStatus: "pass", openError: "", mergedError: "" },
+      openPullRequests: [
+        {
+          number: 647,
+          title: "[ops] Show packet outcomes in PR readiness",
+          headRefName: "codex/ops-pr-readiness-packet-outcomes-wave2",
+          baseRefName: "codex/ops-packet-outcome-churn-wave2",
+          isDraft: true,
+          mergeStateStatus: "UNKNOWN",
+          updatedAt: "2026-05-07T16:55:00Z",
+          url: "https://example.test/pr/647",
+          author: { login: "codex" },
+        },
+        {
+          number: 646,
+          title: "[ops] Warn on packet outcome churn",
+          headRefName: "codex/ops-packet-outcome-churn-wave2",
+          baseRefName: "codex/ops-packet-outcome-report-wave2",
+          isDraft: true,
+          mergeStateStatus: "UNKNOWN",
+          updatedAt: "2026-05-07T16:40:00Z",
+          url: "https://example.test/pr/646",
+          author: { login: "codex" },
+        },
+        {
+          number: 552,
+          title: "chore(deps): bump ip-address",
+          headRefName: "dependabot/npm_and_yarn/studio-brain/ip-address-10.2.0",
+          baseRefName: "main",
+          isDraft: false,
+          mergeStateStatus: "BEHIND",
+          updatedAt: "2026-05-06T12:00:00Z",
+          url: "https://example.test/pr/552",
+          author: { login: "dependabot" },
+        },
+        {
+          number: 530,
+          title: "[codex] Add polished firing care preview site",
+          headRefName: "codex/firing-care-preview-copy-polish",
+          baseRefName: "main",
+          isDraft: true,
+          mergeStateStatus: "DIRTY",
+          updatedAt: "2026-05-04T12:00:00Z",
+          url: "https://example.test/pr/530",
+          author: { login: "codex" },
+        },
+      ],
+      recentlyMerged: [
+        {
+          number: 645,
+          title: "[ops] Refresh packet outcomes in wave runner",
+          headRefName: "codex/ops-wave-runner-packet-outcomes-wave2",
+          baseRefName: "codex/ops-packet-outcome-report-wave2",
+          mergedAt: "2026-05-07T16:45:00Z",
+          mergeCommit: { oid: "abc123" },
+          url: "https://example.test/pr/645",
+          author: { login: "codex" },
+        },
+      ],
+    },
+    {
+      id: "mission-control",
+      label: "Mission Control",
+      repo: "owner/mission-control",
+      collection: { openStatus: "pass", mergedStatus: "pass", openError: "", mergedError: "" },
+      openPullRequests: [],
+      recentlyMerged: [],
+    },
+  ],
+};
+
+test("buildPrStackAudit classifies current PR lanes and stack edges", () => {
+  const report = buildPrStackAudit(fixture, { generatedAt: "2026-05-07T17:00:00.000Z", runId: "test-pr-stack", repos, openLimit: 40 });
+
+  assert.equal(report.schema, "studiobrain-ops-pr-stack-audit.v1");
+  assert.equal(report.readOnly, true);
+  assert.equal(report.summary.open, 4);
+  assert.equal(report.summary.categories.stacked, 2);
+  assert.equal(report.summary.categories.dependency, 1);
+  assert.equal(report.summary.categories.conflict, 1);
+  assert.equal(report.repos[0].summary.openLimitReached, false);
+  assert.equal(report.stackEdges.length, 1);
+  assert.equal(report.stackEdges[0].basePr, 646);
+  assert.equal(report.stackEdges[0].childPr, 647);
+  assert.ok(report.warnings.some((warning) => warning.includes("dirty/conflicted")));
+  assert.ok(report.warnings.some((warning) => warning.includes("dependency PRs")));
+
+  const markdown = renderMarkdown(report);
+  assert.match(markdown, /Ops PR Stack Audit/);
+  assert.match(markdown, /#646/);
+  assert.match(markdown, /#647/);
+  assert.match(markdown, /Stacked Edges/);
+  assert.match(markdown, /dependency/);
+});
+
+test("buildPrStackAudit stays compatible with its JSON schema", () => {
+  const report = buildPrStackAudit(fixture, { generatedAt: "2026-05-07T17:00:00.000Z", runId: "test-pr-stack", repos, openLimit: 40 });
+  const schema = JSON.parse(readFileSync("schemas/ops/pr-stack-audit.v1.schema.json", "utf8"));
+
+  assert.deepEqual(validateJsonSchema(report, schema), []);
+});
+
+test("buildPrStackAudit warns when open PR collection reaches the configured limit", () => {
+  const report = buildPrStackAudit(fixture, { generatedAt: "2026-05-07T17:00:00.000Z", runId: "test-pr-stack", repos, openLimit: 4 });
+
+  assert.equal(report.status, "warn");
+  assert.equal(report.repos[0].summary.openLimitReached, true);
+  assert.ok(report.warnings.some((warning) => warning.includes("reached limit 4")));
+});

--- a/scripts/ops/validate_ops_artifacts.mjs
+++ b/scripts/ops/validate_ops_artifacts.mjs
@@ -59,6 +59,11 @@ const DEFAULT_ARTIFACTS = [
     schema: "schemas/ops/ops-wave-runner.v1.schema.json",
   },
   {
+    id: "pr-stack-audit",
+    artifact: "output/ops/pr-stack/pr-stack-audit-latest.json",
+    schema: "schemas/ops/pr-stack-audit.v1.schema.json",
+  },
+  {
     id: "pr-readiness-packet",
     artifact: "output/ops/pr-readiness/pr-readiness-latest.json",
     schema: "schemas/ops/pr-readiness-packet.v1.schema.json",


### PR DESCRIPTION
## Summary
- Add a read-only PR stack audit generator for portal and Mission Control PR metadata.
- Classify open PRs as stacked, dependency, draft, preview-only, conflicted, behind, ops, or open.
- Emit stack edges plus limit-saturation warnings to ignored JSON/Markdown under output/ops/pr-stack.
- Wire the artifact into schema validation, ops CI, Makefile, and ops docs.

## Evidence
- Slice 077 recorded as slice-20260507-077.
- Live generator wrote output/ops/pr-stack/pr-stack-audit-latest.json and warned that the portal open PR list hit limit 40.
- Artifact validation passed 13/13 with pr-stack-audit included.

## Testing
- node --check scripts/ops/pr_stack_audit.mjs
- node --test scripts/ops/pr_stack_audit.test.mjs
- node scripts/ops/pr_stack_audit.mjs --json --write
- node scripts/ops/validate_ops_artifacts.mjs --json --write
- bash scripts/ops/ops_ci_validate.sh
- git diff --check

## Risk
Low. GitHub metadata read-only; no merge, close, rebase, deploy, host, Docker, DB, package, firewall, SSH, sudoers, or secret actions.

## Rollback
Revert the commit and regenerate ignored output/ops artifacts if local latest files used this schema.

## Follow-ups
- Feed compact PR stack summaries into PR readiness or work-packet evidence.
- Add a merge-order view that groups complete stack chains when open-limit is large enough.