### PR TITLE
[ops] Add dependency upstream watch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL := /bin/bash
 PG_CONTAINER ?= studiobrain_postgres
 PGDATABASE ?= monsoonfire_studio_os
 
-.PHONY: ops-check ops-inventory ops-postgres-review ops-postgres-sql ops-postgres-top-queries ops-postgres-query-tasks ops-postgres-growth-snapshot ops-postgres-autovacuum-stats ops-postgres-roles-extensions ops-docker-review ops-docker-posture ops-docker-tag-policy ops-capacity ops-import-pressure ops-cleanup-candidates ops-backup-evidence ops-postgres-backup-artifacts ops-restore-prereq ops-redis-minio-backup-evidence ops-db-docker-backup-rollup ops-command-surface-guard ops-ubuntu-review ops-host-failed-unit-trends ops-package-posture ops-time-sync ops-network-review ops-host-drift ops-systemd-drift ops-portal-bridge-review ops-app-review ops-dependency-review ops-dependency-security-scout ops-dependency-remediation-packet ops-idle-worker-effectivity ops-effectivity-report ops-evidence-freshness ops-slice-ledger ops-tool-inventory ops-admin-effectivity-audit ops-proactive-radar ops-pr-stack-readiness ops-privileged-evidence-read ops-privileged-evidence-capture ops-privileged-evidence-capture-smoke ops-work-packet ops-incident-bundle ops-incident-bundle-v2 ops-ci-validate ops-post-deploy-verify ops-docs ops-backlog ops-report
+.PHONY: ops-check ops-inventory ops-postgres-review ops-postgres-sql ops-postgres-top-queries ops-postgres-query-tasks ops-postgres-growth-snapshot ops-postgres-autovacuum-stats ops-postgres-roles-extensions ops-docker-review ops-docker-posture ops-docker-tag-policy ops-capacity ops-import-pressure ops-cleanup-candidates ops-backup-evidence ops-postgres-backup-artifacts ops-restore-prereq ops-redis-minio-backup-evidence ops-db-docker-backup-rollup ops-command-surface-guard ops-ubuntu-review ops-host-failed-unit-trends ops-package-posture ops-time-sync ops-network-review ops-host-drift ops-systemd-drift ops-portal-bridge-review ops-app-review ops-dependency-review ops-dependency-security-scout ops-dependency-remediation-packet ops-dependency-upstream-watch ops-idle-worker-effectivity ops-effectivity-report ops-evidence-freshness ops-slice-ledger ops-tool-inventory ops-admin-effectivity-audit ops-proactive-radar ops-pr-stack-readiness ops-privileged-evidence-read ops-privileged-evidence-capture ops-privileged-evidence-capture-smoke ops-work-packet ops-incident-bundle ops-incident-bundle-v2 ops-ci-validate ops-post-deploy-verify ops-docs ops-backlog ops-report
 
 ops-check: ops-inventory ops-docker-review ops-capacity ops-cleanup-candidates ops-backup-evidence ops-ubuntu-review ops-network-review ops-host-drift ops-systemd-drift ops-portal-bridge-review ops-app-review
 
@@ -119,6 +119,9 @@ ops-dependency-security-scout:
 
 ops-dependency-remediation-packet:
 	node scripts/ops/dependency_remediation_packet.mjs --write
+
+ops-dependency-upstream-watch:
+	node scripts/ops/dependency_upstream_watch.mjs --write
 
 ops-idle-worker-effectivity:
 	node ./scripts/studiobrain-idle-worker-effectivity-audit.mjs --json

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -55,6 +55,7 @@ make ops-app-review
 make ops-dependency-review
 make ops-dependency-security-scout
 make ops-dependency-remediation-packet
+make ops-dependency-upstream-watch
 make ops-idle-worker-effectivity
 make ops-effectivity-report
 make ops-evidence-freshness
@@ -80,6 +81,7 @@ npm run ops:db-docker-backup:rollup
 npm run ops:command-surface:guard
 npm run ops:dependency:security-scout
 npm run ops:dependency:remediation-packet
+npm run ops:dependency:upstream-watch
 npm run ops:docker:tag-policy
 ```
 
@@ -100,6 +102,7 @@ node scripts/ops/proactive_issue_radar.mjs --write
 node scripts/ops/command_surface_guard.mjs --write
 node scripts/ops/dependency_security_scout.mjs --write
 node scripts/ops/dependency_remediation_packet.mjs --write
+node scripts/ops/dependency_upstream_watch.mjs --write
 node scripts/ops/docker_floating_tag_policy.mjs --write
 bash scripts/ops/privileged_evidence_read.sh
 bash scripts/ops/privileged_evidence_capture.sh --smoke --output-dir output/ops/privileged-evidence
@@ -122,6 +125,8 @@ bash scripts/ops/incident_bundle_v2.sh output/ops/incidents-v2/manual-smoke
 `ops-dependency-security-scout` compares open Dependabot alerts, open Dependabot PR readiness, and local `npm audit` summaries across the repo's package surfaces. It writes issue-ready follow-up tasks under `output/ops/dependency-security-scout` and does not install, update, or fix packages.
 
 `ops-dependency-remediation-packet` turns high/critical npm audit findings into a read-only decision packet with dependency chains, owner-package candidates, latest-version hints, safe next steps, acceptance criteria, and rollback notes. It writes under `output/ops/dependency-remediation` and does not install, update, override, or remove dependencies.
+
+`ops-dependency-upstream-watch` checks high/critical npm audit chains against read-only npm registry version metadata and classifies whether the chain has a normal update candidate, still needs upstream movement, or would require a higher-risk override experiment. It writes under `output/ops/dependency-upstream-watch` and does not install, update, override, or remove dependencies.
 
 `ops-docker-tag-policy` scans tracked Compose files and Dockerfiles for `latest`, `stable`, branch-like, broad major-only, and digest-pinned image references. It writes issue-ready follow-ups under `output/ops/docker-tag-policy` and does not pull, recreate, restart, or edit Docker resources.
 

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "test:ops:command-surface": "node --test ./scripts/ops/command_surface_guard.test.mjs",
     "ops:dependency:security-scout": "node ./scripts/ops/dependency_security_scout.mjs --write --json",
     "ops:dependency:remediation-packet": "node ./scripts/ops/dependency_remediation_packet.mjs --write --json",
+    "ops:dependency:upstream-watch": "node ./scripts/ops/dependency_upstream_watch.mjs --write --json",
     "ops:docker:tag-policy": "node ./scripts/ops/docker_floating_tag_policy.mjs --write --json",
     "portal:smoke:native-browser:shadow": "node ./scripts/native-browser-shadow-verifier.mjs --surface portal --base-url https://portal.monsoonfire.com --output-dir output/native-browser/portal/prod --shadow-of verify.portal.smoke --canonical-artifact-root output/playwright/portal/prod",
     "codex:browser:verify:portal": "node ./scripts/native-browser-shadow-verifier.mjs --surface portal --base-url https://portal.monsoonfire.com --output-dir output/native-browser/portal/prod --shadow-of verify.portal.smoke --canonical-artifact-root output/playwright/portal/prod --app-handoff",

--- a/scripts/ops/dependency_upstream_watch.mjs
+++ b/scripts/ops/dependency_upstream_watch.mjs
@@ -1,0 +1,383 @@
+#!/usr/bin/env node
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, relative, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const REPO_ROOT = resolve(dirname(__filename), "..", "..");
+const DEFAULT_OUTPUT_DIR = resolve(REPO_ROOT, "output", "ops", "dependency-upstream-watch");
+
+function usage() {
+  return `Dependency upstream watch
+
+Usage:
+  node scripts/ops/dependency_upstream_watch.mjs [--json] [--write]
+
+Options:
+  --json                 Print JSON.
+  --write                Write latest JSON and Markdown artifacts.
+  --workspace <path>     Workspace to audit. Default: repo root.
+  --output-dir <path>    Artifact directory. Default: output/ops/dependency-upstream-watch.
+  --skip-npm-view        Skip read-only npm registry version lookups.
+`;
+}
+
+function parseArgs(argv) {
+  const options = {
+    json: false,
+    write: false,
+    workspace: ".",
+    outputDir: DEFAULT_OUTPUT_DIR,
+    npmView: true
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--help" || arg === "-h") {
+      process.stdout.write(usage());
+      process.exit(0);
+    }
+    if (arg === "--json") {
+      options.json = true;
+      continue;
+    }
+    if (arg === "--write") {
+      options.write = true;
+      continue;
+    }
+    if (arg === "--skip-npm-view") {
+      options.npmView = false;
+      continue;
+    }
+    if (arg === "--workspace" || arg === "--output-dir") {
+      if (!argv[index + 1]) throw new Error(`${arg} requires a value.`);
+      options[arg === "--workspace" ? "workspace" : "outputDir"] = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith("--workspace=")) {
+      options.workspace = arg.slice("--workspace=".length);
+      continue;
+    }
+    if (arg.startsWith("--output-dir=")) {
+      options.outputDir = arg.slice("--output-dir=".length);
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+  options.workspaceDir = resolve(REPO_ROOT, options.workspace);
+  options.outputDir = resolve(REPO_ROOT, options.outputDir);
+  return options;
+}
+
+function windowsCommand(command) {
+  if (process.platform !== "win32") return command;
+  if (command === "npm") return "npm.cmd";
+  return command;
+}
+
+function windowsShellQuote(value) {
+  const text = String(value);
+  if (/^[A-Za-z0-9_./:=@-]+$/.test(text)) return text;
+  return `"${text.replace(/"/g, '\\"')}"`;
+}
+
+function run(command, args, options = {}) {
+  const resolved = windowsCommand(command);
+  const useCmdShim = process.platform === "win32" && /\.cmd$/i.test(resolved);
+  const actualCommand = useCmdShim ? "cmd.exe" : resolved;
+  const actualArgs = useCmdShim ? ["/d", "/s", "/c", [resolved, ...args].map(windowsShellQuote).join(" ")] : args;
+  const result = spawnSync(actualCommand, actualArgs, {
+    cwd: options.cwd || REPO_ROOT,
+    encoding: "utf8",
+    windowsHide: true,
+    timeout: options.timeoutMs || 120_000
+  });
+  return {
+    status: result.status ?? null,
+    stdout: result.stdout || "",
+    stderr: result.stderr || "",
+    error: result.error?.message || ""
+  };
+}
+
+function safeJsonParse(raw, fallback) {
+  try {
+    return JSON.parse(raw || "");
+  } catch {
+    return fallback;
+  }
+}
+
+function repoRelative(path) {
+  return relative(REPO_ROOT, path).replace(/\\/g, "/") || ".";
+}
+
+function readJson(path, fallback) {
+  if (!existsSync(path)) return fallback;
+  return safeJsonParse(readFileSync(path, "utf8"), fallback);
+}
+
+function auditWorkspace(workspaceDir) {
+  const result = run("npm", ["audit", "--package-lock-only", "--json"], {
+    cwd: workspaceDir,
+    timeoutMs: 120_000
+  });
+  const audit = safeJsonParse(result.stdout, {});
+  return {
+    status: result.status === 0 ? "clean" : audit.vulnerabilities ? "vulnerabilities_found" : "audit_error",
+    exitStatus: result.status,
+    audit,
+    error: result.status === 0 || audit.vulnerabilities ? "" : firstLines(result.stderr || result.error)
+  };
+}
+
+function firstLines(text, maxLines = 4) {
+  return String(text || "").split(/\r?\n/).filter(Boolean).slice(0, maxLines).join("\n");
+}
+
+function packageNameFromPath(path) {
+  if (!path) return "(root)";
+  const parts = path.split("node_modules/");
+  const last = parts[parts.length - 1];
+  if (!last) return "";
+  const segments = last.split("/");
+  return last.startsWith("@") ? `${segments[0]}/${segments[1]}` : segments[0];
+}
+
+function buildLockGraph(lock) {
+  const packages = lock.packages && typeof lock.packages === "object" ? lock.packages : {};
+  const nodes = Object.entries(packages).map(([path, meta]) => ({
+    path,
+    name: path ? meta.name || packageNameFromPath(path) : "(root)",
+    version: meta.version || "",
+    dependencies: {
+      ...(meta.dependencies || {}),
+      ...(meta.devDependencies || {}),
+      ...(meta.optionalDependencies || {}),
+      ...(meta.peerDependencies || {})
+    }
+  }));
+  const byName = new Map();
+  for (const node of nodes) {
+    if (!byName.has(node.name)) byName.set(node.name, []);
+    byName.get(node.name).push(node);
+  }
+  return { nodes, byName };
+}
+
+function shortestChainTo(graph, targetName) {
+  const root = graph.nodes.find((node) => node.path === "");
+  if (!root) return [];
+  const queue = [{ node: root, chain: [root] }];
+  const visited = new Set([root.path]);
+  while (queue.length > 0) {
+    const current = queue.shift();
+    if (current.node.name === targetName && current.node.path !== "") return current.chain;
+    for (const depName of Object.keys(current.node.dependencies || {})) {
+      for (const candidate of graph.byName.get(depName) || []) {
+        if (visited.has(candidate.path)) continue;
+        visited.add(candidate.path);
+        queue.push({ node: candidate, chain: [...current.chain, candidate] });
+      }
+    }
+  }
+  return [];
+}
+
+function majorOf(version) {
+  const match = String(version || "").match(/^v?(\d+)/);
+  return match ? Number(match[1]) : null;
+}
+
+function compareVersions(a, b) {
+  const left = String(a || "").split(/[.-]/).map((part) => Number.parseInt(part, 10));
+  const right = String(b || "").split(/[.-]/).map((part) => Number.parseInt(part, 10));
+  for (let index = 0; index < Math.max(left.length, right.length); index += 1) {
+    const l = Number.isFinite(left[index]) ? left[index] : 0;
+    const r = Number.isFinite(right[index]) ? right[index] : 0;
+    if (l !== r) return l - r;
+  }
+  return 0;
+}
+
+function requestedMajorRange(spec) {
+  const match = String(spec || "").trim().match(/(?:\^|~|>=|>|=)?\s*(\d+)/);
+  return match ? Number(match[1]) : null;
+}
+
+function registryVersions(packageName, enabled) {
+  if (!enabled || !packageName || packageName === "(root)") return { status: "skipped", versions: [] };
+  const result = run("npm", ["view", packageName, "versions", "--json"], { timeoutMs: 60_000 });
+  if (result.status !== 0) {
+    return { status: "unavailable", versions: [], error: firstLines(result.stderr || result.error, 2) };
+  }
+  const parsed = safeJsonParse(result.stdout, []);
+  return { status: "ok", versions: (Array.isArray(parsed) ? parsed : [parsed]).map(String).sort(compareVersions) };
+}
+
+function versionFacts(node, parent, registry) {
+  const versions = registry.versions || [];
+  const latest = versions.at(-1) || "";
+  const currentMajor = majorOf(node.version);
+  const requestedMajor = requestedMajorRange(parent?.dependencies?.[node.name] || "");
+  const latestSameMajor = versions.filter((version) => majorOf(version) === currentMajor).at(-1) || "";
+  const latestRequestedMajor = versions.filter((version) => majorOf(version) === requestedMajor).at(-1) || "";
+  return {
+    name: node.name,
+    currentVersion: node.version || "",
+    requestedBy: parent?.name || "",
+    requestedRange: parent?.dependencies?.[node.name] || "",
+    registryStatus: registry.status,
+    latest,
+    latestSameMajor,
+    latestRequestedMajor,
+    latestMajor: majorOf(latest),
+    requestedMajor,
+    majorMismatch: latest && requestedMajor !== null && majorOf(latest) !== requestedMajor
+  };
+}
+
+function advisoryUrls(vulnerability) {
+  return (Array.isArray(vulnerability.via) ? vulnerability.via : [])
+    .filter((item) => item && typeof item === "object")
+    .map((item) => item.url)
+    .filter(Boolean)
+    .slice(0, 5);
+}
+
+function watchItems(audit, lock, options) {
+  const graph = buildLockGraph(lock);
+  const vulnerabilities = audit.vulnerabilities && typeof audit.vulnerabilities === "object" ? audit.vulnerabilities : {};
+  return Object.values(vulnerabilities)
+    .filter((vulnerability) => vulnerability.severity === "high" || vulnerability.severity === "critical")
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .map((vulnerability) => {
+      const chain = shortestChainTo(graph, vulnerability.name);
+      const registryByName = new Map(chain.slice(1).map((node) => [node.name, registryVersions(node.name, options.npmView)]));
+      const facts = chain.slice(1).map((node, index) => versionFacts(node, chain[index], registryByName.get(node.name) || { status: "skipped", versions: [] }));
+      const vulnerableFact = facts.find((fact) => fact.name === vulnerability.name);
+      const blockingFacts = facts.filter((fact) => fact.majorMismatch);
+      let classification = "unknown";
+      if (!options.npmView) classification = "registry_lookup_skipped";
+      else if (vulnerableFact?.latestRequestedMajor && compareVersions(vulnerableFact.latestRequestedMajor, vulnerableFact.currentVersion) > 0) classification = "lockfile_refresh_candidate";
+      else if (blockingFacts.length > 0) classification = "override_or_upstream_wait";
+      else if (vulnerableFact?.latest && compareVersions(vulnerableFact.latest, vulnerableFact.currentVersion) > 0) classification = "normal_update_candidate";
+      else classification = "no_safe_upstream_candidate";
+      return {
+        name: vulnerability.name,
+        severity: vulnerability.severity,
+        range: vulnerability.range || "",
+        fixAvailable: vulnerability.fixAvailable ?? false,
+        advisories: advisoryUrls(vulnerability),
+        classification,
+        chain: chain.map((node, index) => ({
+          name: node.name,
+          version: node.version || "",
+          requested: chain[index - 1]?.dependencies?.[node.name] || ""
+        })),
+        versionFacts: facts,
+        safeNextStep: safeNextStep(classification)
+      };
+    });
+}
+
+function safeNextStep(classification) {
+  if (classification === "normal_update_candidate") {
+    return "Open a small dependency PR for the owner package and verify npm audit plus relevant tool smoke checks.";
+  }
+  if (classification === "lockfile_refresh_candidate") {
+    return "Open a small lockfile-only transitive refresh PR and verify npm audit plus relevant owner-tool smoke checks.";
+  }
+  if (classification === "override_or_upstream_wait") {
+    return "Do not apply a blind override. Track upstream parent-package movement or test an override only in a throwaway branch with owner-tool smoke checks.";
+  }
+  if (classification === "registry_lookup_skipped") {
+    return "Re-run without --skip-npm-view when registry access is available.";
+  }
+  return "Keep this as an accepted-risk watch item until upstream exposes a compatible patched path.";
+}
+
+function statusFor(items, auditResult) {
+  if (auditResult.status === "audit_error") return "unknown";
+  if (items.length === 0) return "ok";
+  if (items.some((item) => item.classification === "normal_update_candidate" || item.classification === "lockfile_refresh_candidate")) return "actionable";
+  return "watch";
+}
+
+function markdown(report) {
+  const lines = [
+    "# Dependency Upstream Watch",
+    "",
+    `Generated: ${report.generatedAt}`,
+    `Workspace: \`${report.workspace}\``,
+    `Status: \`${report.status}\``,
+    "",
+    "This packet is read-only. It does not install, update, override, or remove dependencies.",
+    ""
+  ];
+  if (report.items.length === 0) {
+    lines.push("No high or critical upstream watch items were found.");
+    return `${lines.join("\n")}\n`;
+  }
+  for (const item of report.items) {
+    lines.push(`## ${item.severity.toUpperCase()}: ${item.name}`);
+    lines.push("");
+    lines.push(`- Classification: \`${item.classification}\``);
+    lines.push(`- Affected range: \`${item.range || "unknown"}\``);
+    lines.push(`- Safe next step: ${item.safeNextStep}`);
+    lines.push("");
+    lines.push("Dependency chain:");
+    lines.push("");
+    for (const [index, node] of item.chain.entries()) {
+      const requested = node.requested ? ` requested \`${node.requested}\`` : "";
+      lines.push(`${index + 1}. \`${node.name}@${node.version || "unknown"}\`${requested}`);
+    }
+    lines.push("");
+    lines.push("Registry watch:");
+    lines.push("");
+    for (const fact of item.versionFacts) {
+      lines.push(`- \`${fact.name}\`: current \`${fact.currentVersion || "unknown"}\`, requested \`${fact.requestedRange || "n/a"}\`, latest \`${fact.latest || fact.registryStatus}\`, latest same major \`${fact.latestSameMajor || "none"}\`${fact.majorMismatch ? ", major mismatch" : ""}`);
+    }
+    lines.push("");
+    lines.push("Rollback notes: revert any future dependency PR or override PR; this watcher itself has no host or lockfile side effects.");
+    lines.push("");
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const packageLockPath = resolve(options.workspaceDir, "package-lock.json");
+  if (!existsSync(packageLockPath)) throw new Error(`No package-lock.json found in ${repoRelative(options.workspaceDir)}.`);
+  const auditResult = auditWorkspace(options.workspaceDir);
+  const lock = readJson(packageLockPath, {});
+  const items = watchItems(auditResult.audit || {}, lock, options);
+  const report = {
+    generatedAt: new Date().toISOString(),
+    readOnly: true,
+    workspace: repoRelative(options.workspaceDir),
+    packageLock: repoRelative(packageLockPath),
+    auditStatus: auditResult.status,
+    auditExitStatus: auditResult.exitStatus,
+    auditError: auditResult.error,
+    status: statusFor(items, auditResult),
+    items
+  };
+  const reportMarkdown = markdown(report);
+  if (options.write) {
+    mkdirSync(options.outputDir, { recursive: true });
+    writeFileSync(resolve(options.outputDir, "latest.json"), `${JSON.stringify(report, null, 2)}\n`);
+    writeFileSync(resolve(options.outputDir, "latest.md"), reportMarkdown);
+  }
+  if (options.json) process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  else process.stdout.write(reportMarkdown);
+}
+
+try {
+  main();
+} catch (error) {
+  process.stderr.write(`dependency upstream watch failed: ${error.message}\n`);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- add a read-only upstream watch packet for high/critical npm audit chains
- classify whether a finding has a normal update path, a lockfile-only refresh path, or still needs upstream movement/override review
- document the new Makefile, npm, and direct-script command surfaces

## Evidence
- current root audit still reports high `basic-ftp`
- watch packet finds `basic-ftp@5.3.1` inside `get-uri`'s requested `^5.0.2` range and classifies the issue as `lockfile_refresh_candidate`

## Testing
- `node --check scripts\\ops\\dependency_upstream_watch.mjs`
- `npm run ops:dependency:upstream-watch`
- `npm run ops:command-surface:guard:check`
- `git diff --check`

## Risk / rollback
- Risk: low; read-only reporting and command wrappers only.
- Rollback: revert this PR to remove the watcher command surface and script.