### PR TITLE
[ops] Add admin effectivity trend report

### DIFF
--- a/docs/ops/admin-effectivity-loop.md
+++ b/docs/ops/admin-effectivity-loop.md
@@ -127,6 +127,7 @@ Use `node scripts/ops/packet_outcome_report.mjs --json --write` for a compact op
 - `workPacketOutcomeHealth`: 1 when the latest work-packet report is fresh and its outcome ledger is clean or still warming up; 0.4 when mature outcomes show too many stale/misleading packets; 0.6 when blocked packet outcomes need triage.
 
 The audit fails if required tools are missing or a slice failed. It warns when no slices are recorded, no-op rate is high, the underlying ops effectivity report cannot run, or the latest work-packet outcome health is degraded.
+Use `node scripts/ops/admin_effectivity_trend.mjs --json --write --limit 10` after checkpoint audits to compare recent five-slice windows. The trend report is read-only and highlights usefulness/no-op movement, tool freshness drift, work-packet outcome health drift, and the latest audit status.
 
 ## Blocker Classes
 

--- a/schemas/ops/admin-effectivity-trend.v1.schema.json
+++ b/schemas/ops/admin-effectivity-trend.v1.schema.json
@@ -1,0 +1,101 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://studio-brain.local/schemas/ops/admin-effectivity-trend.v1.schema.json",
+  "title": "Studio Brain Admin Effectivity Trend v1",
+  "type": "object",
+  "required": ["schema", "generatedAt", "runId", "status", "readOnly", "sources", "summary", "trend", "warnings", "audits"],
+  "properties": {
+    "schema": { "const": "studiobrain-admin-effectivity-trend.v1" },
+    "generatedAt": { "type": "string", "format": "date-time" },
+    "runId": { "type": "string" },
+    "status": { "enum": ["pass", "warn"] },
+    "readOnly": { "const": true },
+    "sources": {
+      "type": "object",
+      "required": ["auditDir", "limit", "artifactsConsidered", "auditsIncluded"],
+      "properties": {
+        "auditDir": { "type": "string" },
+        "limit": { "type": "number", "minimum": 1 },
+        "artifactsConsidered": { "type": "number", "minimum": 0 },
+        "auditsIncluded": { "type": "number", "minimum": 0 }
+      },
+      "additionalProperties": false
+    },
+    "summary": {
+      "type": "object",
+      "required": ["audits", "latestStatus", "statusCounts", "averageUsefulness", "averageVerification", "averageNoOpRate", "toolFreshnessPassRate", "workPacketOutcomePassRate"],
+      "properties": {
+        "audits": { "type": "number", "minimum": 0 },
+        "latestStatus": { "type": "string" },
+        "statusCounts": {
+          "type": "object",
+          "additionalProperties": { "type": "number", "minimum": 0 }
+        },
+        "averageUsefulness": { "type": ["number", "null"] },
+        "averageVerification": { "type": ["number", "null"] },
+        "averageNoOpRate": { "type": ["number", "null"] },
+        "toolFreshnessPassRate": { "type": ["number", "null"] },
+        "workPacketOutcomePassRate": { "type": ["number", "null"] }
+      },
+      "additionalProperties": false
+    },
+    "trend": {
+      "type": "object",
+      "required": ["fromGeneratedAt", "toGeneratedAt", "fromSlice", "toSlice", "usefulnessDelta", "verificationDelta", "noOpRateDelta", "toolInventoryFreshnessDelta", "workPacketOutcomeHealthDelta"],
+      "properties": {
+        "fromGeneratedAt": { "type": "string" },
+        "toGeneratedAt": { "type": "string" },
+        "fromSlice": { "type": "string" },
+        "toSlice": { "type": "string" },
+        "usefulnessDelta": { "type": ["number", "null"] },
+        "verificationDelta": { "type": ["number", "null"] },
+        "noOpRateDelta": { "type": ["number", "null"] },
+        "toolInventoryFreshnessDelta": { "type": ["number", "null"] },
+        "workPacketOutcomeHealthDelta": { "type": ["number", "null"] }
+      },
+      "additionalProperties": false
+    },
+    "warnings": { "type": "array", "items": { "type": "string" } },
+    "audits": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["artifact", "generatedAt", "runId", "status", "sliceWindow", "scores"],
+        "properties": {
+          "artifact": { "type": "string" },
+          "generatedAt": { "type": "string" },
+          "runId": { "type": "string" },
+          "status": { "type": "string" },
+          "sliceWindow": {
+            "type": "object",
+            "required": ["from", "to", "count"],
+            "properties": {
+              "from": { "type": "string" },
+              "to": { "type": "string" },
+              "count": { "type": "number", "minimum": 0 }
+            },
+            "additionalProperties": false
+          },
+          "scores": {
+            "type": "object",
+            "required": ["usefulness", "verification", "noOpRate", "blockedLaneClarity", "toolInventoryFreshness", "workPacketOutcomeHealth"],
+            "properties": {
+              "usefulness": { "type": ["number", "null"] },
+              "verification": { "type": ["number", "null"] },
+              "noOpRate": { "type": ["number", "null"] },
+              "blockedLaneClarity": { "type": ["number", "null"] },
+              "toolInventoryFreshness": { "type": ["number", "null"] },
+              "workPacketOutcomeHealth": { "type": ["number", "null"] }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "artifactPath": { "type": "string" },
+    "markdownPath": { "type": "string" },
+    "artifacts": { "type": "object" }
+  },
+  "additionalProperties": false
+}

--- a/scripts/ops/admin_effectivity_trend.mjs
+++ b/scripts/ops/admin_effectivity_trend.mjs
@@ -1,0 +1,324 @@
+#!/usr/bin/env node
+
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const REPO_ROOT = resolve(dirname(__filename), "..", "..");
+const DEFAULT_AUDIT_DIR = resolve(REPO_ROOT, "output", "ops", "effectivity");
+const DEFAULT_OUTPUT_DIR = DEFAULT_AUDIT_DIR;
+
+function clean(value) {
+  return String(value ?? "").replace(/\r/g, "").trim();
+}
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function repoRelative(path) {
+  return relative(REPO_ROOT, resolve(REPO_ROOT, path)).replace(/\\/g, "/");
+}
+
+function usage() {
+  return `Studio Brain admin effectivity trend
+
+Usage:
+  node scripts/ops/admin_effectivity_trend.mjs [--json] [--write]
+
+Options:
+  --json              Print JSON report.
+  --write             Write timestamped JSON/Markdown and latest artifacts.
+  --audit-dir <path>  Directory containing admin-effectivity audit JSON artifacts.
+  --output-dir <path> Artifact directory. Default: output/ops/effectivity.
+  --limit <number>    Number of recent audits to trend. Default: 10.
+  --run-id <id>       Stable run id. Default: admin-effectivity-trend timestamp.
+`;
+}
+
+function readFlagValue(argv, index, name) {
+  const arg = argv[index];
+  if (arg === name) {
+    if (!argv[index + 1]) throw new Error(`${name} requires a value.`);
+    return { matched: true, value: argv[index + 1], nextIndex: index + 1 };
+  }
+  if (arg.startsWith(`${name}=`)) {
+    return { matched: true, value: arg.slice(name.length + 1), nextIndex: index };
+  }
+  return { matched: false, value: "", nextIndex: index };
+}
+
+function parseArgs(argv = process.argv.slice(2)) {
+  const options = {
+    json: false,
+    write: false,
+    auditDir: DEFAULT_AUDIT_DIR,
+    outputDir: DEFAULT_OUTPUT_DIR,
+    limit: 10,
+    runId: "",
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--help" || arg === "-h") {
+      process.stdout.write(usage());
+      process.exit(0);
+    }
+    if (arg === "--json") {
+      options.json = true;
+      continue;
+    }
+    if (arg === "--write") {
+      options.write = true;
+      continue;
+    }
+    const mappings = [
+      ["--audit-dir", "auditDir"],
+      ["--output-dir", "outputDir"],
+      ["--limit", "limit"],
+      ["--run-id", "runId"],
+    ];
+    let consumed = false;
+    for (const [flag, key] of mappings) {
+      const parsed = readFlagValue(argv, index, flag);
+      if (!parsed.matched) continue;
+      options[key] = parsed.value;
+      index = parsed.nextIndex;
+      consumed = true;
+      break;
+    }
+    if (consumed) continue;
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+  options.auditDir = resolve(REPO_ROOT, options.auditDir);
+  options.outputDir = resolve(REPO_ROOT, options.outputDir);
+  options.limit = Math.max(1, Number(options.limit) || 10);
+  return options;
+}
+
+function safeNumber(value, fallback = null) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : fallback;
+}
+
+function readAuditArtifacts(auditDir = DEFAULT_AUDIT_DIR) {
+  if (!existsSync(auditDir)) return [];
+  const rows = [];
+  for (const name of readdirSync(auditDir)) {
+    if (!/^admin-effectivity.*\.json$/i.test(name)) continue;
+    if (/trend/i.test(name)) continue;
+    const path = resolve(auditDir, name);
+    try {
+      const audit = JSON.parse(readFileSync(path, "utf8"));
+      if (audit?.schema !== "studiobrain-admin-effectivity-audit.v1") continue;
+      rows.push({
+        artifact: repoRelative(path),
+        audit,
+      });
+    } catch {
+      rows.push({
+        artifact: repoRelative(path),
+        audit: {
+          schema: "studiobrain-admin-effectivity-audit.v1",
+          generatedAt: "",
+          runId: name,
+          status: "invalid_json",
+          scores: {},
+          sliceWindow: { from: "", to: "", count: 0 },
+        },
+      });
+    }
+  }
+  const byIdentity = new Map();
+  for (const row of rows) {
+    const key = `${clean(row.audit.runId)}|${clean(row.audit.generatedAt)}`;
+    const prior = byIdentity.get(key);
+    if (!prior || /latest/i.test(prior.artifact)) byIdentity.set(key, row);
+  }
+  return Array.from(byIdentity.values())
+    .sort((left, right) => clean(left.audit.generatedAt).localeCompare(clean(right.audit.generatedAt)));
+}
+
+function average(values) {
+  const numbers = values.map((value) => safeNumber(value)).filter((value) => value !== null);
+  if (numbers.length === 0) return null;
+  return Number((numbers.reduce((sum, value) => sum + value, 0) / numbers.length).toFixed(3));
+}
+
+function statusCounts(audits) {
+  return audits.reduce((counts, row) => {
+    const status = clean(row.status) || "unknown";
+    counts[status] = (counts[status] || 0) + 1;
+    return counts;
+  }, {});
+}
+
+function pickScores(audit) {
+  return {
+    usefulness: safeNumber(audit?.scores?.usefulness),
+    verification: safeNumber(audit?.scores?.verification),
+    noOpRate: safeNumber(audit?.scores?.noOpRate),
+    blockedLaneClarity: safeNumber(audit?.scores?.blockedLaneClarity),
+    toolInventoryFreshness: safeNumber(audit?.scores?.toolInventoryFreshness),
+    workPacketOutcomeHealth: safeNumber(audit?.scores?.workPacketOutcomeHealth),
+  };
+}
+
+function trendDelta(first, latest, key) {
+  const left = safeNumber(first?.scores?.[key]);
+  const right = safeNumber(latest?.scores?.[key]);
+  if (left === null || right === null) return null;
+  return Number((right - left).toFixed(3));
+}
+
+function buildTrendReport(inputAudits = [], options = {}) {
+  const generatedAt = clean(options.generatedAt) || nowIso();
+  const runId = clean(options.runId) || `admin-effectivity-trend-${generatedAt.replace(/[-:]/g, "").replace(/\.\d+Z$/, "Z")}`;
+  const limit = Math.max(1, Number(options.limit) || 10);
+  const selected = inputAudits.slice(-limit).map((row) => ({
+    artifact: clean(row.artifact),
+    generatedAt: clean(row.audit?.generatedAt),
+    runId: clean(row.audit?.runId),
+    status: clean(row.audit?.status) || "unknown",
+    sliceWindow: {
+      from: clean(row.audit?.sliceWindow?.from),
+      to: clean(row.audit?.sliceWindow?.to),
+      count: safeNumber(row.audit?.sliceWindow?.count, 0),
+    },
+    scores: pickScores(row.audit),
+  }));
+  const first = selected[0] || null;
+  const latest = selected[selected.length - 1] || null;
+  const warnings = [];
+  if (selected.length === 0) warnings.push("no admin effectivity audit artifacts found");
+  if (latest && latest.status !== "pass") warnings.push(`latest audit status is ${latest.status}`);
+  if (latest?.scores?.toolInventoryFreshness !== null && latest.scores.toolInventoryFreshness < 1) warnings.push("latest tool inventory freshness is below pass threshold");
+  if (latest?.scores?.workPacketOutcomeHealth !== null && latest.scores.workPacketOutcomeHealth < 1) warnings.push("latest work-packet outcome health is below pass threshold");
+  const usefulnessDelta = trendDelta(first, latest, "usefulness");
+  const noOpDelta = trendDelta(first, latest, "noOpRate");
+  if (usefulnessDelta !== null && usefulnessDelta < -0.1) warnings.push(`usefulness declined by ${Math.abs(usefulnessDelta).toFixed(3)}`);
+  if (noOpDelta !== null && noOpDelta > 0.1) warnings.push(`no-op rate increased by ${noOpDelta.toFixed(3)}`);
+  return {
+    schema: "studiobrain-admin-effectivity-trend.v1",
+    generatedAt,
+    runId,
+    status: warnings.length > 0 ? "warn" : "pass",
+    readOnly: true,
+    sources: {
+      auditDir: clean(options.auditDir) || repoRelative(DEFAULT_AUDIT_DIR),
+      limit,
+      artifactsConsidered: inputAudits.length,
+      auditsIncluded: selected.length,
+    },
+    summary: {
+      audits: selected.length,
+      latestStatus: latest?.status || "",
+      statusCounts: statusCounts(selected),
+      averageUsefulness: average(selected.map((row) => row.scores.usefulness)),
+      averageVerification: average(selected.map((row) => row.scores.verification)),
+      averageNoOpRate: average(selected.map((row) => row.scores.noOpRate)),
+      toolFreshnessPassRate: average(selected.map((row) => row.scores.toolInventoryFreshness)),
+      workPacketOutcomePassRate: average(selected.map((row) => row.scores.workPacketOutcomeHealth)),
+    },
+    trend: {
+      fromGeneratedAt: first?.generatedAt || "",
+      toGeneratedAt: latest?.generatedAt || "",
+      fromSlice: first?.sliceWindow?.from || "",
+      toSlice: latest?.sliceWindow?.to || "",
+      usefulnessDelta,
+      verificationDelta: trendDelta(first, latest, "verification"),
+      noOpRateDelta: noOpDelta,
+      toolInventoryFreshnessDelta: trendDelta(first, latest, "toolInventoryFreshness"),
+      workPacketOutcomeHealthDelta: trendDelta(first, latest, "workPacketOutcomeHealth"),
+    },
+    warnings,
+    audits: selected,
+  };
+}
+
+function renderMarkdown(report) {
+  const warnings = report.warnings.map((warning) => `- ${warning}`).join("\n") || "- None.";
+  const rows = report.audits.map((audit) => (
+    `| ${audit.generatedAt || "unknown"} | ${audit.status} | ${audit.sliceWindow.from || ""} -> ${audit.sliceWindow.to || ""} | ${audit.scores.usefulness ?? ""} | ${audit.scores.noOpRate ?? ""} | ${audit.scores.toolInventoryFreshness ?? ""} | ${audit.scores.workPacketOutcomeHealth ?? ""} |`
+  )).join("\n") || "| none | | | | | | |";
+  return `# Admin Effectivity Trend
+
+Generated: ${report.generatedAt}
+Status: ${report.status}
+Run ID: ${report.runId}
+
+## Summary
+
+- Audits: ${report.summary.audits}
+- Latest status: ${report.summary.latestStatus || "unknown"}
+- Average usefulness: ${report.summary.averageUsefulness ?? ""}
+- Average verification: ${report.summary.averageVerification ?? ""}
+- Average no-op rate: ${report.summary.averageNoOpRate ?? ""}
+- Tool freshness pass rate: ${report.summary.toolFreshnessPassRate ?? ""}
+- Work-packet outcome pass rate: ${report.summary.workPacketOutcomePassRate ?? ""}
+
+## Trend
+
+- From: ${report.trend.fromGeneratedAt || "unknown"} (${report.trend.fromSlice || "unknown"})
+- To: ${report.trend.toGeneratedAt || "unknown"} (${report.trend.toSlice || "unknown"})
+- Usefulness delta: ${report.trend.usefulnessDelta ?? ""}
+- Verification delta: ${report.trend.verificationDelta ?? ""}
+- No-op rate delta: ${report.trend.noOpRateDelta ?? ""}
+- Tool freshness delta: ${report.trend.toolInventoryFreshnessDelta ?? ""}
+- Work-packet outcome delta: ${report.trend.workPacketOutcomeHealthDelta ?? ""}
+
+## Warnings
+
+${warnings}
+
+## Audits
+
+| Generated | Status | Slice window | Usefulness | No-op | Tool fresh | Outcome health |
+| --- | --- | --- | ---: | ---: | ---: | ---: |
+${rows}
+`;
+}
+
+function writeArtifacts(options, report) {
+  mkdirSync(options.outputDir, { recursive: true });
+  const jsonPath = resolve(options.outputDir, `${report.runId}.json`);
+  const markdownPath = resolve(options.outputDir, `${report.runId}.md`);
+  const latestJson = resolve(options.outputDir, "admin-effectivity-trend-latest.json");
+  const latestMarkdown = resolve(options.outputDir, "admin-effectivity-trend-latest.md");
+  writeFileSync(jsonPath, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+  writeFileSync(markdownPath, renderMarkdown(report), "utf8");
+  writeFileSync(latestJson, `${JSON.stringify({ ...report, artifactPath: repoRelative(jsonPath), markdownPath: repoRelative(markdownPath) }, null, 2)}\n`, "utf8");
+  writeFileSync(latestMarkdown, renderMarkdown(report), "utf8");
+  return {
+    jsonPath: repoRelative(jsonPath),
+    markdownPath: repoRelative(markdownPath),
+    latestJson: repoRelative(latestJson),
+    latestMarkdown: repoRelative(latestMarkdown),
+  };
+}
+
+function main(argv = process.argv.slice(2)) {
+  try {
+    const options = parseArgs(argv);
+    const report = buildTrendReport(readAuditArtifacts(options.auditDir), {
+      auditDir: repoRelative(options.auditDir),
+      generatedAt: nowIso(),
+      limit: options.limit,
+      runId: options.runId,
+    });
+    if (options.write) report.artifacts = writeArtifacts(options, report);
+    if (options.json) process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    else process.stdout.write(`admin effectivity trend: ${report.status}, audits=${report.summary.audits}\n`);
+    return report;
+  } catch (error) {
+    process.stderr.write(`admin_effectivity_trend failed: ${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+    return null;
+  }
+}
+
+export { buildTrendReport, readAuditArtifacts, renderMarkdown };
+
+if (process.argv[1] && resolve(process.argv[1]) === __filename) {
+  main();
+}

--- a/scripts/ops/admin_effectivity_trend.test.mjs
+++ b/scripts/ops/admin_effectivity_trend.test.mjs
@@ -1,0 +1,73 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+import { buildTrendReport, renderMarkdown } from "./admin_effectivity_trend.mjs";
+import { validateJsonSchema } from "./validate_ops_artifacts.mjs";
+
+function audit({ generatedAt, runId, status = "pass", from = "slice-1", to = "slice-5", usefulness = 0.8, noOpRate = 0, toolInventoryFreshness = 1, workPacketOutcomeHealth = 1 }) {
+  return {
+    artifact: `output/ops/effectivity/${runId}.json`,
+    audit: {
+      schema: "studiobrain-admin-effectivity-audit.v1",
+      generatedAt,
+      runId,
+      status,
+      sliceWindow: { from, to, count: 5 },
+      scores: {
+        usefulness,
+        verification: 1,
+        noOpRate,
+        blockedLaneClarity: 1,
+        toolInventoryFreshness,
+        workPacketOutcomeHealth,
+      },
+    },
+  };
+}
+
+test("buildTrendReport summarizes recent admin effectivity audits", () => {
+  const report = buildTrendReport(
+    [
+      audit({ generatedAt: "2026-05-07T10:00:00.000Z", runId: "audit-1", from: "slice-081", to: "slice-085", usefulness: 0.8 }),
+      audit({ generatedAt: "2026-05-07T11:00:00.000Z", runId: "audit-2", from: "slice-086", to: "slice-090", usefulness: 0.9 }),
+    ],
+    { generatedAt: "2026-05-07T12:00:00.000Z", runId: "trend-test", limit: 10, auditDir: "output/ops/effectivity" },
+  );
+
+  assert.equal(report.schema, "studiobrain-admin-effectivity-trend.v1");
+  assert.equal(report.status, "pass");
+  assert.equal(report.summary.audits, 2);
+  assert.equal(report.summary.latestStatus, "pass");
+  assert.equal(report.summary.averageUsefulness, 0.85);
+  assert.equal(report.trend.usefulnessDelta, 0.1);
+  assert.equal(report.trend.fromSlice, "slice-081");
+  assert.equal(report.trend.toSlice, "slice-090");
+  assert.match(renderMarkdown(report), /Admin Effectivity Trend/);
+});
+
+test("buildTrendReport warns on degraded latest audit or regressions", () => {
+  const report = buildTrendReport(
+    [
+      audit({ generatedAt: "2026-05-07T10:00:00.000Z", runId: "audit-1", usefulness: 0.95 }),
+      audit({ generatedAt: "2026-05-07T11:00:00.000Z", runId: "audit-2", status: "warn", usefulness: 0.7, noOpRate: 0.2, toolInventoryFreshness: 0 }),
+    ],
+    { generatedAt: "2026-05-07T12:00:00.000Z", runId: "trend-warn", limit: 10 },
+  );
+
+  assert.equal(report.status, "warn");
+  assert.ok(report.warnings.some((warning) => warning.includes("latest audit status")));
+  assert.ok(report.warnings.some((warning) => warning.includes("usefulness declined")));
+  assert.ok(report.warnings.some((warning) => warning.includes("no-op rate increased")));
+  assert.ok(report.warnings.some((warning) => warning.includes("tool inventory freshness")));
+});
+
+test("buildTrendReport stays compatible with schema", () => {
+  const report = buildTrendReport(
+    [audit({ generatedAt: "2026-05-07T11:00:00.000Z", runId: "audit-schema" })],
+    { generatedAt: "2026-05-07T12:00:00.000Z", runId: "trend-schema", limit: 1 },
+  );
+  const schema = JSON.parse(readFileSync("schemas/ops/admin-effectivity-trend.v1.schema.json", "utf8"));
+
+  assert.deepEqual(validateJsonSchema(report, schema), []);
+});

--- a/scripts/ops/artifact_registry.mjs
+++ b/scripts/ops/artifact_registry.mjs
@@ -37,8 +37,15 @@ const PRODUCER_METADATA = {
     producerCommand: "node scripts/ops/admin_effectivity_audit.mjs --json --write --last 5 --slice-run-id admin-infra-20260507",
     producerStep: "admin-effectivity-audit",
     safeWriteRoot: "output/ops/effectivity",
-    consumers: ["ops-work-packet", "mission-control-admin-import"],
+    consumers: ["admin-effectivity-trend", "ops-work-packet", "mission-control-admin-import"],
     requiredFor: ["five-slice-audit"],
+  },
+  "admin-effectivity-trend": {
+    producerCommand: "node scripts/ops/admin_effectivity_trend.mjs --json --write --limit 10",
+    producerStep: "admin-effectivity-trend",
+    safeWriteRoot: "output/ops/effectivity",
+    consumers: ["operator-handoff", "five-slice-audit"],
+    requiredFor: ["trend-review"],
   },
   "slice-ledger-summary": {
     producerCommand: "node scripts/ops/slice_ledger.mjs --summary --last 5 --run-id admin-infra-20260507 --json",
@@ -127,6 +134,12 @@ const OPS_ARTIFACT_REGISTRY = [
     id: "admin-effectivity-audit",
     artifact: "output/ops/effectivity/admin-effectivity-audit-latest.json",
     schema: "schemas/ops/admin-effectivity-audit.v1.schema.json",
+    freshnessTier: "loop",
+  },
+  {
+    id: "admin-effectivity-trend",
+    artifact: "output/ops/effectivity/admin-effectivity-trend-latest.json",
+    schema: "schemas/ops/admin-effectivity-trend.v1.schema.json",
     freshnessTier: "loop",
   },
   {

--- a/scripts/ops/ops_ci_validate.sh
+++ b/scripts/ops/ops_ci_validate.sh
@@ -45,6 +45,7 @@ check_file "scripts/ops/swarm_lane_preflight.mjs"
 check_file "scripts/ops/ops_wave_runner.mjs"
 check_file "scripts/ops/slice_ledger.mjs"
 check_file "scripts/ops/admin_effectivity_audit.mjs"
+check_file "scripts/ops/admin_effectivity_trend.mjs"
 check_file "scripts/ops/tooling_quality_report.mjs"
 check_file "scripts/ops/tooling_findings_export.mjs"
 check_file "scripts/ops/installed_tool_inventory.mjs"
@@ -75,6 +76,7 @@ for script in \
   "scripts/ops/ops_wave_runner.mjs" \
   "scripts/ops/slice_ledger.mjs" \
   "scripts/ops/admin_effectivity_audit.mjs" \
+  "scripts/ops/admin_effectivity_trend.mjs" \
   "scripts/ops/tooling_quality_report.mjs" \
   "scripts/ops/tooling_findings_export.mjs" \
   "scripts/ops/installed_tool_inventory.mjs" \
@@ -124,6 +126,12 @@ if node --test "${REPO_ROOT}/scripts/ops/admin_effectivity_audit.test.mjs" >"${O
   pass "node --test scripts/ops/admin_effectivity_audit.test.mjs"
 else
   fail "node --test scripts/ops/admin_effectivity_audit.test.mjs"
+fi
+
+if node --test "${REPO_ROOT}/scripts/ops/admin_effectivity_trend.test.mjs" >"${OUT_DIR}/admin-effectivity-trend.test.out" 2>&1; then
+  pass "node --test scripts/ops/admin_effectivity_trend.test.mjs"
+else
+  fail "node --test scripts/ops/admin_effectivity_trend.test.mjs"
 fi
 
 if node --test "${REPO_ROOT}/scripts/ops/tooling_quality_report.test.mjs" >"${OUT_DIR}/tooling-quality-report.test.out" 2>&1; then
@@ -221,6 +229,13 @@ if node "${REPO_ROOT}/scripts/ops/packet_outcome_report.mjs" --json --write >"${
   pass "packet_outcome_report smoke"
 else
   fail "packet_outcome_report smoke"
+fi
+
+section "Admin Effectivity Trend Smoke"
+if node "${REPO_ROOT}/scripts/ops/admin_effectivity_trend.mjs" --json --write >"${OUT_DIR}/admin-effectivity-trend.json"; then
+  pass "admin_effectivity_trend smoke"
+else
+  fail "admin_effectivity_trend smoke"
 fi
 
 section "PR Stack Audit Smoke"


### PR DESCRIPTION
## Summary
- add a read-only admin effectivity trend reporter over recent audit artifacts
- register the trend artifact with schema validation and producer metadata
- include the trend script in ops CI smoke coverage

## Evidence
- generated trend report summarized 10 recent admin-effectivity audits with status=pass
- artifact validation now checks 14/14 registered artifacts including admin-effectivity-trend

## Testing
- node --test scripts/ops/admin_effectivity_trend.test.mjs scripts/ops/artifact_registry.test.mjs scripts/ops/validate_ops_artifacts.test.mjs
- node --check scripts/ops/admin_effectivity_trend.mjs
- node scripts/ops/admin_effectivity_trend.mjs --json --write --limit 10
- node scripts/ops/validate_ops_artifacts.mjs --json --write
- bash scripts/ops/ops_ci_validate.sh
- git diff --check

## Risk
Low. Read-only reporting, schema, registry, CI smoke, and docs only. No host mutation, deployment, restart, prune, package, firewall, or database changes.

## Rollback
Revert commit d2b80009 to remove the trend reporter, registry entry, schema, and CI smoke.

## Follow-up
- feed trend warnings into PR readiness and/or owner handoff
- build a work-packet quality lint harness