### PR TITLE
[ops] Link proactive radar to producer artifacts

### DIFF
--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -122,7 +122,7 @@ bash scripts/ops/incident_bundle_v2.sh output/ops/incidents-v2/manual-smoke
 
 `ops-privileged-evidence-capture-smoke` writes a non-root local smoke artifact under `output/ops/privileged-evidence` and is safe for development. Installing the host-side privileged collector, timer, group, or sudoers allowlist is intentionally separate and approval-gated; see `22-privileged-evidence-capture.md`.
 
-`ops-proactive-radar` is a read-only loop-start command. It looks for merge-blocked PRs, stacked draft PR pressure, stale ops artifacts, dirty worktree risk, and hidden ops scripts without printing secrets or mutating the host.
+`ops-proactive-radar` is a read-only loop-start command. It looks for merge-blocked PRs, stacked draft PR pressure, stale ops artifacts, dirty worktree risk, and hidden ops scripts without printing secrets or mutating the host. It also reads `docs/ops/output-artifact-producers.json` so stale producer evidence points to exact `output/ops/...` paths and safe refresh commands.
 
 `ops-pr-stack-readiness` is a read-only GitHub PR-stack packet. It groups open PRs by stack, identifies dirty non-draft PRs, stale PRs, and non-main draft chains, and writes artifacts under `output/ops/pr-stack`.
 

--- a/docs/ops/output-artifact-producers.json
+++ b/docs/ops/output-artifact-producers.json
@@ -36,6 +36,12 @@
       "retentionClass": "ticket-evidence",
       "cleanupApproval": "human"
     },
+    "proactive-radar": {
+      "outputPath": "output/ops/proactive-radar",
+      "freshnessDays": 1,
+      "retentionClass": "next-slice-evidence",
+      "cleanupApproval": "human"
+    },
     "output-retention": {
       "outputPath": "output/ops/output-retention",
       "freshnessDays": 7,

--- a/docs/ops/output-artifact-producers.json
+++ b/docs/ops/output-artifact-producers.json
@@ -8,66 +8,77 @@
   "producers": {
     "dependency-zero-baseline": {
       "outputPath": "output/ops/dependency-zero-baseline",
+      "refreshCommand": "make ops-dependency-zero-baseline",
       "freshnessDays": 1,
       "retentionClass": "latest-plus-history",
       "cleanupApproval": "human"
     },
     "dependency-security-scout": {
       "outputPath": "output/ops/dependency-security-scout",
+      "refreshCommand": "make ops-dependency-security-scout",
       "freshnessDays": 1,
       "retentionClass": "latest-plus-history",
       "cleanupApproval": "human"
     },
     "dependency-remediation": {
       "outputPath": "output/ops/dependency-remediation",
+      "refreshCommand": "make ops-dependency-remediation-packet",
       "freshnessDays": 7,
       "retentionClass": "decision-packet",
       "cleanupApproval": "human"
     },
     "dependency-upstream-watch": {
       "outputPath": "output/ops/dependency-upstream-watch",
+      "refreshCommand": "make ops-dependency-upstream-watch",
       "freshnessDays": 7,
       "retentionClass": "trend",
       "cleanupApproval": "human"
     },
     "pr-stack": {
       "outputPath": "output/ops/pr-stack",
+      "refreshCommand": "make ops-pr-stack-readiness",
       "freshnessDays": 1,
       "retentionClass": "ticket-evidence",
       "cleanupApproval": "human"
     },
     "proactive-radar": {
       "outputPath": "output/ops/proactive-radar",
+      "refreshCommand": "make ops-proactive-radar",
       "freshnessDays": 1,
       "retentionClass": "next-slice-evidence",
       "cleanupApproval": "human"
     },
     "output-retention": {
       "outputPath": "output/ops/output-retention",
+      "refreshCommand": "make ops-output-retention",
       "freshnessDays": 7,
       "retentionClass": "self-audit",
       "cleanupApproval": "human"
     },
     "command-manifest": {
       "outputPath": "output/ops/command-manifest",
+      "refreshCommand": "make ops-command-manifest",
       "freshnessDays": 7,
       "retentionClass": "tool-inventory",
       "cleanupApproval": "human"
     },
     "incidents": {
       "outputPath": "output/ops/incidents",
+      "refreshCommand": "make ops-incident-bundle",
       "freshnessDays": 30,
       "retentionClass": "incident",
       "cleanupApproval": "human"
     },
     "incidents-v2": {
       "outputPath": "output/ops/incidents-v2",
+      "refreshCommand": "make ops-incident-bundle-v2",
       "freshnessDays": 30,
       "retentionClass": "incident",
       "cleanupApproval": "human"
     },
     "privileged-evidence": {
       "outputPath": "output/ops/privileged-evidence",
+      "refreshCommand": "make ops-privileged-evidence-read",
       "freshnessDays": 7,
       "retentionClass": "approval-gated-evidence",
       "cleanupApproval": "human"

--- a/scripts/ops/ops_command_manifest.mjs
+++ b/scripts/ops/ops_command_manifest.mjs
@@ -218,6 +218,7 @@ function buildManifest() {
       .map((producer) => ({
         id: producer.id,
         outputPath: producer.outputPath || producer.path || "",
+        refreshCommand: producer.refreshCommand || "",
         freshnessDays: producer.freshnessDays ?? null,
         retentionClass: producer.retentionClass || producer.retention || "unspecified"
       }));
@@ -308,6 +309,7 @@ function buildManifest() {
     producerPolicies: producers.map((producer) => ({
       id: producer.id,
       outputPath: producer.outputPath || producer.path || "",
+      refreshCommand: producer.refreshCommand || "",
       freshnessDays: producer.freshnessDays ?? null,
       retentionClass: producer.retentionClass || producer.retention || "unspecified"
     })),

--- a/scripts/ops/proactive_issue_radar.mjs
+++ b/scripts/ops/proactive_issue_radar.mjs
@@ -252,6 +252,7 @@ function producerArtifactFreshness() {
     return {
       producer,
       outputPath: outputPath || "",
+      refreshCommand: clean(config.refreshCommand) || "",
       retentionClass: clean(config.retentionClass) || "review",
       cleanupApproval: clean(config.cleanupApproval) || "human",
       freshnessDays,
@@ -324,7 +325,7 @@ function buildFindings({ prs, status, freshness, producerArtifacts, scripts }) {
       staleArtifacts.length ? `${staleArtifacts.length} tracked docs stale/missing` : "",
       staleProducerArtifacts.length ? `${staleProducerArtifacts.length} producer output path(s) stale/missing` : "",
       ...staleArtifacts.slice(0, 3).map((entry) => `${entry.path} ${entry.exists ? `${entry.ageDays}d old` : "missing"}`),
-      ...staleProducerArtifacts.slice(0, 5).map((entry) => `${entry.producer} -> ${entry.outputPath || "missing outputPath"} ${entry.ageDays === null ? "missing" : `${entry.ageDays}d old`} threshold=${entry.freshnessDays}d`)
+      ...staleProducerArtifacts.slice(0, 5).map((entry) => `${entry.producer} -> ${entry.outputPath || "missing outputPath"} ${entry.ageDays === null ? "missing" : `${entry.ageDays}d old`} threshold=${entry.freshnessDays}d refresh=${entry.refreshCommand || "not listed"}`)
     ].filter(Boolean).join("; ");
     findings.push(makeFinding("medium", "stale-ops-artifacts", "Ops evidence artifacts may be stale", "docs/ops and output/ops", evidence, "Recommendations may be based on outdated evidence.", "Refresh the named docs or producer outputs with read-only scripts.", "Docs/output-only update; git history preserves old evidence."));
   }
@@ -479,7 +480,7 @@ function renderMarkdown(report) {
   if (!staleProducers.length) lines.push("- No stale producer output paths from policy thresholds.");
   for (const entry of staleProducers) {
     const freshness = entry.ageDays === null ? "missing" : `${entry.ageDays} days old`;
-    lines.push(`- ${entry.producer}: ${entry.outputPath || "missing outputPath"} (${freshness}; threshold ${entry.freshnessDays} days; retention ${entry.retentionClass})`);
+    lines.push(`- ${entry.producer}: ${entry.outputPath || "missing outputPath"} (${freshness}; threshold ${entry.freshnessDays} days; refresh \`${entry.refreshCommand || "not listed"}\`; retention ${entry.retentionClass})`);
   }
   lines.push("");
   return `${lines.join("\n")}\n`;

--- a/scripts/ops/proactive_issue_radar.mjs
+++ b/scripts/ops/proactive_issue_radar.mjs
@@ -371,6 +371,30 @@ function buildRecommendations(findings) {
   }));
 }
 
+function buildProducerRefreshTasks(producerArtifacts) {
+  return producerArtifacts
+    .filter((entry) => entry.stale)
+    .map((entry) => {
+      const freshness = entry.ageDays === null ? "missing" : `${entry.ageDays} days old`;
+      const refreshCommand = entry.refreshCommand || "not listed";
+      return {
+        title: `[ops] Refresh ${entry.producer} evidence artifact`,
+        labels: ["ops", "docs", "reliability"],
+        priority: entry.freshnessDays <= 1 ? "P2" : "P3",
+        problem: `${entry.producer} evidence is ${freshness}; freshness threshold is ${entry.freshnessDays} days.`,
+        evidence: `Producer ${entry.producer} expects ${entry.outputPath || "missing outputPath"}; latest artifact ${entry.newestArtifact || "not found"}.`,
+        risk: "The ops doctor can recommend stale next actions when producer evidence is missing or outside its freshness window.",
+        proposedFix: `Run the read-only refresh command \`${refreshCommand}\`, then rerun \`make ops-proactive-radar\` to confirm the artifact is fresh.`,
+        acceptanceCriteria: [
+          `${entry.outputPath || "producer output path"} exists with latest JSON or Markdown evidence.`,
+          `Radar reports ${entry.producer} as fresh.`,
+          "No destructive cleanup or host mutation is executed."
+        ],
+        safetyNotes: `Cleanup approval remains ${entry.cleanupApproval || "human"}; rollback is to discard regenerated ignored output artifacts or revert any docs-only evidence update.`
+      };
+    });
+}
+
 function buildReport(options) {
   const generatedAt = nowIso();
   const runId = clean(options.runId) || `proactive-radar-${generatedAt.replace(/[-:]/g, "").replace(/\.\d+Z$/, "Z")}`;
@@ -381,6 +405,7 @@ function buildReport(options) {
   const producerArtifacts = producerArtifactFreshness();
   const scripts = scriptInventory();
   const findings = buildFindings({ prs, status, freshness, producerArtifacts, scripts });
+  const producerRefreshTasks = buildProducerRefreshTasks(producerArtifacts);
   return {
     schema: "studio-brain.ops.proactive-radar.v1",
     generatedAt,
@@ -408,7 +433,8 @@ function buildReport(options) {
       }
     },
     findings,
-    recommendations: buildRecommendations(findings)
+    recommendations: buildRecommendations(findings),
+    producerRefreshTasks
   };
 }
 
@@ -465,6 +491,23 @@ function renderMarkdown(report) {
     lines.push(`- Suggested PR title: ${recommendation.suggestedPrTitle}`);
     lines.push("- Acceptance criteria:");
     for (const item of recommendation.acceptanceCriteria) lines.push(`  - ${item}`);
+    lines.push("");
+  }
+  lines.push("## Producer Refresh Tasks");
+  lines.push("");
+  if (!report.producerRefreshTasks.length) lines.push("- No stale producer refresh tasks from current policy thresholds.");
+  for (const task of report.producerRefreshTasks) {
+    lines.push(`### ${task.title}`);
+    lines.push("");
+    lines.push(`- Labels: ${task.labels.join(", ")}`);
+    lines.push(`- Priority: ${task.priority}`);
+    lines.push(`- Problem: ${task.problem}`);
+    lines.push(`- Evidence: ${task.evidence}`);
+    lines.push(`- Risk: ${task.risk}`);
+    lines.push(`- Proposed fix: ${task.proposedFix}`);
+    lines.push("- Acceptance criteria:");
+    for (const item of task.acceptanceCriteria) lines.push(`  - ${item}`);
+    lines.push(`- Safety notes: ${task.safetyNotes}`);
     lines.push("");
   }
   const stale = report.sources.artifactFreshness.filter((entry) => entry.stale);

--- a/scripts/ops/proactive_issue_radar.mjs
+++ b/scripts/ops/proactive_issue_radar.mjs
@@ -21,6 +21,15 @@ function repoRelative(path) {
   return relative(REPO_ROOT, path).replace(/\\/g, "/");
 }
 
+function readJsonFile(path, fallback = null) {
+  if (!existsSync(path)) return fallback;
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    return fallback;
+  }
+}
+
 function usage() {
   return `Studio Brain proactive issue radar
 
@@ -208,6 +217,61 @@ function artifactFreshness() {
   });
 }
 
+function newestFileMtime(root) {
+  if (!existsSync(root)) return null;
+  let newest = null;
+  const visit = (path) => {
+    const stat = statSync(path);
+    if (stat.isDirectory()) {
+      for (const entry of readdirSync(path)) visit(resolve(path, entry));
+      return;
+    }
+    if (!newest || stat.mtimeMs > newest.mtimeMs) newest = { path, mtime: stat.mtime, mtimeMs: stat.mtimeMs };
+  };
+  visit(root);
+  return newest;
+}
+
+function producerArtifactFreshness() {
+  const policyPath = resolve(REPO_ROOT, "docs", "ops", "output-artifact-producers.json");
+  const policy = readJsonFile(policyPath, { default: {}, producers: {} });
+  const defaults = policy.default || {};
+  const producers = policy.producers && typeof policy.producers === "object" ? policy.producers : {};
+  const now = Date.now();
+
+  return Object.entries(producers).map(([producer, rawConfig]) => {
+    const config = { ...defaults, ...(rawConfig || {}) };
+    const outputPath = clean(config.outputPath);
+    const freshnessDays = Number.isFinite(Number(config.freshnessDays)) ? Number(config.freshnessDays) : 14;
+    const resolvedOutput = outputPath ? resolve(REPO_ROOT, outputPath) : "";
+    const latestJson = resolvedOutput ? resolve(resolvedOutput, "latest.json") : "";
+    const latestMarkdown = resolvedOutput ? resolve(resolvedOutput, "latest.md") : "";
+    const latestFile = statFile(latestJson) || statFile(latestMarkdown) || newestFileMtime(resolvedOutput);
+    const ageDays = latestFile ? (now - latestFile.mtimeMs) / 86_400_000 : null;
+
+    return {
+      producer,
+      outputPath: outputPath || "",
+      retentionClass: clean(config.retentionClass) || "review",
+      cleanupApproval: clean(config.cleanupApproval) || "human",
+      freshnessDays,
+      exists: Boolean(resolvedOutput && existsSync(resolvedOutput)),
+      latestJson: latestJson && existsSync(latestJson) ? repoRelative(latestJson) : "",
+      latestMarkdown: latestMarkdown && existsSync(latestMarkdown) ? repoRelative(latestMarkdown) : "",
+      newestArtifact: latestFile?.path ? repoRelative(latestFile.path) : "",
+      newestAt: latestFile?.mtime ? latestFile.mtime.toISOString() : "",
+      ageDays: ageDays === null ? null : Number(ageDays.toFixed(1)),
+      stale: ageDays === null || ageDays > freshnessDays
+    };
+  });
+}
+
+function statFile(path) {
+  if (!path || !existsSync(path)) return null;
+  const stat = statSync(path);
+  return { path, mtime: stat.mtime, mtimeMs: stat.mtimeMs };
+}
+
 function scriptInventory() {
   const scripts = walkFiles(resolve(REPO_ROOT, "scripts", "ops"), (path) => /\.(sh|mjs|sql)$/i.test(path));
   const makefile = resolve(REPO_ROOT, "Makefile");
@@ -234,12 +298,13 @@ function makeFinding(severity, id, title, component, evidence, impact, safeNextS
   return { severity, id, title, component, evidence, impact, safeNextStep, rollback };
 }
 
-function buildFindings({ prs, status, freshness, scripts }) {
+function buildFindings({ prs, status, freshness, producerArtifacts, scripts }) {
   const findings = [];
   const rows = prs.rows || [];
   const dirtyNonDraft = rows.filter((pr) => !pr.isDraft && pr.mergeStateStatus !== "CLEAN");
   const stackedDrafts = rows.filter((pr) => pr.isDraft && pr.baseRefName && pr.baseRefName !== "main");
   const staleArtifacts = freshness.filter((entry) => entry.stale);
+  const staleProducerArtifacts = producerArtifacts.filter((entry) => entry.stale);
   const hiddenScripts = scripts.filter((entry) => !entry.makeTarget);
 
   if (!prs.ok) {
@@ -254,8 +319,14 @@ function buildFindings({ prs, status, freshness, scripts }) {
   if (status.ok && status.dirtyCount > 0) {
     findings.push(makeFinding("medium", "current-worktree-dirty", "Current worktree has local changes", "Local repository", `${status.dirtyCount} changed path(s) on ${status.branch}.`, "Implementation from this checkout may mix unrelated changes.", "Use a clean worktree from origin/main for ops slices.", "Leave the dirty checkout untouched."));
   }
-  if (staleArtifacts.length) {
-    findings.push(makeFinding("medium", "stale-ops-artifacts", "Ops evidence artifacts may be stale", "docs/ops", `${staleArtifacts.length} tracked ops artifact(s) are stale or missing.`, "Recommendations may be based on outdated evidence.", "Refresh the oldest docs with read-only scripts.", "Docs-only update; git history preserves old evidence."));
+  if (staleArtifacts.length || staleProducerArtifacts.length) {
+    const evidence = [
+      staleArtifacts.length ? `${staleArtifacts.length} tracked docs stale/missing` : "",
+      staleProducerArtifacts.length ? `${staleProducerArtifacts.length} producer output path(s) stale/missing` : "",
+      ...staleArtifacts.slice(0, 3).map((entry) => `${entry.path} ${entry.exists ? `${entry.ageDays}d old` : "missing"}`),
+      ...staleProducerArtifacts.slice(0, 5).map((entry) => `${entry.producer} -> ${entry.outputPath || "missing outputPath"} ${entry.ageDays === null ? "missing" : `${entry.ageDays}d old`} threshold=${entry.freshnessDays}d`)
+    ].filter(Boolean).join("; ");
+    findings.push(makeFinding("medium", "stale-ops-artifacts", "Ops evidence artifacts may be stale", "docs/ops and output/ops", evidence, "Recommendations may be based on outdated evidence.", "Refresh the named docs or producer outputs with read-only scripts.", "Docs/output-only update; git history preserves old evidence."));
   }
   if (hiddenScripts.length) {
     findings.push(makeFinding("low", "ops-scripts-without-make-targets", "Some ops scripts lack Makefile wrappers", "scripts/ops", `${hiddenScripts.length} script(s) do not appear to have make targets.`, "Useful diagnostics may remain hidden from operators.", "Add wrappers or README direct-command entries for high-value scripts.", "Makefile/doc change only."));
@@ -306,8 +377,9 @@ function buildReport(options) {
   const status = gitStatus();
   const prs = openPullRequests(repo);
   const freshness = artifactFreshness();
+  const producerArtifacts = producerArtifactFreshness();
   const scripts = scriptInventory();
-  const findings = buildFindings({ prs, status, freshness, scripts });
+  const findings = buildFindings({ prs, status, freshness, producerArtifacts, scripts });
   return {
     schema: "studio-brain.ops.proactive-radar.v1",
     generatedAt,
@@ -328,6 +400,7 @@ function buildReport(options) {
         unstable: prs.rows.filter((pr) => pr.mergeStateStatus === "UNSTABLE").length
       },
       artifactFreshness: freshness,
+      producerArtifactFreshness: producerArtifacts,
       scriptInventory: {
         count: scripts.length,
         withoutMakeTarget: scripts.filter((script) => !script.makeTarget).map((script) => script.path)
@@ -358,6 +431,8 @@ function renderMarkdown(report) {
     `- Local dirty paths: ${report.sources.gitStatus.dirtyCount ?? "unknown"}`,
     `- Ops scripts inventoried: ${report.sources.scriptInventory.count}`,
     `- Ops scripts without Makefile target: ${report.sources.scriptInventory.withoutMakeTarget.length}`,
+    `- Producer artifact paths tracked: ${report.sources.producerArtifactFreshness.length}`,
+    `- Stale or missing producer artifact paths: ${report.sources.producerArtifactFreshness.filter((entry) => entry.stale).length}`,
     "",
     "## Findings",
     ""
@@ -396,6 +471,16 @@ function renderMarkdown(report) {
   lines.push("");
   if (!stale.length) lines.push("- No stale tracked ops evidence artifacts from this threshold.");
   for (const entry of stale) lines.push(`- ${entry.path}: ${entry.exists ? `${entry.ageDays} days old` : "missing"}`);
+  lines.push("");
+
+  const staleProducers = report.sources.producerArtifactFreshness.filter((entry) => entry.stale);
+  lines.push("## Producer Artifact Freshness");
+  lines.push("");
+  if (!staleProducers.length) lines.push("- No stale producer output paths from policy thresholds.");
+  for (const entry of staleProducers) {
+    const freshness = entry.ageDays === null ? "missing" : `${entry.ageDays} days old`;
+    lines.push(`- ${entry.producer}: ${entry.outputPath || "missing outputPath"} (${freshness}; threshold ${entry.freshnessDays} days; retention ${entry.retentionClass})`);
+  }
   lines.push("");
   return `${lines.join("\n")}\n`;
 }


### PR DESCRIPTION
## Summary
- adds producer artifact freshness to the proactive issue radar from docs/ops/output-artifact-producers.json
- reports exact output/ops producer paths, thresholds, retention classes, latest artifact paths, and safe refresh commands in JSON/Markdown
- registers the proactive-radar output producer so retention scans do not fall back to default policy
- carries refreshCommand through the command manifest for downstream next-slice tooling
- generates issue-ready producer refresh tasks for stale or missing evidence outputs

## Evidence
- Fresh worktree branch from current main: codex/ops-next-slice-artifact-links
- Radar now reports stale/missing producer outputs such as output/ops/dependency-zero-baseline with refresh commands like make ops-dependency-zero-baseline
- Radar now emits producerRefreshTasks with problem, evidence, risk, proposed fix, acceptance criteria, and safety notes

## Testing
- node --check scripts/ops/proactive_issue_radar.mjs
- node --check scripts/ops/ops_command_manifest.mjs
- npm run ops:proactive:radar
- npm run ops:output:retention
- npm run ops:command-manifest:check
- npm run ops:command-surface:guard:check
- git diff --check

## Risk
Low. Read-only reporting and docs policy only; no host, Docker, DB, or service mutation.

## Rollback
Revert this PR to return the proactive radar to docs-only freshness checks and remove refreshCommand/producer policy additions.

## Follow-up Tickets
- Add a selector that ranks stale producer evidence by severity, freshness threshold, and command safety class.
- Persist last successful producer refresh status across clean worktrees or CI artifacts.