### PR TITLE
[ops] Add dependency zero-baseline guard and cadence

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL := /bin/bash
 PG_CONTAINER ?= studiobrain_postgres
 PGDATABASE ?= monsoonfire_studio_os
 
-.PHONY: ops-check ops-inventory ops-postgres-review ops-postgres-sql ops-postgres-top-queries ops-postgres-query-tasks ops-postgres-growth-snapshot ops-postgres-autovacuum-stats ops-postgres-roles-extensions ops-docker-review ops-docker-posture ops-docker-tag-policy ops-capacity ops-import-pressure ops-cleanup-candidates ops-backup-evidence ops-postgres-backup-artifacts ops-restore-prereq ops-redis-minio-backup-evidence ops-db-docker-backup-rollup ops-command-surface-guard ops-ubuntu-review ops-host-failed-unit-trends ops-package-posture ops-time-sync ops-network-review ops-host-drift ops-systemd-drift ops-portal-bridge-review ops-app-review ops-dependency-review ops-dependency-security-scout ops-dependency-remediation-packet ops-dependency-upstream-watch ops-idle-worker-effectivity ops-effectivity-report ops-evidence-freshness ops-slice-ledger ops-tool-inventory ops-admin-effectivity-audit ops-proactive-radar ops-pr-stack-readiness ops-privileged-evidence-read ops-privileged-evidence-capture ops-privileged-evidence-capture-smoke ops-work-packet ops-incident-bundle ops-incident-bundle-v2 ops-ci-validate ops-post-deploy-verify ops-docs ops-backlog ops-report
+.PHONY: ops-check ops-inventory ops-postgres-review ops-postgres-sql ops-postgres-top-queries ops-postgres-query-tasks ops-postgres-growth-snapshot ops-postgres-autovacuum-stats ops-postgres-roles-extensions ops-docker-review ops-docker-posture ops-docker-tag-policy ops-capacity ops-import-pressure ops-cleanup-candidates ops-backup-evidence ops-postgres-backup-artifacts ops-restore-prereq ops-redis-minio-backup-evidence ops-db-docker-backup-rollup ops-command-surface-guard ops-ubuntu-review ops-host-failed-unit-trends ops-package-posture ops-time-sync ops-network-review ops-host-drift ops-systemd-drift ops-portal-bridge-review ops-app-review ops-dependency-review ops-dependency-security-scout ops-dependency-remediation-packet ops-dependency-upstream-watch ops-dependency-zero-baseline ops-idle-worker-effectivity ops-effectivity-report ops-evidence-freshness ops-slice-ledger ops-tool-inventory ops-admin-effectivity-audit ops-proactive-radar ops-pr-stack-readiness ops-privileged-evidence-read ops-privileged-evidence-capture ops-privileged-evidence-capture-smoke ops-work-packet ops-incident-bundle ops-incident-bundle-v2 ops-ci-validate ops-post-deploy-verify ops-docs ops-backlog ops-report
 
 ops-check: ops-inventory ops-docker-review ops-capacity ops-cleanup-candidates ops-backup-evidence ops-ubuntu-review ops-network-review ops-host-drift ops-systemd-drift ops-portal-bridge-review ops-app-review
 
@@ -122,6 +122,9 @@ ops-dependency-remediation-packet:
 
 ops-dependency-upstream-watch:
 	node scripts/ops/dependency_upstream_watch.mjs --write
+
+ops-dependency-zero-baseline:
+	node scripts/ops/dependency_zero_baseline_guard.mjs --write
 
 ops-idle-worker-effectivity:
 	node ./scripts/studiobrain-idle-worker-effectivity-audit.mjs --json

--- a/docs/ops/26-dependency-security-cadence.md
+++ b/docs/ops/26-dependency-security-cadence.md
@@ -1,0 +1,172 @@
+# Dependency Security Cadence
+
+Generated: 2026-05-08
+
+## Purpose
+
+Keep the dependency lane boring: verify the all-clean baseline regularly, distinguish active risk from stale external alerts, and use small reviewable PRs for remediation.
+
+## Current Baseline
+
+- Baseline file: `docs/ops/dependency-zero-baseline.json`
+- Guard command: `npm run ops:dependency:zero-baseline`
+- Strict guard command: `node scripts/ops/dependency_zero_baseline_guard.mjs --strict --json`
+- Current expected state: Dependabot open alerts `0`, active local alerts `0`, stale alerts `0`, npm audit high/critical `0`, npm audit total `0`, upstream-watch items `0`
+
+## Daily Check
+
+Run:
+
+```bash
+npm run ops:dependency:zero-baseline
+```
+
+Acceptance:
+
+- `status` is `ok`.
+- `findings` is empty.
+- GitHub alert evidence is available unless this is an explicitly local-only run.
+
+If the command reports `unknown`, refresh GitHub CLI auth and npm registry access before treating the result as a security finding.
+
+## Weekly Check
+
+Run:
+
+```bash
+npm run ops:dependency:security-scout
+npm run ops:dependency:upstream-watch
+npm run ops:dependency:zero-baseline
+```
+
+Review:
+
+- new Dependabot alerts
+- local `npm audit` high/critical or total count
+- vulnerable dependency chains
+- whether upstream packages now have a normal update or lockfile-only refresh path
+
+## Stale Alert Workflow
+
+Use stale classification only when:
+
+- GitHub still reports an open alert, and
+- the local workspace audit is clean, and
+- the vulnerable package is no longer in the affected local audit set.
+
+Safe next step:
+
+1. Re-run `npm run ops:dependency:security-scout`.
+2. Confirm `localPosture.classification` is `stale_alert_verify`.
+3. Wait for GitHub alert indexing or manually review the alert in GitHub.
+4. Do not open a remediation PR for a stale alert unless local evidence regresses.
+
+Rollback:
+
+- There is no code rollback for stale-alert verification.
+- If a stale-alert classification is wrong, fix the scout classifier in a PR and rerun the guard.
+
+## Lockfile-Only Refresh Workflow
+
+Use this path when upstream-watch reports `lockfile_refresh_candidate`.
+
+Safe command shape:
+
+```bash
+npm update <package> --package-lock-only --ignore-scripts
+```
+
+Acceptance:
+
+- Only the intended lockfile changes.
+- The root lockfile `name` remains `monsoonfire-portal`.
+- `npm audit --package-lock-only --json` reports zero vulnerabilities.
+- `npm run ops:dependency:security-scout` reports `status: ok`.
+- `npm run ops:dependency:upstream-watch` reports `status: ok`.
+- `npm run ops:dependency:zero-baseline` reports `status: ok`.
+
+Rollback:
+
+- Revert the lockfile PR.
+- Do not run `npm audit fix` as rollback.
+
+## Normal Update Workflow
+
+Use this path when upstream-watch reports `normal_update_candidate`.
+
+Acceptance:
+
+- Package update is scoped to the owning workspace.
+- Tests for the owning package pass.
+- Dependency scout and zero-baseline guard return `ok`.
+- PR body includes evidence, test output, risk, and rollback notes.
+
+Rollback:
+
+- Revert the dependency PR.
+- If the package touches deploy tooling, verify deploy preflight after revert.
+
+## Override Or Upstream-Wait Workflow
+
+Use this path when upstream-watch reports `override_or_upstream_wait`.
+
+Default action:
+
+- Prefer waiting for upstream or opening an upstream issue.
+- Use overrides only after a compatibility experiment proves the override is safe.
+
+Required evidence before an override PR:
+
+- dependency chain
+- requested range at each parent
+- latest compatible and latest major versions
+- focused tests for the impacted tool
+- rollback instructions
+
+## Approval Boundaries
+
+These are not allowed from this cadence without a separate reviewable PR:
+
+- `npm audit fix`
+- package installs unrelated to the finding
+- broad dependency upgrades
+- override additions without compatibility evidence
+- deploys
+- host package upgrades
+- secret rotation
+
+## Ticket Template
+
+Title:
+`[security] remediate dependency regression in <workspace>`
+
+Body:
+
+```markdown
+## Problem
+The dependency zero-baseline guard no longer reports `ok`.
+
+## Evidence
+- Guard status:
+- Scout status:
+- Upstream-watch status:
+- Affected workspace:
+- Vulnerable chain:
+
+## Risk
+Unreviewed dependency vulnerabilities can remain active or remediation can target the wrong package.
+
+## Proposed Fix
+Use the safest classified path: stale-alert verification, lockfile-only refresh, normal update, or override/upstream wait.
+
+## Acceptance Criteria
+- `npm audit --package-lock-only --json` is clean for the affected workspace.
+- `npm run ops:dependency:security-scout` is `ok`.
+- `npm run ops:dependency:upstream-watch` is `ok`.
+- `npm run ops:dependency:zero-baseline` is `ok`.
+
+## Safety Notes
+- No `npm audit fix`.
+- Rollback is reverting the dependency PR.
+- Deploy impact is reviewed separately.
+```

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -23,6 +23,7 @@ This directory is the durable operations surface for Studio Brain. It separates 
 | `20-swarm-slice-48-approval-backlog.md` | Issue-ready backlog entries for remaining approval gates. |
 | `21-swarm-slice-49-roadmap-30-60-90.md` | Refreshed 30/60/90 Studio Brain ops roadmap. |
 | `22-privileged-evidence-capture.md` | Approval-gated workaround for sudo-unavailable agents: a narrow root capture job plus read-only agent reader. |
+| `26-dependency-security-cadence.md` | Daily/weekly dependency guard cadence, stale-alert handling, and safe lockfile refresh workflow. |
 
 ## Safe Commands
 

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -56,6 +56,7 @@ make ops-dependency-review
 make ops-dependency-security-scout
 make ops-dependency-remediation-packet
 make ops-dependency-upstream-watch
+make ops-dependency-zero-baseline
 make ops-idle-worker-effectivity
 make ops-effectivity-report
 make ops-evidence-freshness
@@ -82,6 +83,7 @@ npm run ops:command-surface:guard
 npm run ops:dependency:security-scout
 npm run ops:dependency:remediation-packet
 npm run ops:dependency:upstream-watch
+npm run ops:dependency:zero-baseline
 npm run ops:docker:tag-policy
 ```
 
@@ -103,6 +105,7 @@ node scripts/ops/command_surface_guard.mjs --write
 node scripts/ops/dependency_security_scout.mjs --write
 node scripts/ops/dependency_remediation_packet.mjs --write
 node scripts/ops/dependency_upstream_watch.mjs --write
+node scripts/ops/dependency_zero_baseline_guard.mjs --write
 node scripts/ops/docker_floating_tag_policy.mjs --write
 bash scripts/ops/privileged_evidence_read.sh
 bash scripts/ops/privileged_evidence_capture.sh --smoke --output-dir output/ops/privileged-evidence
@@ -127,6 +130,8 @@ bash scripts/ops/incident_bundle_v2.sh output/ops/incidents-v2/manual-smoke
 `ops-dependency-remediation-packet` turns high/critical npm audit findings into a read-only decision packet with dependency chains, owner-package candidates, latest-version hints, safe next steps, acceptance criteria, and rollback notes. It writes under `output/ops/dependency-remediation` and does not install, update, override, or remove dependencies.
 
 `ops-dependency-upstream-watch` checks high/critical npm audit chains against read-only npm registry version metadata and classifies whether the chain has a normal update candidate, still needs upstream movement, or would require a higher-risk override experiment. It writes under `output/ops/dependency-upstream-watch` and does not install, update, override, or remove dependencies.
+
+`ops-dependency-zero-baseline` compares the current dependency scout and upstream-watch output against `docs/ops/dependency-zero-baseline.json`, the all-clean baseline recorded after the `basic-ftp` lockfile refresh. It writes under `output/ops/dependency-zero-baseline`; use `node scripts/ops/dependency_zero_baseline_guard.mjs --strict` when a non-zero exit should fail a guard job. It does not run `npm audit fix`, install, update, override, or remove dependencies.
 
 `ops-docker-tag-policy` scans tracked Compose files and Dockerfiles for `latest`, `stable`, branch-like, broad major-only, and digest-pinned image references. It writes issue-ready follow-ups under `output/ops/docker-tag-policy` and does not pull, recreate, restart, or edit Docker resources.
 

--- a/docs/ops/dependency-zero-baseline.json
+++ b/docs/ops/dependency-zero-baseline.json
@@ -1,0 +1,16 @@
+{
+  "schema": "studio-brain.ops.dependency-zero-baseline.v1",
+  "recordedAt": "2026-05-08T00:00:00.000Z",
+  "sourceCommit": "4f36915e",
+  "expectations": {
+    "dependencyScoutStatus": "ok",
+    "maxOpenDependabotAlerts": 0,
+    "maxActiveDependabotAlerts": 0,
+    "maxStaleDependabotAlerts": 0,
+    "maxAuditHighCritical": 0,
+    "maxAuditTotal": 0,
+    "upstreamWatchStatus": "ok",
+    "maxUpstreamWatchItems": 0
+  },
+  "approvalBoundary": "This baseline is evidence only. Do not run npm audit fix, install packages, update packages, or merge dependency changes without a reviewable PR."
+}

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "ops:dependency:security-scout": "node ./scripts/ops/dependency_security_scout.mjs --write --json",
     "ops:dependency:remediation-packet": "node ./scripts/ops/dependency_remediation_packet.mjs --write --json",
     "ops:dependency:upstream-watch": "node ./scripts/ops/dependency_upstream_watch.mjs --write --json",
+    "ops:dependency:zero-baseline": "node ./scripts/ops/dependency_zero_baseline_guard.mjs --write --json",
     "ops:docker:tag-policy": "node ./scripts/ops/docker_floating_tag_policy.mjs --write --json",
     "portal:smoke:native-browser:shadow": "node ./scripts/native-browser-shadow-verifier.mjs --surface portal --base-url https://portal.monsoonfire.com --output-dir output/native-browser/portal/prod --shadow-of verify.portal.smoke --canonical-artifact-root output/playwright/portal/prod",
     "codex:browser:verify:portal": "node ./scripts/native-browser-shadow-verifier.mjs --surface portal --base-url https://portal.monsoonfire.com --output-dir output/native-browser/portal/prod --shadow-of verify.portal.smoke --canonical-artifact-root output/playwright/portal/prod --app-handoff",

--- a/scripts/ops/dependency_security_scout.mjs
+++ b/scripts/ops/dependency_security_scout.mjs
@@ -507,6 +507,11 @@ function buildReport(options) {
       auditHighCritical: highCritical,
       auditTotal: workspaces.reduce((acc, workspace) => acc + (workspace.audit?.counts?.total || 0), 0)
     },
+    issueExportPolicy: {
+      mode: "non_ok_only",
+      emitsForStatuses: ["warning", "degraded", "advisory"],
+      cleanStateMessage: "No issue-ready dependency tasks are emitted when the scout status is ok."
+    },
     workspaces,
     approvalBoundary: "This report does not approve dependency upgrades, npm audit fix, package installs, deploys, or lockfile changes."
   };
@@ -532,6 +537,12 @@ function renderMarkdown(report) {
     `- Workspaces checked: ${report.summary.workspaces}`,
     `- npm audit high/critical: ${report.summary.auditHighCritical}`,
     `- npm audit total: ${report.summary.auditTotal}`,
+    "",
+    "## Issue Export Policy",
+    "",
+    `- Mode: ${report.issueExportPolicy?.mode || "unknown"}`,
+    `- Emits for statuses: ${(report.issueExportPolicy?.emitsForStatuses || []).join(", ") || "unknown"}`,
+    `- Clean state: ${report.issueExportPolicy?.cleanStateMessage || "No dependency tasks emitted."}`,
     "",
     "## Dependabot Alerts",
     "",

--- a/scripts/ops/dependency_zero_baseline_guard.mjs
+++ b/scripts/ops/dependency_zero_baseline_guard.mjs
@@ -1,0 +1,290 @@
+#!/usr/bin/env node
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, relative, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const REPO_ROOT = resolve(dirname(__filename), "..", "..");
+const DEFAULT_BASELINE = resolve(REPO_ROOT, "docs", "ops", "dependency-zero-baseline.json");
+const DEFAULT_OUTPUT_DIR = resolve(REPO_ROOT, "output", "ops", "dependency-zero-baseline");
+
+function usage() {
+  return `Dependency zero-baseline guard
+
+Usage:
+  node scripts/ops/dependency_zero_baseline_guard.mjs [--json] [--write] [--strict]
+
+Options:
+  --json                  Print JSON.
+  --write                 Write latest JSON and Markdown artifacts.
+  --strict                Exit non-zero when the baseline regresses or evidence is unavailable.
+  --baseline <path>       Baseline JSON. Default: docs/ops/dependency-zero-baseline.json.
+  --output-dir <path>     Artifact directory. Default: output/ops/dependency-zero-baseline.
+  --skip-github           Pass through to dependency scout when GitHub evidence is intentionally unavailable.
+
+This guard is read-only. It does not run npm audit fix, install, update, override, or remove dependencies.
+`;
+}
+
+function parseArgs(argv) {
+  const options = {
+    json: false,
+    write: false,
+    strict: false,
+    baseline: DEFAULT_BASELINE,
+    outputDir: DEFAULT_OUTPUT_DIR,
+    github: true
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--help" || arg === "-h") {
+      process.stdout.write(usage());
+      process.exit(0);
+    }
+    if (arg === "--json") {
+      options.json = true;
+      continue;
+    }
+    if (arg === "--write") {
+      options.write = true;
+      continue;
+    }
+    if (arg === "--strict") {
+      options.strict = true;
+      continue;
+    }
+    if (arg === "--skip-github") {
+      options.github = false;
+      continue;
+    }
+    if (arg === "--baseline" || arg === "--output-dir") {
+      if (!argv[index + 1]) throw new Error(`${arg} requires a value.`);
+      options[arg === "--baseline" ? "baseline" : "outputDir"] = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith("--baseline=")) {
+      options.baseline = arg.slice("--baseline=".length);
+      continue;
+    }
+    if (arg.startsWith("--output-dir=")) {
+      options.outputDir = arg.slice("--output-dir=".length);
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+  options.baseline = resolve(REPO_ROOT, options.baseline);
+  options.outputDir = resolve(REPO_ROOT, options.outputDir);
+  return options;
+}
+
+function repoRelative(path) {
+  return relative(REPO_ROOT, path).replace(/\\/g, "/") || ".";
+}
+
+function safeJsonParse(raw, fallback) {
+  try {
+    return JSON.parse(raw || "");
+  } catch {
+    return fallback;
+  }
+}
+
+function readJson(path) {
+  if (!existsSync(path)) throw new Error(`Missing baseline file: ${repoRelative(path)}`);
+  const parsed = safeJsonParse(readFileSync(path, "utf8"), null);
+  if (!parsed || typeof parsed !== "object") throw new Error(`Could not parse JSON: ${repoRelative(path)}`);
+  return parsed;
+}
+
+function runNodeScript(scriptPath, args) {
+  const result = spawnSync(process.execPath, [scriptPath, ...args], {
+    cwd: REPO_ROOT,
+    encoding: "utf8",
+    windowsHide: true,
+    timeout: 180_000
+  });
+  return {
+    status: result.status ?? null,
+    stdout: result.stdout || "",
+    stderr: result.stderr || "",
+    error: result.error?.message || ""
+  };
+}
+
+function firstLines(text, maxLines = 4) {
+  return String(text || "").split(/\r?\n/).filter(Boolean).slice(0, maxLines).join("\n");
+}
+
+function collectEvidence(options) {
+  const scoutArgs = ["scripts/ops/dependency_security_scout.mjs", "--json"];
+  if (!options.github) scoutArgs.push("--skip-github");
+  const scoutResult = runNodeScript(scoutArgs[0], scoutArgs.slice(1));
+  const upstreamResult = runNodeScript("scripts/ops/dependency_upstream_watch.mjs", ["--json"]);
+  return {
+    githubEvidenceRequired: options.github,
+    scout: {
+      command: `node ${scoutArgs.join(" ")}`,
+      exitStatus: scoutResult.status,
+      error: firstLines(scoutResult.stderr || scoutResult.error),
+      report: safeJsonParse(scoutResult.stdout, null)
+    },
+    upstreamWatch: {
+      command: "node scripts/ops/dependency_upstream_watch.mjs --json",
+      exitStatus: upstreamResult.status,
+      error: firstLines(upstreamResult.stderr || upstreamResult.error),
+      report: safeJsonParse(upstreamResult.stdout, null)
+    }
+  };
+}
+
+function addFinding(findings, severity, title, evidence, action) {
+  findings.push({
+    severity,
+    title,
+    evidence,
+    likelyImpact: severity === "high"
+      ? "A dependency security regression can ship unnoticed or operators can chase the wrong remediation path."
+      : "Dependency evidence is incomplete, so the zero baseline cannot be trusted.",
+    recommendedAction: action,
+    safeNextStep: "Run the dependency scout and upstream watch directly, then address any high/critical item in a small dependency PR.",
+    rollback: "Revert the dependency PR or this guard PR; do not run npm audit fix as rollback.",
+    prSuitable: true
+  });
+}
+
+function compareBaseline(baseline, evidence) {
+  const expectations = baseline.expectations || {};
+  const scout = evidence.scout.report;
+  const upstream = evidence.upstreamWatch.report;
+  const findings = [];
+
+  if (evidence.scout.exitStatus !== 0 || !scout) {
+    addFinding(findings, "medium", "Dependency scout evidence unavailable", evidence.scout.error || `exit=${evidence.scout.exitStatus}`, "Restore GitHub/npm access or rerun without --skip-github only when GitHub evidence is intentionally unavailable.");
+  } else {
+    if (evidence.githubEvidenceRequired) {
+      const alertStatus = scout.github?.alerts?.status || "unknown";
+      const prStatus = scout.github?.dependabotPrs?.status || "unknown";
+      if (alertStatus !== "ok" || prStatus !== "ok") {
+        addFinding(findings, "medium", "GitHub dependency evidence unavailable", `alerts=${alertStatus}; dependabotPrs=${prStatus}`, "Restore GitHub CLI authentication or rerun with --skip-github only for an explicitly local-only audit.");
+      }
+    }
+    if (scout.status !== expectations.dependencyScoutStatus) {
+      addFinding(findings, "high", "Dependency scout status regressed", `expected=${expectations.dependencyScoutStatus}; actual=${scout.status}`, "Open the scout packet and classify active versus stale alerts.");
+    }
+    const checks = [
+      ["Open Dependabot alerts exceeded baseline", scout.summary?.openAlerts, expectations.maxOpenDependabotAlerts],
+      ["Active Dependabot alerts exceeded baseline", scout.summary?.activeAlerts, expectations.maxActiveDependabotAlerts],
+      ["Stale Dependabot alerts exceeded baseline", scout.summary?.staleAlerts, expectations.maxStaleDependabotAlerts],
+      ["npm audit high/critical exceeded baseline", scout.summary?.auditHighCritical, expectations.maxAuditHighCritical],
+      ["npm audit total exceeded baseline", scout.summary?.auditTotal, expectations.maxAuditTotal]
+    ];
+    for (const [title, actual, expected] of checks) {
+      if (Number(actual || 0) > Number(expected || 0)) {
+        addFinding(findings, "high", title, `expected<=${expected}; actual=${actual}`, "Use the remediation packet and upstream watch before choosing a lockfile refresh, normal update, or override experiment.");
+      }
+    }
+  }
+
+  if (evidence.upstreamWatch.exitStatus !== 0 || !upstream) {
+    addFinding(findings, "medium", "Dependency upstream-watch evidence unavailable", evidence.upstreamWatch.error || `exit=${evidence.upstreamWatch.exitStatus}`, "Restore npm registry access and rerun upstream-watch.");
+  } else {
+    if (upstream.status !== expectations.upstreamWatchStatus) {
+      addFinding(findings, "high", "Dependency upstream-watch status regressed", `expected=${expectations.upstreamWatchStatus}; actual=${upstream.status}`, "Review whether vulnerable chains now have a safe normal update or lockfile refresh candidate.");
+    }
+    if ((upstream.items || []).length > Number(expectations.maxUpstreamWatchItems || 0)) {
+      addFinding(findings, "high", "Dependency upstream-watch items exceeded baseline", `expected<=${expectations.maxUpstreamWatchItems}; actual=${upstream.items.length}`, "Generate a remediation packet for each high/critical chain.");
+    }
+  }
+
+  return findings;
+}
+
+function renderMarkdown(report) {
+  const lines = [
+    "# Dependency Zero-Baseline Guard",
+    "",
+    `Generated: ${report.generatedAt}`,
+    `Status: \`${report.status}\``,
+    `Read-only: ${report.readOnly ? "yes" : "no"}`,
+    "",
+    "## Baseline",
+    "",
+    `- File: \`${report.baseline.path}\``,
+    `- Source commit: \`${report.baseline.sourceCommit || "unknown"}\``,
+    `- Approval boundary: ${report.approvalBoundary}`,
+    "",
+    "## Evidence",
+    "",
+    `- Dependency scout: exit=${report.evidence.scout.exitStatus}; status=\`${report.evidence.scout.report?.status || "unavailable"}\`; audit high/critical=${report.evidence.scout.report?.summary?.auditHighCritical ?? "unknown"}; audit total=${report.evidence.scout.report?.summary?.auditTotal ?? "unknown"}; open alerts=${report.evidence.scout.report?.summary?.openAlerts ?? "unknown"}`,
+    `- Upstream watch: exit=${report.evidence.upstreamWatch.exitStatus}; status=\`${report.evidence.upstreamWatch.report?.status || "unavailable"}\`; items=${(report.evidence.upstreamWatch.report?.items || []).length}`,
+    "",
+    "## Findings",
+    ""
+  ];
+  if (!report.findings.length) {
+    lines.push("- None. Dependency posture still matches the zero baseline.");
+  } else {
+    for (const finding of report.findings) {
+      lines.push(`### ${finding.severity.toUpperCase()}: ${finding.title}`);
+      lines.push("");
+      lines.push(`- Evidence: ${finding.evidence}`);
+      lines.push(`- Likely impact: ${finding.likelyImpact}`);
+      lines.push(`- Recommended action: ${finding.recommendedAction}`);
+      lines.push(`- Safe next step: ${finding.safeNextStep}`);
+      lines.push(`- Rollback: ${finding.rollback}`);
+      lines.push("");
+    }
+  }
+  lines.push("");
+  lines.push("## Safety Notes");
+  lines.push("");
+  lines.push("- This guard does not install, update, override, remove, prune, or fix dependencies.");
+  lines.push("- Treat regressions as evidence for a small reviewed PR, not approval for `npm audit fix`.");
+  return `${lines.join("\n")}\n`;
+}
+
+function writeArtifacts(report, options) {
+  mkdirSync(options.outputDir, { recursive: true });
+  const jsonPath = resolve(options.outputDir, "latest.json");
+  const markdownPath = resolve(options.outputDir, "latest.md");
+  writeFileSync(jsonPath, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+  writeFileSync(markdownPath, renderMarkdown(report), "utf8");
+  report.paths = {
+    json: repoRelative(jsonPath),
+    markdown: repoRelative(markdownPath)
+  };
+}
+
+function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const baseline = readJson(options.baseline);
+  const evidence = collectEvidence(options);
+  const findings = compareBaseline(baseline, evidence);
+  const report = {
+    schema: "studio-brain.ops.dependency-zero-baseline-guard.v1",
+    generatedAt: new Date().toISOString(),
+    readOnly: true,
+    status: findings.some((finding) => finding.severity === "high") ? "regressed" : findings.length ? "unknown" : "ok",
+    baseline: {
+      path: repoRelative(options.baseline),
+      sourceCommit: baseline.sourceCommit || "",
+      expectations: baseline.expectations || {}
+    },
+    approvalBoundary: baseline.approvalBoundary || "Dependency mutations require a reviewed PR.",
+    evidence,
+    findings
+  };
+  if (options.write) writeArtifacts(report, options);
+  process.stdout.write(options.json ? `${JSON.stringify(report, null, 2)}\n` : renderMarkdown(report));
+  if (options.strict && report.status !== "ok") process.exit(2);
+}
+
+try {
+  main();
+} catch (error) {
+  process.stderr.write(`dependency zero-baseline guard failed: ${error.message}\n`);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- adds a read-only dependency zero-baseline guard around the existing dependency scout and upstream-watch tools
- records the current all-clean baseline from the post-basic-ftp refresh state
- exposes Make/npm/direct command wrappers and docs

## Evidence
- dependency scout currently reports open alerts=0, active alerts=0, stale alerts=0, high/critical audit=0, total audit=0
- upstream-watch currently reports status=ok and items=[]
- command surface guard recognizes the new target/script

## Testing
- node --check scripts/ops/dependency_zero_baseline_guard.mjs
- npm run ops:dependency:zero-baseline
- node scripts/ops/dependency_zero_baseline_guard.mjs --strict --json
- npm run ops:command-surface:guard:check
- git diff --check

## Risk
Low. Read-only ops tooling and documentation. The strict flag only changes the guard process exit code; it does not mutate dependencies.

## Rollback
Revert this PR to remove the guard, baseline file, and command wrappers.

## Follow-up
- add dependency freshness cadence docs
- add historical snapshot storage for upstream-watch summaries