### PR TITLE
[ops] Add dependency remediation packet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL := /bin/bash
 PG_CONTAINER ?= studiobrain_postgres
 PGDATABASE ?= monsoonfire_studio_os
 
-.PHONY: ops-check ops-inventory ops-postgres-review ops-postgres-sql ops-postgres-top-queries ops-postgres-query-tasks ops-postgres-growth-snapshot ops-postgres-autovacuum-stats ops-postgres-roles-extensions ops-docker-review ops-docker-posture ops-docker-tag-policy ops-capacity ops-import-pressure ops-cleanup-candidates ops-backup-evidence ops-postgres-backup-artifacts ops-restore-prereq ops-redis-minio-backup-evidence ops-db-docker-backup-rollup ops-command-surface-guard ops-ubuntu-review ops-host-failed-unit-trends ops-package-posture ops-time-sync ops-network-review ops-host-drift ops-systemd-drift ops-portal-bridge-review ops-app-review ops-dependency-review ops-dependency-security-scout ops-idle-worker-effectivity ops-effectivity-report ops-evidence-freshness ops-slice-ledger ops-tool-inventory ops-admin-effectivity-audit ops-proactive-radar ops-pr-stack-readiness ops-privileged-evidence-read ops-privileged-evidence-capture ops-privileged-evidence-capture-smoke ops-work-packet ops-incident-bundle ops-incident-bundle-v2 ops-ci-validate ops-post-deploy-verify ops-docs ops-backlog ops-report
+.PHONY: ops-check ops-inventory ops-postgres-review ops-postgres-sql ops-postgres-top-queries ops-postgres-query-tasks ops-postgres-growth-snapshot ops-postgres-autovacuum-stats ops-postgres-roles-extensions ops-docker-review ops-docker-posture ops-docker-tag-policy ops-capacity ops-import-pressure ops-cleanup-candidates ops-backup-evidence ops-postgres-backup-artifacts ops-restore-prereq ops-redis-minio-backup-evidence ops-db-docker-backup-rollup ops-command-surface-guard ops-ubuntu-review ops-host-failed-unit-trends ops-package-posture ops-time-sync ops-network-review ops-host-drift ops-systemd-drift ops-portal-bridge-review ops-app-review ops-dependency-review ops-dependency-security-scout ops-dependency-remediation-packet ops-idle-worker-effectivity ops-effectivity-report ops-evidence-freshness ops-slice-ledger ops-tool-inventory ops-admin-effectivity-audit ops-proactive-radar ops-pr-stack-readiness ops-privileged-evidence-read ops-privileged-evidence-capture ops-privileged-evidence-capture-smoke ops-work-packet ops-incident-bundle ops-incident-bundle-v2 ops-ci-validate ops-post-deploy-verify ops-docs ops-backlog ops-report
 
 ops-check: ops-inventory ops-docker-review ops-capacity ops-cleanup-candidates ops-backup-evidence ops-ubuntu-review ops-network-review ops-host-drift ops-systemd-drift ops-portal-bridge-review ops-app-review
 
@@ -116,6 +116,9 @@ ops-dependency-review:
 
 ops-dependency-security-scout:
 	node scripts/ops/dependency_security_scout.mjs --write
+
+ops-dependency-remediation-packet:
+	node scripts/ops/dependency_remediation_packet.mjs --write
 
 ops-idle-worker-effectivity:
 	node ./scripts/studiobrain-idle-worker-effectivity-audit.mjs --json

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -54,6 +54,7 @@ make ops-portal-bridge-review
 make ops-app-review
 make ops-dependency-review
 make ops-dependency-security-scout
+make ops-dependency-remediation-packet
 make ops-idle-worker-effectivity
 make ops-effectivity-report
 make ops-evidence-freshness
@@ -78,6 +79,7 @@ npm run ops:evidence:freshness
 npm run ops:db-docker-backup:rollup
 npm run ops:command-surface:guard
 npm run ops:dependency:security-scout
+npm run ops:dependency:remediation-packet
 npm run ops:docker:tag-policy
 ```
 
@@ -97,6 +99,7 @@ bash scripts/ops/effectivity_report.sh
 node scripts/ops/proactive_issue_radar.mjs --write
 node scripts/ops/command_surface_guard.mjs --write
 node scripts/ops/dependency_security_scout.mjs --write
+node scripts/ops/dependency_remediation_packet.mjs --write
 node scripts/ops/docker_floating_tag_policy.mjs --write
 bash scripts/ops/privileged_evidence_read.sh
 bash scripts/ops/privileged_evidence_capture.sh --smoke --output-dir output/ops/privileged-evidence
@@ -117,6 +120,8 @@ bash scripts/ops/incident_bundle_v2.sh output/ops/incidents-v2/manual-smoke
 `ops-command-surface-guard` checks that documented `make`, `npm run`, and direct `scripts/ops` commands still resolve. It writes artifacts under `output/ops/command-surface-guard` and is meant to catch command-wrapper drift before PRs stack up.
 
 `ops-dependency-security-scout` compares open Dependabot alerts, open Dependabot PR readiness, and local `npm audit` summaries across the repo's package surfaces. It writes issue-ready follow-up tasks under `output/ops/dependency-security-scout` and does not install, update, or fix packages.
+
+`ops-dependency-remediation-packet` turns high/critical npm audit findings into a read-only decision packet with dependency chains, owner-package candidates, latest-version hints, safe next steps, acceptance criteria, and rollback notes. It writes under `output/ops/dependency-remediation` and does not install, update, override, or remove dependencies.
 
 `ops-docker-tag-policy` scans tracked Compose files and Dockerfiles for `latest`, `stable`, branch-like, broad major-only, and digest-pinned image references. It writes issue-ready follow-ups under `output/ops/docker-tag-policy` and does not pull, recreate, restart, or edit Docker resources.
 

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "ops:command-surface:guard:check": "node ./scripts/ops/command_surface_guard.mjs --json",
     "test:ops:command-surface": "node --test ./scripts/ops/command_surface_guard.test.mjs",
     "ops:dependency:security-scout": "node ./scripts/ops/dependency_security_scout.mjs --write --json",
+    "ops:dependency:remediation-packet": "node ./scripts/ops/dependency_remediation_packet.mjs --write --json",
     "ops:docker:tag-policy": "node ./scripts/ops/docker_floating_tag_policy.mjs --write --json",
     "portal:smoke:native-browser:shadow": "node ./scripts/native-browser-shadow-verifier.mjs --surface portal --base-url https://portal.monsoonfire.com --output-dir output/native-browser/portal/prod --shadow-of verify.portal.smoke --canonical-artifact-root output/playwright/portal/prod",
     "codex:browser:verify:portal": "node ./scripts/native-browser-shadow-verifier.mjs --surface portal --base-url https://portal.monsoonfire.com --output-dir output/native-browser/portal/prod --shadow-of verify.portal.smoke --canonical-artifact-root output/playwright/portal/prod --app-handoff",

--- a/scripts/ops/dependency_remediation_packet.mjs
+++ b/scripts/ops/dependency_remediation_packet.mjs
@@ -1,0 +1,365 @@
+#!/usr/bin/env node
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, relative, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const REPO_ROOT = resolve(dirname(__filename), "..", "..");
+const DEFAULT_OUTPUT_DIR = resolve(REPO_ROOT, "output", "ops", "dependency-remediation");
+
+function usage() {
+  return `Dependency remediation packet
+
+Usage:
+  node scripts/ops/dependency_remediation_packet.mjs [--json] [--write]
+
+Options:
+  --json                 Print JSON.
+  --write                Write latest JSON and Markdown artifacts.
+  --workspace <path>     Workspace to audit. Default: repo root.
+  --output-dir <path>    Artifact directory. Default: output/ops/dependency-remediation.
+  --include-moderate     Include moderate vulnerabilities. Default: high and critical only.
+  --skip-npm-view        Skip read-only npm registry latest-version hints.
+`;
+}
+
+function parseArgs(argv) {
+  const options = {
+    json: false,
+    write: false,
+    workspace: ".",
+    outputDir: DEFAULT_OUTPUT_DIR,
+    includeModerate: false,
+    npmView: true
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--help" || arg === "-h") {
+      process.stdout.write(usage());
+      process.exit(0);
+    }
+    if (arg === "--json") {
+      options.json = true;
+      continue;
+    }
+    if (arg === "--write") {
+      options.write = true;
+      continue;
+    }
+    if (arg === "--include-moderate") {
+      options.includeModerate = true;
+      continue;
+    }
+    if (arg === "--skip-npm-view") {
+      options.npmView = false;
+      continue;
+    }
+    if (arg === "--workspace" || arg === "--output-dir") {
+      if (!argv[index + 1]) throw new Error(`${arg} requires a value.`);
+      options[arg === "--workspace" ? "workspace" : "outputDir"] = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith("--workspace=")) {
+      options.workspace = arg.slice("--workspace=".length);
+      continue;
+    }
+    if (arg.startsWith("--output-dir=")) {
+      options.outputDir = arg.slice("--output-dir=".length);
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+  options.workspaceDir = resolve(REPO_ROOT, options.workspace);
+  options.outputDir = resolve(REPO_ROOT, options.outputDir);
+  return options;
+}
+
+function windowsCommand(command) {
+  if (process.platform !== "win32") return command;
+  if (command === "npm") return "npm.cmd";
+  return command;
+}
+
+function windowsShellQuote(value) {
+  const text = String(value);
+  if (/^[A-Za-z0-9_./:=@-]+$/.test(text)) return text;
+  return `"${text.replace(/"/g, '\\"')}"`;
+}
+
+function run(command, args, options = {}) {
+  const resolved = windowsCommand(command);
+  const useCmdShim = process.platform === "win32" && /\.cmd$/i.test(resolved);
+  const actualCommand = useCmdShim ? "cmd.exe" : resolved;
+  const actualArgs = useCmdShim ? ["/d", "/s", "/c", [resolved, ...args].map(windowsShellQuote).join(" ")] : args;
+  const result = spawnSync(actualCommand, actualArgs, {
+    cwd: options.cwd || REPO_ROOT,
+    encoding: "utf8",
+    windowsHide: true,
+    timeout: options.timeoutMs || 120_000
+  });
+  return {
+    status: result.status ?? null,
+    stdout: result.stdout || "",
+    stderr: result.stderr || "",
+    error: result.error?.message || ""
+  };
+}
+
+function safeJsonParse(raw, fallback) {
+  try {
+    return JSON.parse(raw || "");
+  } catch {
+    return fallback;
+  }
+}
+
+function repoRelative(path) {
+  return relative(REPO_ROOT, path).replace(/\\/g, "/") || ".";
+}
+
+function readJson(path, fallback) {
+  if (!existsSync(path)) return fallback;
+  return safeJsonParse(readFileSync(path, "utf8"), fallback);
+}
+
+function firstLines(text, maxLines = 4) {
+  return String(text || "").split(/\r?\n/).filter(Boolean).slice(0, maxLines).join("\n");
+}
+
+function auditWorkspace(workspaceDir) {
+  const result = run("npm", ["audit", "--package-lock-only", "--json"], {
+    cwd: workspaceDir,
+    timeoutMs: 120_000
+  });
+  const audit = safeJsonParse(result.stdout, {});
+  return {
+    status: result.status === 0 ? "clean" : audit.vulnerabilities ? "vulnerabilities_found" : "audit_error",
+    exitStatus: result.status,
+    error: result.status === 0 || audit.vulnerabilities ? "" : firstLines(result.stderr || result.error),
+    audit
+  };
+}
+
+function packageNameFromPath(path) {
+  if (!path) return "(root)";
+  const parts = path.split("node_modules/");
+  const last = parts[parts.length - 1];
+  if (!last) return "";
+  const segments = last.split("/");
+  return last.startsWith("@") ? `${segments[0]}/${segments[1]}` : segments[0];
+}
+
+function buildLockGraph(lock) {
+  const packages = lock.packages && typeof lock.packages === "object" ? lock.packages : {};
+  const nodes = Object.entries(packages).map(([path, meta]) => ({
+    path,
+    name: path ? meta.name || packageNameFromPath(path) : "(root)",
+    version: meta.version || "",
+    dependencies: {
+      ...(meta.dependencies || {}),
+      ...(meta.devDependencies || {}),
+      ...(meta.optionalDependencies || {}),
+      ...(meta.peerDependencies || {})
+    }
+  }));
+  const byName = new Map();
+  for (const node of nodes) {
+    if (!byName.has(node.name)) byName.set(node.name, []);
+    byName.get(node.name).push(node);
+  }
+  return { nodes, byName };
+}
+
+function shortestChainTo(graph, targetName) {
+  const root = graph.nodes.find((node) => node.path === "");
+  if (!root) return [];
+  const queue = [{ node: root, chain: [root] }];
+  const visited = new Set([root.path]);
+  while (queue.length > 0) {
+    const current = queue.shift();
+    if (current.node.name === targetName && current.node.path !== "") return current.chain;
+    for (const depName of Object.keys(current.node.dependencies || {})) {
+      for (const candidate of graph.byName.get(depName) || []) {
+        if (visited.has(candidate.path)) continue;
+        visited.add(candidate.path);
+        queue.push({ node: candidate, chain: [...current.chain, candidate] });
+      }
+    }
+  }
+  return [];
+}
+
+function npmLatest(packageName, enabled) {
+  if (!enabled || !packageName || packageName === "(root)") return { status: "skipped", version: "" };
+  const result = run("npm", ["view", packageName, "version", "--json"], { timeoutMs: 60_000 });
+  if (result.status !== 0) {
+    return { status: "unavailable", version: "", error: firstLines(result.stderr || result.error, 2) };
+  }
+  const parsed = safeJsonParse(result.stdout, "");
+  return { status: "ok", version: Array.isArray(parsed) ? parsed.at(-1) || "" : String(parsed || "").replace(/^"|"$/g, "") };
+}
+
+function normalizeVia(via) {
+  return (Array.isArray(via) ? via : []).map((item) => {
+    if (typeof item === "string") return { name: item };
+    return {
+      name: item.name || "",
+      title: item.title || "",
+      url: item.url || "",
+      severity: item.severity || "",
+      range: item.range || "",
+      cwe: item.cwe || []
+    };
+  });
+}
+
+function buildFindings(audit, lock, options) {
+  const graph = buildLockGraph(lock);
+  const allowed = new Set(options.includeModerate ? ["moderate", "high", "critical"] : ["high", "critical"]);
+  return Object.values(audit.vulnerabilities || {})
+    .filter((vulnerability) => allowed.has(vulnerability.severity))
+    .sort((a, b) => severityRank(b.severity) - severityRank(a.severity) || a.name.localeCompare(b.name))
+    .map((vulnerability) => {
+      const chain = shortestChainTo(graph, vulnerability.name);
+      const directOwner = chain.find((node, index) => index > 0 && (chain[0].dependencies || {})[node.name]) || chain[1] || null;
+      const nearestParent = chain.length > 1 ? chain[chain.length - 2] : null;
+      const packagesForHints = [...new Set([directOwner?.name, nearestParent?.name, vulnerability.name].filter(Boolean))];
+      const latestHints = Object.fromEntries(packagesForHints.map((name) => [name, npmLatest(name, options.npmView)]));
+      return {
+        name: vulnerability.name,
+        severity: vulnerability.severity,
+        isDirect: Boolean(vulnerability.isDirect),
+        range: vulnerability.range || "",
+        fixAvailable: vulnerability.fixAvailable ?? false,
+        nodes: vulnerability.nodes || [],
+        via: normalizeVia(vulnerability.via),
+        chain: chain.map((node) => ({
+          name: node.name,
+          version: node.version,
+          path: node.path || "(root)",
+          requested: chain[chain.indexOf(node) - 1]?.dependencies?.[node.name] || ""
+        })),
+        directOwner: directOwner ? { name: directOwner.name, version: directOwner.version } : null,
+        nearestParent: nearestParent ? { name: nearestParent.name, version: nearestParent.version } : null,
+        latestHints
+      };
+    });
+}
+
+function severityRank(severity) {
+  return { low: 1, moderate: 2, high: 3, critical: 4 }[severity] || 0;
+}
+
+function statusFor(findings, auditResult) {
+  if (auditResult.status === "audit_error") return "unknown";
+  if (findings.some((finding) => finding.severity === "critical")) return "critical";
+  if (findings.some((finding) => finding.severity === "high")) return "warning";
+  return "ok";
+}
+
+function markdown(report) {
+  const lines = [
+    "# Dependency Remediation Packet",
+    "",
+    `Generated: ${report.generatedAt}`,
+    `Workspace: \`${report.workspace}\``,
+    `Status: \`${report.status}\``,
+    "",
+    "This packet is read-only. It does not install, update, override, or remove dependencies.",
+    ""
+  ];
+  if (report.findings.length === 0) {
+    lines.push("No high or critical dependency remediation candidates were found.");
+    return `${lines.join("\n")}\n`;
+  }
+  for (const finding of report.findings) {
+    lines.push(`## ${finding.severity.toUpperCase()}: ${finding.name}`);
+    lines.push("");
+    lines.push(`- Affected range: \`${finding.range || "unknown"}\``);
+    lines.push(`- Direct dependency: \`${finding.isDirect ? "yes" : "no"}\``);
+    lines.push(`- npm fixAvailable: \`${JSON.stringify(finding.fixAvailable)}\``);
+    if (finding.directOwner) lines.push(`- Root-level owner candidate: \`${finding.directOwner.name}@${finding.directOwner.version || "unknown"}\``);
+    if (finding.nearestParent) lines.push(`- Nearest parent candidate: \`${finding.nearestParent.name}@${finding.nearestParent.version || "unknown"}\``);
+    lines.push("");
+    lines.push("### Evidence");
+    lines.push("");
+    for (const via of finding.via) {
+      if (via.title) lines.push(`- ${via.title} (${via.url || "no advisory URL"})`);
+    }
+    lines.push("");
+    lines.push("Dependency chain:");
+    lines.push("");
+    for (const [index, node] of finding.chain.entries()) {
+      const request = node.requested ? ` requested \`${node.requested}\`` : "";
+      lines.push(`${index + 1}. \`${node.name}@${node.version || "unknown"}\`${request}`);
+    }
+    lines.push("");
+    lines.push("Latest-version hints:");
+    lines.push("");
+    for (const [name, hint] of Object.entries(finding.latestHints)) {
+      lines.push(`- \`${name}\`: ${hint.status === "ok" ? `latest \`${hint.version}\`` : `\`${hint.status}\``}`);
+    }
+    lines.push("");
+    lines.push("### Recommended Safe Next Step");
+    lines.push("");
+    if (finding.isDirect) {
+      lines.push("- Open a small dependency PR updating the direct dependency to a patched version, then run the relevant workspace tests and `npm audit --package-lock-only --json`.");
+    } else {
+      lines.push("- Prefer an upstream owner-package bump first. If the chain remains vulnerable, test an npm `overrides` candidate in a throwaway branch and verify the owning tool still works before proposing a PR.");
+    }
+    lines.push("");
+    lines.push("### Rollback Notes");
+    lines.push("");
+    lines.push("- Revert the dependency PR or remove the tested override and restore the prior lockfile. No host mutation is required.");
+    lines.push("");
+    lines.push("### Issue-Ready Acceptance Criteria");
+    lines.push("");
+    lines.push("- `npm audit --package-lock-only --json` no longer reports this package in the audited workspace.");
+    lines.push("- The dependency chain is documented in the PR body.");
+    lines.push("- Relevant tool smoke checks pass, especially for the root-level owner package.");
+    lines.push("");
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const packageLockPath = resolve(options.workspaceDir, "package-lock.json");
+  if (!existsSync(packageLockPath)) {
+    throw new Error(`No package-lock.json found in ${repoRelative(options.workspaceDir)}.`);
+  }
+  const auditResult = auditWorkspace(options.workspaceDir);
+  const lock = readJson(packageLockPath, {});
+  const findings = buildFindings(auditResult.audit || {}, lock, options);
+  const report = {
+    generatedAt: new Date().toISOString(),
+    workspace: repoRelative(options.workspaceDir),
+    packageLock: repoRelative(packageLockPath),
+    auditStatus: auditResult.status,
+    auditExitStatus: auditResult.exitStatus,
+    auditError: auditResult.error,
+    status: statusFor(findings, auditResult),
+    findings
+  };
+  const reportMarkdown = markdown(report);
+  if (options.write) {
+    mkdirSync(options.outputDir, { recursive: true });
+    writeFileSync(resolve(options.outputDir, "latest.json"), `${JSON.stringify(report, null, 2)}\n`);
+    writeFileSync(resolve(options.outputDir, "latest.md"), reportMarkdown);
+  }
+  if (options.json) {
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  } else {
+    process.stdout.write(reportMarkdown);
+  }
+}
+
+try {
+  main();
+} catch (error) {
+  process.stderr.write(`dependency remediation packet failed: ${error.message}\n`);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- add a read-only dependency remediation packet generator for high/critical npm audit findings
- include dependency chain evidence, owner-package candidates, latest-version hints, safe next steps, acceptance criteria, and rollback notes
- document the new Makefile/npm/direct script surfaces

## Evidence
- current root audit still reports high `basic-ftp` via `firebase-tools -> proxy-agent -> pac-proxy-agent -> get-uri -> basic-ftp`
- packet writes artifacts under `output/ops/dependency-remediation` without installing, updating, overriding, or removing dependencies

## Testing
- `node --check scripts\\ops\\dependency_remediation_packet.mjs`
- `npm run ops:dependency:remediation-packet`
- `npm run ops:command-surface:guard:check`
- `git diff --check`

## Risk / rollback
- Risk: low; read-only script and documentation wrapper only.
- Rollback: revert this PR to remove the command surface and script.