### PR TITLE
[ops] Add proactive issue radar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL := /bin/bash
 PG_CONTAINER ?= studiobrain_postgres
 PGDATABASE ?= monsoonfire_studio_os
 
-.PHONY: ops-check ops-inventory ops-postgres-review ops-postgres-sql ops-postgres-top-queries ops-postgres-query-tasks ops-postgres-growth-snapshot ops-postgres-autovacuum-stats ops-postgres-roles-extensions ops-docker-review ops-docker-posture ops-capacity ops-import-pressure ops-cleanup-candidates ops-backup-evidence ops-postgres-backup-artifacts ops-restore-prereq ops-redis-minio-backup-evidence ops-ubuntu-review ops-host-failed-unit-trends ops-package-posture ops-time-sync ops-network-review ops-host-drift ops-systemd-drift ops-portal-bridge-review ops-app-review ops-dependency-review ops-idle-worker-effectivity ops-effectivity-report ops-slice-ledger ops-tool-inventory ops-admin-effectivity-audit ops-privileged-evidence-read ops-privileged-evidence-capture ops-privileged-evidence-capture-smoke ops-work-packet ops-incident-bundle ops-incident-bundle-v2 ops-ci-validate ops-post-deploy-verify ops-docs ops-backlog ops-report
+.PHONY: ops-check ops-inventory ops-postgres-review ops-postgres-sql ops-postgres-top-queries ops-postgres-query-tasks ops-postgres-growth-snapshot ops-postgres-autovacuum-stats ops-postgres-roles-extensions ops-docker-review ops-docker-posture ops-capacity ops-import-pressure ops-cleanup-candidates ops-backup-evidence ops-postgres-backup-artifacts ops-restore-prereq ops-redis-minio-backup-evidence ops-ubuntu-review ops-host-failed-unit-trends ops-package-posture ops-time-sync ops-network-review ops-host-drift ops-systemd-drift ops-portal-bridge-review ops-app-review ops-dependency-review ops-idle-worker-effectivity ops-effectivity-report ops-slice-ledger ops-tool-inventory ops-admin-effectivity-audit ops-proactive-radar ops-privileged-evidence-read ops-privileged-evidence-capture ops-privileged-evidence-capture-smoke ops-work-packet ops-incident-bundle ops-incident-bundle-v2 ops-ci-validate ops-post-deploy-verify ops-docs ops-backlog ops-report
 
 ops-check: ops-inventory ops-docker-review ops-capacity ops-cleanup-candidates ops-backup-evidence ops-ubuntu-review ops-network-review ops-host-drift ops-systemd-drift ops-portal-bridge-review ops-app-review
 
@@ -119,6 +119,9 @@ ops-tool-inventory:
 
 ops-admin-effectivity-audit:
 	node scripts/ops/admin_effectivity_audit.mjs --write
+
+ops-proactive-radar:
+	node scripts/ops/proactive_issue_radar.mjs --write
 
 ops-privileged-evidence-read:
 	bash scripts/ops/privileged_evidence_read.sh

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL := /bin/bash
 PG_CONTAINER ?= studiobrain_postgres
 PGDATABASE ?= monsoonfire_studio_os
 
-.PHONY: ops-check ops-inventory ops-postgres-review ops-postgres-sql ops-postgres-top-queries ops-postgres-query-tasks ops-postgres-growth-snapshot ops-postgres-autovacuum-stats ops-postgres-roles-extensions ops-docker-review ops-docker-posture ops-capacity ops-import-pressure ops-cleanup-candidates ops-backup-evidence ops-postgres-backup-artifacts ops-restore-prereq ops-redis-minio-backup-evidence ops-ubuntu-review ops-host-failed-unit-trends ops-package-posture ops-time-sync ops-network-review ops-host-drift ops-systemd-drift ops-portal-bridge-review ops-app-review ops-dependency-review ops-idle-worker-effectivity ops-effectivity-report ops-slice-ledger ops-tool-inventory ops-admin-effectivity-audit ops-proactive-radar ops-privileged-evidence-read ops-privileged-evidence-capture ops-privileged-evidence-capture-smoke ops-work-packet ops-incident-bundle ops-incident-bundle-v2 ops-ci-validate ops-post-deploy-verify ops-docs ops-backlog ops-report
+.PHONY: ops-check ops-inventory ops-postgres-review ops-postgres-sql ops-postgres-top-queries ops-postgres-query-tasks ops-postgres-growth-snapshot ops-postgres-autovacuum-stats ops-postgres-roles-extensions ops-docker-review ops-docker-posture ops-capacity ops-import-pressure ops-cleanup-candidates ops-backup-evidence ops-postgres-backup-artifacts ops-restore-prereq ops-redis-minio-backup-evidence ops-ubuntu-review ops-host-failed-unit-trends ops-package-posture ops-time-sync ops-network-review ops-host-drift ops-systemd-drift ops-portal-bridge-review ops-app-review ops-dependency-review ops-idle-worker-effectivity ops-effectivity-report ops-slice-ledger ops-tool-inventory ops-admin-effectivity-audit ops-proactive-radar ops-pr-stack-readiness ops-privileged-evidence-read ops-privileged-evidence-capture ops-privileged-evidence-capture-smoke ops-work-packet ops-incident-bundle ops-incident-bundle-v2 ops-ci-validate ops-post-deploy-verify ops-docs ops-backlog ops-report
 
 ops-check: ops-inventory ops-docker-review ops-capacity ops-cleanup-candidates ops-backup-evidence ops-ubuntu-review ops-network-review ops-host-drift ops-systemd-drift ops-portal-bridge-review ops-app-review
 
@@ -122,6 +122,9 @@ ops-admin-effectivity-audit:
 
 ops-proactive-radar:
 	node scripts/ops/proactive_issue_radar.mjs --write
+
+ops-pr-stack-readiness:
+	node scripts/ops/pr_stack_readiness.mjs --write
 
 ops-privileged-evidence-read:
 	bash scripts/ops/privileged_evidence_read.sh

--- a/docs/ops/24-proactive-admin-loop-wave1.md
+++ b/docs/ops/24-proactive-admin-loop-wave1.md
@@ -1,0 +1,86 @@
+# Proactive Administrator Loop Wave 1
+
+This wave turns the Studio Brain administrator from a set of useful checks into an iterative operating loop: plan, implement, audit, verify value, recommend, and repeat. The focus is proactive issue discovery and tooling that helps future agents notice drift before it becomes an incident.
+
+## Operating Rules
+
+- Use clean worktrees from `origin/main` for implementation.
+- Keep primary discovery read-only.
+- Prefer scripts, reports, runbooks, and issue-ready tickets over live host mutation.
+- Do not run destructive cleanup, service restarts, package upgrades, firewall or SSH changes, schema changes, secret rotation, or live Docker recreates without explicit approval.
+- Every wave should leave behind an artifact under `docs/ops/` or `output/ops/` that a later operator can verify.
+- After every 5 slices, run an effectiveness audit and decide whether the work is producing real leverage.
+
+## 50-Slice Plan
+
+| # | Slice | Lane | Deliverable / Acceptance |
+| ---: | --- | --- | --- |
+| 1 | Proactive radar command | Tooling | Read-only command summarizes PR risk, stale evidence, dirty worktrees, hidden scripts, and next recommendations. |
+| 2 | Wave 1 plan artifact | Docs | This 50-slice plan exists under `docs/ops/` with safety gates and acceptance notes. |
+| 3 | Radar Makefile wrapper | Tooling | `make ops-proactive-radar` runs the radar and writes ignored artifacts. |
+| 4 | Radar README entry | Docs | `docs/ops/README.md` lists the new command and sharing rules. |
+| 5 | Wave audit 1 | SRE | Run syntax checks and radar; verify output is actionable rather than noise. |
+| 6 | PR stack merge-order packet | GitHub ops | Report draft stack bases, merge order, stale branches, and blockers without closing PRs. |
+| 7 | Dirty PR conflict packet | GitHub ops | For PR #492 and future dirty PRs, generate issue-ready conflict-resolution notes. |
+| 8 | Draft stack stale-age policy | GitHub ops | Define stale draft thresholds and owner actions. |
+| 9 | Draft stack dashboard artifact | Tooling | Store latest PR stack summary under `output/ops/pr-stack/`. |
+| 10 | Wave audit 2 | SRE | Confirm PR tooling reduces ambiguity and does not overstate mergeability. |
+| 11 | Evidence freshness thresholds | Ops docs | Formalize warning/critical age thresholds for inventory, risk, capacity, DBA, Docker, backup docs. |
+| 12 | Evidence freshness checker | Tooling | Script exits warn when critical docs are stale or missing. |
+| 13 | Evidence freshness admin import | Mission Control bridge | Produce JSON shape suitable for admin task import. |
+| 14 | Stale evidence backlog export | Docs/backlog | Issue-ready entries for refreshing stale artifacts. |
+| 15 | Wave audit 3 | SRE | Verify stale-evidence findings cite file mtimes and safe refresh commands. |
+| 16 | Host privileged-evidence status contract | Ubuntu | Normalize `sudo_unavailable` and privileged capture availability into machine-readable status. |
+| 17 | AIDE/livepatch capture checklist refresh | Ubuntu | Approval-gated exact commands and expected artifacts. |
+| 18 | Reboot/update evidence bridge | Ubuntu | Read current non-privileged update/reboot evidence where available; privileged slots remain gated. |
+| 19 | Open-port evidence bridge | Security | Normalize available listener/firewall evidence and missing privileged captures. |
+| 20 | Wave audit 4 | SRE | Ensure security posture reports do not imply unaudited host safety. |
+| 21 | Docker live-apply readiness packet | Docker | Document exact service-window steps for applying merged healthchecks. |
+| 22 | Docker compose drift radar | Docker | Compare tracked compose files with generated config where Docker is available; degrade gracefully. |
+| 23 | Docker log growth radar | Docker | Summarize available json-log sizing and missing privileged reads. |
+| 24 | Docker cleanup approval queue refresh | Docker/docs | Rebuild cleanup candidates grouped by approval level. |
+| 25 | Wave audit 5 | SRE | Verify Docker reports never prune, stop, or recreate containers. |
+| 26 | Postgres visibility matrix | DBA | Matrix of available vs missing DBA evidence: sizes, locks, pg_stat_statements, backups. |
+| 27 | Postgres slow-query task export | DBA | Convert top query families into issue-ready performance tasks when data exists. |
+| 28 | Postgres restore-confidence radar | DBA/backup | Report backup artifact age plus restore-drill evidence age. |
+| 29 | Postgres bloat uncertainty notes | DBA | Document what current dead-tuple/bloat probes can and cannot prove. |
+| 30 | Wave audit 6 | SRE | Verify DBA output is read-only and marks missing data as unknown. |
+| 31 | Backup component confidence model | Backup | Score Postgres, Redis, MinIO, config, restore drill independently. |
+| 32 | Backup failure task export | Backup/docs | Generate issue-ready tasks for stale/missing backup evidence. |
+| 33 | Backup encryption/retention evidence slots | Backup/security | Separate known facts from approval-gated evidence needs. |
+| 34 | Restore drill operator checklist v2 | Backup | Human-safe disposable-target checklist with hard stop before production restore. |
+| 35 | Wave audit 7 | SRE | Confirm backup confidence cannot pass solely from backup file presence. |
+| 36 | Dependency risk radar | App ops | Summarize npm audit inventory, outdated packages, pinned risky packages, and fix boundaries. |
+| 37 | Secret reference drift radar | Security | List secret names and config references only; no values. |
+| 38 | Env example coverage checker | App ops | Compare documented env names with references, without printing values. |
+| 39 | Runtime endpoint exposure matrix | Security/perf | Map public/local/LAN/admin endpoints and risk notes from tracked config. |
+| 40 | Wave audit 8 | SRE | Verify app/security reports avoid secret leakage and false certainty. |
+| 41 | Incident bundle coverage matrix | SRE | Show which lanes incident bundle v2 covers and which are missing. |
+| 42 | Incident bundle redaction test | SRE/security | Add automated check for token/env/private-key leakage in generated bundles. |
+| 43 | Post-deploy verifier coverage matrix | SRE | Clarify which live paths are verified after deploy and which are advisory. |
+| 44 | Value audit scorecard | SRE | Score each slice as useful, no-op, blocked, or needs follow-up. |
+| 45 | Wave audit 9 | SRE | Stop or redirect any lane that is producing noisy artifacts. |
+| 46 | Admin issue import packet | Mission Control bridge | Produce import-ready JSON for top risks, stale evidence, backups, and approval gates. |
+| 47 | Approval queue copy refresh | UX/docs | Make cleanup/security/package approval cards owner-friendly with rollback notes. |
+| 48 | 30/60/90 roadmap refresh | Docs | Reorder roadmap based on actual findings from this wave. |
+| 49 | Loop handoff generator | Automation | One command emits latest artifacts, blockers, next 10 slices, and recommended swarm roles. |
+| 50 | Wave closeout and next loop seed | Lead | Audit value, publish/PR safe changes, save handoff, and create the next 50-slice seed. |
+
+## First Implementation Artifacts
+
+- `scripts/ops/proactive_issue_radar.mjs`
+- `make ops-proactive-radar`
+- `output/ops/proactive-radar/latest.json`
+- `output/ops/proactive-radar/latest.md`
+
+## Value Test
+
+This wave is valuable only if it reduces operator uncertainty. A slice should be kept when it:
+
+- finds a real stale, dirty, missing, blocked, or risky state;
+- names evidence and safe next step;
+- avoids printing secrets;
+- avoids service-impacting mutation;
+- helps the next agent choose work without re-reading the whole ops folder.
+
+If a slice only creates decorative status text, mark it as no-op and redirect.

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -52,6 +52,7 @@ make ops-app-review
 make ops-dependency-review
 make ops-idle-worker-effectivity
 make ops-effectivity-report
+make ops-proactive-radar
 make ops-privileged-evidence-read
 make ops-privileged-evidence-capture-smoke
 make ops-work-packet
@@ -60,6 +61,12 @@ make ops-incident-bundle-v2
 make ops-ci-validate
 make ops-post-deploy-verify
 make ops-report
+```
+
+Windows-friendly npm equivalent:
+
+```bash
+npm run ops:proactive:radar
 ```
 
 The scripts under `scripts/ops/` avoid environment dumps and degrade when Docker, PostgreSQL, or host-only tools are unavailable.
@@ -75,6 +82,7 @@ bash scripts/ops/import_pressure.sh --target /home/wuff/imports
 bash scripts/ops/cleanup_candidates.sh --import-target /home/wuff/imports
 bash scripts/ops/npm_audit_inventory.sh
 bash scripts/ops/effectivity_report.sh
+node scripts/ops/proactive_issue_radar.mjs --write
 bash scripts/ops/privileged_evidence_read.sh
 bash scripts/ops/privileged_evidence_capture.sh --smoke --output-dir output/ops/privileged-evidence
 node scripts/studiobrain-ops-work-packet.mjs --write
@@ -82,6 +90,8 @@ bash scripts/ops/incident_bundle_v2.sh output/ops/incidents-v2/manual-smoke
 ```
 
 `ops-privileged-evidence-capture-smoke` writes a non-root local smoke artifact under `output/ops/privileged-evidence` and is safe for development. Installing the host-side privileged collector, timer, group, or sudoers allowlist is intentionally separate and approval-gated; see `22-privileged-evidence-capture.md`.
+
+`ops-proactive-radar` is a read-only loop-start command. It looks for merge-blocked PRs, stacked draft PR pressure, stale ops artifacts, dirty worktree risk, and hidden ops scripts without printing secrets or mutating the host.
 
 ## Approval Boundaries
 

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -53,6 +53,7 @@ make ops-dependency-review
 make ops-idle-worker-effectivity
 make ops-effectivity-report
 make ops-proactive-radar
+make ops-pr-stack-readiness
 make ops-privileged-evidence-read
 make ops-privileged-evidence-capture-smoke
 make ops-work-packet
@@ -67,6 +68,7 @@ Windows-friendly npm equivalent:
 
 ```bash
 npm run ops:proactive:radar
+npm run ops:pr-stack:readiness
 ```
 
 The scripts under `scripts/ops/` avoid environment dumps and degrade when Docker, PostgreSQL, or host-only tools are unavailable.
@@ -92,6 +94,8 @@ bash scripts/ops/incident_bundle_v2.sh output/ops/incidents-v2/manual-smoke
 `ops-privileged-evidence-capture-smoke` writes a non-root local smoke artifact under `output/ops/privileged-evidence` and is safe for development. Installing the host-side privileged collector, timer, group, or sudoers allowlist is intentionally separate and approval-gated; see `22-privileged-evidence-capture.md`.
 
 `ops-proactive-radar` is a read-only loop-start command. It looks for merge-blocked PRs, stacked draft PR pressure, stale ops artifacts, dirty worktree risk, and hidden ops scripts without printing secrets or mutating the host.
+
+`ops-pr-stack-readiness` is a read-only GitHub PR-stack packet. It groups open PRs by stack, identifies dirty non-draft PRs, stale PRs, and non-main draft chains, and writes artifacts under `output/ops/pr-stack`.
 
 ## Approval Boundaries
 

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "portal:smoke:playwright": "node ./scripts/portal-playwright-smoke.mjs --output-dir output/playwright/portal",
     "ops:portal:bridge:smoke": "npm --prefix studio-brain run build && node ./scripts/ops-portal-bridge-smoke.mjs --json",
     "ops:portal:public:smoke": "node ./scripts/ops-portal-public-smoke.mjs --json",
+    "ops:proactive:radar": "node ./scripts/ops/proactive_issue_radar.mjs --write --json",
     "portal:smoke:native-browser:shadow": "node ./scripts/native-browser-shadow-verifier.mjs --surface portal --base-url https://portal.monsoonfire.com --output-dir output/native-browser/portal/prod --shadow-of verify.portal.smoke --canonical-artifact-root output/playwright/portal/prod",
     "codex:browser:verify:portal": "node ./scripts/native-browser-shadow-verifier.mjs --surface portal --base-url https://portal.monsoonfire.com --output-dir output/native-browser/portal/prod --shadow-of verify.portal.smoke --canonical-artifact-root output/playwright/portal/prod --app-handoff",
     "codex:browser:verify:portal:local": "node ./scripts/native-browser-shadow-verifier.mjs --surface portal --base-url http://127.0.0.1:5173 --output-dir output/native-browser/portal/local --shadow-of verify.portal.smoke.local --canonical-artifact-root output/playwright/portal/local --app-handoff",

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "ops:portal:bridge:smoke": "npm --prefix studio-brain run build && node ./scripts/ops-portal-bridge-smoke.mjs --json",
     "ops:portal:public:smoke": "node ./scripts/ops-portal-public-smoke.mjs --json",
     "ops:proactive:radar": "node ./scripts/ops/proactive_issue_radar.mjs --write --json",
+    "ops:pr-stack:readiness": "node ./scripts/ops/pr_stack_readiness.mjs --write --json",
     "portal:smoke:native-browser:shadow": "node ./scripts/native-browser-shadow-verifier.mjs --surface portal --base-url https://portal.monsoonfire.com --output-dir output/native-browser/portal/prod --shadow-of verify.portal.smoke --canonical-artifact-root output/playwright/portal/prod",
     "codex:browser:verify:portal": "node ./scripts/native-browser-shadow-verifier.mjs --surface portal --base-url https://portal.monsoonfire.com --output-dir output/native-browser/portal/prod --shadow-of verify.portal.smoke --canonical-artifact-root output/playwright/portal/prod --app-handoff",
     "codex:browser:verify:portal:local": "node ./scripts/native-browser-shadow-verifier.mjs --surface portal --base-url http://127.0.0.1:5173 --output-dir output/native-browser/portal/local --shadow-of verify.portal.smoke.local --canonical-artifact-root output/playwright/portal/local --app-handoff",

--- a/scripts/ops/pr_stack_readiness.mjs
+++ b/scripts/ops/pr_stack_readiness.mjs
@@ -1,0 +1,326 @@
+#!/usr/bin/env node
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, relative, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const REPO_ROOT = resolve(dirname(__filename), "..", "..");
+const DEFAULT_OUTPUT_DIR = resolve(REPO_ROOT, "output", "ops", "pr-stack");
+const DEFAULT_REPO = "monsoonfirepottery-byte/monsoonfire-portal";
+
+function clean(value) {
+  return String(value ?? "").replace(/\r/g, "").trim();
+}
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function repoRelative(path) {
+  return relative(REPO_ROOT, path).replace(/\\/g, "/");
+}
+
+function usage() {
+  return `Studio Brain PR stack readiness packet
+
+Usage:
+  node scripts/ops/pr_stack_readiness.mjs [--json] [--write]
+
+Options:
+  --json                 Print JSON to stdout.
+  --write                Write timestamped JSON and Markdown artifacts.
+  --repo <owner/name>    GitHub repo. Default: ${DEFAULT_REPO}.
+  --output-dir <path>    Artifact directory. Default: output/ops/pr-stack.
+  --run-id <id>          Stable run id.
+`;
+}
+
+function readFlagValue(argv, index, name) {
+  const arg = argv[index];
+  if (arg === name) {
+    if (!argv[index + 1]) throw new Error(`${name} requires a value.`);
+    return { matched: true, value: argv[index + 1], nextIndex: index + 1 };
+  }
+  if (arg.startsWith(`${name}=`)) {
+    return { matched: true, value: arg.slice(name.length + 1), nextIndex: index };
+  }
+  return { matched: false, value: "", nextIndex: index };
+}
+
+function parseArgs(argv) {
+  const options = { json: false, write: false, repo: DEFAULT_REPO, outputDir: DEFAULT_OUTPUT_DIR, runId: "" };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--help" || arg === "-h") {
+      process.stdout.write(usage());
+      process.exit(0);
+    }
+    if (arg === "--json") {
+      options.json = true;
+      continue;
+    }
+    if (arg === "--write") {
+      options.write = true;
+      continue;
+    }
+    const mappings = [["--repo", "repo"], ["--output-dir", "outputDir"], ["--run-id", "runId"]];
+    let consumed = false;
+    for (const [flag, key] of mappings) {
+      const parsed = readFlagValue(argv, index, flag);
+      if (!parsed.matched) continue;
+      options[key] = parsed.value;
+      index = parsed.nextIndex;
+      consumed = true;
+      break;
+    }
+    if (consumed) continue;
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+  options.outputDir = resolve(REPO_ROOT, options.outputDir);
+  return options;
+}
+
+function runJson(command, args) {
+  const result = spawnSync(command, args, {
+    cwd: REPO_ROOT,
+    encoding: "utf8",
+    windowsHide: true,
+    timeout: 45_000,
+    env: { ...process.env }
+  });
+  if (result.error || result.status !== 0) {
+    return {
+      ok: false,
+      error: result.error?.message || clean(result.stderr) || `exit ${result.status}`,
+      json: null
+    };
+  }
+  try {
+    return { ok: true, error: "", json: JSON.parse(clean(result.stdout) || "null") };
+  } catch (error) {
+    return { ok: false, error: `invalid JSON: ${error.message}`, json: null };
+  }
+}
+
+function fetchPullRequests(repo) {
+  const result = runJson("gh", [
+    "pr",
+    "list",
+    "--repo",
+    repo,
+    "--state",
+    "open",
+    "--limit",
+    "100",
+    "--json",
+    "number,title,isDraft,mergeStateStatus,headRefName,baseRefName,updatedAt,url"
+  ]);
+  if (!result.ok) return { ok: false, error: result.error, rows: [] };
+  return { ok: true, error: "", rows: Array.isArray(result.json) ? result.json : [] };
+}
+
+function ageDays(updatedAt) {
+  const time = Date.parse(updatedAt);
+  if (!Number.isFinite(time)) return null;
+  return Number(((Date.now() - time) / 86_400_000).toFixed(1));
+}
+
+function classify(pr) {
+  const age = ageDays(pr.updatedAt);
+  const blockers = [];
+  if (!pr.isDraft && pr.mergeStateStatus === "DIRTY") blockers.push("non-draft DIRTY");
+  if (!pr.isDraft && pr.mergeStateStatus === "UNSTABLE") blockers.push("checks pending or unstable");
+  if (pr.isDraft) blockers.push("draft");
+  if (pr.baseRefName !== "main") blockers.push(`stacked on ${pr.baseRefName}`);
+  if (age !== null && age > 7) blockers.push(`${age} days since update`);
+  return {
+    number: pr.number,
+    title: pr.title,
+    url: pr.url,
+    head: pr.headRefName,
+    base: pr.baseRefName,
+    isDraft: pr.isDraft,
+    mergeStateStatus: pr.mergeStateStatus,
+    updatedAt: pr.updatedAt,
+    ageDays: age,
+    blockers,
+    readiness: blockers.length === 0 ? "ready_to_review" : blockers.some((item) => item.includes("DIRTY")) ? "blocked" : "needs_triage"
+  };
+}
+
+function buildChains(rows) {
+  const byBase = new Map();
+  for (const pr of rows) {
+    if (!byBase.has(pr.base)) byBase.set(pr.base, []);
+    byBase.get(pr.base).push(pr);
+  }
+  for (const list of byBase.values()) list.sort((a, b) => a.number - b.number);
+
+  const roots = byBase.get("main") || [];
+  const visited = new Set();
+  const chains = [];
+  for (const root of roots) {
+    const chain = [];
+    let current = root;
+    while (current && !visited.has(current.number)) {
+      chain.push(current);
+      visited.add(current.number);
+      const children = byBase.get(current.head) || [];
+      current = children[0] || null;
+    }
+    chains.push(chain);
+  }
+  const orphans = rows.filter((pr) => !visited.has(pr.number));
+  return { chains, orphans };
+}
+
+function buildReport(options) {
+  const generatedAt = nowIso();
+  const runId = clean(options.runId) || `pr-stack-${generatedAt.replace(/[-:]/g, "").replace(/\.\d+Z$/, "Z")}`;
+  const prs = fetchPullRequests(options.repo);
+  const classified = prs.rows.map(classify).sort((a, b) => a.number - b.number);
+  const { chains, orphans } = buildChains(classified);
+  const dirtyNonDraft = classified.filter((pr) => !pr.isDraft && pr.mergeStateStatus === "DIRTY");
+  const unstableNonDraft = classified.filter((pr) => !pr.isDraft && pr.mergeStateStatus === "UNSTABLE");
+  const stackedDrafts = classified.filter((pr) => pr.isDraft && pr.base !== "main");
+  const stale = classified.filter((pr) => pr.ageDays !== null && pr.ageDays > 7);
+  const recommendations = [];
+  if (dirtyNonDraft.length) {
+    recommendations.push({
+      priority: "P1",
+      title: "Resolve dirty non-draft PRs before release work",
+      evidence: dirtyNonDraft.map((pr) => `#${pr.number} ${pr.mergeStateStatus}`).join(", "),
+      safeNextStep: "Create conflict-resolution worktrees and issue-ready packets; do not force-push without owner review."
+    });
+  }
+  if (stackedDrafts.length) {
+    recommendations.push({
+      priority: "P2",
+      title: "Collapse or restack large draft chains",
+      evidence: `${stackedDrafts.length} draft PR(s) target non-main bases.`,
+      safeNextStep: "Promote only the next base-ready slice; close or supersede stale drafts after human review."
+    });
+  }
+  if (stale.length) {
+    recommendations.push({
+      priority: "P3",
+      title: "Review stale open PRs",
+      evidence: `${stale.length} PR(s) have not been updated in more than 7 days.`,
+      safeNextStep: "Mark as keep, supersede, restack, or close in a review packet."
+    });
+  }
+  return {
+    schema: "studio-brain.ops.pr-stack-readiness.v1",
+    generatedAt,
+    runId,
+    readOnly: true,
+    repo: options.repo,
+    status: prs.ok ? dirtyNonDraft.length ? "blocked" : stackedDrafts.length ? "triage_needed" : "ok" : "unavailable",
+    source: { ok: prs.ok, error: prs.error, count: classified.length },
+    summary: {
+      open: classified.length,
+      nonDraft: classified.filter((pr) => !pr.isDraft).length,
+      drafts: classified.filter((pr) => pr.isDraft).length,
+      dirtyNonDraft: dirtyNonDraft.length,
+      unstableNonDraft: unstableNonDraft.length,
+      stackedDrafts: stackedDrafts.length,
+      staleOver7Days: stale.length,
+      chainCount: chains.length,
+      orphanCount: orphans.length
+    },
+    chains: chains.map((chain) => chain.map((pr) => ({ number: pr.number, head: pr.head, base: pr.base, readiness: pr.readiness, blockers: pr.blockers }))),
+    orphans: orphans.map((pr) => ({ number: pr.number, head: pr.head, base: pr.base, readiness: pr.readiness, blockers: pr.blockers })),
+    pullRequests: classified,
+    recommendations
+  };
+}
+
+function renderMarkdown(report) {
+  const lines = [
+    "# Studio Brain PR Stack Readiness",
+    "",
+    `- Generated at: ${report.generatedAt}`,
+    `- Run ID: ${report.runId}`,
+    `- Status: ${report.status}`,
+    `- Repo: ${report.repo}`,
+    `- Read-only: ${report.readOnly ? "yes" : "no"}`,
+    "",
+    "## Summary",
+    "",
+    `- Open PRs: ${report.summary.open}`,
+    `- Non-draft PRs: ${report.summary.nonDraft}`,
+    `- Draft PRs: ${report.summary.drafts}`,
+    `- Dirty non-draft PRs: ${report.summary.dirtyNonDraft}`,
+    `- Unstable non-draft PRs: ${report.summary.unstableNonDraft}`,
+    `- Stacked draft PRs: ${report.summary.stackedDrafts}`,
+    `- Stale over 7 days: ${report.summary.staleOver7Days}`,
+    `- Chain count: ${report.summary.chainCount}`,
+    `- Orphan count: ${report.summary.orphanCount}`,
+    "",
+    "## Recommendations",
+    ""
+  ];
+  if (!report.recommendations.length) lines.push("- No PR-stack recommendations from current evidence.");
+  for (const rec of report.recommendations) {
+    lines.push(`### ${rec.title}`);
+    lines.push("");
+    lines.push(`- Priority: ${rec.priority}`);
+    lines.push(`- Evidence: ${rec.evidence}`);
+    lines.push(`- Safe next step: ${rec.safeNextStep}`);
+    lines.push("");
+  }
+  lines.push("## Chains");
+  lines.push("");
+  for (const [index, chain] of report.chains.entries()) {
+    lines.push(`### Chain ${index + 1}`);
+    lines.push("");
+    for (const pr of chain) {
+      lines.push(`- #${pr.number} ${pr.head} -> ${pr.base}: ${pr.readiness}${pr.blockers.length ? ` (${pr.blockers.join("; ")})` : ""}`);
+    }
+    lines.push("");
+  }
+  if (report.orphans.length) {
+    lines.push("## Orphans");
+    lines.push("");
+    for (const pr of report.orphans) {
+      lines.push(`- #${pr.number} ${pr.head} -> ${pr.base}: ${pr.readiness}${pr.blockers.length ? ` (${pr.blockers.join("; ")})` : ""}`);
+    }
+    lines.push("");
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+function writeArtifacts(report, options) {
+  mkdirSync(options.outputDir, { recursive: true });
+  const jsonPath = resolve(options.outputDir, `${report.runId}.json`);
+  const markdownPath = resolve(options.outputDir, `${report.runId}.md`);
+  const latestJson = resolve(options.outputDir, "latest.json");
+  const latestMarkdown = resolve(options.outputDir, "latest.md");
+  const markdown = renderMarkdown(report);
+  writeFileSync(jsonPath, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+  writeFileSync(markdownPath, markdown, "utf8");
+  writeFileSync(latestJson, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+  writeFileSync(latestMarkdown, markdown, "utf8");
+  return {
+    json: repoRelative(jsonPath),
+    markdown: repoRelative(markdownPath),
+    latestJson: repoRelative(latestJson),
+    latestMarkdown: repoRelative(latestMarkdown)
+  };
+}
+
+function main() {
+  try {
+    const options = parseArgs(process.argv.slice(2));
+    const report = buildReport(options);
+    if (options.write) report.paths = writeArtifacts(report, options);
+    process.stdout.write(options.json ? `${JSON.stringify(report, null, 2)}\n` : renderMarkdown(report));
+  } catch (error) {
+    process.stderr.write(`pr_stack_readiness: ${error.message}\n`);
+    process.exit(1);
+  }
+}
+
+main();

--- a/scripts/ops/proactive_issue_radar.mjs
+++ b/scripts/ops/proactive_issue_radar.mjs
@@ -1,0 +1,434 @@
+#!/usr/bin/env node
+
+import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { dirname, relative, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const REPO_ROOT = resolve(dirname(__filename), "..", "..");
+const DEFAULT_OUTPUT_DIR = resolve(REPO_ROOT, "output", "ops", "proactive-radar");
+
+function clean(value) {
+  return String(value ?? "").replace(/\r/g, "").trim();
+}
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function repoRelative(path) {
+  return relative(REPO_ROOT, path).replace(/\\/g, "/");
+}
+
+function usage() {
+  return `Studio Brain proactive issue radar
+
+Usage:
+  node scripts/ops/proactive_issue_radar.mjs [--json] [--write]
+
+Options:
+  --json                 Print JSON to stdout.
+  --write                Write timestamped JSON and Markdown artifacts.
+  --output-dir <path>    Artifact directory. Default: output/ops/proactive-radar.
+  --repo <owner/name>    GitHub repo. Default: inferred from origin.
+  --run-id <id>          Stable run id.
+`;
+}
+
+function readFlagValue(argv, index, name) {
+  const arg = argv[index];
+  if (arg === name) {
+    if (!argv[index + 1]) throw new Error(`${name} requires a value.`);
+    return { matched: true, value: argv[index + 1], nextIndex: index + 1 };
+  }
+  if (arg.startsWith(`${name}=`)) {
+    return { matched: true, value: arg.slice(name.length + 1), nextIndex: index };
+  }
+  return { matched: false, value: "", nextIndex: index };
+}
+
+function parseArgs(argv) {
+  const options = {
+    json: false,
+    write: false,
+    outputDir: DEFAULT_OUTPUT_DIR,
+    repo: "",
+    runId: ""
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--help" || arg === "-h") {
+      process.stdout.write(usage());
+      process.exit(0);
+    }
+    if (arg === "--json") {
+      options.json = true;
+      continue;
+    }
+    if (arg === "--write") {
+      options.write = true;
+      continue;
+    }
+    const mappings = [
+      ["--output-dir", "outputDir"],
+      ["--repo", "repo"],
+      ["--run-id", "runId"]
+    ];
+    let consumed = false;
+    for (const [flag, key] of mappings) {
+      const parsed = readFlagValue(argv, index, flag);
+      if (!parsed.matched) continue;
+      options[key] = parsed.value;
+      index = parsed.nextIndex;
+      consumed = true;
+      break;
+    }
+    if (consumed) continue;
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+  options.outputDir = resolve(REPO_ROOT, options.outputDir);
+  return options;
+}
+
+function run(command, args, timeout = 30_000) {
+  const result = spawnSync(command, args, {
+    cwd: REPO_ROOT,
+    encoding: "utf8",
+    windowsHide: true,
+    timeout,
+    env: { ...process.env }
+  });
+  return {
+    ok: !result.error && result.status === 0,
+    stdout: clean(result.stdout),
+    stderr: clean(result.stderr),
+    error: result.error?.message || "",
+    status: result.status
+  };
+}
+
+function runJson(command, args, timeout = 30_000) {
+  const result = run(command, args, timeout);
+  if (!result.ok) return { ok: false, error: result.error || result.stderr || `exit ${result.status}`, json: null };
+  try {
+    return { ok: true, error: "", json: JSON.parse(result.stdout || "null") };
+  } catch (error) {
+    return { ok: false, error: `invalid JSON: ${error.message}`, json: null };
+  }
+}
+
+function commandExists(command) {
+  const result = spawnSync(process.platform === "win32" ? "where" : "sh", process.platform === "win32" ? [command] : ["-lc", `command -v ${shellQuote(command)}`], {
+    encoding: "utf8",
+    windowsHide: true
+  });
+  return result.status === 0;
+}
+
+function shellQuote(value) {
+  return `'${String(value).replace(/'/g, "'\\''")}'`;
+}
+
+function inferRepoFromRemote() {
+  const remote = run("git", ["remote", "get-url", "origin"]);
+  const match = remote.stdout.match(/github\.com[:/](.+?)(?:\.git)?$/i);
+  return match ? match[1] : "monsoonfirepottery-byte/monsoonfire-portal";
+}
+
+function gitStatus() {
+  const status = run("git", ["status", "--short", "--branch"]);
+  if (!status.ok) return { ok: false, branch: "", dirtyCount: null, error: status.stderr || status.error };
+  const lines = status.stdout.split(/\n/).filter(Boolean);
+  return {
+    ok: true,
+    branch: clean(lines[0]?.replace(/^##\s*/, "")),
+    dirtyCount: Math.max(0, lines.length - 1),
+    error: ""
+  };
+}
+
+function openPullRequests(repo) {
+  if (!commandExists("gh")) return { ok: false, error: "gh unavailable", rows: [] };
+  const result = runJson("gh", [
+    "pr",
+    "list",
+    "--repo",
+    repo,
+    "--state",
+    "open",
+    "--limit",
+    "100",
+    "--json",
+    "number,title,isDraft,mergeStateStatus,headRefName,baseRefName,updatedAt,url"
+  ], 45_000);
+  if (!result.ok) return { ok: false, error: result.error, rows: [] };
+  return { ok: true, error: "", rows: Array.isArray(result.json) ? result.json : [] };
+}
+
+function walkFiles(root, predicate, out = []) {
+  if (!existsSync(root)) return out;
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    const path = resolve(root, entry.name);
+    if (entry.isDirectory()) {
+      walkFiles(path, predicate, out);
+    } else if (predicate(path)) {
+      out.push(path);
+    }
+  }
+  return out;
+}
+
+function artifactFreshness() {
+  const paths = [
+    "docs/ops/00-system-inventory.md",
+    "docs/ops/01-risk-register.md",
+    "docs/ops/02-kanban-backlog.md",
+    "docs/ops/03-capacity-plan.md",
+    "docs/ops/04-postgres-dba-review.md",
+    "docs/ops/05-docker-ops-review.md",
+    "docs/ops/06-runbooks.md",
+    "docs/ops/07-maintenance-calendar.md",
+    "docs/ops/16-effectivity-audit-2026-05-06.md",
+    "docs/ops/22-privileged-evidence-capture.md",
+    "docs/ops/23-backup-restore-confidence.md"
+  ].map((path) => resolve(REPO_ROOT, path));
+  const now = Date.now();
+  return paths.map((path) => {
+    if (!existsSync(path)) return { path: repoRelative(path), exists: false, ageDays: null, stale: true };
+    const stat = statSync(path);
+    const ageDays = (now - stat.mtimeMs) / 86_400_000;
+    return {
+      path: repoRelative(path),
+      exists: true,
+      modifiedAt: stat.mtime.toISOString(),
+      ageDays: Number(ageDays.toFixed(1)),
+      stale: ageDays > 14
+    };
+  });
+}
+
+function scriptInventory() {
+  const scripts = walkFiles(resolve(REPO_ROOT, "scripts", "ops"), (path) => /\.(sh|mjs|sql)$/i.test(path));
+  const makefile = resolve(REPO_ROOT, "Makefile");
+  const makeText = existsSync(makefile) ? readFileSync(makefile, "utf8") : "";
+  return scripts.map((path) => {
+    const rel = repoRelative(path);
+    const basename = rel.split("/").at(-1);
+    return {
+      path: rel,
+      type: basename.endsWith(".sql") ? "sql" : basename.endsWith(".mjs") ? "node" : "shell",
+      makeTarget: inferMakeTarget(makeText, basename)
+    };
+  });
+}
+
+function inferMakeTarget(makeText, basename) {
+  if (!makeText) return "";
+  const escaped = basename.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = makeText.match(new RegExp("^(ops-[^:\\s]+):[\\s\\S]{0,160}" + escaped, "m"));
+  return match?.[1] || "";
+}
+
+function makeFinding(severity, id, title, component, evidence, impact, safeNextStep, rollback) {
+  return { severity, id, title, component, evidence, impact, safeNextStep, rollback };
+}
+
+function buildFindings({ prs, status, freshness, scripts }) {
+  const findings = [];
+  const rows = prs.rows || [];
+  const dirtyNonDraft = rows.filter((pr) => !pr.isDraft && pr.mergeStateStatus !== "CLEAN");
+  const stackedDrafts = rows.filter((pr) => pr.isDraft && pr.baseRefName && pr.baseRefName !== "main");
+  const staleArtifacts = freshness.filter((entry) => entry.stale);
+  const hiddenScripts = scripts.filter((entry) => !entry.makeTarget);
+
+  if (!prs.ok) {
+    findings.push(makeFinding("high", "github-pr-visibility-unavailable", "GitHub PR visibility is unavailable", "GitHub", prs.error, "Merge and release risk cannot be assessed automatically.", "Restore gh auth/network and rerun the radar.", "No repo rollback; this is read-only."));
+  }
+  if (dirtyNonDraft.length) {
+    findings.push(makeFinding("high", "non-draft-prs-not-mergeable", "Non-draft PRs are not mergeable", "GitHub PR stack", dirtyNonDraft.map((pr) => `#${pr.number} ${pr.mergeStateStatus}`).join(", "), "Ready-looking PRs can remain blocked until release time.", "Create conflict-resolution packets in clean worktrees.", "No mutation required; do not close or rewrite PRs without approval."));
+  }
+  if (stackedDrafts.length > 10) {
+    findings.push(makeFinding("medium", "large-stacked-draft-pr-backlog", "Large stacked draft PR backlog", "GitHub PR stack", `${stackedDrafts.length} draft PR(s) target non-main bases.`, "Stack depth makes merge order and CI meaning hard to reason about.", "Generate a merge-order/readiness packet and close, restack, or promote only with owner review.", "Docs/report only."));
+  }
+  if (status.ok && status.dirtyCount > 0) {
+    findings.push(makeFinding("medium", "current-worktree-dirty", "Current worktree has local changes", "Local repository", `${status.dirtyCount} changed path(s) on ${status.branch}.`, "Implementation from this checkout may mix unrelated changes.", "Use a clean worktree from origin/main for ops slices.", "Leave the dirty checkout untouched."));
+  }
+  if (staleArtifacts.length) {
+    findings.push(makeFinding("medium", "stale-ops-artifacts", "Ops evidence artifacts may be stale", "docs/ops", `${staleArtifacts.length} tracked ops artifact(s) are stale or missing.`, "Recommendations may be based on outdated evidence.", "Refresh the oldest docs with read-only scripts.", "Docs-only update; git history preserves old evidence."));
+  }
+  if (hiddenScripts.length) {
+    findings.push(makeFinding("low", "ops-scripts-without-make-targets", "Some ops scripts lack Makefile wrappers", "scripts/ops", `${hiddenScripts.length} script(s) do not appear to have make targets.`, "Useful diagnostics may remain hidden from operators.", "Add wrappers or README direct-command entries for high-value scripts.", "Makefile/doc change only."));
+  }
+  return findings;
+}
+
+function priority(severity) {
+  if (severity === "critical") return "P0";
+  if (severity === "high") return "P1";
+  if (severity === "medium") return "P2";
+  return "P3";
+}
+
+function recommendationTitle(id, fallback) {
+  const titles = {
+    "github-pr-visibility-unavailable": "Restore automated PR visibility",
+    "non-draft-prs-not-mergeable": "Create conflict-resolution packets for dirty PRs",
+    "large-stacked-draft-pr-backlog": "Generate merge-order readiness for stacked draft PRs",
+    "current-worktree-dirty": "Enforce clean-worktree lanes for ops slices",
+    "stale-ops-artifacts": "Refresh stale ops evidence artifacts",
+    "ops-scripts-without-make-targets": "Expose hidden ops scripts through Makefile wrappers"
+  };
+  return titles[id] || `Investigate ${fallback.toLowerCase()}`;
+}
+
+function buildRecommendations(findings) {
+  return findings.map((finding) => ({
+    title: recommendationTitle(finding.id, finding.title),
+    type: finding.component.includes("GitHub") ? "reliability" : finding.component.includes("docs") ? "documentation" : "ops",
+    priority: priority(finding.severity),
+    effort: finding.severity === "high" ? "M" : "S",
+    risk: "low",
+    suggestedBranchName: `codex/ops-${finding.id}`.slice(0, 80),
+    suggestedPrTitle: `[ops] ${recommendationTitle(finding.id, finding.title)}`,
+    acceptanceCriteria: [
+      "Evidence is captured in JSON and Markdown artifacts.",
+      "Safe next step and rollback notes are present.",
+      "No destructive command is executed."
+    ]
+  }));
+}
+
+function buildReport(options) {
+  const generatedAt = nowIso();
+  const runId = clean(options.runId) || `proactive-radar-${generatedAt.replace(/[-:]/g, "").replace(/\.\d+Z$/, "Z")}`;
+  const repo = clean(options.repo) || inferRepoFromRemote();
+  const status = gitStatus();
+  const prs = openPullRequests(repo);
+  const freshness = artifactFreshness();
+  const scripts = scriptInventory();
+  const findings = buildFindings({ prs, status, freshness, scripts });
+  return {
+    schema: "studio-brain.ops.proactive-radar.v1",
+    generatedAt,
+    runId,
+    readOnly: true,
+    redaction: "No environment variables, secrets, or .env values are printed.",
+    repo,
+    status: findings.some((finding) => finding.severity === "critical" || finding.severity === "high") ? "action_needed" : findings.length ? "watch" : "ok",
+    sources: {
+      gitStatus: status,
+      pullRequests: {
+        ok: prs.ok,
+        error: prs.error,
+        count: prs.rows.length,
+        nonDraft: prs.rows.filter((pr) => !pr.isDraft).length,
+        draft: prs.rows.filter((pr) => pr.isDraft).length,
+        dirty: prs.rows.filter((pr) => pr.mergeStateStatus === "DIRTY").length,
+        unstable: prs.rows.filter((pr) => pr.mergeStateStatus === "UNSTABLE").length
+      },
+      artifactFreshness: freshness,
+      scriptInventory: {
+        count: scripts.length,
+        withoutMakeTarget: scripts.filter((script) => !script.makeTarget).map((script) => script.path)
+      }
+    },
+    findings,
+    recommendations: buildRecommendations(findings)
+  };
+}
+
+function renderMarkdown(report) {
+  const lines = [
+    "# Studio Brain Proactive Issue Radar",
+    "",
+    `- Generated at: ${report.generatedAt}`,
+    `- Run ID: ${report.runId}`,
+    `- Status: ${report.status}`,
+    `- Repo: ${report.repo}`,
+    `- Read-only: ${report.readOnly ? "yes" : "no"}`,
+    "",
+    "## Summary",
+    "",
+    `- Open PRs: ${report.sources.pullRequests.count}`,
+    `- Non-draft PRs: ${report.sources.pullRequests.nonDraft}`,
+    `- Draft PRs: ${report.sources.pullRequests.draft}`,
+    `- Dirty PRs: ${report.sources.pullRequests.dirty}`,
+    `- Unstable PRs: ${report.sources.pullRequests.unstable}`,
+    `- Local dirty paths: ${report.sources.gitStatus.dirtyCount ?? "unknown"}`,
+    `- Ops scripts inventoried: ${report.sources.scriptInventory.count}`,
+    `- Ops scripts without Makefile target: ${report.sources.scriptInventory.withoutMakeTarget.length}`,
+    "",
+    "## Findings",
+    ""
+  ];
+  if (!report.findings.length) {
+    lines.push("- No proactive findings from available evidence.");
+  }
+  for (const finding of report.findings) {
+    lines.push(`### ${finding.title}`);
+    lines.push("");
+    lines.push(`- Severity: ${finding.severity}`);
+    lines.push(`- Component: ${finding.component}`);
+    lines.push(`- Evidence: ${finding.evidence}`);
+    lines.push(`- Impact: ${finding.impact}`);
+    lines.push(`- Safe next step: ${finding.safeNextStep}`);
+    lines.push(`- Rollback/undo notes: ${finding.rollback}`);
+    lines.push("");
+  }
+  lines.push("## Recommendations");
+  lines.push("");
+  for (const recommendation of report.recommendations) {
+    lines.push(`### ${recommendation.title}`);
+    lines.push("");
+    lines.push(`- Type: ${recommendation.type}`);
+    lines.push(`- Priority: ${recommendation.priority}`);
+    lines.push(`- Effort: ${recommendation.effort}`);
+    lines.push(`- Risk: ${recommendation.risk}`);
+    lines.push(`- Suggested branch: ${recommendation.suggestedBranchName}`);
+    lines.push(`- Suggested PR title: ${recommendation.suggestedPrTitle}`);
+    lines.push("- Acceptance criteria:");
+    for (const item of recommendation.acceptanceCriteria) lines.push(`  - ${item}`);
+    lines.push("");
+  }
+  const stale = report.sources.artifactFreshness.filter((entry) => entry.stale);
+  lines.push("## Stale Or Missing Evidence");
+  lines.push("");
+  if (!stale.length) lines.push("- No stale tracked ops evidence artifacts from this threshold.");
+  for (const entry of stale) lines.push(`- ${entry.path}: ${entry.exists ? `${entry.ageDays} days old` : "missing"}`);
+  lines.push("");
+  return `${lines.join("\n")}\n`;
+}
+
+function writeArtifacts(report, options) {
+  mkdirSync(options.outputDir, { recursive: true });
+  const jsonPath = resolve(options.outputDir, `${report.runId}.json`);
+  const markdownPath = resolve(options.outputDir, `${report.runId}.md`);
+  const latestJson = resolve(options.outputDir, "latest.json");
+  const latestMarkdown = resolve(options.outputDir, "latest.md");
+  const markdown = renderMarkdown(report);
+  writeFileSync(jsonPath, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+  writeFileSync(markdownPath, markdown, "utf8");
+  writeFileSync(latestJson, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+  writeFileSync(latestMarkdown, markdown, "utf8");
+  return {
+    json: repoRelative(jsonPath),
+    markdown: repoRelative(markdownPath),
+    latestJson: repoRelative(latestJson),
+    latestMarkdown: repoRelative(latestMarkdown)
+  };
+}
+
+function main() {
+  try {
+    const options = parseArgs(process.argv.slice(2));
+    const report = buildReport(options);
+    if (options.write) report.paths = writeArtifacts(report, options);
+    process.stdout.write(options.json ? `${JSON.stringify(report, null, 2)}\n` : renderMarkdown(report));
+  } catch (error) {
+    process.stderr.write(`proactive_issue_radar: ${error.message}\n`);
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- add a read-only proactive issue radar for Studio Brain administrator loops
- add a PR-stack readiness packet for dirty, stale, and stacked PR triage
- add the first 50-slice proactive admin loop plan
- expose both reports through Makefile, npm, and docs/ops README

## Evidence
- read-only scouts identified the strongest next step as connecting existing ops docs/scripts into machine-readable triage
- proactive radar currently surfaces dirty PR #492, stacked draft PR pressure, and ops scripts without Makefile wrappers
- PR stack readiness distinguishes true DIRTY non-draft PRs from pending/unstable CI and reports 70 stacked non-main draft PRs

## Testing
- node --check scripts/ops/proactive_issue_radar.mjs
- node --check scripts/ops/pr_stack_readiness.mjs
- node scripts/ops/proactive_issue_radar.mjs --write --json
- npm run ops:proactive:radar
- npm run ops:pr-stack:readiness
- git diff --check

## Risk
Low. Read-only reporting and docs only. No host mutation, restart, prune, schema change, or deploy.

## Rollback
Revert this PR to remove the radar scripts, docs entry, npm scripts, and Makefile wrappers.

## Follow-up tickets
- create conflict-resolution packets for dirty non-draft PRs
- collapse or restack the large draft PR chain with owner review
- expose or document hidden ops scripts without Makefile wrappers
- add Docker/Postgres/backup proactive rollup from scout recommendations