### PR TITLE
[ops] Add dependency remediation producer policy

### DIFF
--- a/docs/ops/output-artifact-producers.json
+++ b/docs/ops/output-artifact-producers.json
@@ -18,6 +18,12 @@
       "retentionClass": "latest-plus-history",
       "cleanupApproval": "human"
     },
+    "dependency-remediation": {
+      "outputPath": "output/ops/dependency-remediation",
+      "freshnessDays": 7,
+      "retentionClass": "decision-packet",
+      "cleanupApproval": "human"
+    },
     "dependency-upstream-watch": {
       "outputPath": "output/ops/dependency-upstream-watch",
       "freshnessDays": 7,


### PR DESCRIPTION
## Summary
- add an explicit output producer policy for `dependency-remediation`
- set the artifact path to `output/ops/dependency-remediation` with a 7-day decision-packet freshness window

## Evidence
- Merged-main audit after #694 reported `dependency-remediation` as the only producer relying on default retention policy.
- After this change, local `ops:output:retention` returns `status: ok` in a fresh worktree.

## Testing
- `npm run ops:output:retention`
- `npm run ops:command-manifest:check`
- `git diff --check`

## Risk / Rollback
- Risk: low. Metadata-only docs change; no cleanup, host action, or package change.
- Rollback: revert this PR.