### PR TITLE
[ops] Add output producer artifact paths

### DIFF
--- a/docs/ops/output-artifact-producers.json
+++ b/docs/ops/output-artifact-producers.json
@@ -7,46 +7,55 @@
   },
   "producers": {
     "dependency-zero-baseline": {
+      "outputPath": "output/ops/dependency-zero-baseline",
       "freshnessDays": 1,
       "retentionClass": "latest-plus-history",
       "cleanupApproval": "human"
     },
     "dependency-security-scout": {
+      "outputPath": "output/ops/dependency-security-scout",
       "freshnessDays": 1,
       "retentionClass": "latest-plus-history",
       "cleanupApproval": "human"
     },
     "dependency-upstream-watch": {
+      "outputPath": "output/ops/dependency-upstream-watch",
       "freshnessDays": 7,
       "retentionClass": "trend",
       "cleanupApproval": "human"
     },
     "pr-stack": {
+      "outputPath": "output/ops/pr-stack",
       "freshnessDays": 1,
       "retentionClass": "ticket-evidence",
       "cleanupApproval": "human"
     },
     "output-retention": {
+      "outputPath": "output/ops/output-retention",
       "freshnessDays": 7,
       "retentionClass": "self-audit",
       "cleanupApproval": "human"
     },
     "command-manifest": {
+      "outputPath": "output/ops/command-manifest",
       "freshnessDays": 7,
       "retentionClass": "tool-inventory",
       "cleanupApproval": "human"
     },
     "incidents": {
+      "outputPath": "output/ops/incidents",
       "freshnessDays": 30,
       "retentionClass": "incident",
       "cleanupApproval": "human"
     },
     "incidents-v2": {
+      "outputPath": "output/ops/incidents-v2",
       "freshnessDays": 30,
       "retentionClass": "incident",
       "cleanupApproval": "human"
     },
     "privileged-evidence": {
+      "outputPath": "output/ops/privileged-evidence",
       "freshnessDays": 7,
       "retentionClass": "approval-gated-evidence",
       "cleanupApproval": "human"


### PR DESCRIPTION
## Summary
- add explicit `outputPath` metadata to every tracked ops output producer
- let retention reports and the command manifest expose concrete artifact locations instead of inferred paths

## Evidence
- #692 introduced the command manifest and #693 made missing producer policy visible.
- This fills the next metadata gap: policies now include the path that a dashboard, selector, or handoff packet should link to.

## Testing
- `npm run ops:output:retention`
- `npm run ops:command-manifest:check`
- `git diff --check origin/main...HEAD`

## Risk / Rollback
- Risk: low. Metadata-only docs change; no scripts execute cleanup or host actions.
- Rollback: revert this PR.

## Follow-ups
- Teach dashboards or next-slice selectors to link to `outputPath/latest.json` and `outputPath/latest.md` when present.