### PR TITLE
[ops] Surface next executable packet in readiness

### DIFF
--- a/schemas/ops/pr-readiness-packet.v1.schema.json
+++ b/schemas/ops/pr-readiness-packet.v1.schema.json
@@ -107,6 +107,26 @@
                 "additionalProperties": false
               }
             },
+            "nextExecutablePacket": {
+              "type": "object",
+              "required": ["status", "packetId", "title", "priority", "risk", "recommendedOwner", "safeNextStep", "suggestedBranchName", "suggestedPrTitle", "verification", "sourceSignalCount", "totalPackets", "approvalGatedCount"],
+              "properties": {
+                "status": { "type": "string" },
+                "packetId": { "type": "string" },
+                "title": { "type": "string" },
+                "priority": { "type": "string" },
+                "risk": { "type": "string" },
+                "recommendedOwner": { "type": "string" },
+                "safeNextStep": { "type": "string" },
+                "suggestedBranchName": { "type": "string" },
+                "suggestedPrTitle": { "type": "string" },
+                "verification": { "type": "array", "items": { "type": "string" } },
+                "sourceSignalCount": { "type": "number", "minimum": 0 },
+                "totalPackets": { "type": "number", "minimum": 0 },
+                "approvalGatedCount": { "type": "number", "minimum": 0 }
+              },
+              "additionalProperties": false
+            },
             "humanGates": { "type": "number", "minimum": 0 },
             "toolInstallNowCandidates": { "type": ["number", "null"], "minimum": 0 },
             "toolInstallApprovalRequired": { "type": ["number", "null"], "minimum": 0 },

--- a/scripts/ops/pr_readiness_packet.mjs
+++ b/scripts/ops/pr_readiness_packet.mjs
@@ -87,9 +87,47 @@ function summarizeArtifactValidation(report) {
   };
 }
 
+function emptyNextExecutablePacket() {
+  return {
+    status: "",
+    packetId: "",
+    title: "",
+    priority: "",
+    risk: "",
+    recommendedOwner: "",
+    safeNextStep: "",
+    suggestedBranchName: "",
+    suggestedPrTitle: "",
+    verification: [],
+    sourceSignalCount: 0,
+    totalPackets: 0,
+    approvalGatedCount: 0,
+  };
+}
+
+function summarizeNextExecutablePacket(packet) {
+  const next = packet?.nextExecutablePacket;
+  if (!next || typeof next !== "object") return emptyNextExecutablePacket();
+  return {
+    status: clean(next.status),
+    packetId: clean(next.packetId),
+    title: clean(next.title),
+    priority: clean(next.priority),
+    risk: clean(next.risk),
+    recommendedOwner: clean(next.recommendedOwner),
+    safeNextStep: clean(next.safeNextStep),
+    suggestedBranchName: clean(next.suggestedBranchName),
+    suggestedPrTitle: clean(next.suggestedPrTitle),
+    verification: Array.isArray(next.verification) ? next.verification.map(clean).filter(Boolean).slice(0, 3) : [],
+    sourceSignalCount: Number(next.sourceSignalCount) || 0,
+    totalPackets: Number(next.totalPackets) || 0,
+    approvalGatedCount: Number(next.approvalGatedCount) || 0,
+  };
+}
+
 function summarizeWorkPacket(packet) {
-  if (!packet) return { status: "missing", generatedAt: "", packets: 0, freshSources: 0, staleSources: 0, topPacket: "", readyPackets: 0, approvalGatedPackets: 0, topPackets: [], humanGates: 0, effectivityEvidenceLanes: null, effectivityApprovalRequiredLanes: null, effectivityHighSeverityLanes: null };
-  if (packet.status === "invalid_json") return { status: "invalid_json", generatedAt: "", packets: 0, freshSources: 0, staleSources: 0, topPacket: "", readyPackets: 0, approvalGatedPackets: 0, topPackets: [], humanGates: 0, effectivityEvidenceLanes: null, effectivityApprovalRequiredLanes: null, effectivityHighSeverityLanes: null, parseError: packet.parseError || "" };
+  if (!packet) return { status: "missing", generatedAt: "", packets: 0, freshSources: 0, staleSources: 0, topPacket: "", readyPackets: 0, approvalGatedPackets: 0, topPackets: [], nextExecutablePacket: emptyNextExecutablePacket(), humanGates: 0, effectivityEvidenceLanes: null, effectivityApprovalRequiredLanes: null, effectivityHighSeverityLanes: null };
+  if (packet.status === "invalid_json") return { status: "invalid_json", generatedAt: "", packets: 0, freshSources: 0, staleSources: 0, topPacket: "", readyPackets: 0, approvalGatedPackets: 0, topPackets: [], nextExecutablePacket: emptyNextExecutablePacket(), humanGates: 0, effectivityEvidenceLanes: null, effectivityApprovalRequiredLanes: null, effectivityHighSeverityLanes: null, parseError: packet.parseError || "" };
   const packets = Array.isArray(packet.packets) ? packet.packets : [];
   return {
     status: packets.length > 0 ? "present" : "empty",
@@ -106,6 +144,7 @@ function summarizeWorkPacket(packet) {
       status: clean(entry.status),
       priority: clean(entry.priority),
     })),
+    nextExecutablePacket: summarizeNextExecutablePacket(packet),
     humanGates: packets.filter((entry) => clean(entry.humanGate)).length,
     toolInstallNowCandidates: packet.evidenceSummary?.toolInstallNowCandidates ?? null,
     toolInstallApprovalRequired: packet.evidenceSummary?.toolInstallApprovalRequired ?? null,
@@ -336,6 +375,8 @@ function renderMarkdown(packet) {
   const topPackets = packet.evidence.workPacket.topPackets
     .map((item) => `- ${item.priority || "P?"} ${item.status || "unknown"} ${item.packetId || ""}: ${item.title}`)
     .join("\n") || "- None recorded.";
+  const nextPacket = packet.evidence.workPacket.nextExecutablePacket;
+  const nextPacketVerification = nextPacket.verification.map((item) => `- ${item}`).join("\n") || "- None recorded.";
   const outcomeCommand = packet.outcomeLedger.recordCommand
     ? `\`${packet.outcomeLedger.recordCommand}\``
     : "Pass `--packet-id <ops-wp-id>` to include a ready-to-run outcome command.";
@@ -378,6 +419,22 @@ ${dirtyFiles}
 ## Work Packet Window
 
 ${topPackets}
+
+## Next Executable Packet
+
+- Status: ${nextPacket.status || ""}
+- Packet ID: ${nextPacket.packetId || ""}
+- Title: ${nextPacket.title || ""}
+- Priority: ${nextPacket.priority || ""}
+- Owner: ${nextPacket.recommendedOwner || ""}
+- Safe next step: ${nextPacket.safeNextStep || ""}
+- Branch: ${nextPacket.suggestedBranchName || ""}
+- PR title: ${nextPacket.suggestedPrTitle || ""}
+- Source signals: ${nextPacket.sourceSignalCount}
+
+### Next Packet Verification
+
+${nextPacketVerification}
 
 ## Outcome Ledger
 

--- a/scripts/ops/pr_readiness_packet.test.mjs
+++ b/scripts/ops/pr_readiness_packet.test.mjs
@@ -37,6 +37,21 @@ const workPacket = {
     { packetId: "ops-wp-ready", title: "[ops] Refresh evidence", status: "ready", priority: "P1", humanGate: "" },
     { packetId: "ops-wp-gated", title: "[backup] Restore drill", status: "approval_gated", priority: "P0", humanGate: "human approval" },
   ],
+  nextExecutablePacket: {
+    status: "ready",
+    packetId: "ops-wp-ready",
+    title: "[ops] Refresh evidence",
+    priority: "P1",
+    risk: "low",
+    recommendedOwner: "Codex",
+    safeNextStep: "Run the evidence refresh.",
+    suggestedBranchName: "codex/ops-refresh-evidence",
+    suggestedPrTitle: "[ops] Refresh evidence",
+    verification: ["Rerun packet generation", "Validate artifacts"],
+    sourceSignalCount: 4,
+    totalPackets: 2,
+    approvalGatedCount: 1,
+  },
 };
 
 const waveRunner = {
@@ -109,6 +124,9 @@ test("buildPrReadinessPacket summarizes current evidence without executable inst
   assert.equal(packet.evidence.workPacket.freshSources, 5);
   assert.equal(packet.evidence.workPacket.readyPackets, 1);
   assert.equal(packet.evidence.workPacket.approvalGatedPackets, 1);
+  assert.equal(packet.evidence.workPacket.nextExecutablePacket.packetId, "ops-wp-ready");
+  assert.equal(packet.evidence.workPacket.nextExecutablePacket.suggestedBranchName, "codex/ops-refresh-evidence");
+  assert.equal(packet.evidence.workPacket.nextExecutablePacket.verification.length, 2);
   assert.equal(packet.evidence.packetOutcome.status, "pass");
   assert.equal(packet.evidence.packetOutcome.total, 2);
   assert.equal(packet.evidence.sliceLedger.requestedCoverage.status, "covered");
@@ -128,9 +146,12 @@ test("buildPrReadinessPacket summarizes current evidence without executable inst
   const markdown = renderMarkdown(packet);
   assert.match(markdown, /Tool Recommendation Summary/);
   assert.match(markdown, /Work Packet Window/);
+  assert.match(markdown, /Next Executable Packet/);
   assert.match(markdown, /Outcome Ledger/);
   assert.match(markdown, /Packet outcomes/);
   assert.match(markdown, /ops-wp-ready/);
+  assert.match(markdown, /Run the evidence refresh/);
+  assert.match(markdown, /codex\/ops-refresh-evidence/);
   assert.match(markdown, /--record-outcome ops-wp-ready/);
   assert.match(markdown, /workPacketMaxPackets=8/);
   assert.match(markdown, /ready=1/);


### PR DESCRIPTION
## Summary
- carry `nextExecutablePacket` from the work-packet artifact into PR readiness evidence
- render a dedicated Next Executable Packet section in the readiness Markdown
- keep install commands out of readiness output while showing branch, PR title, safe next step, and verification

## Evidence
- slice recorded: slice-20260507-086
- generated readiness packet includes next executable packet `ops-wp-cb60e9ffe9fa` from latest work-packet evidence
- artifact validation passed 13/13 with the refreshed PR readiness artifact
- full ops CI smoke passed

## Testing
- `node --check scripts/ops/pr_readiness_packet.mjs`
- `node --test scripts/ops/pr_readiness_packet.test.mjs`
- `node scripts/ops/pr_readiness_packet.mjs --json --write --slice-ids slice-20260507-086`
- `node scripts/ops/validate_ops_artifacts.mjs --json --write`
- `bash scripts/ops/ops_ci_validate.sh`
- `git diff --check`

## Risk / Rollback
Low risk: additive readiness evidence and Markdown rendering. Roll back with a normal git revert and regenerate ignored readiness artifacts.