### PR TITLE
[ops] Add PR stack triage dispositions

### DIFF
--- a/scripts/ops/pr_stack_readiness.mjs
+++ b/scripts/ops/pr_stack_readiness.mjs
@@ -285,6 +285,75 @@ function countBy(rows, selector) {
   return counts;
 }
 
+function cleanupTasks(rows) {
+  const tasks = [];
+  const closeCandidates = rows.filter((pr) => pr.disposition?.action === "close_candidate");
+  if (closeCandidates.length) {
+    tasks.push({
+      title: "[ops] Review stale draft PR close candidates",
+      labels: ["ops", "cleanup", "docs"],
+      approvalRequired: true,
+      body: [
+        "## Problem",
+        `${closeCandidates.length} draft PR(s) are older than 7 days and still open.`,
+        "",
+        "## Evidence",
+        ...closeCandidates.map((pr) => `- #${pr.number} ${pr.title} (${pr.ageDays} days old): ${pr.url}`),
+        "",
+        "## Risk",
+        "Stale drafts add noise to PR readiness and can be mistaken for active work.",
+        "",
+        "## Proposed Fix",
+        "Confirm whether each draft has been superseded or captured in backlog, then close only with human approval.",
+        "",
+        "## Acceptance Criteria",
+        "- Each close candidate is marked keep, supersede, or close.",
+        "- Any useful work is copied into a fresh main-based slice or backlog item.",
+        "- Closed PRs have a comment pointing to the replacement or rationale.",
+        "",
+        "## Safety Notes",
+        "- Human approval required.",
+        "- Do not delete branches until the owner approves cleanup.",
+        "- Rollback is reopening the PR if the branch still exists."
+      ].join("\n")
+    });
+  }
+
+  const supersedeCandidates = rows.filter((pr) => pr.disposition?.action === "supersede_or_restack");
+  if (supersedeCandidates.length) {
+    const evidenceLines = supersedeCandidates.slice(0, 30).map((pr) => `- #${pr.number} ${pr.head} -> ${pr.base}; dependsOn=${pr.dependsOnPr ? `#${pr.dependsOnPr}` : "unknown"}`);
+    if (supersedeCandidates.length > 30) evidenceLines.push(`- ...and ${supersedeCandidates.length - 30} more.`);
+    tasks.push({
+      title: "[ops] Collapse or restack stacked draft PR chain",
+      labels: ["ops", "cleanup", "reliability"],
+      approvalRequired: true,
+      body: [
+        "## Problem",
+        `${supersedeCandidates.length} draft PR(s) are stacked on non-main branches.`,
+        "",
+        "## Evidence",
+        ...evidenceLines,
+        "",
+        "## Risk",
+        "Large stacked draft chains make merge order hard to reason about and can hide stale or superseded work.",
+        "",
+        "## Proposed Fix",
+        "Promote only the next useful slice from current main, then supersede or close obsolete drafts after human review.",
+        "",
+        "## Acceptance Criteria",
+        "- One next executable slice is identified from current main.",
+        "- Stale stacked drafts are marked keep, supersede, or close.",
+        "- No force-push, branch deletion, or PR closing happens without explicit approval.",
+        "",
+        "## Safety Notes",
+        "- Human approval required for closing PRs or deleting branches.",
+        "- Rollback is reopening a PR or restoring from the remote branch if preserved."
+      ].join("\n")
+    });
+  }
+  return tasks;
+}
+
 function buildChains(rows) {
   const byBase = new Map();
   for (const pr of rows) {
@@ -370,7 +439,8 @@ function buildReport(options) {
     chains: chains.map((chain) => chain.map((pr) => ({ number: pr.number, head: pr.head, base: pr.base, dependsOnPr: pr.dependsOnPr, childPrs: pr.childPrs, readiness: pr.readiness, blockers: pr.blockers, disposition: pr.disposition }))),
     orphans: orphans.map((pr) => ({ number: pr.number, head: pr.head, base: pr.base, dependsOnPr: pr.dependsOnPr, childPrs: pr.childPrs, readiness: pr.readiness, blockers: pr.blockers, disposition: pr.disposition })),
     pullRequests: classified,
-    recommendations
+    recommendations,
+    cleanupTasks: cleanupTasks(classified)
   };
 }
 
@@ -419,6 +489,23 @@ function renderMarkdown(report) {
   );
   for (const pr of report.pullRequests) {
     lines.push(`| #${pr.number} | ${pr.isDraft ? "yes" : "no"} | ${pr.ageDays ?? "?"} | ${pr.freshness?.bucket || "unknown"} | \`${pr.base}\` | ${pr.dependsOnPr ? `#${pr.dependsOnPr}` : ""} | ${pr.childPrs.length ? pr.childPrs.map((child) => `#${child}`).join(", ") : ""} | ${pr.disposition?.action || "unknown"} | ${pr.disposition?.approval || "unknown"} | ${pr.disposition?.reason || ""} |`);
+  }
+  lines.push(
+    "",
+    "## Cleanup Tasks",
+    ""
+  );
+  if (!report.cleanupTasks?.length) {
+    lines.push("- No cleanup tasks from current evidence.");
+  }
+  for (const task of report.cleanupTasks || []) {
+    lines.push(`### ${task.title}`);
+    lines.push("");
+    lines.push(`- Approval required: ${task.approvalRequired ? "yes" : "no"}`);
+    lines.push(`- Labels: ${task.labels.join(", ")}`);
+    lines.push("");
+    lines.push(task.body);
+    lines.push("");
   }
   lines.push(
     "",

--- a/scripts/ops/pr_stack_readiness.mjs
+++ b/scripts/ops/pr_stack_readiness.mjs
@@ -164,6 +164,8 @@ function classify(pr) {
   if (!pr.isDraft && pr.mergeStateStatus === "DIRTY") blockers.push("non-draft DIRTY");
   if (!pr.isDraft && pr.mergeStateStatus === "UNSTABLE") blockers.push("checks pending or unstable");
   if (!pr.isDraft && pr.mergeStateStatus === "BEHIND") blockers.push("behind main");
+  if (!pr.isDraft && pr.mergeStateStatus === "BLOCKED") blockers.push("blocked by merge requirements");
+  if (!pr.isDraft && pr.mergeStateStatus === "UNKNOWN") blockers.push("unknown mergeability");
   if (pr.isDraft) blockers.push("draft");
   if (pr.baseRefName !== "main") blockers.push(`stacked on ${pr.baseRefName}`);
   if (age !== null && age > 7) blockers.push(`${age} days since update`);
@@ -205,6 +207,20 @@ function dispositionFor(pr) {
       action: "update_branch_or_rebase",
       approval: "codex",
       reason: "Non-draft PR is behind main; update from current main and rerun checks before merge."
+    };
+  }
+  if (!pr.isDraft && pr.mergeStateStatus === "BLOCKED") {
+    return {
+      action: "wait_for_required_checks_or_policy",
+      approval: "codex",
+      reason: "Non-draft PR is blocked by required checks, review policy, or merge requirements."
+    };
+  }
+  if (!pr.isDraft && pr.mergeStateStatus === "UNKNOWN") {
+    return {
+      action: "refresh_mergeability",
+      approval: "codex",
+      reason: "GitHub has not resolved mergeability; refresh the packet before acting."
     };
   }
   if (!pr.isDraft && pr.blockers.length === 0) {

--- a/scripts/ops/pr_stack_readiness.mjs
+++ b/scripts/ops/pr_stack_readiness.mjs
@@ -127,6 +127,37 @@ function ageDays(updatedAt) {
   return Number(((Date.now() - time) / 86_400_000).toFixed(1));
 }
 
+function freshnessFor(age) {
+  if (age === null) {
+    return {
+      bucket: "unknown",
+      recommendedAction: "Confirm the PR updatedAt timestamp from GitHub."
+    };
+  }
+  if (age > 7) {
+    return {
+      bucket: "old_7d",
+      recommendedAction: "Review for close, supersede, or explicit keep decision."
+    };
+  }
+  if (age > 3) {
+    return {
+      bucket: "stale_72h",
+      recommendedAction: "Refresh evidence before promoting or stacking more work."
+    };
+  }
+  if (age > 1) {
+    return {
+      bucket: "watch_24h",
+      recommendedAction: "Keep visible; refresh if it blocks merge order."
+    };
+  }
+  return {
+    bucket: "fresh",
+    recommendedAction: "No freshness action needed."
+  };
+}
+
 function classify(pr) {
   const age = ageDays(pr.updatedAt);
   const blockers = [];
@@ -146,6 +177,7 @@ function classify(pr) {
     mergeStateStatus: pr.mergeStateStatus,
     updatedAt: pr.updatedAt,
     ageDays: age,
+    freshness: freshnessFor(age),
     blockers,
     readiness: blockers.length === 0 ? "ready_to_review" : blockers.some((item) => item.includes("DIRTY")) ? "blocked" : "needs_triage"
   };
@@ -316,7 +348,8 @@ function buildReport(options) {
       staleOver7Days: stale.length,
       chainCount: chains.length,
       orphanCount: orphans.length,
-      dispositions: countBy(classified, (pr) => pr.disposition?.action)
+      dispositions: countBy(classified, (pr) => pr.disposition?.action),
+      freshnessBuckets: countBy(classified, (pr) => pr.freshness?.bucket)
     },
     chains: chains.map((chain) => chain.map((pr) => ({ number: pr.number, head: pr.head, base: pr.base, dependsOnPr: pr.dependsOnPr, childPrs: pr.childPrs, readiness: pr.readiness, blockers: pr.blockers, disposition: pr.disposition }))),
     orphans: orphans.map((pr) => ({ number: pr.number, head: pr.head, base: pr.base, dependsOnPr: pr.dependsOnPr, childPrs: pr.childPrs, readiness: pr.readiness, blockers: pr.blockers, disposition: pr.disposition })),
@@ -355,13 +388,21 @@ function renderMarkdown(report) {
   }
   lines.push(
     "",
+    "## Freshness Summary",
+    ""
+  );
+  for (const [bucket, count] of Object.entries(report.summary.freshnessBuckets || {}).sort((a, b) => a[0].localeCompare(b[0]))) {
+    lines.push(`- ${bucket}: ${count}`);
+  }
+  lines.push(
+    "",
     "## Triage Packet",
     "",
-    "| PR | Draft | Base | Depends on | Children | Disposition | Approval | Reason |",
-    "| --- | --- | --- | --- | --- | --- | --- | --- |"
+    "| PR | Draft | Age | Freshness | Base | Depends on | Children | Disposition | Approval | Reason |",
+    "| --- | --- | ---: | --- | --- | --- | --- | --- | --- | --- |"
   );
   for (const pr of report.pullRequests) {
-    lines.push(`| #${pr.number} | ${pr.isDraft ? "yes" : "no"} | \`${pr.base}\` | ${pr.dependsOnPr ? `#${pr.dependsOnPr}` : ""} | ${pr.childPrs.length ? pr.childPrs.map((child) => `#${child}`).join(", ") : ""} | ${pr.disposition?.action || "unknown"} | ${pr.disposition?.approval || "unknown"} | ${pr.disposition?.reason || ""} |`);
+    lines.push(`| #${pr.number} | ${pr.isDraft ? "yes" : "no"} | ${pr.ageDays ?? "?"} | ${pr.freshness?.bucket || "unknown"} | \`${pr.base}\` | ${pr.dependsOnPr ? `#${pr.dependsOnPr}` : ""} | ${pr.childPrs.length ? pr.childPrs.map((child) => `#${child}`).join(", ") : ""} | ${pr.disposition?.action || "unknown"} | ${pr.disposition?.approval || "unknown"} | ${pr.disposition?.reason || ""} |`);
   }
   lines.push(
     "",

--- a/scripts/ops/pr_stack_readiness.mjs
+++ b/scripts/ops/pr_stack_readiness.mjs
@@ -132,10 +132,11 @@ function classify(pr) {
   const blockers = [];
   if (!pr.isDraft && pr.mergeStateStatus === "DIRTY") blockers.push("non-draft DIRTY");
   if (!pr.isDraft && pr.mergeStateStatus === "UNSTABLE") blockers.push("checks pending or unstable");
+  if (!pr.isDraft && pr.mergeStateStatus === "BEHIND") blockers.push("behind main");
   if (pr.isDraft) blockers.push("draft");
   if (pr.baseRefName !== "main") blockers.push(`stacked on ${pr.baseRefName}`);
   if (age !== null && age > 7) blockers.push(`${age} days since update`);
-  return {
+  const row = {
     number: pr.number,
     title: pr.title,
     url: pr.url,
@@ -148,6 +149,92 @@ function classify(pr) {
     blockers,
     readiness: blockers.length === 0 ? "ready_to_review" : blockers.some((item) => item.includes("DIRTY")) ? "blocked" : "needs_triage"
   };
+  row.disposition = dispositionFor(row);
+  return row;
+}
+
+function dispositionFor(pr) {
+  if (!pr.isDraft && pr.mergeStateStatus === "DIRTY") {
+    return {
+      action: "rebase_or_conflict_review",
+      approval: "codex_with_human_review",
+      reason: "Non-draft PR has merge conflicts or dirty state; resolve in a clean worktree before merge."
+    };
+  }
+  if (!pr.isDraft && pr.mergeStateStatus === "UNSTABLE") {
+    return {
+      action: "wait_for_checks",
+      approval: "codex",
+      reason: "Non-draft PR is waiting on checks or has an unstable status; do not restack until checks settle."
+    };
+  }
+  if (!pr.isDraft && pr.mergeStateStatus === "BEHIND") {
+    return {
+      action: "update_branch_or_rebase",
+      approval: "codex",
+      reason: "Non-draft PR is behind main; update from current main and rerun checks before merge."
+    };
+  }
+  if (!pr.isDraft && pr.blockers.length === 0) {
+    return {
+      action: "keep_ready",
+      approval: "codex",
+      reason: "Non-draft PR has no current readiness blockers."
+    };
+  }
+  if (pr.isDraft && pr.ageDays !== null && pr.ageDays > 7) {
+    return {
+      action: "close_candidate",
+      approval: "human",
+      reason: "Draft is older than 7 days; close only after confirming it has been superseded or captured in backlog."
+    };
+  }
+  if (pr.isDraft && pr.base !== "main") {
+    return {
+      action: "supersede_or_restack",
+      approval: "human",
+      reason: "Draft is stacked on another branch; prefer rebuilding useful pieces from current main over reviving the whole chain."
+    };
+  }
+  if (pr.isDraft) {
+    return {
+      action: "keep_for_review",
+      approval: "human",
+      reason: "Draft targets main; review scope and decide whether to promote, supersede, or close."
+    };
+  }
+  return {
+    action: "needs_manual_triage",
+    approval: "human",
+    reason: "The PR state did not match a known readiness bucket."
+  };
+}
+
+function attachDependencyMap(rows) {
+  const byHead = new Map(rows.map((pr) => [pr.head, pr]));
+  const childrenByNumber = new Map();
+  for (const pr of rows) {
+    const parent = byHead.get(pr.base);
+    pr.dependsOnPr = parent ? parent.number : null;
+    if (parent) {
+      const children = childrenByNumber.get(parent.number) || [];
+      children.push(pr.number);
+      childrenByNumber.set(parent.number, children);
+    }
+  }
+  for (const pr of rows) {
+    pr.childPrs = childrenByNumber.get(pr.number) || [];
+  }
+  return rows;
+}
+
+function countBy(rows, selector) {
+  const counts = {};
+  for (const row of rows) {
+    const key = selector(row) || "unknown";
+    counts[key] = (counts[key] || 0) + 1;
+  }
+  return counts;
 }
 
 function buildChains(rows) {
@@ -180,7 +267,7 @@ function buildReport(options) {
   const generatedAt = nowIso();
   const runId = clean(options.runId) || `pr-stack-${generatedAt.replace(/[-:]/g, "").replace(/\.\d+Z$/, "Z")}`;
   const prs = fetchPullRequests(options.repo);
-  const classified = prs.rows.map(classify).sort((a, b) => a.number - b.number);
+  const classified = attachDependencyMap(prs.rows.map(classify).sort((a, b) => a.number - b.number));
   const { chains, orphans } = buildChains(classified);
   const dirtyNonDraft = classified.filter((pr) => !pr.isDraft && pr.mergeStateStatus === "DIRTY");
   const unstableNonDraft = classified.filter((pr) => !pr.isDraft && pr.mergeStateStatus === "UNSTABLE");
@@ -228,10 +315,11 @@ function buildReport(options) {
       stackedDrafts: stackedDrafts.length,
       staleOver7Days: stale.length,
       chainCount: chains.length,
-      orphanCount: orphans.length
+      orphanCount: orphans.length,
+      dispositions: countBy(classified, (pr) => pr.disposition?.action)
     },
-    chains: chains.map((chain) => chain.map((pr) => ({ number: pr.number, head: pr.head, base: pr.base, readiness: pr.readiness, blockers: pr.blockers }))),
-    orphans: orphans.map((pr) => ({ number: pr.number, head: pr.head, base: pr.base, readiness: pr.readiness, blockers: pr.blockers })),
+    chains: chains.map((chain) => chain.map((pr) => ({ number: pr.number, head: pr.head, base: pr.base, dependsOnPr: pr.dependsOnPr, childPrs: pr.childPrs, readiness: pr.readiness, blockers: pr.blockers, disposition: pr.disposition }))),
+    orphans: orphans.map((pr) => ({ number: pr.number, head: pr.head, base: pr.base, dependsOnPr: pr.dependsOnPr, childPrs: pr.childPrs, readiness: pr.readiness, blockers: pr.blockers, disposition: pr.disposition })),
     pullRequests: classified,
     recommendations
   };
@@ -259,9 +347,27 @@ function renderMarkdown(report) {
     `- Chain count: ${report.summary.chainCount}`,
     `- Orphan count: ${report.summary.orphanCount}`,
     "",
-    "## Recommendations",
+    "## Disposition Summary",
     ""
   ];
+  for (const [action, count] of Object.entries(report.summary.dispositions || {}).sort((a, b) => a[0].localeCompare(b[0]))) {
+    lines.push(`- ${action}: ${count}`);
+  }
+  lines.push(
+    "",
+    "## Triage Packet",
+    "",
+    "| PR | Draft | Base | Depends on | Children | Disposition | Approval | Reason |",
+    "| --- | --- | --- | --- | --- | --- | --- | --- |"
+  );
+  for (const pr of report.pullRequests) {
+    lines.push(`| #${pr.number} | ${pr.isDraft ? "yes" : "no"} | \`${pr.base}\` | ${pr.dependsOnPr ? `#${pr.dependsOnPr}` : ""} | ${pr.childPrs.length ? pr.childPrs.map((child) => `#${child}`).join(", ") : ""} | ${pr.disposition?.action || "unknown"} | ${pr.disposition?.approval || "unknown"} | ${pr.disposition?.reason || ""} |`);
+  }
+  lines.push(
+    "",
+    "## Recommendations",
+    ""
+  );
   if (!report.recommendations.length) lines.push("- No PR-stack recommendations from current evidence.");
   for (const rec of report.recommendations) {
     lines.push(`### ${rec.title}`);


### PR DESCRIPTION
## Summary
- adds read-only PR-stack dispositions for keep, wait, update/rebase, conflict review, supersede/restack, and close-candidate
- adds parent/child PR dependency metadata to the readiness JSON and Markdown
- fixes false readiness for non-draft PRs that are behind main

## Evidence
- current PR stack packet reports 78 open PRs, 76 drafts, 70 stacked drafts, 4 stale PRs
- #689 is correctly classified as update_branch_or_rebase after #688 merged

## Testing
- node --check scripts/ops/pr_stack_readiness.mjs
- npm run ops:pr-stack:readiness
- git diff --check

## Risk
Low. Read-only reporting only; does not mutate branches, close PRs, or force-push.

## Rollback
Revert this PR to restore the older readiness-only packet.

## Follow-up
- generate issue-ready cleanup cards for human-approved close/supersede candidates
- add a freshness guard for stale draft stacks