### PR TITLE
[ops] Add output retention scanner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL := /bin/bash
 PG_CONTAINER ?= studiobrain_postgres
 PGDATABASE ?= monsoonfire_studio_os
 
-.PHONY: ops-check ops-inventory ops-postgres-review ops-postgres-sql ops-postgres-top-queries ops-postgres-query-tasks ops-postgres-growth-snapshot ops-postgres-autovacuum-stats ops-postgres-roles-extensions ops-docker-review ops-docker-posture ops-docker-tag-policy ops-capacity ops-import-pressure ops-cleanup-candidates ops-backup-evidence ops-postgres-backup-artifacts ops-restore-prereq ops-redis-minio-backup-evidence ops-db-docker-backup-rollup ops-command-surface-guard ops-ubuntu-review ops-host-failed-unit-trends ops-package-posture ops-time-sync ops-network-review ops-host-drift ops-systemd-drift ops-portal-bridge-review ops-app-review ops-dependency-review ops-dependency-security-scout ops-dependency-remediation-packet ops-dependency-upstream-watch ops-dependency-zero-baseline ops-idle-worker-effectivity ops-effectivity-report ops-evidence-freshness ops-slice-ledger ops-tool-inventory ops-admin-effectivity-audit ops-proactive-radar ops-pr-stack-readiness ops-privileged-evidence-read ops-privileged-evidence-capture ops-privileged-evidence-capture-smoke ops-work-packet ops-incident-bundle ops-incident-bundle-v2 ops-ci-validate ops-post-deploy-verify ops-docs ops-backlog ops-report
+.PHONY: ops-check ops-inventory ops-postgres-review ops-postgres-sql ops-postgres-top-queries ops-postgres-query-tasks ops-postgres-growth-snapshot ops-postgres-autovacuum-stats ops-postgres-roles-extensions ops-docker-review ops-docker-posture ops-docker-tag-policy ops-capacity ops-import-pressure ops-cleanup-candidates ops-backup-evidence ops-postgres-backup-artifacts ops-restore-prereq ops-redis-minio-backup-evidence ops-db-docker-backup-rollup ops-command-surface-guard ops-output-retention ops-ubuntu-review ops-host-failed-unit-trends ops-package-posture ops-time-sync ops-network-review ops-host-drift ops-systemd-drift ops-portal-bridge-review ops-app-review ops-dependency-review ops-dependency-security-scout ops-dependency-remediation-packet ops-dependency-upstream-watch ops-dependency-zero-baseline ops-idle-worker-effectivity ops-effectivity-report ops-evidence-freshness ops-slice-ledger ops-tool-inventory ops-admin-effectivity-audit ops-proactive-radar ops-pr-stack-readiness ops-privileged-evidence-read ops-privileged-evidence-capture ops-privileged-evidence-capture-smoke ops-work-packet ops-incident-bundle ops-incident-bundle-v2 ops-ci-validate ops-post-deploy-verify ops-docs ops-backlog ops-report
 
 ops-check: ops-inventory ops-docker-review ops-capacity ops-cleanup-candidates ops-backup-evidence ops-ubuntu-review ops-network-review ops-host-drift ops-systemd-drift ops-portal-bridge-review ops-app-review
 
@@ -83,6 +83,9 @@ ops-db-docker-backup-rollup:
 
 ops-command-surface-guard:
 	node scripts/ops/command_surface_guard.mjs --write
+
+ops-output-retention:
+	node scripts/ops/output_retention_scanner.mjs --write
 
 ops-ubuntu-review:
 	bash scripts/ops/ubuntu_failed_units.sh

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -44,6 +44,7 @@ make ops-restore-prereq
 make ops-redis-minio-backup-evidence
 make ops-db-docker-backup-rollup
 make ops-command-surface-guard
+make ops-output-retention
 make ops-ubuntu-review
 make ops-host-failed-unit-trends
 make ops-package-posture
@@ -81,6 +82,7 @@ npm run ops:pr-stack:readiness
 npm run ops:evidence:freshness
 npm run ops:db-docker-backup:rollup
 npm run ops:command-surface:guard
+npm run ops:output:retention
 npm run ops:dependency:security-scout
 npm run ops:dependency:remediation-packet
 npm run ops:dependency:upstream-watch
@@ -103,6 +105,7 @@ bash scripts/ops/npm_audit_inventory.sh
 bash scripts/ops/effectivity_report.sh
 node scripts/ops/proactive_issue_radar.mjs --write
 node scripts/ops/command_surface_guard.mjs --write
+node scripts/ops/output_retention_scanner.mjs --write
 node scripts/ops/dependency_security_scout.mjs --write
 node scripts/ops/dependency_remediation_packet.mjs --write
 node scripts/ops/dependency_upstream_watch.mjs --write
@@ -125,6 +128,8 @@ bash scripts/ops/incident_bundle_v2.sh output/ops/incidents-v2/manual-smoke
 `ops-db-docker-backup-rollup` runs the existing read-only Docker, PostgreSQL, backup, Redis/MinIO, and restore-prerequisite packets, stores their text evidence under `output/ops/db-docker-backup`, and summarizes degraded lanes with issue-ready follow-up tasks.
 
 `ops-command-surface-guard` checks that documented `make`, `npm run`, and direct `scripts/ops` commands still resolve. It writes artifacts under `output/ops/command-surface-guard` and is meant to catch command-wrapper drift before PRs stack up.
+
+`ops-output-retention` scans ignored `output/ops` artifacts for file count, total size, largest producers, stale files, and retention recommendations. It writes under `output/ops/output-retention` and never deletes, rotates, compresses, or prunes artifacts.
 
 `ops-dependency-security-scout` compares open Dependabot alerts, open Dependabot PR readiness, and local `npm audit` summaries across the repo's package surfaces. It writes issue-ready follow-up tasks under `output/ops/dependency-security-scout` and does not install, update, or fix packages.
 

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -131,6 +131,8 @@ bash scripts/ops/incident_bundle_v2.sh output/ops/incidents-v2/manual-smoke
 
 `ops-output-retention` scans ignored `output/ops` artifacts for file count, total size, largest producers, stale files, and retention recommendations. It writes under `output/ops/output-retention` and never deletes, rotates, compresses, or prunes artifacts.
 
+The scanner reads producer freshness expectations from `docs/ops/output-artifact-producers.json`; missing producers fall back to a conservative 14-day review window and human-approved cleanup.
+
 `ops-dependency-security-scout` compares open Dependabot alerts, open Dependabot PR readiness, and local `npm audit` summaries across the repo's package surfaces. It writes issue-ready follow-up tasks under `output/ops/dependency-security-scout` and does not install, update, or fix packages.
 
 `ops-dependency-remediation-packet` turns high/critical npm audit findings into a read-only decision packet with dependency chains, owner-package candidates, latest-version hints, safe next steps, acceptance criteria, and rollback notes. It writes under `output/ops/dependency-remediation` and does not install, update, override, or remove dependencies.

--- a/docs/ops/output-artifact-producers.json
+++ b/docs/ops/output-artifact-producers.json
@@ -1,0 +1,50 @@
+{
+  "schema": "studio-brain.ops.output-artifact-producers.v1",
+  "default": {
+    "freshnessDays": 14,
+    "retentionClass": "review",
+    "cleanupApproval": "human"
+  },
+  "producers": {
+    "dependency-zero-baseline": {
+      "freshnessDays": 1,
+      "retentionClass": "latest-plus-history",
+      "cleanupApproval": "human"
+    },
+    "dependency-security-scout": {
+      "freshnessDays": 1,
+      "retentionClass": "latest-plus-history",
+      "cleanupApproval": "human"
+    },
+    "dependency-upstream-watch": {
+      "freshnessDays": 7,
+      "retentionClass": "trend",
+      "cleanupApproval": "human"
+    },
+    "pr-stack": {
+      "freshnessDays": 1,
+      "retentionClass": "ticket-evidence",
+      "cleanupApproval": "human"
+    },
+    "output-retention": {
+      "freshnessDays": 7,
+      "retentionClass": "self-audit",
+      "cleanupApproval": "human"
+    },
+    "incidents": {
+      "freshnessDays": 30,
+      "retentionClass": "incident",
+      "cleanupApproval": "human"
+    },
+    "incidents-v2": {
+      "freshnessDays": 30,
+      "retentionClass": "incident",
+      "cleanupApproval": "human"
+    },
+    "privileged-evidence": {
+      "freshnessDays": 7,
+      "retentionClass": "approval-gated-evidence",
+      "cleanupApproval": "human"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "ops:db-docker-backup:rollup": "node ./scripts/ops/db_docker_backup_rollup.mjs --write --json",
     "ops:command-surface:guard": "node ./scripts/ops/command_surface_guard.mjs --write --json",
     "ops:command-surface:guard:check": "node ./scripts/ops/command_surface_guard.mjs --json",
+    "ops:output:retention": "node ./scripts/ops/output_retention_scanner.mjs --write --json",
     "test:ops:command-surface": "node --test ./scripts/ops/command_surface_guard.test.mjs",
     "ops:dependency:security-scout": "node ./scripts/ops/dependency_security_scout.mjs --write --json",
     "ops:dependency:remediation-packet": "node ./scripts/ops/dependency_remediation_packet.mjs --write --json",

--- a/scripts/ops/output_retention_scanner.mjs
+++ b/scripts/ops/output_retention_scanner.mjs
@@ -1,0 +1,291 @@
+#!/usr/bin/env node
+
+import { existsSync, mkdirSync, readdirSync, statSync, writeFileSync } from "node:fs";
+import { dirname, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const REPO_ROOT = resolve(dirname(__filename), "..", "..");
+const DEFAULT_SCAN_DIR = resolve(REPO_ROOT, "output", "ops");
+const DEFAULT_OUTPUT_DIR = resolve(REPO_ROOT, "output", "ops", "output-retention");
+
+function usage() {
+  return `Ops output retention scanner
+
+Usage:
+  node scripts/ops/output_retention_scanner.mjs [--json] [--write]
+
+Options:
+  --json                  Print JSON.
+  --write                 Write latest JSON and Markdown artifacts.
+  --scan-dir <path>       Directory to scan. Default: output/ops.
+  --output-dir <path>     Artifact directory. Default: output/ops/output-retention.
+  --warn-mb <number>      Warning threshold for total size. Default: 250.
+  --critical-mb <number>  Critical threshold for total size. Default: 1000.
+  --stale-days <number>   Stale artifact age threshold. Default: 14.
+
+This scanner is read-only except for optional report writes. It never deletes, rotates, compresses, or prunes artifacts.
+`;
+}
+
+function parseArgs(argv) {
+  const options = {
+    json: false,
+    write: false,
+    scanDir: DEFAULT_SCAN_DIR,
+    outputDir: DEFAULT_OUTPUT_DIR,
+    warnMb: 250,
+    criticalMb: 1000,
+    staleDays: 14
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--help" || arg === "-h") {
+      process.stdout.write(usage());
+      process.exit(0);
+    }
+    if (arg === "--json") {
+      options.json = true;
+      continue;
+    }
+    if (arg === "--write") {
+      options.write = true;
+      continue;
+    }
+    const valueFlags = new Map([
+      ["--scan-dir", "scanDir"],
+      ["--output-dir", "outputDir"],
+      ["--warn-mb", "warnMb"],
+      ["--critical-mb", "criticalMb"],
+      ["--stale-days", "staleDays"]
+    ]);
+    let consumed = false;
+    for (const [flag, key] of valueFlags.entries()) {
+      if (arg === flag) {
+        if (!argv[index + 1]) throw new Error(`${flag} requires a value.`);
+        options[key] = argv[index + 1];
+        index += 1;
+        consumed = true;
+        break;
+      }
+      if (arg.startsWith(`${flag}=`)) {
+        options[key] = arg.slice(flag.length + 1);
+        consumed = true;
+        break;
+      }
+    }
+    if (consumed) continue;
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+  options.scanDir = resolve(REPO_ROOT, options.scanDir);
+  options.outputDir = resolve(REPO_ROOT, options.outputDir);
+  options.warnMb = Number(options.warnMb);
+  options.criticalMb = Number(options.criticalMb);
+  options.staleDays = Number(options.staleDays);
+  return options;
+}
+
+function repoRelative(path) {
+  return relative(REPO_ROOT, path).replace(/\\/g, "/") || ".";
+}
+
+function walk(dir, root = dir, files = []) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const path = resolve(dir, entry.name);
+    if (entry.isDirectory()) {
+      walk(path, root, files);
+      continue;
+    }
+    if (!entry.isFile()) continue;
+    const stat = statSync(path);
+    files.push({
+      path,
+      relativePath: relative(root, path).replace(/\\/g, "/"),
+      sizeBytes: stat.size,
+      modifiedAt: stat.mtime.toISOString()
+    });
+  }
+  return files;
+}
+
+function ageDays(iso) {
+  const time = Date.parse(iso);
+  if (!Number.isFinite(time)) return null;
+  return Number(((Date.now() - time) / 86_400_000).toFixed(1));
+}
+
+function groupByProducer(files) {
+  const groups = new Map();
+  for (const file of files) {
+    const producer = file.relativePath.split("/")[0] || "(root)";
+    const group = groups.get(producer) || {
+      producer,
+      files: 0,
+      sizeBytes: 0,
+      newestAt: "",
+      oldestAt: "",
+      staleFiles: 0
+    };
+    group.files += 1;
+    group.sizeBytes += file.sizeBytes;
+    if (!group.newestAt || file.modifiedAt > group.newestAt) group.newestAt = file.modifiedAt;
+    if (!group.oldestAt || file.modifiedAt < group.oldestAt) group.oldestAt = file.modifiedAt;
+    groups.set(producer, group);
+  }
+  return [...groups.values()].sort((a, b) => b.sizeBytes - a.sizeBytes);
+}
+
+function buildReport(options) {
+  const generatedAt = new Date().toISOString();
+  if (!existsSync(options.scanDir)) {
+    return {
+      schema: "studio-brain.ops.output-retention.v1",
+      generatedAt,
+      readOnly: true,
+      status: "ok",
+      scanDir: repoRelative(options.scanDir),
+      summary: { exists: false, files: 0, totalBytes: 0, totalMb: 0, staleFiles: 0 },
+      producers: [],
+      findings: [],
+      retentionAdvice: ["No output/ops directory exists yet; no retention action needed."]
+    };
+  }
+
+  const files = walk(options.scanDir);
+  const staleCutoff = options.staleDays;
+  const filesWithAge = files.map((file) => ({ ...file, ageDays: ageDays(file.modifiedAt) }));
+  const staleFiles = filesWithAge.filter((file) => file.ageDays !== null && file.ageDays > staleCutoff);
+  const totalBytes = filesWithAge.reduce((acc, file) => acc + file.sizeBytes, 0);
+  const totalMb = Number((totalBytes / 1_048_576).toFixed(2));
+  const producers = groupByProducer(filesWithAge);
+  for (const producer of producers) {
+    producer.sizeMb = Number((producer.sizeBytes / 1_048_576).toFixed(2));
+    producer.newestAgeDays = ageDays(producer.newestAt);
+    producer.oldestAgeDays = ageDays(producer.oldestAt);
+    producer.staleFiles = filesWithAge.filter((file) => file.relativePath.startsWith(`${producer.producer}/`) && file.ageDays !== null && file.ageDays > staleCutoff).length;
+  }
+
+  const findings = [];
+  if (totalMb >= options.criticalMb) {
+    findings.push({
+      severity: "critical",
+      title: "Ops output artifact size exceeds critical threshold",
+      evidence: `${totalMb} MB >= ${options.criticalMb} MB`,
+      safeNextStep: "Review largest producers and approve a retention policy before deleting artifacts."
+    });
+  } else if (totalMb >= options.warnMb) {
+    findings.push({
+      severity: "medium",
+      title: "Ops output artifact size exceeds warning threshold",
+      evidence: `${totalMb} MB >= ${options.warnMb} MB`,
+      safeNextStep: "Review largest producers and document retention expectations."
+    });
+  }
+  if (staleFiles.length) {
+    findings.push({
+      severity: "low",
+      title: "Stale ops output artifacts found",
+      evidence: `${staleFiles.length} file(s) older than ${staleCutoff} days`,
+      safeNextStep: "Classify artifacts as keep, archive, or cleanup-candidate; do not delete without approval."
+    });
+  }
+
+  return {
+    schema: "studio-brain.ops.output-retention.v1",
+    generatedAt,
+    readOnly: true,
+    status: findings.some((finding) => finding.severity === "critical") ? "critical" : findings.length ? "review" : "ok",
+    scanDir: repoRelative(options.scanDir),
+    thresholds: {
+      warnMb: options.warnMb,
+      criticalMb: options.criticalMb,
+      staleDays: options.staleDays
+    },
+    summary: {
+      exists: true,
+      files: filesWithAge.length,
+      totalBytes,
+      totalMb,
+      staleFiles: staleFiles.length,
+      producerCount: producers.length
+    },
+    producers,
+    largestFiles: filesWithAge.sort((a, b) => b.sizeBytes - a.sizeBytes).slice(0, 20).map((file) => ({
+      path: repoRelative(file.path),
+      sizeBytes: file.sizeBytes,
+      sizeMb: Number((file.sizeBytes / 1_048_576).toFixed(2)),
+      modifiedAt: file.modifiedAt,
+      ageDays: file.ageDays
+    })),
+    findings,
+    retentionAdvice: [
+      "This report is evidence only; it does not delete or rotate artifacts.",
+      "Prefer retention by producer directory so incident bundles and trend snapshots keep useful history.",
+      "Classify cleanup candidates as approval-required unless the producer has an explicit retention policy."
+    ]
+  };
+}
+
+function renderMarkdown(report) {
+  const lines = [
+    "# Ops Output Retention Scanner",
+    "",
+    `Generated: ${report.generatedAt}`,
+    `Status: \`${report.status}\``,
+    `Read-only: ${report.readOnly ? "yes" : "no"}`,
+    `Scan dir: \`${report.scanDir}\``,
+    "",
+    "## Summary",
+    "",
+    `- Exists: ${report.summary.exists ? "yes" : "no"}`,
+    `- Files: ${report.summary.files}`,
+    `- Total size: ${report.summary.totalMb} MB`,
+    `- Stale files: ${report.summary.staleFiles}`,
+    "",
+    "## Findings",
+    ""
+  ];
+  if (!report.findings.length) lines.push("- No retention findings.");
+  for (const finding of report.findings) {
+    lines.push(`- ${finding.severity.toUpperCase()}: ${finding.title}; ${finding.evidence}; next: ${finding.safeNextStep}`);
+  }
+  lines.push("", "## Producers", "", "| Producer | Files | Size MB | Newest age | Oldest age | Stale files |", "| --- | ---: | ---: | ---: | ---: | ---: |");
+  for (const producer of report.producers || []) {
+    lines.push(`| \`${producer.producer}\` | ${producer.files} | ${producer.sizeMb} | ${producer.newestAgeDays ?? "?"} | ${producer.oldestAgeDays ?? "?"} | ${producer.staleFiles} |`);
+  }
+  if (!(report.producers || []).length) lines.push("| n/a | 0 | 0 | n/a | n/a | 0 |");
+  lines.push("", "## Largest Files", "", "| Path | Size MB | Age days |", "| --- | ---: | ---: |");
+  for (const file of report.largestFiles || []) {
+    lines.push(`| \`${file.path}\` | ${file.sizeMb} | ${file.ageDays ?? "?"} |`);
+  }
+  if (!(report.largestFiles || []).length) lines.push("| n/a | 0 | n/a |");
+  lines.push("", "## Retention Advice", "");
+  for (const item of report.retentionAdvice) lines.push(`- ${item}`);
+  return `${lines.join("\n")}\n`;
+}
+
+function writeArtifacts(report, options) {
+  mkdirSync(options.outputDir, { recursive: true });
+  const jsonPath = resolve(options.outputDir, "latest.json");
+  const markdownPath = resolve(options.outputDir, "latest.md");
+  writeFileSync(jsonPath, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+  writeFileSync(markdownPath, renderMarkdown(report), "utf8");
+  report.paths = {
+    json: repoRelative(jsonPath),
+    markdown: repoRelative(markdownPath)
+  };
+}
+
+function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const report = buildReport(options);
+  if (options.write) writeArtifacts(report, options);
+  process.stdout.write(options.json ? `${JSON.stringify(report, null, 2)}\n` : renderMarkdown(report));
+}
+
+try {
+  main();
+} catch (error) {
+  process.stderr.write(`output_retention_scanner: ${error.message}\n`);
+  process.exit(1);
+}

--- a/scripts/ops/output_retention_scanner.mjs
+++ b/scripts/ops/output_retention_scanner.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { existsSync, mkdirSync, readdirSync, statSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
 import { dirname, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -8,6 +8,7 @@ const __filename = fileURLToPath(import.meta.url);
 const REPO_ROOT = resolve(dirname(__filename), "..", "..");
 const DEFAULT_SCAN_DIR = resolve(REPO_ROOT, "output", "ops");
 const DEFAULT_OUTPUT_DIR = resolve(REPO_ROOT, "output", "ops", "output-retention");
+const DEFAULT_PRODUCER_POLICY = resolve(REPO_ROOT, "docs", "ops", "output-artifact-producers.json");
 
 function usage() {
   return `Ops output retention scanner
@@ -20,6 +21,7 @@ Options:
   --write                 Write latest JSON and Markdown artifacts.
   --scan-dir <path>       Directory to scan. Default: output/ops.
   --output-dir <path>     Artifact directory. Default: output/ops/output-retention.
+  --producer-policy <path> Producer freshness policy. Default: docs/ops/output-artifact-producers.json.
   --warn-mb <number>      Warning threshold for total size. Default: 250.
   --critical-mb <number>  Critical threshold for total size. Default: 1000.
   --stale-days <number>   Stale artifact age threshold. Default: 14.
@@ -34,6 +36,7 @@ function parseArgs(argv) {
     write: false,
     scanDir: DEFAULT_SCAN_DIR,
     outputDir: DEFAULT_OUTPUT_DIR,
+    producerPolicy: DEFAULT_PRODUCER_POLICY,
     warnMb: 250,
     criticalMb: 1000,
     staleDays: 14
@@ -55,6 +58,7 @@ function parseArgs(argv) {
     const valueFlags = new Map([
       ["--scan-dir", "scanDir"],
       ["--output-dir", "outputDir"],
+      ["--producer-policy", "producerPolicy"],
       ["--warn-mb", "warnMb"],
       ["--critical-mb", "criticalMb"],
       ["--stale-days", "staleDays"]
@@ -79,6 +83,7 @@ function parseArgs(argv) {
   }
   options.scanDir = resolve(REPO_ROOT, options.scanDir);
   options.outputDir = resolve(REPO_ROOT, options.outputDir);
+  options.producerPolicy = resolve(REPO_ROOT, options.producerPolicy);
   options.warnMb = Number(options.warnMb);
   options.criticalMb = Number(options.criticalMb);
   options.staleDays = Number(options.staleDays);
@@ -87,6 +92,25 @@ function parseArgs(argv) {
 
 function repoRelative(path) {
   return relative(REPO_ROOT, path).replace(/\\/g, "/") || ".";
+}
+
+function safeJsonParse(raw, fallback) {
+  try {
+    return JSON.parse(raw || "");
+  } catch {
+    return fallback;
+  }
+}
+
+function readProducerPolicy(path) {
+  const fallback = {
+    schema: "studio-brain.ops.output-artifact-producers.v1",
+    default: { freshnessDays: 14, retentionClass: "review", cleanupApproval: "human" },
+    producers: {}
+  };
+  if (!existsSync(path)) return { ...fallback, status: "missing", path: repoRelative(path) };
+  const parsed = safeJsonParse(readFileSync(path, "utf8"), fallback);
+  return { ...fallback, ...parsed, status: "ok", path: repoRelative(path) };
 }
 
 function walk(dir, root = dir, files = []) {
@@ -135,8 +159,16 @@ function groupByProducer(files) {
   return [...groups.values()].sort((a, b) => b.sizeBytes - a.sizeBytes);
 }
 
+function policyForProducer(policy, producer) {
+  return {
+    ...policy.default,
+    ...(policy.producers?.[producer] || {})
+  };
+}
+
 function buildReport(options) {
   const generatedAt = new Date().toISOString();
+  const producerPolicy = readProducerPolicy(options.producerPolicy);
   if (!existsSync(options.scanDir)) {
     return {
       schema: "studio-brain.ops.output-retention.v1",
@@ -144,6 +176,7 @@ function buildReport(options) {
       readOnly: true,
       status: "ok",
       scanDir: repoRelative(options.scanDir),
+      producerPolicy,
       summary: { exists: false, files: 0, totalBytes: 0, totalMb: 0, staleFiles: 0 },
       producers: [],
       findings: [],
@@ -159,10 +192,13 @@ function buildReport(options) {
   const totalMb = Number((totalBytes / 1_048_576).toFixed(2));
   const producers = groupByProducer(filesWithAge);
   for (const producer of producers) {
+    const policy = policyForProducer(producerPolicy, producer.producer);
     producer.sizeMb = Number((producer.sizeBytes / 1_048_576).toFixed(2));
     producer.newestAgeDays = ageDays(producer.newestAt);
     producer.oldestAgeDays = ageDays(producer.oldestAt);
     producer.staleFiles = filesWithAge.filter((file) => file.relativePath.startsWith(`${producer.producer}/`) && file.ageDays !== null && file.ageDays > staleCutoff).length;
+    producer.policy = policy;
+    producer.policyStatus = producer.newestAgeDays !== null && producer.newestAgeDays > Number(policy.freshnessDays || 14) ? "stale" : "ok";
   }
 
   const findings = [];
@@ -189,6 +225,15 @@ function buildReport(options) {
       safeNextStep: "Classify artifacts as keep, archive, or cleanup-candidate; do not delete without approval."
     });
   }
+  const staleProducers = producers.filter((producer) => producer.policyStatus === "stale");
+  if (staleProducers.length) {
+    findings.push({
+      severity: "medium",
+      title: "Ops output producers are stale against policy",
+      evidence: staleProducers.map((producer) => `${producer.producer}: newest age ${producer.newestAgeDays}d > ${producer.policy.freshnessDays}d`).join("; "),
+      safeNextStep: "Run the producer command or mark the evidence lane intentionally dormant; do not delete artifacts as a freshness fix."
+    });
+  }
 
   return {
     schema: "studio-brain.ops.output-retention.v1",
@@ -196,6 +241,7 @@ function buildReport(options) {
     readOnly: true,
     status: findings.some((finding) => finding.severity === "critical") ? "critical" : findings.length ? "review" : "ok",
     scanDir: repoRelative(options.scanDir),
+    producerPolicy,
     thresholds: {
       warnMb: options.warnMb,
       criticalMb: options.criticalMb,
@@ -249,11 +295,11 @@ function renderMarkdown(report) {
   for (const finding of report.findings) {
     lines.push(`- ${finding.severity.toUpperCase()}: ${finding.title}; ${finding.evidence}; next: ${finding.safeNextStep}`);
   }
-  lines.push("", "## Producers", "", "| Producer | Files | Size MB | Newest age | Oldest age | Stale files |", "| --- | ---: | ---: | ---: | ---: | ---: |");
+  lines.push("", "## Producers", "", "| Producer | Files | Size MB | Newest age | Policy days | Policy status | Retention class | Stale files |", "| --- | ---: | ---: | ---: | ---: | --- | --- | ---: |");
   for (const producer of report.producers || []) {
-    lines.push(`| \`${producer.producer}\` | ${producer.files} | ${producer.sizeMb} | ${producer.newestAgeDays ?? "?"} | ${producer.oldestAgeDays ?? "?"} | ${producer.staleFiles} |`);
+    lines.push(`| \`${producer.producer}\` | ${producer.files} | ${producer.sizeMb} | ${producer.newestAgeDays ?? "?"} | ${producer.policy?.freshnessDays ?? "?"} | ${producer.policyStatus || "unknown"} | ${producer.policy?.retentionClass || "unknown"} | ${producer.staleFiles} |`);
   }
-  if (!(report.producers || []).length) lines.push("| n/a | 0 | 0 | n/a | n/a | 0 |");
+  if (!(report.producers || []).length) lines.push("| n/a | 0 | 0 | n/a | n/a | n/a | n/a | 0 |");
   lines.push("", "## Largest Files", "", "| Path | Size MB | Age days |", "| --- | ---: | ---: |");
   for (const file of report.largestFiles || []) {
     lines.push(`| \`${file.path}\` | ${file.sizeMb} | ${file.ageDays ?? "?"} |`);


### PR DESCRIPTION
## Summary
- adds a read-only scanner for ignored output/ops artifact growth and freshness
- reports file count, total size, producer directories, largest files, stale artifacts, thresholds, and retention advice
- exposes Make/npm/direct docs for the command

## Evidence
- clean worktree run found output/ops absent, then subsequent report captured the scanner's own two output files
- command surface guard recognizes the new Make/npm/direct command surfaces

## Testing
- node --check scripts/ops/output_retention_scanner.mjs
- npm run ops:output:retention
- npm run ops:command-surface:guard:check
- git diff --check

## Risk
Low. The scanner never deletes, rotates, compresses, prunes, or mutates host artifacts beyond optional report writes.

## Rollback
Revert this PR to remove the scanner and command wrappers.

## Follow-up
- map ops artifact producers to expected freshness windows
- bridge stale critical evidence into issue-ready backlog tasks