### PR TITLE
[ops] Add PR stack merge readiness

### DIFF
--- a/schemas/ops/pr-stack-audit.v1.schema.json
+++ b/schemas/ops/pr-stack-audit.v1.schema.json
@@ -12,6 +12,7 @@
     "purpose",
     "repos",
     "stackEdges",
+    "mergePlan",
     "summary",
     "warnings",
     "operatorNotes"
@@ -59,6 +60,7 @@
                 "updatedAt",
                 "author",
                 "category",
+                "mergeReadiness",
                 "recommendedDisposition"
               ],
               "properties": {
@@ -73,6 +75,16 @@
                 "updatedAt": { "type": "string" },
                 "author": { "type": "string" },
                 "category": { "type": "string" },
+                "mergeReadiness": {
+                  "type": "object",
+                  "required": ["status", "blockers", "baseDependencyPr"],
+                  "properties": {
+                    "status": { "enum": ["ready", "blocked"] },
+                    "blockers": { "type": "array", "items": { "type": "string" } },
+                    "baseDependencyPr": { "type": ["number", "null"] }
+                  },
+                  "additionalProperties": false
+                },
                 "recommendedDisposition": { "type": "string" }
               },
               "additionalProperties": false
@@ -135,9 +147,52 @@
         "additionalProperties": false
       }
     },
+    "mergePlan": {
+      "type": "object",
+      "required": ["status", "nextMergeCandidate", "mergeOrder", "blockedCount", "readyCount"],
+      "properties": {
+        "status": { "enum": ["candidate_ready", "blocked", "empty"] },
+        "nextMergeCandidate": {
+          "type": ["object", "null"],
+          "required": ["repoId", "number", "title", "url", "headRefName", "baseRefName"],
+          "properties": {
+            "repoId": { "type": "string" },
+            "number": { "type": "number" },
+            "title": { "type": "string" },
+            "url": { "type": "string" },
+            "headRefName": { "type": "string" },
+            "baseRefName": { "type": "string" }
+          },
+          "additionalProperties": false
+        },
+        "mergeOrder": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["repoId", "order", "number", "title", "url", "headRefName", "baseRefName", "category", "status", "blockers"],
+            "properties": {
+              "repoId": { "type": "string" },
+              "order": { "type": "number", "minimum": 1 },
+              "number": { "type": "number" },
+              "title": { "type": "string" },
+              "url": { "type": "string" },
+              "headRefName": { "type": "string" },
+              "baseRefName": { "type": "string" },
+              "category": { "type": "string" },
+              "status": { "enum": ["ready", "blocked"] },
+              "blockers": { "type": "array", "items": { "type": "string" } }
+            },
+            "additionalProperties": false
+          }
+        },
+        "blockedCount": { "type": "number", "minimum": 0 },
+        "readyCount": { "type": "number", "minimum": 0 }
+      },
+      "additionalProperties": false
+    },
     "summary": {
       "type": "object",
-      "required": ["repos", "open", "recentlyMerged", "categories", "warnings"],
+      "required": ["repos", "open", "recentlyMerged", "categories", "warnings", "mergeReady", "mergeBlocked"],
       "properties": {
         "repos": { "type": "number", "minimum": 0 },
         "open": { "type": "number", "minimum": 0 },
@@ -146,7 +201,9 @@
           "type": "object",
           "additionalProperties": { "type": "number", "minimum": 0 }
         },
-        "warnings": { "type": "number", "minimum": 0 }
+        "warnings": { "type": "number", "minimum": 0 },
+        "mergeReady": { "type": "number", "minimum": 0 },
+        "mergeBlocked": { "type": "number", "minimum": 0 }
       },
       "additionalProperties": false
     },

--- a/scripts/ops/pr_stack_audit.mjs
+++ b/scripts/ops/pr_stack_audit.mjs
@@ -219,6 +219,35 @@ function dispositionFor(pr, category) {
   return "Review scope and checks before deciding merge order.";
 }
 
+function mergeStateBlocker(mergeStateStatus) {
+  const state = clean(mergeStateStatus).toUpperCase();
+  if (!state) return "merge_state_unknown";
+  if (state === "CLEAN" || state === "HAS_HOOKS") return "";
+  if (state === "DIRTY") return "merge_conflict";
+  if (state === "BEHIND") return "behind_base";
+  if (state === "BLOCKED") return "blocked_by_policy";
+  if (state === "UNKNOWN") return "merge_state_unknown";
+  return `merge_state_${state.toLowerCase()}`;
+}
+
+function mergeReadinessFor(pr, category, openByHead = new Map()) {
+  const blockers = [];
+  const baseDependency = openByHead.get(clean(pr.baseRefName)) || null;
+  const stateBlocker = mergeStateBlocker(pr.mergeStateStatus);
+  if (pr.isDraft) blockers.push("draft");
+  if (stateBlocker) blockers.push(stateBlocker);
+  if (baseDependency) blockers.push(`base_pr_open:#${baseDependency.number}`);
+  if (category === "dependency") blockers.push("dependency_lane");
+  if (category === "preview_draft") blockers.push("preview_owner_gate");
+  if (category === "conflict" && !blockers.includes("merge_conflict")) blockers.push("merge_conflict");
+  if (category === "behind" && !blockers.includes("behind_base")) blockers.push("behind_base");
+  return {
+    status: blockers.length === 0 ? "ready" : "blocked",
+    blockers: Array.from(new Set(blockers)),
+    baseDependencyPr: baseDependency ? Number(baseDependency.number) : null,
+  };
+}
+
 function normalizeOpenPr(pr, repoId) {
   const category = categoryFor(pr);
   return {
@@ -235,6 +264,14 @@ function normalizeOpenPr(pr, repoId) {
     category,
     recommendedDisposition: dispositionFor(pr, category),
   };
+}
+
+function attachMergeReadiness(openPullRequests) {
+  const openByHead = new Map(openPullRequests.map((pr) => [pr.headRefName, pr]));
+  return openPullRequests.map((pr) => ({
+    ...pr,
+    mergeReadiness: mergeReadinessFor(pr, pr.category, openByHead),
+  }));
 }
 
 function normalizeMergedPr(pr, repoId) {
@@ -264,6 +301,66 @@ function stackEdges(openPrs) {
     }));
 }
 
+function mergeOrderForRepo(openPrs) {
+  const byHead = new Map(openPrs.map((pr) => [pr.headRefName, pr]));
+  const childrenByBase = new Map();
+  for (const pr of openPrs) {
+    if (!byHead.has(pr.baseRefName)) continue;
+    const children = childrenByBase.get(pr.baseRefName) || [];
+    children.push(pr);
+    childrenByBase.set(pr.baseRefName, children);
+  }
+  const roots = openPrs
+    .filter((pr) => !byHead.has(pr.baseRefName))
+    .sort((left, right) => Number(left.number) - Number(right.number));
+  const order = [];
+  const seen = new Set();
+  function visit(pr) {
+    if (!pr || seen.has(pr.number)) return;
+    seen.add(pr.number);
+    order.push(pr);
+    const children = (childrenByBase.get(pr.headRefName) || []).sort((left, right) => Number(left.number) - Number(right.number));
+    for (const child of children) visit(child);
+  }
+  for (const root of roots) visit(root);
+  for (const pr of [...openPrs].sort((left, right) => Number(left.number) - Number(right.number))) visit(pr);
+  return order;
+}
+
+function mergePlanForRepos(repos) {
+  const mergeOrder = repos.flatMap((repo) =>
+    mergeOrderForRepo(repo.openPullRequests).map((pr, index) => ({
+      repoId: repo.id,
+      order: index + 1,
+      number: pr.number,
+      title: pr.title,
+      url: pr.url,
+      headRefName: pr.headRefName,
+      baseRefName: pr.baseRefName,
+      category: pr.category,
+      status: pr.mergeReadiness.status,
+      blockers: pr.mergeReadiness.blockers,
+    })),
+  );
+  const next = mergeOrder.find((item) => item.status === "ready") || null;
+  return {
+    status: next ? "candidate_ready" : mergeOrder.length > 0 ? "blocked" : "empty",
+    nextMergeCandidate: next
+      ? {
+          repoId: next.repoId,
+          number: next.number,
+          title: next.title,
+          url: next.url,
+          headRefName: next.headRefName,
+          baseRefName: next.baseRefName,
+        }
+      : null,
+    mergeOrder,
+    blockedCount: mergeOrder.filter((item) => item.status === "blocked").length,
+    readyCount: mergeOrder.filter((item) => item.status === "ready").length,
+  };
+}
+
 function countBy(items, field) {
   return items.reduce((acc, item) => {
     const key = clean(item[field]) || "unknown";
@@ -276,7 +373,7 @@ function buildPrStackAudit(inputs = {}, options = {}) {
   const generatedAt = clean(options.generatedAt) || nowIso();
   const repos = (options.repos || DEFAULT_REPOS).map((repoConfig) => {
     const source = inputs.repos?.find((entry) => entry.id === repoConfig.id) || collectRepo(repoConfig, options);
-    const openPullRequests = source.openPullRequests.map((pr) => normalizeOpenPr(pr, source.id));
+    const openPullRequests = attachMergeReadiness(source.openPullRequests.map((pr) => normalizeOpenPr(pr, source.id)));
     const recentlyMerged = source.recentlyMerged.map((pr) => normalizeMergedPr(pr, source.id));
     const openLimit = Number.isFinite(options.openLimit) ? options.openLimit : null;
     return {
@@ -298,6 +395,7 @@ function buildPrStackAudit(inputs = {}, options = {}) {
   });
   const allOpen = repos.flatMap((repo) => repo.openPullRequests);
   const allMerged = repos.flatMap((repo) => repo.recentlyMerged);
+  const mergePlan = mergePlanForRepos(repos);
   const collectionWarnings = repos.flatMap((repo) => [
     repo.collection.openStatus !== "pass" ? `${repo.id} open PR collection: ${repo.collection.openError || repo.collection.openStatus}` : "",
     repo.collection.mergedStatus !== "pass" ? `${repo.id} merged PR collection: ${repo.collection.mergedError || repo.collection.mergedStatus}` : "",
@@ -318,12 +416,15 @@ function buildPrStackAudit(inputs = {}, options = {}) {
     purpose: "Inventory open ops-adjacent PRs, stacked branches, stale drafts, and recently merged PRs without mutating GitHub state.",
     repos,
     stackEdges: stackEdges(allOpen),
+    mergePlan,
     summary: {
       repos: repos.length,
       open: allOpen.length,
       recentlyMerged: allMerged.length,
       categories: countBy(allOpen, "category"),
       warnings: warnings.length,
+      mergeReady: mergePlan.readyCount,
+      mergeBlocked: mergePlan.blockedCount,
     },
     warnings,
     operatorNotes: [
@@ -336,10 +437,16 @@ function buildPrStackAudit(inputs = {}, options = {}) {
 
 function renderMarkdown(report) {
   const warnings = report.warnings.map((warning) => `- ${warning}`).join("\n") || "- None.";
+  const nextMerge = report.mergePlan.nextMergeCandidate
+    ? `[#${report.mergePlan.nextMergeCandidate.number}](${report.mergePlan.nextMergeCandidate.url}) ${report.mergePlan.nextMergeCandidate.headRefName} -> ${report.mergePlan.nextMergeCandidate.baseRefName}`
+    : "None.";
+  const mergeRows = report.mergePlan.mergeOrder.map((item) =>
+    `| ${item.order} | ${item.repoId} | [#${item.number}](${item.url}) | ${item.headRefName} | ${item.baseRefName} | ${item.status} | ${item.blockers.join(", ") || ""} |`,
+  ).join("\n") || "|  |  | _none_ |  |  |  |  |";
   const repoSections = report.repos.map((repo) => {
     const openRows = repo.openPullRequests.map((pr) =>
-      `| [#${pr.number}](${pr.url}) | ${pr.headRefName} | ${pr.baseRefName} | ${pr.isDraft ? "yes" : "no"} | ${pr.mergeStateStatus || ""} | ${pr.category} | ${pr.recommendedDisposition} |`,
-    ).join("\n") || "| _none_ |  |  |  |  |  |  |";
+      `| [#${pr.number}](${pr.url}) | ${pr.headRefName} | ${pr.baseRefName} | ${pr.isDraft ? "yes" : "no"} | ${pr.mergeStateStatus || ""} | ${pr.category} | ${pr.mergeReadiness.status} | ${pr.mergeReadiness.blockers.join(", ") || ""} | ${pr.recommendedDisposition} |`,
+    ).join("\n") || "| _none_ |  |  |  |  |  |  |  |  |";
     const mergedRows = repo.recentlyMerged.slice(0, 8).map((pr) =>
       `| [#${pr.number}](${pr.url}) | ${pr.title} | ${pr.mergeCommit || ""} | ${pr.mergedAt || ""} |`,
     ).join("\n") || "| _none_ |  |  |  |";
@@ -353,8 +460,8 @@ function renderMarkdown(report) {
 
 ### Open PRs
 
-| PR | Head | Base | Draft | Merge state | Category | Recommended disposition |
-| --- | --- | --- | --- | --- | --- | --- |
+| PR | Head | Base | Draft | Merge state | Category | Readiness | Blockers | Recommended disposition |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
 ${openRows}
 
 ### Recently Merged
@@ -379,6 +486,17 @@ Run ID: ${report.runId}
 - Open PRs: ${report.summary.open}
 - Recently merged captured: ${report.summary.recentlyMerged}
 - Categories: ${JSON.stringify(report.summary.categories)}
+- Merge ready: ${report.summary.mergeReady}
+- Merge blocked: ${report.summary.mergeBlocked}
+
+## Merge Readiness
+
+- Status: ${report.mergePlan.status}
+- Next merge candidate: ${nextMerge}
+
+| Order | Repo | PR | Head | Base | Status | Blockers |
+| --- | --- | --- | --- | --- | --- | --- |
+${mergeRows}
 
 ## Warnings
 

--- a/scripts/ops/pr_stack_audit.test.mjs
+++ b/scripts/ops/pr_stack_audit.test.mjs
@@ -100,6 +100,11 @@ test("buildPrStackAudit classifies current PR lanes and stack edges", () => {
   assert.equal(report.stackEdges.length, 1);
   assert.equal(report.stackEdges[0].basePr, 646);
   assert.equal(report.stackEdges[0].childPr, 647);
+  assert.equal(report.mergePlan.status, "blocked");
+  assert.equal(report.mergePlan.readyCount, 0);
+  assert.equal(report.mergePlan.blockedCount, 4);
+  assert.equal(report.repos[0].openPullRequests[0].mergeReadiness.baseDependencyPr, 646);
+  assert.ok(report.repos[0].openPullRequests[0].mergeReadiness.blockers.includes("base_pr_open:#646"));
   assert.ok(report.warnings.some((warning) => warning.includes("dirty/conflicted")));
   assert.ok(report.warnings.some((warning) => warning.includes("dependency PRs")));
 
@@ -108,7 +113,32 @@ test("buildPrStackAudit classifies current PR lanes and stack edges", () => {
   assert.match(markdown, /#646/);
   assert.match(markdown, /#647/);
   assert.match(markdown, /Stacked Edges/);
+  assert.match(markdown, /Merge Readiness/);
+  assert.match(markdown, /base_pr_open:#646/);
   assert.match(markdown, /dependency/);
+});
+
+test("buildPrStackAudit exposes the next clean merge candidate", () => {
+  const cleanFixture = structuredClone(fixture);
+  cleanFixture.repos[0].openPullRequests.push({
+    number: 660,
+    title: "[ops] Ready small diagnostics",
+    headRefName: "codex/ops-ready-diagnostics",
+    baseRefName: "main",
+    isDraft: false,
+    mergeStateStatus: "CLEAN",
+    updatedAt: "2026-05-07T17:00:00Z",
+    url: "https://example.test/pr/660",
+    author: { login: "codex" },
+  });
+
+  const report = buildPrStackAudit(cleanFixture, { generatedAt: "2026-05-07T17:00:00.000Z", runId: "test-pr-stack", repos, openLimit: 40 });
+
+  assert.equal(report.mergePlan.status, "candidate_ready");
+  assert.equal(report.mergePlan.readyCount, 1);
+  assert.equal(report.mergePlan.nextMergeCandidate.number, 660);
+  assert.equal(report.mergePlan.nextMergeCandidate.headRefName, "codex/ops-ready-diagnostics");
+  assert.match(renderMarkdown(report), /Next merge candidate: \[#660\]/);
 });
 
 test("buildPrStackAudit stays compatible with its JSON schema", () => {


### PR DESCRIPTION
## Summary
- add per-PR merge-readiness blockers to the PR stack audit
- add a bottom-up merge order and next merge candidate summary
- render merge readiness in the Markdown artifact without mutating GitHub state

## Evidence
- slice recorded: slice-20260507-087
- live PR stack audit captured 41 open PRs, `mergePlan.status = blocked`, `ready = 0`, `blocked = 41`, next candidate `null`
- artifact validation passed 13/13 with refreshed PR stack audit artifact
- full ops CI smoke passed

## Testing
- `node --check scripts/ops/pr_stack_audit.mjs`
- `node --test scripts/ops/pr_stack_audit.test.mjs`
- `node scripts/ops/pr_stack_audit.mjs --json --write`
- `node scripts/ops/validate_ops_artifacts.mjs --json --write`
- `bash scripts/ops/ops_ci_validate.sh`
- `git diff --check`

## Risk / Rollback
Low risk: read-only GitHub metadata summarization only. Roll back with a normal git revert and regenerate ignored PR stack artifacts.