### PR TITLE
[ops] Add dependency security scout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL := /bin/bash
 PG_CONTAINER ?= studiobrain_postgres
 PGDATABASE ?= monsoonfire_studio_os
 
-.PHONY: ops-check ops-inventory ops-postgres-review ops-postgres-sql ops-postgres-top-queries ops-postgres-query-tasks ops-postgres-growth-snapshot ops-postgres-autovacuum-stats ops-postgres-roles-extensions ops-docker-review ops-docker-posture ops-capacity ops-import-pressure ops-cleanup-candidates ops-backup-evidence ops-postgres-backup-artifacts ops-restore-prereq ops-redis-minio-backup-evidence ops-db-docker-backup-rollup ops-ubuntu-review ops-host-failed-unit-trends ops-package-posture ops-time-sync ops-network-review ops-host-drift ops-systemd-drift ops-portal-bridge-review ops-app-review ops-dependency-review ops-idle-worker-effectivity ops-effectivity-report ops-evidence-freshness ops-slice-ledger ops-tool-inventory ops-admin-effectivity-audit ops-proactive-radar ops-pr-stack-readiness ops-privileged-evidence-read ops-privileged-evidence-capture ops-privileged-evidence-capture-smoke ops-work-packet ops-incident-bundle ops-incident-bundle-v2 ops-ci-validate ops-post-deploy-verify ops-docs ops-backlog ops-report
+.PHONY: ops-check ops-inventory ops-postgres-review ops-postgres-sql ops-postgres-top-queries ops-postgres-query-tasks ops-postgres-growth-snapshot ops-postgres-autovacuum-stats ops-postgres-roles-extensions ops-docker-review ops-docker-posture ops-capacity ops-import-pressure ops-cleanup-candidates ops-backup-evidence ops-postgres-backup-artifacts ops-restore-prereq ops-redis-minio-backup-evidence ops-db-docker-backup-rollup ops-ubuntu-review ops-host-failed-unit-trends ops-package-posture ops-time-sync ops-network-review ops-host-drift ops-systemd-drift ops-portal-bridge-review ops-app-review ops-dependency-review ops-dependency-security-scout ops-idle-worker-effectivity ops-effectivity-report ops-evidence-freshness ops-slice-ledger ops-tool-inventory ops-admin-effectivity-audit ops-proactive-radar ops-pr-stack-readiness ops-privileged-evidence-read ops-privileged-evidence-capture ops-privileged-evidence-capture-smoke ops-work-packet ops-incident-bundle ops-incident-bundle-v2 ops-ci-validate ops-post-deploy-verify ops-docs ops-backlog ops-report
 
 ops-check: ops-inventory ops-docker-review ops-capacity ops-cleanup-candidates ops-backup-evidence ops-ubuntu-review ops-network-review ops-host-drift ops-systemd-drift ops-portal-bridge-review ops-app-review
 
@@ -107,6 +107,9 @@ ops-app-review:
 
 ops-dependency-review:
 	bash scripts/ops/npm_audit_inventory.sh
+
+ops-dependency-security-scout:
+	node scripts/ops/dependency_security_scout.mjs --write
 
 ops-idle-worker-effectivity:
 	node ./scripts/studiobrain-idle-worker-effectivity-audit.mjs --json

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -51,6 +51,7 @@ make ops-systemd-drift
 make ops-portal-bridge-review
 make ops-app-review
 make ops-dependency-review
+make ops-dependency-security-scout
 make ops-idle-worker-effectivity
 make ops-effectivity-report
 make ops-evidence-freshness
@@ -73,6 +74,7 @@ npm run ops:proactive:radar
 npm run ops:pr-stack:readiness
 npm run ops:evidence:freshness
 npm run ops:db-docker-backup:rollup
+npm run ops:dependency:security-scout
 ```
 
 The scripts under `scripts/ops/` avoid environment dumps and degrade when Docker, PostgreSQL, or host-only tools are unavailable.
@@ -89,6 +91,7 @@ bash scripts/ops/cleanup_candidates.sh --import-target /home/wuff/imports
 bash scripts/ops/npm_audit_inventory.sh
 bash scripts/ops/effectivity_report.sh
 node scripts/ops/proactive_issue_radar.mjs --write
+node scripts/ops/dependency_security_scout.mjs --write
 bash scripts/ops/privileged_evidence_read.sh
 bash scripts/ops/privileged_evidence_capture.sh --smoke --output-dir output/ops/privileged-evidence
 node scripts/studiobrain-ops-work-packet.mjs --write
@@ -104,6 +107,8 @@ bash scripts/ops/incident_bundle_v2.sh output/ops/incidents-v2/manual-smoke
 `ops-evidence-freshness` checks whether the main ops evidence artifacts are recent enough to trust and writes issue-ready refresh tasks under `output/ops/evidence-freshness`.
 
 `ops-db-docker-backup-rollup` runs the existing read-only Docker, PostgreSQL, backup, Redis/MinIO, and restore-prerequisite packets, stores their text evidence under `output/ops/db-docker-backup`, and summarizes degraded lanes with issue-ready follow-up tasks.
+
+`ops-dependency-security-scout` compares open Dependabot alerts, open Dependabot PR readiness, and local `npm audit` summaries across the repo's package surfaces. It writes issue-ready follow-up tasks under `output/ops/dependency-security-scout` and does not install, update, or fix packages.
 
 ## Approval Boundaries
 

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "ops:pr-stack:readiness": "node ./scripts/ops/pr_stack_readiness.mjs --write --json",
     "ops:evidence:freshness": "node ./scripts/ops/evidence_freshness_guard.mjs --write --json",
     "ops:db-docker-backup:rollup": "node ./scripts/ops/db_docker_backup_rollup.mjs --write --json",
+    "ops:dependency:security-scout": "node ./scripts/ops/dependency_security_scout.mjs --write --json",
     "portal:smoke:native-browser:shadow": "node ./scripts/native-browser-shadow-verifier.mjs --surface portal --base-url https://portal.monsoonfire.com --output-dir output/native-browser/portal/prod --shadow-of verify.portal.smoke --canonical-artifact-root output/playwright/portal/prod",
     "codex:browser:verify:portal": "node ./scripts/native-browser-shadow-verifier.mjs --surface portal --base-url https://portal.monsoonfire.com --output-dir output/native-browser/portal/prod --shadow-of verify.portal.smoke --canonical-artifact-root output/playwright/portal/prod --app-handoff",
     "codex:browser:verify:portal:local": "node ./scripts/native-browser-shadow-verifier.mjs --surface portal --base-url http://127.0.0.1:5173 --output-dir output/native-browser/portal/local --shadow-of verify.portal.smoke.local --canonical-artifact-root output/playwright/portal/local --app-handoff",

--- a/scripts/ops/dependency_security_scout.mjs
+++ b/scripts/ops/dependency_security_scout.mjs
@@ -1,0 +1,461 @@
+#!/usr/bin/env node
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, relative, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const REPO_ROOT = resolve(dirname(__filename), "..", "..");
+const DEFAULT_OUTPUT_DIR = resolve(REPO_ROOT, "output", "ops", "dependency-security-scout");
+const DEFAULT_REPO = "monsoonfirepottery-byte/monsoonfire-portal";
+const DEFAULT_WORKSPACES = [".", "web", "functions", "studio-brain", "studio-brain-mcp", "codex-agents"];
+
+function usage() {
+  return `Studio Brain dependency security scout
+
+Usage:
+  node scripts/ops/dependency_security_scout.mjs [--json] [--write]
+
+Options:
+  --json                  Print JSON.
+  --write                 Write latest JSON and Markdown artifacts.
+  --output-dir <path>     Artifact directory. Default: output/ops/dependency-security-scout.
+  --repo <owner/repo>     GitHub repo for Dependabot alert/PR lookup.
+  --skip-npm-audit        Skip local npm audit probes.
+  --skip-github           Skip GitHub alert and PR lookup.
+`;
+}
+
+function parseArgs(argv) {
+  const options = {
+    json: false,
+    write: false,
+    outputDir: DEFAULT_OUTPUT_DIR,
+    repo: DEFAULT_REPO,
+    npmAudit: true,
+    github: true
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--help" || arg === "-h") {
+      process.stdout.write(usage());
+      process.exit(0);
+    }
+    if (arg === "--json") {
+      options.json = true;
+      continue;
+    }
+    if (arg === "--write") {
+      options.write = true;
+      continue;
+    }
+    if (arg === "--skip-npm-audit") {
+      options.npmAudit = false;
+      continue;
+    }
+    if (arg === "--skip-github") {
+      options.github = false;
+      continue;
+    }
+    if (arg === "--output-dir" || arg === "--repo") {
+      if (!argv[index + 1]) throw new Error(`${arg} requires a value.`);
+      options[arg === "--output-dir" ? "outputDir" : "repo"] = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith("--output-dir=")) {
+      options.outputDir = arg.slice("--output-dir=".length);
+      continue;
+    }
+    if (arg.startsWith("--repo=")) {
+      options.repo = arg.slice("--repo=".length);
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+  options.outputDir = resolve(REPO_ROOT, options.outputDir);
+  return options;
+}
+
+function repoRelative(path) {
+  return relative(REPO_ROOT, path).replace(/\\/g, "/");
+}
+
+function commandExists(command) {
+  const result = spawnSync(process.platform === "win32" ? "where.exe" : "sh", process.platform === "win32" ? [windowsCommand(command)] : ["-lc", `command -v ${command}`], {
+    encoding: "utf8",
+    windowsHide: true
+  });
+  return result.status === 0;
+}
+
+function windowsCommand(command) {
+  if (process.platform !== "win32") return command;
+  if (command === "npm") return "npm.cmd";
+  if (command === "npx") return "npx.cmd";
+  if (command === "gh") return "gh.exe";
+  return command;
+}
+
+function run(command, args, options = {}) {
+  const resolved = windowsCommand(command);
+  const useCmdShim = process.platform === "win32" && /\.cmd$/i.test(resolved);
+  const actualCommand = useCmdShim ? "cmd.exe" : resolved;
+  const actualArgs = useCmdShim ? ["/d", "/s", "/c", [resolved, ...args].map(windowsShellQuote).join(" ")] : args;
+  const result = spawnSync(actualCommand, actualArgs, {
+    cwd: options.cwd || REPO_ROOT,
+    encoding: "utf8",
+    windowsHide: true,
+    timeout: options.timeoutMs || 120_000,
+    env: { ...process.env, ...options.env }
+  });
+  return {
+    status: result.status ?? null,
+    stdout: result.stdout || "",
+    stderr: result.stderr || "",
+    error: result.error?.message || ""
+  };
+}
+
+function windowsShellQuote(value) {
+  const text = String(value);
+  if (/^[A-Za-z0-9_./:=@-]+$/.test(text)) return text;
+  return `"${text.replace(/"/g, '\\"')}"`;
+}
+
+function safeJsonParse(raw, fallback) {
+  try {
+    return JSON.parse(raw || "");
+  } catch {
+    return fallback;
+  }
+}
+
+function githubAlerts(repo) {
+  if (!commandExists("gh")) {
+    return { status: "skipped_gh_unavailable", alerts: [], error: "" };
+  }
+  const result = run("gh", [
+    "api",
+    `repos/${repo}/dependabot/alerts?state=open`
+  ], { timeoutMs: 120_000 });
+  if (result.status !== 0) {
+    return { status: "unavailable", alerts: [], error: firstLines(result.stderr || result.error) };
+  }
+  const parsed = safeJsonParse(result.stdout, []);
+  const alerts = (Array.isArray(parsed) ? parsed : []).map((alert) => ({
+    number: alert.number,
+    state: alert.state,
+    dependency: alert.dependency?.package?.name || "",
+    ecosystem: alert.dependency?.package?.ecosystem || "",
+    manifestPath: alert.dependency?.manifest_path || "",
+    scope: alert.dependency?.scope || "",
+    severity: alert.security_advisory?.severity || "",
+    ghsaId: alert.security_advisory?.ghsa_id || "",
+    cveId: alert.security_advisory?.cve_id || "",
+    summary: alert.security_advisory?.summary || "",
+    vulnerableRange: alert.security_vulnerability?.vulnerable_version_range || "",
+    patchedVersions: alert.security_vulnerability?.patched_versions || "",
+    htmlUrl: alert.html_url || ""
+  }));
+  return { status: "ok", alerts, error: "" };
+}
+
+function dependabotPrs(repo) {
+  if (!commandExists("gh")) {
+    return { status: "skipped_gh_unavailable", prs: [], error: "" };
+  }
+  const result = run("gh", [
+    "pr",
+    "list",
+    "--repo",
+    repo,
+    "--author",
+    "app/dependabot",
+    "--state",
+    "open",
+    "--json",
+    "number,title,headRefName,baseRefName,isDraft,mergeStateStatus,statusCheckRollup,url,updatedAt",
+    "--limit",
+    "50"
+  ], { timeoutMs: 120_000 });
+  if (result.status !== 0) {
+    return { status: "unavailable", prs: [], error: firstLines(result.stderr || result.error) };
+  }
+  const parsed = safeJsonParse(result.stdout, []);
+  const prs = (Array.isArray(parsed) ? parsed : []).map((pr) => {
+    const checks = Array.isArray(pr.statusCheckRollup) ? pr.statusCheckRollup : [];
+    const failing = checks.filter((check) => check.conclusion && check.conclusion !== "SUCCESS" && check.conclusion !== "SKIPPED");
+    const pending = checks.filter((check) => check.status && check.status !== "COMPLETED");
+    return {
+      number: pr.number,
+      title: pr.title,
+      url: pr.url,
+      headRefName: pr.headRefName,
+      baseRefName: pr.baseRefName,
+      isDraft: Boolean(pr.isDraft),
+      mergeStateStatus: pr.mergeStateStatus || "",
+      updatedAt: pr.updatedAt || "",
+      checks: {
+        total: checks.length,
+        failing: failing.length,
+        pending: pending.length,
+        passing: checks.filter((check) => check.conclusion === "SUCCESS").length
+      }
+    };
+  });
+  return { status: "ok", prs, error: "" };
+}
+
+function workspaceSummary(dir) {
+  const absolute = resolve(REPO_ROOT, dir);
+  const packageJson = resolve(absolute, "package.json");
+  const packageLock = resolve(absolute, "package-lock.json");
+  const summary = {
+    path: dir,
+    packageJson: repoRelative(packageJson),
+    packageLock: existsSync(packageLock) ? repoRelative(packageLock) : "",
+    packageName: "",
+    dependencies: 0,
+    devDependencies: 0,
+    status: existsSync(packageJson) ? "present" : "missing_package_json",
+    audit: { status: "not_run" }
+  };
+  if (!existsSync(packageJson)) return summary;
+  const pkg = safeJsonParse(readFileSync(packageJson, "utf8"), {});
+  summary.packageName = pkg.name || "(unnamed)";
+  summary.dependencies = pkg.dependencies && typeof pkg.dependencies === "object" ? Object.keys(pkg.dependencies).length : 0;
+  summary.devDependencies = pkg.devDependencies && typeof pkg.devDependencies === "object" ? Object.keys(pkg.devDependencies).length : 0;
+  if (!existsSync(packageLock)) {
+    summary.audit = { status: "skipped_missing_lockfile" };
+  }
+  return summary;
+}
+
+function npmAuditWorkspace(summary, enabled) {
+  if (!enabled) {
+    summary.audit = { status: "skipped_by_flag" };
+    return summary;
+  }
+  if (!summary.packageLock) return summary;
+  if (!commandExists("npm")) {
+    summary.audit = { status: "skipped_npm_unavailable" };
+    return summary;
+  }
+  const result = run("npm", ["audit", "--package-lock-only", "--json"], {
+    cwd: resolve(REPO_ROOT, summary.path),
+    timeoutMs: 120_000
+  });
+  const audit = safeJsonParse(result.stdout, {});
+  const counts = audit.metadata?.vulnerabilities || {};
+  const vulnerabilities = audit.vulnerabilities && typeof audit.vulnerabilities === "object" ? Object.keys(audit.vulnerabilities).sort() : [];
+  summary.audit = {
+    status: result.status === 0 ? "clean" : vulnerabilities.length > 0 ? "vulnerabilities_found" : "audit_error",
+    exitStatus: result.status,
+    counts: {
+      info: counts.info || 0,
+      low: counts.low || 0,
+      moderate: counts.moderate || 0,
+      high: counts.high || 0,
+      critical: counts.critical || 0,
+      total: counts.total || 0
+    },
+    affectedPackages: vulnerabilities.slice(0, 30),
+    stderrSummary: firstLines(result.stderr || result.error)
+  };
+  return summary;
+}
+
+function firstLines(value) {
+  return String(value || "")
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .filter((line) => !/npm notice/i.test(line))
+    .slice(0, 3)
+    .join(" | ");
+}
+
+function issueReadyTasks(report) {
+  const tasks = [];
+  const alertGroups = new Map();
+  for (const alert of report.github.alerts.alerts || []) {
+    const key = `${alert.dependency}|${alert.manifestPath}`;
+    const existing = alertGroups.get(key) || [];
+    existing.push(alert);
+    alertGroups.set(key, existing);
+  }
+  for (const [key, alerts] of alertGroups.entries()) {
+    const [dependency, manifestPath] = key.split("|");
+    tasks.push({
+      title: `[deps] Review ${dependency} alert in ${manifestPath}`,
+      body: [
+        "## Problem",
+        `${alerts.length} open Dependabot alert(s) affect \`${dependency}\` in \`${manifestPath}\`.`,
+        "",
+        "## Evidence",
+        ...alerts.map((alert) => `- #${alert.number}: ${alert.ghsaId || alert.cveId} ${alert.severity} patched in ${alert.patchedVersions || "unknown"}`),
+        "",
+        "## Risk",
+        "The dependency surface remains exposed until the lockfile update is merged and verified.",
+        "",
+        "## Proposed Fix",
+        "Review the matching Dependabot PR if present, run package-specific checks, and merge only after CI passes.",
+        "",
+        "## Acceptance Criteria",
+        "- Matching alert closes or is explicitly dismissed with rationale.",
+        "- CI and package-specific tests pass.",
+        "- No manual `npm audit fix` or broad dependency update is used without review.",
+        "",
+        "## Safety Notes",
+        "- This scout is read-only.",
+        "- Dependency upgrades remain PR-gated and rollback is the previous lockfile commit."
+      ].join("\n"),
+      labels: ["ops", "security", "dependencies"]
+    });
+  }
+  for (const workspace of report.workspaces) {
+    const counts = workspace.audit?.counts || {};
+    if ((counts.high || 0) + (counts.critical || 0) === 0) continue;
+    tasks.push({
+      title: `[deps] Triage high npm audit findings in ${workspace.path}`,
+      body: [
+        "## Problem",
+        `\`${workspace.path}\` reports high or critical npm audit findings.`,
+        "",
+        "## Evidence",
+        `- Counts: high=${counts.high || 0}, critical=${counts.critical || 0}, total=${counts.total || 0}`,
+        `- Affected package sample: ${(workspace.audit.affectedPackages || []).join(", ") || "none"}`,
+        "",
+        "## Risk",
+        "Local npm audit may reveal dependency risk that is not represented by currently open GitHub alerts.",
+        "",
+        "## Proposed Fix",
+        "Open a targeted dependency PR or confirm an existing Dependabot PR covers the chain.",
+        "",
+        "## Acceptance Criteria",
+        "- High/critical count is zero or tracked by an explicit accepted-risk ticket.",
+        "- Relevant package tests pass.",
+        "- Lockfile-only changes are reviewed.",
+        "",
+        "## Safety Notes",
+        "- Do not run `npm audit fix` automatically.",
+        "- Rollback is reverting the dependency PR."
+      ].join("\n"),
+      labels: ["ops", "security", "dependencies"]
+    });
+  }
+  return tasks;
+}
+
+function buildReport(options) {
+  const alerts = options.github ? githubAlerts(options.repo) : { status: "skipped_by_flag", alerts: [], error: "" };
+  const prs = options.github ? dependabotPrs(options.repo) : { status: "skipped_by_flag", prs: [], error: "" };
+  const workspaces = DEFAULT_WORKSPACES
+    .map(workspaceSummary)
+    .map((summary) => npmAuditWorkspace(summary, options.npmAudit));
+  const highCritical = workspaces.reduce((acc, workspace) => acc + (workspace.audit?.counts?.high || 0) + (workspace.audit?.counts?.critical || 0), 0);
+  const report = {
+    schema: "studio-brain.ops.dependency-security-scout.v1",
+    generatedAt: new Date().toISOString(),
+    readOnly: true,
+    status: highCritical > 0 ? "warning" : (alerts.alerts || []).length > 0 ? "degraded" : "ok",
+    github: { alerts, dependabotPrs: prs },
+    summary: {
+      openAlerts: (alerts.alerts || []).length,
+      openDependabotPrs: (prs.prs || []).length,
+      workspaces: workspaces.length,
+      auditHighCritical: highCritical,
+      auditTotal: workspaces.reduce((acc, workspace) => acc + (workspace.audit?.counts?.total || 0), 0)
+    },
+    workspaces,
+    approvalBoundary: "This report does not approve dependency upgrades, npm audit fix, package installs, deploys, or lockfile changes."
+  };
+  report.issueReadyTasks = issueReadyTasks(report);
+  return report;
+}
+
+function renderMarkdown(report) {
+  const lines = [
+    "# Dependency Security Scout",
+    "",
+    `- Generated at: ${report.generatedAt}`,
+    `- Status: ${report.status}`,
+    `- Read-only: ${report.readOnly ? "yes" : "no"}`,
+    `- Approval boundary: ${report.approvalBoundary}`,
+    "",
+    "## Summary",
+    "",
+    `- Open Dependabot alerts: ${report.summary.openAlerts}`,
+    `- Open Dependabot PRs: ${report.summary.openDependabotPrs}`,
+    `- Workspaces checked: ${report.summary.workspaces}`,
+    `- npm audit high/critical: ${report.summary.auditHighCritical}`,
+    `- npm audit total: ${report.summary.auditTotal}`,
+    "",
+    "## Dependabot Alerts",
+    "",
+    "| Alert | Severity | Dependency | Manifest | Patched versions | Advisory |",
+    "| --- | --- | --- | --- | --- | --- |"
+  ];
+  for (const alert of report.github.alerts.alerts || []) {
+    lines.push(`| #${alert.number} | ${alert.severity} | \`${alert.dependency}\` | \`${alert.manifestPath}\` | ${alert.patchedVersions || "unknown"} | ${alert.ghsaId || alert.cveId || ""} |`);
+  }
+  if (!(report.github.alerts.alerts || []).length) lines.push("| n/a | n/a | n/a | n/a | n/a | n/a |");
+  lines.push("");
+  lines.push("## Dependabot PRs");
+  lines.push("");
+  lines.push("| PR | State | Checks | Branch | Title |");
+  lines.push("| --- | --- | --- | --- | --- |");
+  for (const pr of report.github.dependabotPrs.prs || []) {
+    lines.push(`| #${pr.number} | ${pr.mergeStateStatus}${pr.isDraft ? " draft" : ""} | pass=${pr.checks.passing} pending=${pr.checks.pending} fail=${pr.checks.failing} | \`${pr.headRefName}\` | ${pr.title} |`);
+  }
+  if (!(report.github.dependabotPrs.prs || []).length) lines.push("| n/a | n/a | n/a | n/a | n/a |");
+  lines.push("");
+  lines.push("## npm Audit Workspaces");
+  lines.push("");
+  lines.push("| Workspace | Audit status | Moderate | High | Critical | Total | Affected sample |");
+  lines.push("| --- | --- | ---: | ---: | ---: | ---: | --- |");
+  for (const workspace of report.workspaces) {
+    const counts = workspace.audit?.counts || {};
+    lines.push(`| \`${workspace.path}\` | ${workspace.audit?.status || "unknown"} | ${counts.moderate || 0} | ${counts.high || 0} | ${counts.critical || 0} | ${counts.total || 0} | ${(workspace.audit?.affectedPackages || []).slice(0, 8).join(", ") || ""} |`);
+  }
+  lines.push("");
+  lines.push("## Issue-Ready Tasks");
+  lines.push("");
+  if (!report.issueReadyTasks.length) lines.push("- No dependency/security follow-up tasks.");
+  for (const task of report.issueReadyTasks) {
+    lines.push(`### ${task.title}`);
+    lines.push("");
+    lines.push(task.body);
+    lines.push("");
+    lines.push(`Labels: ${task.labels.join(", ")}`);
+    lines.push("");
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+function writeArtifacts(report, options) {
+  mkdirSync(options.outputDir, { recursive: true });
+  const jsonPath = resolve(options.outputDir, "latest.json");
+  const markdownPath = resolve(options.outputDir, "latest.md");
+  writeFileSync(jsonPath, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+  writeFileSync(markdownPath, renderMarkdown(report), "utf8");
+  report.paths = {
+    json: repoRelative(jsonPath),
+    markdown: repoRelative(markdownPath)
+  };
+}
+
+function main() {
+  try {
+    const options = parseArgs(process.argv.slice(2));
+    const report = buildReport(options);
+    if (options.write) writeArtifacts(report, options);
+    process.stdout.write(options.json ? `${JSON.stringify(report, null, 2)}\n` : renderMarkdown(report));
+  } catch (error) {
+    process.stderr.write(`dependency_security_scout: ${error.message}\n`);
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- Adds a read-only dependency/security scout that compares open Dependabot alerts, open Dependabot PR readiness, and local npm audit summaries.
- Writes JSON/Markdown artifacts under ignored `output/ops/dependency-security-scout`.
- Adds Makefile/npm/docs wrappers for the report.

## Evidence
- Local run found 3 open Dependabot alerts, all `hono` on root and `studio-brain-mcp` lockfiles.
- Local run found 2 open Dependabot PRs (#673 and #674), and 1 high local npm audit signal on the root package surface (`basic-ftp` plus `hono`).
- Web, functions, and studio-brain package surfaces reported clean in the local audit run.

## Testing
- `node --check scripts\ops\dependency_security_scout.mjs`
- `npm run ops:dependency:security-scout`
- `git diff --check` (only Git CRLF working-copy warnings)

## Risk
Low. This is reporting-only. It does not install packages, run `npm audit fix`, update lockfiles, merge Dependabot PRs, deploy, or read secrets.

## Rollback
Revert this commit to remove the script, docs entry, and npm/Makefile targets. Generated artifacts under `output/ops/dependency-security-scout` are ignored.

## Follow-up Tickets
- Merge or update the `hono` Dependabot PRs after CI is green and branch status is current.
- Investigate the root high `basic-ftp` audit chain separately from the GitHub alert list.