### PR TITLE
[ops] Add host drift manifest artifact

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ OPS_WAVE_STEPS ?=
 OPS_WAVE_SKIP ?=
 OPS_WAVE_FROM_STEP ?=
 
-.PHONY: ops-check ops-inventory ops-postgres-review ops-postgres-sql ops-postgres-top-queries ops-postgres-query-tasks ops-postgres-growth-snapshot ops-postgres-autovacuum-stats ops-postgres-roles-extensions ops-docker-review ops-docker-posture ops-capacity ops-import-pressure ops-cleanup-candidates ops-backup-evidence ops-postgres-backup-artifacts ops-restore-prereq ops-redis-minio-backup-evidence ops-ubuntu-review ops-host-failed-unit-trends ops-package-posture ops-time-sync ops-network-review ops-host-drift ops-systemd-drift ops-portal-bridge-review ops-app-review ops-dependency-review ops-idle-worker-effectivity ops-effectivity-report ops-slice-ledger ops-tool-inventory ops-tool-install-plan ops-admin-effectivity-audit ops-tooling-quality ops-shell-lf-guard ops-shellcheck-report ops-powershell-syntax ops-sql-parse-report ops-actionlint-report ops-compose-config-report ops-validate-artifacts ops-swarm-lane-preflight ops-wave-runner ops-privileged-evidence-read ops-privileged-evidence-capture ops-privileged-evidence-capture-smoke ops-work-packet ops-pr-stack-audit ops-pr-readiness-packet ops-incident-bundle ops-incident-bundle-v2 ops-ci-validate ops-post-deploy-verify ops-docs ops-backlog ops-report
+.PHONY: ops-check ops-inventory ops-postgres-review ops-postgres-sql ops-postgres-top-queries ops-postgres-query-tasks ops-postgres-growth-snapshot ops-postgres-autovacuum-stats ops-postgres-roles-extensions ops-docker-review ops-docker-posture ops-capacity ops-import-pressure ops-cleanup-candidates ops-backup-evidence ops-postgres-backup-artifacts ops-restore-prereq ops-redis-minio-backup-evidence ops-ubuntu-review ops-host-failed-unit-trends ops-package-posture ops-time-sync ops-network-review ops-host-drift ops-host-drift-manifest ops-systemd-drift ops-portal-bridge-review ops-app-review ops-dependency-review ops-idle-worker-effectivity ops-effectivity-report ops-slice-ledger ops-tool-inventory ops-tool-install-plan ops-admin-effectivity-audit ops-tooling-quality ops-shell-lf-guard ops-shellcheck-report ops-powershell-syntax ops-sql-parse-report ops-actionlint-report ops-compose-config-report ops-validate-artifacts ops-swarm-lane-preflight ops-wave-runner ops-privileged-evidence-read ops-privileged-evidence-capture ops-privileged-evidence-capture-smoke ops-work-packet ops-pr-stack-audit ops-pr-readiness-packet ops-incident-bundle ops-incident-bundle-v2 ops-ci-validate ops-post-deploy-verify ops-docs ops-backlog ops-report
 
 ops-check: ops-inventory ops-docker-review ops-capacity ops-cleanup-candidates ops-backup-evidence ops-ubuntu-review ops-network-review ops-host-drift ops-systemd-drift ops-portal-bridge-review ops-app-review
 
@@ -101,6 +101,9 @@ ops-network-review:
 
 ops-host-drift:
 	bash scripts/ops/host_drift_inventory.sh
+
+ops-host-drift-manifest:
+	node scripts/ops/host_drift_manifest.mjs --json --write
 
 ops-systemd-drift:
 	bash scripts/ops/systemd_drift_review.sh

--- a/docs/ops/10-host-drift-inventory.md
+++ b/docs/ops/10-host-drift-inventory.md
@@ -97,6 +97,23 @@ Likely impacts:
 
 This slice adds drift inventory tooling and documents current evidence. It intentionally does not reconcile, delete, reset, stash, or move any live host files.
 
+## Machine-Readable Manifest
+
+Use `make ops-host-drift-manifest` or the direct Node command below when a later slice needs a structured manifest instead of scraping this Markdown note:
+
+```bash
+node scripts/ops/host_drift_manifest.mjs --json --write
+```
+
+For a live-host capture without reading file contents, capture only path/status metadata first, then parse it locally:
+
+```bash
+ssh studiobrain 'git -C /home/wuff/monsoonfire-portal status --porcelain=v1 --untracked-files=all' > output/ops/host-drift/live-status.txt
+node scripts/ops/host_drift_manifest.mjs --status-file output/ops/host-drift/live-status.txt --json --write
+```
+
+The manifest compares path names with `studio-brain/host-drift-allowlist.json`, classifies paths as generated/artifact, source/config, sensitive path name, or unknown, and assigns approval classes such as `safe_with_backup`, `requires_human_approval`, `allowlisted_review_before_cleanup`, and `do_not_touch_security_review`. Sensitive-looking path names are redacted by default; use `--show-sensitive-paths` only in a restricted local review. It is still evidence only: no reset, clean, stash, checkout, delete, move, chmod, restart, or host mutation is performed.
+
 ## Systemd Drift Follow-Up
 
 Use `scripts/ops/systemd_drift_review.sh` or `make ops-systemd-drift` for the narrower host-unit check added after the idle-worker drop-in reconciliation. It compares tracked files under `config/studiobrain/systemd/` with installed paths on the host by normalized text checksum only:

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -46,6 +46,7 @@ make ops-package-posture
 make ops-time-sync
 make ops-network-review
 make ops-host-drift
+make ops-host-drift-manifest
 make ops-systemd-drift
 make ops-portal-bridge-review
 make ops-app-review
@@ -79,6 +80,7 @@ bash scripts/ops/npm_audit_inventory.sh
 bash scripts/ops/effectivity_report.sh
 bash scripts/ops/privileged_evidence_read.sh
 bash scripts/ops/privileged_evidence_capture.sh --smoke --output-dir output/ops/privileged-evidence
+node scripts/ops/host_drift_manifest.mjs --json --write
 node scripts/studiobrain-ops-work-packet.mjs --write
 node scripts/ops/ops_wave_runner.mjs --write
 node scripts/ops/pr_stack_audit.mjs --write
@@ -94,6 +96,8 @@ make ops-wave-runner OPS_WAVE_STEPS=swarm-preflight,work-packet,artifact-validat
 ```
 
 `ops-privileged-evidence-capture-smoke` writes a non-root local smoke artifact under `output/ops/privileged-evidence` and is safe for development. Installing the host-side privileged collector, timer, group, or sudoers allowlist is intentionally separate and approval-gated; see `22-privileged-evidence-capture.md`.
+
+`ops-host-drift-manifest` is path-name-only and read-only. It converts a live or captured `git status --porcelain=v1 --untracked-files=all` listing into JSON/Markdown under `output/ops/host-drift`, compares paths with `studio-brain/host-drift-allowlist.json`, redacts sensitive-looking path names by default, and keeps cleanup/reset/stash/delete decisions approval-gated.
 
 ## Approval Boundaries
 

--- a/schemas/ops/host-drift-manifest.v1.schema.json
+++ b/schemas/ops/host-drift-manifest.v1.schema.json
@@ -1,0 +1,124 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://studio-brain.local/schemas/ops/host-drift-manifest.v1.schema.json",
+  "title": "Studio Brain Host Drift Manifest v1",
+  "type": "object",
+  "required": [
+    "schema",
+    "generatedAt",
+    "runId",
+    "status",
+    "readOnly",
+    "safety",
+    "sources",
+    "git",
+    "summary",
+    "entries",
+    "safeNextSteps"
+  ],
+  "properties": {
+    "schema": { "const": "studiobrain-host-drift-manifest.v1" },
+    "generatedAt": { "type": "string", "format": "date-time" },
+    "runId": { "type": "string" },
+    "status": { "enum": ["pass", "warn", "fail"] },
+    "readOnly": { "const": true },
+    "safety": {
+      "type": "object",
+      "required": ["pathNamesOnly", "readsFileContents", "mutatesHost", "destructiveActions", "sensitivePathNamesRedacted"],
+      "properties": {
+        "pathNamesOnly": { "const": true },
+        "readsFileContents": { "const": false },
+        "mutatesHost": { "const": false },
+        "destructiveActions": { "const": false },
+        "sensitivePathNamesRedacted": { "type": "boolean" }
+      },
+      "additionalProperties": false
+    },
+    "sources": {
+      "type": "object",
+      "required": ["repo", "statusSource", "statusReadStatus", "allowlistPath", "allowlistStatus", "allowlistGeneratedAt"],
+      "properties": {
+        "repo": { "type": "string" },
+        "statusSource": { "type": "string" },
+        "statusReadStatus": { "type": "string" },
+        "allowlistPath": { "type": "string" },
+        "allowlistStatus": { "type": "string" },
+        "allowlistGeneratedAt": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "git": {
+      "type": "object",
+      "properties": {
+        "repo": { "type": "string" },
+        "branch": { "type": "string" },
+        "head": { "type": "string" },
+        "upstream": { "type": "string" },
+        "upstreamStatus": { "type": "string" },
+        "aheadBehind": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "summary": {
+      "type": "object",
+      "required": [
+        "dirtyPaths",
+        "entriesKept",
+        "truncated",
+        "classificationCounts",
+        "statusCounts",
+        "approvalCounts",
+        "allowlistCounts",
+        "allowlistEntries",
+        "expiredAllowlistMatches",
+        "errors"
+      ],
+      "properties": {
+        "dirtyPaths": { "type": "number", "minimum": 0 },
+        "entriesKept": { "type": "number", "minimum": 0 },
+        "truncated": { "type": "boolean" },
+        "classificationCounts": { "type": "object", "additionalProperties": { "type": "number", "minimum": 0 } },
+        "statusCounts": { "type": "object", "additionalProperties": { "type": "number", "minimum": 0 } },
+        "approvalCounts": { "type": "object", "additionalProperties": { "type": "number", "minimum": 0 } },
+        "allowlistCounts": { "type": "object", "additionalProperties": { "type": "number", "minimum": 0 } },
+        "allowlistEntries": { "type": "number", "minimum": 0 },
+        "expiredAllowlistMatches": { "type": "number", "minimum": 0 },
+        "errors": { "type": "array", "items": { "type": "string" } }
+      },
+      "additionalProperties": false
+    },
+    "entries": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["status", "pathClass", "approval", "path", "pathRedacted", "allowlist"],
+        "properties": {
+          "status": { "type": "string" },
+          "pathClass": { "type": "string" },
+          "approval": { "type": "string" },
+          "path": { "type": "string" },
+          "pathRedacted": { "type": "boolean" },
+          "allowlist": {
+            "type": "object",
+            "required": ["status", "path", "owner", "reason", "expiresAt", "expired"],
+            "properties": {
+              "status": { "type": "string" },
+              "path": { "type": "string" },
+              "owner": { "type": "string" },
+              "reason": { "type": "string" },
+              "expiresAt": { "type": "string" },
+              "expired": { "type": "boolean" }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "safeNextSteps": { "type": "array", "items": { "type": "string" } },
+    "artifactPath": { "type": "string" },
+    "markdownPath": { "type": "string" },
+    "artifacts": { "type": "object" }
+  },
+  "additionalProperties": false
+}

--- a/scripts/ops/artifact_registry.mjs
+++ b/scripts/ops/artifact_registry.mjs
@@ -54,6 +54,13 @@ const PRODUCER_METADATA = {
     consumers: ["admin-effectivity-audit", "pr-readiness-packet"],
     requiredFor: ["slice-accountability"],
   },
+  "host-drift-manifest": {
+    producerCommand: "node scripts/ops/host_drift_manifest.mjs --json --write",
+    producerStep: "host-drift-manifest",
+    safeWriteRoot: "output/ops/host-drift",
+    consumers: ["ops-work-packet", "operator-handoff"],
+    requiredFor: ["host-drift-review"],
+  },
   "ops-work-packet": {
     producerCommand: "node scripts/studiobrain-ops-work-packet.mjs --json --write --max-packets 8",
     producerStep: "work-packet",
@@ -153,6 +160,12 @@ const OPS_ARTIFACT_REGISTRY = [
     id: "slice-ledger-summary",
     artifact: "output/ops/effectivity/slice-ledger-latest.json",
     schema: "schemas/ops/slice-ledger-summary.v1.schema.json",
+    freshnessTier: "loop",
+  },
+  {
+    id: "host-drift-manifest",
+    artifact: "output/ops/host-drift/host-drift-manifest-latest.json",
+    schema: "schemas/ops/host-drift-manifest.v1.schema.json",
     freshnessTier: "loop",
   },
   {

--- a/scripts/ops/host_drift_manifest.mjs
+++ b/scripts/ops/host_drift_manifest.mjs
@@ -1,0 +1,455 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const REPO_ROOT = resolve(dirname(__filename), "..", "..");
+const DEFAULT_REPO = REPO_ROOT;
+const DEFAULT_ALLOWLIST = resolve(REPO_ROOT, "studio-brain", "host-drift-allowlist.json");
+const DEFAULT_OUTPUT_DIR = resolve(REPO_ROOT, "output", "ops", "host-drift");
+
+function clean(value) {
+  return String(value ?? "").replace(/\r/g, "").trim();
+}
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function repoRelative(path) {
+  return relative(REPO_ROOT, resolve(REPO_ROOT, path)).replace(/\\/g, "/");
+}
+
+function normalizePath(value) {
+  return clean(value)
+    .replace(/^"|"$/g, "")
+    .replace(/\\/g, "/")
+    .replace(/^\.?\//, "");
+}
+
+function parseArgs(argv = process.argv.slice(2)) {
+  const options = {
+    json: false,
+    write: false,
+    repo: DEFAULT_REPO,
+    statusFile: "",
+    allowlist: DEFAULT_ALLOWLIST,
+    outputDir: DEFAULT_OUTPUT_DIR,
+    runId: "",
+    maxEntries: 1000,
+    showSensitivePaths: false,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = clean(argv[index]);
+    if (arg === "--help" || arg === "-h") {
+      process.stdout.write(usage());
+      process.exit(0);
+    }
+    if (arg === "--json") {
+      options.json = true;
+      continue;
+    }
+    if (arg === "--write") {
+      options.write = true;
+      continue;
+    }
+    if (arg === "--show-sensitive-paths") {
+      options.showSensitivePaths = true;
+      continue;
+    }
+    const next = clean(argv[index + 1]);
+    const read = (flag) => {
+      if (arg === flag) {
+        if (!next) throw new Error(`${flag} requires a value.`);
+        index += 1;
+        return next;
+      }
+      if (arg.startsWith(`${flag}=`)) return arg.slice(flag.length + 1);
+      return null;
+    };
+    const flags = {
+      "--repo": "repo",
+      "--status-file": "statusFile",
+      "--allowlist": "allowlist",
+      "--output-dir": "outputDir",
+      "--run-id": "runId",
+      "--max-entries": "maxEntries",
+    };
+    let matched = false;
+    for (const [flag, key] of Object.entries(flags)) {
+      const value = read(flag);
+      if (value === null) continue;
+      options[key] = key === "maxEntries" ? Number(value) : value;
+      matched = true;
+      break;
+    }
+    if (matched) continue;
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+  if (!Number.isFinite(options.maxEntries) || options.maxEntries < 1) throw new Error("--max-entries must be a positive number.");
+  options.repo = resolve(REPO_ROOT, options.repo);
+  options.statusFile = options.statusFile ? resolve(REPO_ROOT, options.statusFile) : "";
+  options.allowlist = resolve(REPO_ROOT, options.allowlist);
+  options.outputDir = resolve(REPO_ROOT, options.outputDir);
+  return options;
+}
+
+function usage() {
+  return `Studio Brain host drift manifest
+
+Usage:
+  node scripts/ops/host_drift_manifest.mjs [--json] [--write]
+
+Options:
+  --repo <path>          Git checkout to inspect. Default: current repo.
+  --status-file <path>   Parse a captured git status --porcelain=v1 file instead of running git.
+  --allowlist <path>     Host drift allowlist JSON. Default: studio-brain/host-drift-allowlist.json.
+  --output-dir <path>    Artifact directory. Default: output/ops/host-drift.
+  --run-id <id>          Stable run id. Default: host-drift-manifest timestamp.
+  --max-entries <n>      Maximum path rows to keep in JSON. Default: 1000.
+  --show-sensitive-paths Include sensitive-looking path names. Default redacts them.
+
+Safety:
+  Read-only. Captures path names and Git metadata only. Does not read file contents,
+  reset, clean, checkout, stash, delete, move, chmod, restart, or modify host state.
+`;
+}
+
+function git(repo, args, fallback = "", trimOutput = true) {
+  try {
+    const output = execFileSync("git", ["-C", repo, ...args], { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+    return trimOutput ? output.trim() : output;
+  } catch {
+    return fallback;
+  }
+}
+
+function readStatusLines(options) {
+  if (options.statusFile) {
+    if (!existsSync(options.statusFile)) return { source: repoRelative(options.statusFile), lines: [], readStatus: "missing", error: "status file is missing" };
+    return {
+      source: repoRelative(options.statusFile),
+      lines: readFileSync(options.statusFile, "utf8").split(/\r?\n/).filter(Boolean),
+      readStatus: "present",
+      error: "",
+    };
+  }
+  const inside = git(options.repo, ["rev-parse", "--is-inside-work-tree"], "");
+  if (inside !== "true") return { source: options.repo, lines: [], readStatus: "not_git_checkout", error: "repo is not a Git checkout" };
+  return {
+    source: options.repo,
+    lines: git(options.repo, ["status", "--porcelain=v1", "--untracked-files=all"], "", false).split(/\r?\n/).filter(Boolean),
+    readStatus: "present",
+    error: "",
+  };
+}
+
+function parsePorcelainLine(line) {
+  const raw = String(line ?? "");
+  const status = raw.slice(0, 2);
+  const body = raw.slice(3);
+  const path = body.includes(" -> ") ? body.split(" -> ").pop() : body;
+  return {
+    status: clean(status),
+    path: normalizePath(path),
+    rawStatus: status,
+  };
+}
+
+function classifyPath(path) {
+  const low = normalizePath(path).toLowerCase();
+  if (/(^|\/)(\.env|\.env\.|id_rsa|id_ed25519|secrets?|credentials?|firebase|service-account|private-key)/.test(low)) return "sensitive_path_name";
+  if (/\.(pem|key|p12|pfx|kdbx)$/.test(low)) return "sensitive_path_name";
+  if (/^(output|dist|build|coverage|\.next|node_modules|tmp|logs|\.turbo|\.cache)\//.test(low)) return "generated_or_artifact";
+  if (/\.(log|tmp|cache|tgz|zip|gz)$/.test(low)) return "generated_or_artifact";
+  if (/(^|\/)(\.gitignore|makefile|dockerfile|caddyfile(\..*)?)$/.test(low)) return "source_or_config";
+  if (/(^|\/)(compose|docker-compose)\./.test(low)) return "source_or_config";
+  if (/\.(md|ts|tsx|js|jsx|mjs|cjs|json|sql|sh|ps1|yml|yaml|toml|css|html|py|service|timer|conf)$/.test(low)) return "source_or_config";
+  return "unknown";
+}
+
+function loadAllowlist(path, generatedAt) {
+  if (!existsSync(path)) return { status: "missing", path: repoRelative(path), entries: [], errors: ["allowlist file is missing"] };
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf8"));
+    const entries = Array.isArray(parsed.entries) ? parsed.entries.map((entry) => {
+      const expiresAt = clean(entry.expiresAt);
+      const expired = expiresAt ? Date.parse(expiresAt) < Date.parse(generatedAt) : false;
+      return {
+        path: normalizePath(entry.path),
+        owner: clean(entry.owner),
+        reason: clean(entry.reason),
+        expiresAt,
+        expired,
+      };
+    }).filter((entry) => entry.path) : [];
+    return {
+      status: parsed.schemaVersion === "studio-brain-host-drift-allowlist.v1" ? "present" : "warn",
+      path: repoRelative(path),
+      generatedAt: clean(parsed.generatedAt),
+      entries,
+      errors: parsed.schemaVersion === "studio-brain-host-drift-allowlist.v1" ? [] : ["unexpected allowlist schemaVersion"],
+    };
+  } catch (error) {
+    return {
+      status: "invalid_json",
+      path: repoRelative(path),
+      entries: [],
+      errors: [error instanceof Error ? error.message : String(error)],
+    };
+  }
+}
+
+function matchAllowlist(path, allowlist) {
+  const normalized = normalizePath(path);
+  const entry = allowlist.entries.find((item) => normalized === item.path || normalized.startsWith(`${item.path}/`));
+  if (!entry) return { status: "unmatched", path: "", owner: "", reason: "", expiresAt: "", expired: false };
+  return {
+    status: entry.expired ? "expired" : "active",
+    path: entry.path,
+    owner: entry.owner,
+    reason: entry.reason,
+    expiresAt: entry.expiresAt,
+    expired: entry.expired,
+  };
+}
+
+function approvalClass(pathClass, allowlistMatch) {
+  if (pathClass === "sensitive_path_name") return "do_not_touch_security_review";
+  if (allowlistMatch.status === "active") return "allowlisted_review_before_cleanup";
+  if (allowlistMatch.status === "expired") return "requires_human_approval";
+  if (pathClass === "generated_or_artifact") return "safe_with_backup";
+  return "requires_human_approval";
+}
+
+function increment(map, key) {
+  map[key] = (map[key] || 0) + 1;
+}
+
+function collectGitMetadata(options) {
+  if (options.statusFile) {
+    return { repo: options.repo, branch: "", head: "", upstream: "", upstreamStatus: "status_file_only", aheadBehind: "" };
+  }
+  const branch = git(options.repo, ["branch", "--show-current"], "");
+  const upstream = branch ? git(options.repo, ["for-each-ref", "--format=%(upstream:short)", `refs/heads/${branch}`], "") : "";
+  const upstreamStatus = upstream
+    ? git(options.repo, ["show-ref", "--verify", "--quiet", `refs/remotes/${upstream}`], "__missing__") === "__missing__"
+      ? "gone_or_not_fetched"
+      : "present"
+    : "unavailable";
+  const aheadBehind = upstream && upstreamStatus === "present"
+    ? git(options.repo, ["rev-list", "--left-right", "--count", `HEAD...${upstream}`], "")
+    : "";
+  return {
+    repo: options.repo,
+    branch,
+    head: git(options.repo, ["rev-parse", "--short", "HEAD"], ""),
+    upstream,
+    upstreamStatus,
+    aheadBehind,
+  };
+}
+
+function buildHostDriftManifest(inputs = {}, options = {}) {
+  const generatedAt = clean(options.generatedAt) || nowIso();
+  const runId = clean(options.runId) || `host-drift-manifest-${generatedAt.replace(/[-:]/g, "").replace(/\.\d+Z$/, "Z")}`;
+  const allowlist = inputs.allowlist || loadAllowlist(options.allowlist || DEFAULT_ALLOWLIST, generatedAt);
+  const statusLines = inputs.statusLines || [];
+  const maxEntries = Number(options.maxEntries) || 1000;
+  const entries = [];
+  const classificationCounts = {};
+  const statusCounts = {};
+  const approvalCounts = {};
+  const allowlistCounts = {};
+  for (const line of statusLines) {
+    const parsed = parsePorcelainLine(line);
+    if (!parsed.path) continue;
+    const pathClass = classifyPath(parsed.path);
+    const allowlistMatch = matchAllowlist(parsed.path, allowlist);
+    const approval = approvalClass(pathClass, allowlistMatch);
+    increment(classificationCounts, pathClass);
+    increment(statusCounts, parsed.status || "unknown");
+    increment(approvalCounts, approval);
+    increment(allowlistCounts, allowlistMatch.status);
+    if (entries.length < maxEntries) {
+      const pathRedacted = pathClass === "sensitive_path_name" && !options.showSensitivePaths;
+      entries.push({
+        status: parsed.status,
+        pathClass,
+        approval,
+        path: pathRedacted ? "[redacted-sensitive-path-name]" : parsed.path,
+        pathRedacted,
+        allowlist: allowlistMatch,
+      });
+    }
+  }
+  const dirtyPaths = statusLines.filter(Boolean).length;
+  const errors = [];
+  if (allowlist.errors?.length) errors.push(...allowlist.errors.map((error) => `allowlist: ${error}`));
+  if (inputs.statusRead?.error) errors.push(inputs.statusRead.error);
+  const expiredAllowlistMatches = allowlistCounts.expired || 0;
+  const status = inputs.statusRead?.readStatus && inputs.statusRead.readStatus !== "present"
+    ? "warn"
+    : allowlist.status === "invalid_json"
+      ? "fail"
+      : dirtyPaths > 0 || errors.length > 0 || expiredAllowlistMatches > 0
+        ? "warn"
+        : "pass";
+  return {
+    schema: "studiobrain-host-drift-manifest.v1",
+    generatedAt,
+    runId,
+    status,
+    readOnly: true,
+    safety: {
+      pathNamesOnly: true,
+      readsFileContents: false,
+      mutatesHost: false,
+      destructiveActions: false,
+      sensitivePathNamesRedacted: !options.showSensitivePaths,
+    },
+    sources: {
+      repo: clean(options.repo) || DEFAULT_REPO,
+      statusSource: clean(inputs.statusRead?.source) || "",
+      statusReadStatus: clean(inputs.statusRead?.readStatus) || "present",
+      allowlistPath: allowlist.path || repoRelative(options.allowlist || DEFAULT_ALLOWLIST),
+      allowlistStatus: allowlist.status,
+      allowlistGeneratedAt: clean(allowlist.generatedAt),
+    },
+    git: inputs.gitMetadata || {},
+    summary: {
+      dirtyPaths,
+      entriesKept: entries.length,
+      truncated: dirtyPaths > entries.length,
+      classificationCounts,
+      statusCounts,
+      approvalCounts,
+      allowlistCounts,
+      allowlistEntries: allowlist.entries.length,
+      expiredAllowlistMatches,
+      errors,
+    },
+    entries,
+    safeNextSteps: [
+      "Save the manifest with restricted permissions before review.",
+      "Create a host backup branch or restricted patch bundle before any cleanup.",
+      "Review sensitive path names without printing values into tickets.",
+      "Convert accepted source/config drift into small PRs; leave cleanup/reset approval-gated.",
+    ],
+  };
+}
+
+function renderMarkdown(report) {
+  const counts = (items) => Object.entries(items || {}).map(([key, value]) => `- ${key}: ${value}`).join("\n") || "- None.";
+  const entries = report.entries.slice(0, 80).map((entry) => (
+    `| ${entry.status} | ${entry.pathClass} | ${entry.approval} | ${entry.allowlist.status}${entry.allowlist.path ? `:${entry.allowlist.path}` : ""} | \`${entry.path}\` |`
+  )).join("\n") || "|  |  |  |  | No drift paths captured. |";
+  return `# Host Drift Manifest
+
+Generated: ${report.generatedAt}
+Status: ${report.status}
+Run ID: ${report.runId}
+
+## Safety
+
+- Path names only: ${report.safety.pathNamesOnly}
+- Reads file contents: ${report.safety.readsFileContents}
+- Mutates host: ${report.safety.mutatesHost}
+- Destructive actions: ${report.safety.destructiveActions}
+
+## Sources
+
+- Repo: ${report.sources.repo}
+- Status source: ${report.sources.statusSource}
+- Status read status: ${report.sources.statusReadStatus}
+- Allowlist: ${report.sources.allowlistPath}
+- Allowlist status: ${report.sources.allowlistStatus}
+
+## Summary
+
+- Dirty paths: ${report.summary.dirtyPaths}
+- Entries kept: ${report.summary.entriesKept}
+- Truncated: ${report.summary.truncated}
+- Allowlist entries: ${report.summary.allowlistEntries}
+- Expired allowlist matches: ${report.summary.expiredAllowlistMatches}
+
+### Path Classes
+
+${counts(report.summary.classificationCounts)}
+
+### Approval Classes
+
+${counts(report.summary.approvalCounts)}
+
+### Allowlist Matches
+
+${counts(report.summary.allowlistCounts)}
+
+## Drift Entries
+
+| Git | Class | Approval | Allowlist | Path |
+| --- | --- | --- | --- | --- |
+${entries}
+
+## Safe Next Steps
+
+${report.safeNextSteps.map((step) => `- ${step}`).join("\n")}
+`;
+}
+
+function writeArtifacts(options, report) {
+  mkdirSync(options.outputDir, { recursive: true });
+  const jsonPath = resolve(options.outputDir, `${report.runId}.json`);
+  const markdownPath = resolve(options.outputDir, `${report.runId}.md`);
+  const latestJson = resolve(options.outputDir, "host-drift-manifest-latest.json");
+  const latestMarkdown = resolve(options.outputDir, "host-drift-manifest-latest.md");
+  writeFileSync(jsonPath, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+  writeFileSync(markdownPath, renderMarkdown(report), "utf8");
+  writeFileSync(latestJson, `${JSON.stringify({ ...report, artifactPath: repoRelative(jsonPath), markdownPath: repoRelative(markdownPath) }, null, 2)}\n`, "utf8");
+  writeFileSync(latestMarkdown, renderMarkdown(report), "utf8");
+  return {
+    jsonPath: repoRelative(jsonPath),
+    markdownPath: repoRelative(markdownPath),
+    latestJson: repoRelative(latestJson),
+    latestMarkdown: repoRelative(latestMarkdown),
+  };
+}
+
+function main(argv = process.argv.slice(2)) {
+  try {
+    const options = parseArgs(argv);
+    const generatedAt = nowIso();
+    const statusRead = readStatusLines(options);
+    const report = buildHostDriftManifest({
+      allowlist: loadAllowlist(options.allowlist, generatedAt),
+      statusLines: statusRead.lines,
+      statusRead,
+      gitMetadata: collectGitMetadata(options),
+    }, {
+      generatedAt,
+      runId: options.runId,
+      repo: options.repo,
+      allowlist: options.allowlist,
+      maxEntries: options.maxEntries,
+      showSensitivePaths: options.showSensitivePaths,
+    });
+    if (options.write) report.artifacts = writeArtifacts(options, report);
+    if (options.json) process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    else process.stdout.write(`host drift manifest: ${report.status}, dirtyPaths=${report.summary.dirtyPaths}\n`);
+    if (report.status === "fail") process.exitCode = 1;
+    return report;
+  } catch (error) {
+    process.stderr.write(`host_drift_manifest failed: ${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+    return null;
+  }
+}
+
+export { buildHostDriftManifest, classifyPath, parsePorcelainLine, renderMarkdown };
+
+if (process.argv[1] && resolve(process.argv[1]) === __filename) {
+  main();
+}

--- a/scripts/ops/host_drift_manifest.test.mjs
+++ b/scripts/ops/host_drift_manifest.test.mjs
@@ -1,0 +1,144 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+import { buildHostDriftManifest, classifyPath, parsePorcelainLine, renderMarkdown } from "./host_drift_manifest.mjs";
+import { validateJsonSchema } from "./validate_ops_artifacts.mjs";
+
+const allowlist = {
+  status: "present",
+  path: "studio-brain/host-drift-allowlist.json",
+  generatedAt: "2026-05-07T00:00:00.000Z",
+  entries: [
+    {
+      path: "src/autonomic",
+      owner: "platform-primary",
+      reason: "temporary host-only runtime",
+      expiresAt: "2026-06-30T00:00:00.000Z",
+      expired: false,
+    },
+    {
+      path: "lib/expired",
+      owner: "platform-primary",
+      reason: "old host-only runtime",
+      expiresAt: "2026-01-01T00:00:00.000Z",
+      expired: true,
+    },
+  ],
+  errors: [],
+};
+
+test("parsePorcelainLine keeps status and redacted path metadata only", () => {
+  assert.deepEqual(parsePorcelainLine(" M scripts/ops/example.sh"), {
+    status: "M",
+    path: "scripts/ops/example.sh",
+    rawStatus: " M",
+  });
+  assert.deepEqual(parsePorcelainLine("R  old/path.js -> src/new/path.js"), {
+    status: "R",
+    path: "src/new/path.js",
+    rawStatus: "R ",
+  });
+});
+
+test("classifyPath separates generated, source, sensitive, and unknown path names", () => {
+  assert.equal(classifyPath("output/ops/report.json"), "generated_or_artifact");
+  assert.equal(classifyPath("scripts/ops/example.sh"), "source_or_config");
+  assert.equal(classifyPath(".env.production"), "sensitive_path_name");
+  assert.equal(classifyPath("manual-drops/blob"), "unknown");
+});
+
+test("buildHostDriftManifest classifies paths against active and expired allowlist entries", () => {
+  const report = buildHostDriftManifest({
+    allowlist,
+    statusRead: { source: "fixtures/status.txt", readStatus: "present", error: "" },
+    gitMetadata: { branch: "codex/live-drift", head: "abc1234", upstream: "origin/gone", upstreamStatus: "gone_or_not_fetched" },
+    statusLines: [
+      "?? src/autonomic/loop.ts",
+      " M lib/expired/driver.js",
+      "?? output/ops/report.json",
+      "?? .env.local",
+      "?? manual-drops/blob",
+    ],
+  }, {
+    generatedAt: "2026-05-07T12:00:00.000Z",
+    runId: "host-drift-test",
+    repo: "/home/wuff/monsoonfire-portal",
+    maxEntries: 10,
+  });
+
+  assert.equal(report.status, "warn");
+  assert.equal(report.readOnly, true);
+  assert.equal(report.safety.readsFileContents, false);
+  assert.equal(report.safety.sensitivePathNamesRedacted, true);
+  assert.equal(report.summary.dirtyPaths, 5);
+  assert.equal(report.summary.allowlistCounts.active, 1);
+  assert.equal(report.summary.allowlistCounts.expired, 1);
+  assert.equal(report.summary.classificationCounts.sensitive_path_name, 1);
+  assert.equal(report.summary.approvalCounts.safe_with_backup, 1);
+  assert.equal(report.entries[0].allowlist.status, "active");
+  assert.equal(report.entries[1].allowlist.status, "expired");
+  assert.deepEqual(
+    report.entries.find((entry) => entry.pathClass === "sensitive_path_name"),
+    {
+      status: "??",
+      pathClass: "sensitive_path_name",
+      approval: "do_not_touch_security_review",
+      path: "[redacted-sensitive-path-name]",
+      pathRedacted: true,
+      allowlist: { status: "unmatched", path: "", owner: "", reason: "", expiresAt: "", expired: false },
+    },
+  );
+
+  const markdown = renderMarkdown(report);
+  assert.match(markdown, /Host Drift Manifest/);
+  assert.match(markdown, /allowlisted_review_before_cleanup/);
+  assert.match(markdown, /do_not_touch_security_review/);
+});
+
+test("buildHostDriftManifest can reveal sensitive-looking path names only when explicitly requested", () => {
+  const report = buildHostDriftManifest({
+    allowlist,
+    statusRead: { source: "fixtures/status.txt", readStatus: "present", error: "" },
+    statusLines: ["?? .env.local"],
+  }, {
+    generatedAt: "2026-05-07T12:00:00.000Z",
+    runId: "host-drift-sensitive-visible",
+    showSensitivePaths: true,
+  });
+
+  assert.equal(report.safety.sensitivePathNamesRedacted, false);
+  assert.equal(report.entries[0].path, ".env.local");
+  assert.equal(report.entries[0].pathRedacted, false);
+});
+
+test("buildHostDriftManifest truncates path rows without losing total counts", () => {
+  const report = buildHostDriftManifest({
+    allowlist,
+    statusRead: { source: "fixtures/status.txt", readStatus: "present", error: "" },
+    statusLines: ["?? a.js", "?? b.js", "?? c.js"],
+  }, {
+    generatedAt: "2026-05-07T12:00:00.000Z",
+    runId: "host-drift-truncated",
+    maxEntries: 2,
+  });
+
+  assert.equal(report.summary.dirtyPaths, 3);
+  assert.equal(report.summary.entriesKept, 2);
+  assert.equal(report.summary.truncated, true);
+});
+
+test("buildHostDriftManifest stays compatible with its JSON schema", () => {
+  const report = buildHostDriftManifest({
+    allowlist,
+    statusRead: { source: "fixtures/status.txt", readStatus: "present", error: "" },
+    statusLines: ["?? src/autonomic/loop.ts"],
+  }, {
+    generatedAt: "2026-05-07T12:00:00.000Z",
+    runId: "host-drift-schema",
+    repo: "/home/wuff/monsoonfire-portal",
+  });
+  const schema = JSON.parse(readFileSync("schemas/ops/host-drift-manifest.v1.schema.json", "utf8"));
+
+  assert.deepEqual(validateJsonSchema(report, schema), []);
+});

--- a/scripts/ops/ops_ci_validate.sh
+++ b/scripts/ops/ops_ci_validate.sh
@@ -46,6 +46,7 @@ check_file "scripts/ops/ops_wave_runner.mjs"
 check_file "scripts/ops/slice_ledger.mjs"
 check_file "scripts/ops/admin_effectivity_audit.mjs"
 check_file "scripts/ops/admin_effectivity_trend.mjs"
+check_file "scripts/ops/host_drift_manifest.mjs"
 check_file "scripts/ops/work_packet_quality_lint.mjs"
 check_file "scripts/ops/tooling_quality_report.mjs"
 check_file "scripts/ops/tooling_findings_export.mjs"
@@ -78,6 +79,7 @@ for script in \
   "scripts/ops/slice_ledger.mjs" \
   "scripts/ops/admin_effectivity_audit.mjs" \
   "scripts/ops/admin_effectivity_trend.mjs" \
+  "scripts/ops/host_drift_manifest.mjs" \
   "scripts/ops/work_packet_quality_lint.mjs" \
   "scripts/ops/tooling_quality_report.mjs" \
   "scripts/ops/tooling_findings_export.mjs" \
@@ -134,6 +136,12 @@ if node --test "${REPO_ROOT}/scripts/ops/admin_effectivity_trend.test.mjs" >"${O
   pass "node --test scripts/ops/admin_effectivity_trend.test.mjs"
 else
   fail "node --test scripts/ops/admin_effectivity_trend.test.mjs"
+fi
+
+if node --test "${REPO_ROOT}/scripts/ops/host_drift_manifest.test.mjs" >"${OUT_DIR}/host-drift-manifest.test.out" 2>&1; then
+  pass "node --test scripts/ops/host_drift_manifest.test.mjs"
+else
+  fail "node --test scripts/ops/host_drift_manifest.test.mjs"
 fi
 
 if node --test "${REPO_ROOT}/scripts/ops/work_packet_quality_lint.test.mjs" >"${OUT_DIR}/work-packet-quality-lint.test.out" 2>&1; then
@@ -216,6 +224,13 @@ if node "${REPO_ROOT}/scripts/ops/tooling_findings_export.mjs" --json --write >"
   pass "tooling_findings_export smoke"
 else
   fail "tooling_findings_export smoke"
+fi
+
+section "Host Drift Manifest Smoke"
+if node "${REPO_ROOT}/scripts/ops/host_drift_manifest.mjs" --json --write >"${OUT_DIR}/host-drift-manifest.json"; then
+  pass "host_drift_manifest smoke"
+else
+  fail "host_drift_manifest smoke"
 fi
 
 section "Artifact Schema Smoke"


### PR DESCRIPTION
## Summary
- add a path-only host drift manifest generator with JSON/Markdown output
- compare drift paths to `studio-brain/host-drift-allowlist.json` and classify approval level
- register the host-drift manifest as an ops artifact and add CI smoke coverage
- document captured-status-file usage and sensitive-path redaction defaults

## Evidence
- generated `output/ops/host-drift/host-drift-manifest-latest.json` with `readOnly=true`, no file-content reads, and sensitive-path redaction enabled
- artifact validation now checks 16 registered artifacts including host-drift-manifest
- slice ledger recorded slice-20260507-096 with 5 passing command records

## Testing
- node --test scripts/ops/host_drift_manifest.test.mjs
- node --test scripts/ops/host_drift_manifest.test.mjs scripts/ops/artifact_registry.test.mjs scripts/ops/validate_ops_artifacts.test.mjs
- node scripts/ops/host_drift_manifest.mjs --json --write
- node scripts/ops/validate_ops_artifacts.mjs --json --write
- bash scripts/ops/ops_ci_validate.sh
- git diff --check

## Risk
Low. Read-only path metadata and artifact registration only. No host mutation, deploy, restart, reset, clean, stash, delete, package, firewall, database, systemd, Docker, or secret changes.

## Rollback
Revert the commit and regenerate ignored output/ops host-drift and artifact-validation files.

## Follow-up
- feed host-drift manifest freshness into generated work packets
- capture a live host `git status --porcelain=v1 --untracked-files=all` file over SSH and parse it locally for the next review packet