### PR TITLE
[ops] Surface work packet quality in PR readiness

### DIFF
--- a/schemas/ops/pr-readiness-packet.v1.schema.json
+++ b/schemas/ops/pr-readiness-packet.v1.schema.json
@@ -51,7 +51,7 @@
     },
     "evidence": {
       "type": "object",
-      "required": ["artifactValidation", "waveRunner", "workPacket", "packetOutcome", "sliceLedger", "toolInstall"],
+      "required": ["artifactValidation", "waveRunner", "workPacket", "workPacketQuality", "packetOutcome", "sliceLedger", "toolInstall"],
       "properties": {
         "artifactValidation": {
           "type": "object",
@@ -133,6 +133,36 @@
             "effectivityEvidenceLanes": { "type": ["number", "null"], "minimum": 0 },
             "effectivityApprovalRequiredLanes": { "type": ["number", "null"], "minimum": 0 },
             "effectivityHighSeverityLanes": { "type": ["number", "null"], "minimum": 0 },
+            "parseError": { "type": "string" }
+          },
+          "additionalProperties": false
+        },
+        "workPacketQuality": {
+          "type": "object",
+          "required": ["status", "generatedAt", "runId", "findings", "warnings", "failures", "sourceSignalAuditStatus", "topFindings"],
+          "properties": {
+            "status": { "type": "string" },
+            "generatedAt": { "type": "string" },
+            "runId": { "type": "string" },
+            "findings": { "type": "number", "minimum": 0 },
+            "warnings": { "type": "number", "minimum": 0 },
+            "failures": { "type": "number", "minimum": 0 },
+            "sourceSignalAuditStatus": { "type": "string" },
+            "topFindings": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": ["severity", "code", "packetId", "title", "message"],
+                "properties": {
+                  "severity": { "type": "string" },
+                  "code": { "type": "string" },
+                  "packetId": { "type": "string" },
+                  "title": { "type": "string" },
+                  "message": { "type": "string" }
+                },
+                "additionalProperties": false
+              }
+            },
             "parseError": { "type": "string" }
           },
           "additionalProperties": false

--- a/scripts/ops/pr_readiness_packet.mjs
+++ b/scripts/ops/pr_readiness_packet.mjs
@@ -10,6 +10,7 @@ const REPO_ROOT = resolve(dirname(__filename), "..", "..");
 const DEFAULT_OUTPUT_DIR = resolve(REPO_ROOT, "output", "ops", "pr-readiness");
 const DEFAULT_ARTIFACT_VALIDATION = resolve(REPO_ROOT, "output", "ops", "artifact-validation", "artifact-schema-validation-latest.json");
 const DEFAULT_WORK_PACKET = resolve(REPO_ROOT, "output", "ops", "swarm", "latest-work-packet.json");
+const DEFAULT_WORK_PACKET_QUALITY = resolve(REPO_ROOT, "output", "ops", "swarm", "work-packet-quality-latest.json");
 const DEFAULT_SLICE_LEDGER = resolve(REPO_ROOT, "output", "ops", "effectivity", "slice-ledger-latest.json");
 const DEFAULT_TOOL_INSTALL_RECOMMENDATIONS = resolve(REPO_ROOT, "output", "ops", "effectivity", "tool-install-recommendations-latest.json");
 const DEFAULT_WAVE_RUNNER = resolve(REPO_ROOT, "output", "ops", "waves", "ops-wave-runner-latest.json");
@@ -169,6 +170,41 @@ function summarizePacketOutcome(report) {
   };
 }
 
+function summarizeWorkPacketQuality(report) {
+  if (!report) return { status: "missing", generatedAt: "", runId: "", findings: 0, warnings: 0, failures: 0, sourceSignalAuditStatus: "", topFindings: [] };
+  if (report.status === "invalid_json") {
+    return {
+      status: "invalid_json",
+      generatedAt: "",
+      runId: "",
+      findings: 1,
+      warnings: 0,
+      failures: 1,
+      sourceSignalAuditStatus: "",
+      topFindings: [{ severity: "fail", code: "invalid_json", packetId: "", title: "", message: report.parseError || "work-packet quality JSON is invalid" }],
+      parseError: report.parseError || "",
+    };
+  }
+  return {
+    status: clean(report.status) || "unknown",
+    generatedAt: clean(report.generatedAt),
+    runId: clean(report.runId),
+    findings: report.summary?.findings ?? 0,
+    warnings: report.summary?.warnings ?? 0,
+    failures: report.summary?.failures ?? 0,
+    sourceSignalAuditStatus: clean(report.summary?.sourceSignalAuditStatus),
+    topFindings: Array.isArray(report.findings)
+      ? report.findings.slice(0, 5).map((finding) => ({
+          severity: clean(finding.severity),
+          code: clean(finding.code),
+          packetId: clean(finding.packetId),
+          title: clean(finding.title),
+          message: clean(finding.message),
+        }))
+      : [],
+  };
+}
+
 function buildOutcomeLedger(options = {}, evidence = {}) {
   const packetId = clean(options.packetId);
   const pr = clean(options.pr);
@@ -284,6 +320,7 @@ function summarizeToolInstall(report) {
 
 function readinessStatus(packet) {
   if (packet.evidence.artifactValidation.status === "fail" || packet.evidence.artifactValidation.status === "invalid_json") return "fail";
+  if (packet.evidence.workPacketQuality.status === "fail" || packet.evidence.workPacketQuality.status === "invalid_json") return "fail";
   if (packet.evidence.sliceLedger.status === "fail") return "fail";
   if (packet.warnings.length > 0) return "warn";
   return "pass";
@@ -308,6 +345,12 @@ function buildWarnings({ gitState, evidence, outcomeLedger }) {
   }
   if (evidence.workPacket.status === "missing") warnings.push("work-packet latest artifact is missing");
   if ((evidence.workPacket.staleSources ?? 0) > 0) warnings.push("work packet has stale evidence sources");
+  if (evidence.workPacketQuality.status === "missing") warnings.push("work-packet quality latest artifact is missing");
+  else if (evidence.workPacketQuality.status === "warn") warnings.push("work-packet quality lint has warnings");
+  else if (evidence.workPacketQuality.status !== "pass") warnings.push(`work-packet quality lint status is ${evidence.workPacketQuality.status}`);
+  for (const finding of evidence.workPacketQuality.topFindings.slice(0, 3)) {
+    warnings.push(`work-packet quality ${finding.severity} ${finding.code}${finding.packetId ? ` ${finding.packetId}` : ""}: ${finding.message}`);
+  }
   if (evidence.sliceLedger.requestedCoverage.status === "outside_window") {
     warnings.push(`slice ids outside latest slice-ledger window: ${evidence.sliceLedger.requestedCoverage.missing.join(", ")}`);
   } else if (evidence.sliceLedger.requestedCoverage.status === "unknown") {
@@ -331,6 +374,7 @@ export function buildPrReadinessPacket(inputs = {}, options = {}) {
     artifactValidation: summarizeArtifactValidation(inputs.artifactValidation),
     waveRunner: summarizeWaveRunner(inputs.waveRunner),
     workPacket: summarizeWorkPacket(inputs.workPacket),
+    workPacketQuality: summarizeWorkPacketQuality(inputs.workPacketQuality),
     packetOutcome: summarizePacketOutcome(inputs.packetOutcomeReport),
     sliceLedger: summarizeSliceLedger(inputs.sliceLedger),
     toolInstall: summarizeToolInstall(inputs.toolInstallRecommendations),
@@ -413,6 +457,7 @@ ${dirtyFiles}
 | Wave runner | ${packet.evidence.waveRunner.status} | run=${packet.evidence.waveRunner.runId}, workPacketMaxPackets=${packet.evidence.waveRunner.workPacketMaxPackets ?? ""} |
 | Slice ledger | ${packet.evidence.sliceLedger.status} | window=${packet.evidence.sliceLedger.window?.from || ""}..${packet.evidence.sliceLedger.window?.to || ""}, requestedCoverage=${packet.evidence.sliceLedger.requestedCoverage.status}, missing=${packet.evidence.sliceLedger.requestedCoverage.missing.join(", ")}, verification=${packet.evidence.sliceLedger.verification ?? ""}, usefulness=${packet.evidence.sliceLedger.usefulness ?? ""} |
 | Work packet | ${packet.evidence.workPacket.status} | packets=${packet.evidence.workPacket.packets}, ready=${packet.evidence.workPacket.readyPackets}, approvalGated=${packet.evidence.workPacket.approvalGatedPackets}, freshSources=${packet.evidence.workPacket.freshSources ?? ""}, staleSources=${packet.evidence.workPacket.staleSources ?? ""}, lanes=${packet.evidence.workPacket.effectivityEvidenceLanes ?? ""}, approvalLanes=${packet.evidence.workPacket.effectivityApprovalRequiredLanes ?? ""}, highLanes=${packet.evidence.workPacket.effectivityHighSeverityLanes ?? ""}, top="${packet.evidence.workPacket.topPacket}" |
+| Work packet quality | ${packet.evidence.workPacketQuality.status} | findings=${packet.evidence.workPacketQuality.findings}, warnings=${packet.evidence.workPacketQuality.warnings}, failures=${packet.evidence.workPacketQuality.failures}, sourceSignalAudit=${packet.evidence.workPacketQuality.sourceSignalAuditStatus || ""} |
 | Packet outcomes | ${packet.evidence.packetOutcome.status} | total=${packet.evidence.packetOutcome.total}, maturity=${packet.evidence.packetOutcome.maturity}, score=${packet.evidence.packetOutcome.score ?? ""}, orphanedRate=${packet.evidence.packetOutcome.orphanedRate ?? ""}, resetRecommended=${packet.evidence.packetOutcome.resetRecommended} |
 | Tool install recommendations | ${packet.evidence.toolInstall.status} | recommendations=${packet.evidence.toolInstall.recommendations}, installNow=${packet.evidence.toolInstall.installNowCandidates}, approvalRequired=${packet.evidence.toolInstall.approvalRequired} |
 
@@ -477,6 +522,7 @@ function parseArgs(argv) {
     artifactValidation: DEFAULT_ARTIFACT_VALIDATION,
     waveRunner: DEFAULT_WAVE_RUNNER,
     workPacket: DEFAULT_WORK_PACKET,
+    workPacketQuality: DEFAULT_WORK_PACKET_QUALITY,
     packetOutcomeReport: DEFAULT_PACKET_OUTCOME_REPORT,
     sliceLedger: DEFAULT_SLICE_LEDGER,
     toolInstallRecommendations: DEFAULT_TOOL_INSTALL_RECOMMENDATIONS,
@@ -516,6 +562,7 @@ function parseArgs(argv) {
       "--artifact-validation": "artifactValidation",
       "--wave-runner": "waveRunner",
       "--work-packet": "workPacket",
+      "--work-packet-quality": "workPacketQuality",
       "--packet-outcome-report": "packetOutcomeReport",
       "--slice-ledger": "sliceLedger",
       "--tool-install-recommendations": "toolInstallRecommendations",
@@ -524,7 +571,7 @@ function parseArgs(argv) {
     for (const [flag, key] of Object.entries(flags)) {
       const value = read(flag);
       if (value === null) continue;
-      options[key] = ["outputDir", "artifactValidation", "waveRunner", "workPacket", "packetOutcomeReport", "sliceLedger", "toolInstallRecommendations"].includes(key)
+      options[key] = ["outputDir", "artifactValidation", "waveRunner", "workPacket", "workPacketQuality", "packetOutcomeReport", "sliceLedger", "toolInstallRecommendations"].includes(key)
         ? resolve(REPO_ROOT, value)
         : value;
       matched = true;
@@ -550,6 +597,7 @@ Options:
   --artifact-validation <path>         Default: output/ops/artifact-validation/artifact-schema-validation-latest.json.
   --wave-runner <path>                 Default: output/ops/waves/ops-wave-runner-latest.json.
   --work-packet <path>                 Default: output/ops/swarm/latest-work-packet.json.
+  --work-packet-quality <path>         Default: output/ops/swarm/work-packet-quality-latest.json.
   --packet-outcome-report <path>       Default: output/ops/swarm/packet-outcome-report-latest.json.
   --slice-ledger <path>                Default: output/ops/effectivity/slice-ledger-latest.json.
   --tool-install-recommendations <path> Default: output/ops/effectivity/tool-install-recommendations-latest.json.
@@ -581,6 +629,7 @@ function run(rawArgs = process.argv.slice(2)) {
     artifactValidation: readJsonIfExists(options.artifactValidation),
     waveRunner: readJsonIfExists(options.waveRunner),
     workPacket: readJsonIfExists(options.workPacket),
+    workPacketQuality: readJsonIfExists(options.workPacketQuality),
     packetOutcomeReport: readJsonIfExists(options.packetOutcomeReport),
     sliceLedger: readJsonIfExists(options.sliceLedger),
     toolInstallRecommendations: readJsonIfExists(options.toolInstallRecommendations),

--- a/scripts/ops/pr_readiness_packet.test.mjs
+++ b/scripts/ops/pr_readiness_packet.test.mjs
@@ -85,6 +85,25 @@ const packetOutcomeReport = {
   packetChurn: { orphanedRate: 0, resetRecommended: false },
 };
 
+const workPacketQuality = {
+  schema: "studiobrain-work-packet-quality-lint.v1",
+  generatedAt: "2026-05-07T12:02:45.000Z",
+  runId: "work-packet-quality-test",
+  status: "pass",
+  readOnly: true,
+  sources: { workPacket: "output/ops/swarm/latest-work-packet.json", generatedAt: "2026-05-07T12:01:00.000Z" },
+  summary: {
+    packets: 2,
+    readyPackets: 1,
+    approvalGatedPackets: 1,
+    findings: 0,
+    warnings: 0,
+    failures: 0,
+    sourceSignalAuditStatus: "pass",
+  },
+  findings: [],
+};
+
 const toolInstallRecommendations = {
   schema: "studiobrain-ops-tool-install-recommendations.v1",
   generatedAt: "2026-05-07T12:03:00.000Z",
@@ -112,7 +131,7 @@ const toolInstallRecommendations = {
 
 test("buildPrReadinessPacket summarizes current evidence without executable install commands", () => {
   const packet = buildPrReadinessPacket(
-    { gitState, artifactValidation, waveRunner, workPacket, packetOutcomeReport, sliceLedger, toolInstallRecommendations },
+    { gitState, artifactValidation, waveRunner, workPacket, workPacketQuality, packetOutcomeReport, sliceLedger, toolInstallRecommendations },
     { generatedAt: "2026-05-07T12:10:00.000Z", pr: "#123", sliceIds: "slice-046,slice-047", packetId: "ops-wp-ready" },
   );
 
@@ -139,6 +158,8 @@ test("buildPrReadinessPacket summarizes current evidence without executable inst
   assert.equal(packet.evidence.workPacket.effectivityEvidenceLanes, 4);
   assert.equal(packet.evidence.workPacket.effectivityApprovalRequiredLanes, 1);
   assert.equal(packet.evidence.workPacket.effectivityHighSeverityLanes, 1);
+  assert.equal(packet.evidence.workPacketQuality.status, "pass");
+  assert.equal(packet.evidence.workPacketQuality.findings, 0);
   assert.equal(packet.evidence.toolInstall.installNowCandidates, 2);
   assert.equal(packet.evidence.toolInstall.approvalRequired, 1);
   assert.ok(packet.warnings.some((warning) => warning.includes("require approval")));
@@ -149,6 +170,8 @@ test("buildPrReadinessPacket summarizes current evidence without executable inst
   assert.match(markdown, /Next Executable Packet/);
   assert.match(markdown, /Outcome Ledger/);
   assert.match(markdown, /Packet outcomes/);
+  assert.match(markdown, /Work packet quality/);
+  assert.match(markdown, /sourceSignalAudit=pass/);
   assert.match(markdown, /ops-wp-ready/);
   assert.match(markdown, /Run the evidence refresh/);
   assert.match(markdown, /codex\/ops-refresh-evidence/);
@@ -166,7 +189,7 @@ test("buildPrReadinessPacket summarizes current evidence without executable inst
 
 test("buildPrReadinessPacket warns when requested packet id is outside the latest window", () => {
   const packet = buildPrReadinessPacket(
-    { gitState, artifactValidation, waveRunner, workPacket, packetOutcomeReport, sliceLedger, toolInstallRecommendations },
+    { gitState, artifactValidation, waveRunner, workPacket, workPacketQuality, packetOutcomeReport, sliceLedger, toolInstallRecommendations },
     { generatedAt: "2026-05-07T12:10:00.000Z", packetId: "ops-wp-stale" },
   );
 
@@ -180,7 +203,7 @@ test("buildPrReadinessPacket warns when requested packet id is outside the lates
 
 test("buildPrReadinessPacket warns when requested slice ids are outside the latest slice-ledger window", () => {
   const packet = buildPrReadinessPacket(
-    { gitState, artifactValidation, waveRunner, workPacket, packetOutcomeReport, sliceLedger, toolInstallRecommendations },
+    { gitState, artifactValidation, waveRunner, workPacket, workPacketQuality, packetOutcomeReport, sliceLedger, toolInstallRecommendations },
     { generatedAt: "2026-05-07T12:10:00.000Z", sliceIds: "slice-20260507-076,slice-20260507-077" },
   );
 
@@ -198,6 +221,7 @@ test("buildPrReadinessPacket surfaces degraded packet outcome churn", () => {
     artifactValidation,
     waveRunner,
     workPacket,
+    workPacketQuality,
     packetOutcomeReport: {
       ...packetOutcomeReport,
       status: "warn",
@@ -219,6 +243,38 @@ test("buildPrReadinessPacket surfaces degraded packet outcome churn", () => {
   assert.match(renderMarkdown(packet), /orphanedRate=0.75/);
 });
 
+test("buildPrReadinessPacket fails when work-packet quality lint fails", () => {
+  const packet = buildPrReadinessPacket({
+    gitState,
+    artifactValidation,
+    waveRunner,
+    workPacket,
+    workPacketQuality: {
+      ...workPacketQuality,
+      status: "fail",
+      summary: { ...workPacketQuality.summary, findings: 1, warnings: 0, failures: 1 },
+      findings: [
+        {
+          severity: "fail",
+          code: "unsafe-constraints",
+          packetId: "ops-wp-ready",
+          title: "[ops] Refresh evidence",
+          message: "Packet constraints must preserve read-only-first defaults.",
+        },
+      ],
+    },
+    packetOutcomeReport,
+    sliceLedger,
+    toolInstallRecommendations: { ...toolInstallRecommendations, summary: { recommendations: 1, installNowCandidates: 0, approvalRequired: 0 } },
+  });
+
+  assert.equal(packet.status, "fail");
+  assert.equal(packet.evidence.workPacketQuality.failures, 1);
+  assert.ok(packet.warnings.some((warning) => warning.includes("work-packet quality lint status is fail")));
+  assert.ok(packet.warnings.some((warning) => warning.includes("unsafe-constraints")));
+  assert.match(renderMarkdown(packet), /Work packet quality \| fail/);
+});
+
 test("buildPrReadinessPacket warns when dry-run wave evidence mismatches packet count", () => {
   const packet = buildPrReadinessPacket({
     gitState,
@@ -229,6 +285,7 @@ test("buildPrReadinessPacket warns when dry-run wave evidence mismatches packet 
       plan: [{ id: "work-packet", command: "node scripts/studiobrain-ops-work-packet.mjs --json --write --max-packets 1" }],
     },
     workPacket,
+    workPacketQuality,
     packetOutcomeReport,
     sliceLedger,
     toolInstallRecommendations: { ...toolInstallRecommendations, summary: { recommendations: 1, installNowCandidates: 0, approvalRequired: 0 } },
@@ -241,7 +298,7 @@ test("buildPrReadinessPacket warns when dry-run wave evidence mismatches packet 
 
 test("buildPrReadinessPacket stays compatible with its JSON schema", () => {
   const packet = buildPrReadinessPacket(
-    { gitState, artifactValidation, waveRunner, workPacket, packetOutcomeReport, sliceLedger, toolInstallRecommendations },
+    { gitState, artifactValidation, waveRunner, workPacket, workPacketQuality, packetOutcomeReport, sliceLedger, toolInstallRecommendations },
     { generatedAt: "2026-05-07T12:10:00.000Z", pr: "#123", sliceIds: "slice-046,slice-047", packetId: "ops-wp-ready" },
   );
   const schema = JSON.parse(readFileSync("schemas/ops/pr-readiness-packet.v1.schema.json", "utf8"));
@@ -260,6 +317,7 @@ test("buildPrReadinessPacket fails on failing artifact validation", () => {
     },
     waveRunner,
     workPacket,
+    workPacketQuality,
     packetOutcomeReport,
     sliceLedger,
     toolInstallRecommendations: { ...toolInstallRecommendations, summary: { recommendations: 1, installNowCandidates: 0, approvalRequired: 0 } },
@@ -275,6 +333,7 @@ test("buildPrReadinessPacket warns on dirty local state", () => {
     artifactValidation,
     waveRunner,
     workPacket,
+    workPacketQuality,
     packetOutcomeReport,
     sliceLedger,
     toolInstallRecommendations: { ...toolInstallRecommendations, summary: { recommendations: 1, installNowCandidates: 0, approvalRequired: 0 } },


### PR DESCRIPTION
## Summary
- add work-packet quality lint evidence to PR readiness packets
- fail readiness when packet-quality evidence fails or is invalid
- show quality status, finding counts, failures, and source-signal audit status in readiness Markdown

## Evidence
- slice ledger recorded slice-20260507-095 with 4 passing command records
- five-slice audit 091-095 refresh passed: usefulness=0.87, verification=1, noOpRate=0, workPacketOutcomeHealth=1
- generated PR readiness packet shows workPacketQuality status=pass and 0 findings

## Testing
- node --test scripts/ops/pr_readiness_packet.test.mjs
- node --check scripts/ops/pr_readiness_packet.mjs
- node scripts/ops/pr_readiness_packet.mjs --json --write --base codex/ops-work-packet-plain-suggestions-wave2 --slice-ids slice-20260507-095
- node scripts/ops/validate_ops_artifacts.mjs --json --write
- bash scripts/ops/ops_ci_validate.sh
- git diff --check

## Risk
Low. Read-only readiness/reporting changes only. No host mutation, deploy, restart, prune, package, firewall, database, systemd, or secret changes.

## Rollback
Revert the commit and regenerate ignored output/ops readiness/artifact-validation files.

## Follow-up
- record packet outcomes against the current ready packet after using it for a PR
- continue with the next generated ready packet: [drift] Inventory live host checkout drift