### PR TITLE
[ops] Add Caddy proxy Docker healthchecks

### DIFF
--- a/config/studiobrain/monitoring/Caddyfile
+++ b/config/studiobrain/monitoring/Caddyfile
@@ -4,6 +4,9 @@
 }
 
 :18080 {
+    @health path /healthz
+    respond @health "ok" 200
+
     @notlan not remote_ip 192.168.1.0/24 127.0.0.1/8 ::1
     respond @notlan "Forbidden" 403
 
@@ -15,6 +18,9 @@
 }
 
 :18081 {
+    @health path /healthz
+    respond @health "ok" 200
+
     @notlan not remote_ip 192.168.1.0/24 127.0.0.1/8 ::1
     respond @notlan "Forbidden" 403
 

--- a/config/studiobrain/monitoring/docker-compose.yml
+++ b/config/studiobrain/monitoring/docker-compose.yml
@@ -75,6 +75,12 @@ services:
       - "${MONITORING_BIND_HOST:-127.0.0.1}:18081:18081"
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile:ro
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://127.0.0.1:18080/healthz || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
     logging:
       driver: json-file
       options:

--- a/docs/ops/05-docker-ops-review.md
+++ b/docs/ops/05-docker-ops-review.md
@@ -44,13 +44,19 @@ Covered:
 - `studiobrain_minio`
 - `netdata`
 - `uptime-kuma`
+- `monitoring-proxy` in tracked monitoring Compose, via local `/healthz` Caddy probe
+- `studiobrain_proxy` in tracked optional proxy Compose, via local `/healthz` Caddy probe
 
 Missing:
 
 - `studiobrain_otel_collector`
-- `monitoring-proxy`
 - `searxng-searxng-1`
 - `searxng-redis-1`
+
+Notes:
+
+- The live SearXNG Compose path is `/home/wuff/searxng/docker-compose.yml`, outside this tracked repo. Add its healthchecks through an approval-gated host patch or by importing the compose source into a tracked operations lane first.
+- Healthcheck changes require container recreate to take effect; do not restart or recreate containers without explicit approval and a service-window plan.
 
 ## Restart Policy Coverage
 
@@ -139,6 +145,7 @@ Requires service window:
 - Change port binds.
 - Change image tags.
 - Add or alter hard resource caps.
+- Apply healthcheck stanza changes to already-running containers, because Docker Compose must recreate the affected container for the new healthcheck to appear.
 - Restart or recreate containers.
 
 Requires human approval:

--- a/studio-brain/.env.integrity.json
+++ b/studio-brain/.env.integrity.json
@@ -1,6 +1,6 @@
 {
   "schema": "studiobrain-infra-integrity-v1",
-  "generatedAt": "2026-05-06T22:33:57.171Z",
+  "generatedAt": "2026-05-07T21:09:26.624Z",
   "generatedBy": "scripts/integrity-check.mjs",
   "allowUnknown": false,
   "metadata": {
@@ -116,13 +116,13 @@
   "files": [
     {
       "path": "config/studiobrain/monitoring/Caddyfile",
-      "sha256": "d560854e4f28717e355ed2c34e14478b3dbc7ac16f61d9202c0e4abd519b6b1d",
-      "size": 524
+      "sha256": "acff5f2be7517ad651ef6f1d722d8677850e6a8ec7b6c46dfd50898419a76a7c",
+      "size": 636
     },
     {
       "path": "config/studiobrain/monitoring/docker-compose.yml",
-      "sha256": "a6c7ada3951180ef6db007421b9deca0b6e30ad4063d056318333ff380bf17c3",
-      "size": 2276
+      "sha256": "a1bc8c3b47f60ac8bbeec3ac377734293c3fd6ad9de7a0eb601148de28889d83",
+      "size": 2459
     },
     {
       "path": "config/studiobrain/monitoring/netdata-overrides/docker.conf",

--- a/studio-brain/docker-compose.proxy.yml
+++ b/studio-brain/docker-compose.proxy.yml
@@ -10,6 +10,12 @@ services:
       - ./docker/Caddyfile.proxy:/etc/caddy/Caddyfile:ro
     extra_hosts:
       - "host.docker.internal:host-gateway"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://127.0.0.1/healthz || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
     deploy:
       resources:
         limits:


### PR DESCRIPTION
## Summary
- add local `/healthz` Caddy responses for the tracked monitoring proxy ports
- add Docker healthcheck stanzas for the tracked monitoring Caddy proxy and optional Studio Brain proxy
- update Docker ops review to mark repo-owned proxy healthchecks covered and keep SearXNG healthchecks approval-gated because its compose file is external to this repo

## Evidence
- Docker ops review listed `monitoring-proxy` and SearXNG containers as missing healthchecks.
- `config/studiobrain/monitoring/docker-compose.yml` and `studio-brain/docker-compose.proxy.yml` are tracked repo-owned compose files.
- Live SearXNG compose is documented as `/home/wuff/searxng/docker-compose.yml`, outside this tracked repo.

## Testing
- `git diff --check`
- `npx --yes yaml@2.8.3 valid` for `config/studiobrain/monitoring/docker-compose.yml`, `studio-brain/docker-compose.proxy.yml`, and `studio-brain/docker-compose.yml`

Not run: `docker compose config`, because the Docker CLI is not installed in this Windows worktree lane.

## Risk
Low for repository configuration. Runtime effect is deferred until an operator recreates the affected containers.

## Rollback
Revert this PR, then recreate the affected containers during an approved service window if the change had already been applied live.

## Follow-up
- Add SearXNG healthchecks through an approval-gated host patch or by importing its compose source into a tracked ops lane.
- Validate with `docker compose config` on a host with Docker before applying live.