### PR TITLE
[ops] Surface host drift in PR readiness

### DIFF
--- a/schemas/ops/pr-readiness-packet.v1.schema.json
+++ b/schemas/ops/pr-readiness-packet.v1.schema.json
@@ -83,7 +83,7 @@
         },
         "workPacket": {
           "type": "object",
-          "required": ["status", "generatedAt", "packets", "freshSources", "staleSources", "topPacket", "readyPackets", "approvalGatedPackets", "topPackets", "humanGates", "effectivityEvidenceLanes", "effectivityApprovalRequiredLanes", "effectivityHighSeverityLanes"],
+          "required": ["status", "generatedAt", "packets", "freshSources", "staleSources", "topPacket", "readyPackets", "approvalGatedPackets", "topPackets", "humanGates", "effectivityEvidenceLanes", "effectivityApprovalRequiredLanes", "effectivityHighSeverityLanes", "hostDriftStatus", "hostDriftDirtyPaths", "hostDriftRequiresHumanApproval", "hostDriftDoNotTouchSecurityReview", "hostDriftSensitivePathNames", "hostDriftAllowlistStatus", "hostDriftExpiredAllowlistMatches"],
           "properties": {
             "status": { "type": "string" },
             "generatedAt": { "type": "string" },
@@ -133,6 +133,13 @@
             "effectivityEvidenceLanes": { "type": ["number", "null"], "minimum": 0 },
             "effectivityApprovalRequiredLanes": { "type": ["number", "null"], "minimum": 0 },
             "effectivityHighSeverityLanes": { "type": ["number", "null"], "minimum": 0 },
+            "hostDriftStatus": { "type": "string" },
+            "hostDriftDirtyPaths": { "type": ["number", "null"], "minimum": 0 },
+            "hostDriftRequiresHumanApproval": { "type": ["number", "null"], "minimum": 0 },
+            "hostDriftDoNotTouchSecurityReview": { "type": ["number", "null"], "minimum": 0 },
+            "hostDriftSensitivePathNames": { "type": ["number", "null"], "minimum": 0 },
+            "hostDriftAllowlistStatus": { "type": "string" },
+            "hostDriftExpiredAllowlistMatches": { "type": ["number", "null"], "minimum": 0 },
             "parseError": { "type": "string" }
           },
           "additionalProperties": false

--- a/scripts/ops/pr_readiness_packet.mjs
+++ b/scripts/ops/pr_readiness_packet.mjs
@@ -127,8 +127,17 @@ function summarizeNextExecutablePacket(packet) {
 }
 
 function summarizeWorkPacket(packet) {
-  if (!packet) return { status: "missing", generatedAt: "", packets: 0, freshSources: 0, staleSources: 0, topPacket: "", readyPackets: 0, approvalGatedPackets: 0, topPackets: [], nextExecutablePacket: emptyNextExecutablePacket(), humanGates: 0, effectivityEvidenceLanes: null, effectivityApprovalRequiredLanes: null, effectivityHighSeverityLanes: null };
-  if (packet.status === "invalid_json") return { status: "invalid_json", generatedAt: "", packets: 0, freshSources: 0, staleSources: 0, topPacket: "", readyPackets: 0, approvalGatedPackets: 0, topPackets: [], nextExecutablePacket: emptyNextExecutablePacket(), humanGates: 0, effectivityEvidenceLanes: null, effectivityApprovalRequiredLanes: null, effectivityHighSeverityLanes: null, parseError: packet.parseError || "" };
+  const emptyHostDrift = {
+    hostDriftStatus: "",
+    hostDriftDirtyPaths: null,
+    hostDriftRequiresHumanApproval: null,
+    hostDriftDoNotTouchSecurityReview: null,
+    hostDriftSensitivePathNames: null,
+    hostDriftAllowlistStatus: "",
+    hostDriftExpiredAllowlistMatches: null,
+  };
+  if (!packet) return { status: "missing", generatedAt: "", packets: 0, freshSources: 0, staleSources: 0, topPacket: "", readyPackets: 0, approvalGatedPackets: 0, topPackets: [], nextExecutablePacket: emptyNextExecutablePacket(), humanGates: 0, effectivityEvidenceLanes: null, effectivityApprovalRequiredLanes: null, effectivityHighSeverityLanes: null, ...emptyHostDrift };
+  if (packet.status === "invalid_json") return { status: "invalid_json", generatedAt: "", packets: 0, freshSources: 0, staleSources: 0, topPacket: "", readyPackets: 0, approvalGatedPackets: 0, topPackets: [], nextExecutablePacket: emptyNextExecutablePacket(), humanGates: 0, effectivityEvidenceLanes: null, effectivityApprovalRequiredLanes: null, effectivityHighSeverityLanes: null, ...emptyHostDrift, parseError: packet.parseError || "" };
   const packets = Array.isArray(packet.packets) ? packet.packets : [];
   return {
     status: packets.length > 0 ? "present" : "empty",
@@ -152,6 +161,13 @@ function summarizeWorkPacket(packet) {
     effectivityEvidenceLanes: packet.evidenceSummary?.effectivityEvidenceLanes ?? null,
     effectivityApprovalRequiredLanes: packet.evidenceSummary?.effectivityApprovalRequiredLanes ?? null,
     effectivityHighSeverityLanes: packet.evidenceSummary?.effectivityHighSeverityLanes ?? null,
+    hostDriftStatus: clean(packet.evidenceSummary?.hostDriftStatus),
+    hostDriftDirtyPaths: packet.evidenceSummary?.hostDriftDirtyPaths ?? null,
+    hostDriftRequiresHumanApproval: packet.evidenceSummary?.hostDriftRequiresHumanApproval ?? null,
+    hostDriftDoNotTouchSecurityReview: packet.evidenceSummary?.hostDriftDoNotTouchSecurityReview ?? null,
+    hostDriftSensitivePathNames: packet.evidenceSummary?.hostDriftSensitivePathNames ?? null,
+    hostDriftAllowlistStatus: clean(packet.evidenceSummary?.hostDriftAllowlistStatus),
+    hostDriftExpiredAllowlistMatches: packet.evidenceSummary?.hostDriftExpiredAllowlistMatches ?? null,
   };
 }
 
@@ -345,6 +361,8 @@ function buildWarnings({ gitState, evidence, outcomeLedger }) {
   }
   if (evidence.workPacket.status === "missing") warnings.push("work-packet latest artifact is missing");
   if ((evidence.workPacket.staleSources ?? 0) > 0) warnings.push("work packet has stale evidence sources");
+  if ((evidence.workPacket.hostDriftExpiredAllowlistMatches ?? 0) > 0) warnings.push(`${evidence.workPacket.hostDriftExpiredAllowlistMatches} host-drift allowlist match(es) are expired`);
+  if ((evidence.workPacket.hostDriftDoNotTouchSecurityReview ?? 0) > 0) warnings.push(`${evidence.workPacket.hostDriftDoNotTouchSecurityReview} host-drift path(s) need security review before cleanup`);
   if (evidence.workPacketQuality.status === "missing") warnings.push("work-packet quality latest artifact is missing");
   else if (evidence.workPacketQuality.status === "warn") warnings.push("work-packet quality lint has warnings");
   else if (evidence.workPacketQuality.status !== "pass") warnings.push(`work-packet quality lint status is ${evidence.workPacketQuality.status}`);
@@ -456,7 +474,7 @@ ${dirtyFiles}
 | Artifact validation | ${packet.evidence.artifactValidation.status} | checks=${packet.evidence.artifactValidation.checks}, warned=${packet.evidence.artifactValidation.warned}, missing=${packet.evidence.artifactValidation.missing}, failed=${packet.evidence.artifactValidation.failed} |
 | Wave runner | ${packet.evidence.waveRunner.status} | run=${packet.evidence.waveRunner.runId}, workPacketMaxPackets=${packet.evidence.waveRunner.workPacketMaxPackets ?? ""} |
 | Slice ledger | ${packet.evidence.sliceLedger.status} | window=${packet.evidence.sliceLedger.window?.from || ""}..${packet.evidence.sliceLedger.window?.to || ""}, requestedCoverage=${packet.evidence.sliceLedger.requestedCoverage.status}, missing=${packet.evidence.sliceLedger.requestedCoverage.missing.join(", ")}, verification=${packet.evidence.sliceLedger.verification ?? ""}, usefulness=${packet.evidence.sliceLedger.usefulness ?? ""} |
-| Work packet | ${packet.evidence.workPacket.status} | packets=${packet.evidence.workPacket.packets}, ready=${packet.evidence.workPacket.readyPackets}, approvalGated=${packet.evidence.workPacket.approvalGatedPackets}, freshSources=${packet.evidence.workPacket.freshSources ?? ""}, staleSources=${packet.evidence.workPacket.staleSources ?? ""}, lanes=${packet.evidence.workPacket.effectivityEvidenceLanes ?? ""}, approvalLanes=${packet.evidence.workPacket.effectivityApprovalRequiredLanes ?? ""}, highLanes=${packet.evidence.workPacket.effectivityHighSeverityLanes ?? ""}, top="${packet.evidence.workPacket.topPacket}" |
+| Work packet | ${packet.evidence.workPacket.status} | packets=${packet.evidence.workPacket.packets}, ready=${packet.evidence.workPacket.readyPackets}, approvalGated=${packet.evidence.workPacket.approvalGatedPackets}, freshSources=${packet.evidence.workPacket.freshSources ?? ""}, staleSources=${packet.evidence.workPacket.staleSources ?? ""}, lanes=${packet.evidence.workPacket.effectivityEvidenceLanes ?? ""}, approvalLanes=${packet.evidence.workPacket.effectivityApprovalRequiredLanes ?? ""}, highLanes=${packet.evidence.workPacket.effectivityHighSeverityLanes ?? ""}, hostDrift=${packet.evidence.workPacket.hostDriftStatus || ""}, hostDriftDirty=${packet.evidence.workPacket.hostDriftDirtyPaths ?? ""}, hostDriftApproval=${packet.evidence.workPacket.hostDriftRequiresHumanApproval ?? ""}, hostDriftSecurity=${packet.evidence.workPacket.hostDriftDoNotTouchSecurityReview ?? ""}, top="${packet.evidence.workPacket.topPacket}" |
 | Work packet quality | ${packet.evidence.workPacketQuality.status} | findings=${packet.evidence.workPacketQuality.findings}, warnings=${packet.evidence.workPacketQuality.warnings}, failures=${packet.evidence.workPacketQuality.failures}, sourceSignalAudit=${packet.evidence.workPacketQuality.sourceSignalAuditStatus || ""} |
 | Packet outcomes | ${packet.evidence.packetOutcome.status} | total=${packet.evidence.packetOutcome.total}, maturity=${packet.evidence.packetOutcome.maturity}, score=${packet.evidence.packetOutcome.score ?? ""}, orphanedRate=${packet.evidence.packetOutcome.orphanedRate ?? ""}, resetRecommended=${packet.evidence.packetOutcome.resetRecommended} |
 | Tool install recommendations | ${packet.evidence.toolInstall.status} | recommendations=${packet.evidence.toolInstall.recommendations}, installNow=${packet.evidence.toolInstall.installNowCandidates}, approvalRequired=${packet.evidence.toolInstall.approvalRequired} |

--- a/scripts/ops/pr_readiness_packet.test.mjs
+++ b/scripts/ops/pr_readiness_packet.test.mjs
@@ -32,6 +32,13 @@ const workPacket = {
     effectivityEvidenceLanes: 4,
     effectivityApprovalRequiredLanes: 1,
     effectivityHighSeverityLanes: 1,
+    hostDriftStatus: "warn",
+    hostDriftDirtyPaths: 3,
+    hostDriftRequiresHumanApproval: 2,
+    hostDriftDoNotTouchSecurityReview: 0,
+    hostDriftSensitivePathNames: 0,
+    hostDriftAllowlistStatus: "present",
+    hostDriftExpiredAllowlistMatches: 0,
   },
   packets: [
     { packetId: "ops-wp-ready", title: "[ops] Refresh evidence", status: "ready", priority: "P1", humanGate: "" },
@@ -158,6 +165,10 @@ test("buildPrReadinessPacket summarizes current evidence without executable inst
   assert.equal(packet.evidence.workPacket.effectivityEvidenceLanes, 4);
   assert.equal(packet.evidence.workPacket.effectivityApprovalRequiredLanes, 1);
   assert.equal(packet.evidence.workPacket.effectivityHighSeverityLanes, 1);
+  assert.equal(packet.evidence.workPacket.hostDriftStatus, "warn");
+  assert.equal(packet.evidence.workPacket.hostDriftDirtyPaths, 3);
+  assert.equal(packet.evidence.workPacket.hostDriftRequiresHumanApproval, 2);
+  assert.equal(packet.evidence.workPacket.hostDriftAllowlistStatus, "present");
   assert.equal(packet.evidence.workPacketQuality.status, "pass");
   assert.equal(packet.evidence.workPacketQuality.findings, 0);
   assert.equal(packet.evidence.toolInstall.installNowCandidates, 2);
@@ -182,6 +193,9 @@ test("buildPrReadinessPacket summarizes current evidence without executable inst
   assert.match(markdown, /requestedCoverage=covered/);
   assert.match(markdown, /lanes=4/);
   assert.match(markdown, /approvalLanes=1/);
+  assert.match(markdown, /hostDrift=warn/);
+  assert.match(markdown, /hostDriftDirty=3/);
+  assert.match(markdown, /hostDriftApproval=2/);
   assert.match(markdown, /shellcheck/);
   assert.doesNotMatch(markdown, /do not copy this/);
   assert.doesNotMatch(markdown, /do not install Docker/);
@@ -241,6 +255,33 @@ test("buildPrReadinessPacket surfaces degraded packet outcome churn", () => {
   assert.ok(packet.warnings.some((warning) => warning.includes("blockedPackets=1")));
   assert.ok(packet.warnings.some((warning) => warning.includes("recording fresh current packet outcomes")));
   assert.match(renderMarkdown(packet), /orphanedRate=0.75/);
+});
+
+test("buildPrReadinessPacket warns on host drift security review gates", () => {
+  const packet = buildPrReadinessPacket({
+    gitState,
+    artifactValidation,
+    waveRunner,
+    workPacket: {
+      ...workPacket,
+      evidenceSummary: {
+        ...workPacket.evidenceSummary,
+        hostDriftDoNotTouchSecurityReview: 1,
+        hostDriftExpiredAllowlistMatches: 2,
+      },
+    },
+    workPacketQuality,
+    packetOutcomeReport,
+    sliceLedger,
+    toolInstallRecommendations: { ...toolInstallRecommendations, summary: { recommendations: 1, installNowCandidates: 0, approvalRequired: 0 } },
+  });
+
+  assert.equal(packet.status, "warn");
+  assert.equal(packet.evidence.workPacket.hostDriftDoNotTouchSecurityReview, 1);
+  assert.equal(packet.evidence.workPacket.hostDriftExpiredAllowlistMatches, 2);
+  assert.ok(packet.warnings.some((warning) => warning.includes("host-drift allowlist")));
+  assert.ok(packet.warnings.some((warning) => warning.includes("security review")));
+  assert.match(renderMarkdown(packet), /hostDriftSecurity=1/);
 });
 
 test("buildPrReadinessPacket fails when work-packet quality lint fails", () => {


### PR DESCRIPTION
## Summary
- Surface host-drift posture directly in PR readiness packets.
- Include status, dirty-path count, approval-gate count, security-review count, sensitive-path count, allowlist status, and expired allowlist matches from the latest work-packet evidence summary.
- Render the host-drift summary into the PR readiness Markdown so reviewers do not need to open the full work-packet JSON.

## Evidence
- Slice 098 ledger recorded the change as `slice-20260507-098`.
- PR readiness output now shows `hostDriftStatus`, `hostDriftDirtyPaths`, and approval/security review fields under `evidence.workPacket`.
- Artifact schema validation passed for 16 registered artifacts.

## Testing
- `node --check scripts/ops/pr_readiness_packet.mjs`
- `node --test scripts/ops/pr_readiness_packet.test.mjs`
- `node scripts/ops/pr_readiness_packet.mjs --json --write --base codex/ops-work-packet-host-drift-evidence-wave2 --slice-ids slice-20260507-098`
- `node scripts/ops/validate_ops_artifacts.mjs --json --write`
- `bash scripts/ops/ops_ci_validate.sh`
- `git diff --check`

## Risk
Low. This only expands a read-only readiness packet summary and its schema/tests. It performs no host, Docker, database, package, firewall, SSH, sudoers, service, or secret mutations.

## Rollback
Revert commit `def45e66`, then regenerate ignored `output/ops/pr-readiness/*latest*` artifacts if needed.

## Follow-ups
- Add incident bundle readiness around the registered artifact family.
- Continue tooling coverage with ephemeral shellcheck/sqlfluff validators.