### PR TITLE
build(deps): refresh basic-ftp lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3219,9 +3219,9 @@
       "license": "MIT"
     },
     "node_modules/basic-ftp": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
-      "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Summary
- refresh the root lockfile's transitive `basic-ftp` package from 5.3.0 to 5.3.1
- keep `firebase-tools`, `proxy-agent`, `pac-proxy-agent`, and `get-uri` versions unchanged
- clear the remaining high root npm audit finding without a broad `npm audit fix`

## Evidence
- `npm run ops:dependency:upstream-watch` identified `basic-ftp@5.3.1` as a lockfile refresh candidate inside `get-uri`'s requested `^5.0.2` range
- `npm update basic-ftp --package-lock-only --ignore-scripts` produced a 3-line lockfile diff

## Testing
- `npm audit --package-lock-only --json` reports total=0, high=0, critical=0
- `npm ls firebase-tools basic-ftp --package-lock-only` shows `firebase-tools@15.16.0 -> ... -> basic-ftp@5.3.1`
- `git diff --check`

## Risk / rollback
- Risk: low; lockfile-only transitive patch within the existing parent semver range.
- Rollback: revert this PR to restore `basic-ftp@5.3.0` in `package-lock.json`.