### PR TITLE
[ops] Add next slice selector command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL := /bin/bash
 PG_CONTAINER ?= studiobrain_postgres
 PGDATABASE ?= monsoonfire_studio_os
 
-.PHONY: ops-check ops-inventory ops-postgres-review ops-postgres-sql ops-postgres-top-queries ops-postgres-query-tasks ops-postgres-growth-snapshot ops-postgres-autovacuum-stats ops-postgres-roles-extensions ops-docker-review ops-docker-posture ops-docker-tag-policy ops-capacity ops-import-pressure ops-cleanup-candidates ops-backup-evidence ops-postgres-backup-artifacts ops-restore-prereq ops-redis-minio-backup-evidence ops-db-docker-backup-rollup ops-command-surface-guard ops-command-manifest ops-output-retention ops-ubuntu-review ops-host-failed-unit-trends ops-package-posture ops-time-sync ops-network-review ops-host-drift ops-systemd-drift ops-portal-bridge-review ops-app-review ops-dependency-review ops-dependency-security-scout ops-dependency-remediation-packet ops-dependency-upstream-watch ops-dependency-zero-baseline ops-idle-worker-effectivity ops-effectivity-report ops-evidence-freshness ops-slice-ledger ops-tool-inventory ops-admin-effectivity-audit ops-proactive-radar ops-pr-stack-readiness ops-privileged-evidence-read ops-privileged-evidence-capture ops-privileged-evidence-capture-smoke ops-work-packet ops-incident-bundle ops-incident-bundle-v2 ops-ci-validate ops-post-deploy-verify ops-docs ops-backlog ops-report
+.PHONY: ops-check ops-inventory ops-postgres-review ops-postgres-sql ops-postgres-top-queries ops-postgres-query-tasks ops-postgres-growth-snapshot ops-postgres-autovacuum-stats ops-postgres-roles-extensions ops-docker-review ops-docker-posture ops-docker-tag-policy ops-capacity ops-import-pressure ops-cleanup-candidates ops-backup-evidence ops-postgres-backup-artifacts ops-restore-prereq ops-redis-minio-backup-evidence ops-db-docker-backup-rollup ops-command-surface-guard ops-command-manifest ops-output-retention ops-ubuntu-review ops-host-failed-unit-trends ops-package-posture ops-time-sync ops-network-review ops-host-drift ops-systemd-drift ops-portal-bridge-review ops-app-review ops-dependency-review ops-dependency-security-scout ops-dependency-remediation-packet ops-dependency-upstream-watch ops-dependency-zero-baseline ops-idle-worker-effectivity ops-effectivity-report ops-evidence-freshness ops-slice-ledger ops-tool-inventory ops-admin-effectivity-audit ops-proactive-radar ops-next-slice-selector ops-pr-stack-readiness ops-privileged-evidence-read ops-privileged-evidence-capture ops-privileged-evidence-capture-smoke ops-work-packet ops-incident-bundle ops-incident-bundle-v2 ops-ci-validate ops-post-deploy-verify ops-docs ops-backlog ops-report
 
 ops-check: ops-inventory ops-docker-review ops-capacity ops-cleanup-candidates ops-backup-evidence ops-ubuntu-review ops-network-review ops-host-drift ops-systemd-drift ops-portal-bridge-review ops-app-review
 
@@ -152,6 +152,9 @@ ops-admin-effectivity-audit:
 
 ops-proactive-radar:
 	node scripts/ops/proactive_issue_radar.mjs --write
+
+ops-next-slice-selector:
+	node scripts/ops/next_slice_selector.mjs --refresh --write
 
 ops-pr-stack-readiness:
 	node scripts/ops/pr_stack_readiness.mjs --write

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -64,6 +64,7 @@ make ops-idle-worker-effectivity
 make ops-effectivity-report
 make ops-evidence-freshness
 make ops-proactive-radar
+make ops-next-slice-selector
 make ops-pr-stack-readiness
 make ops-privileged-evidence-read
 make ops-privileged-evidence-capture-smoke
@@ -85,6 +86,7 @@ npm run ops:db-docker-backup:rollup
 npm run ops:command-surface:guard
 npm run ops:command-manifest
 npm run ops:output:retention
+npm run ops:next-slice:selector
 npm run ops:dependency:security-scout
 npm run ops:dependency:remediation-packet
 npm run ops:dependency:upstream-watch
@@ -109,6 +111,7 @@ node scripts/ops/proactive_issue_radar.mjs --write
 node scripts/ops/command_surface_guard.mjs --write
 node scripts/ops/ops_command_manifest.mjs --write
 node scripts/ops/output_retention_scanner.mjs --write
+node scripts/ops/next_slice_selector.mjs --refresh --write
 node scripts/ops/dependency_security_scout.mjs --write
 node scripts/ops/dependency_remediation_packet.mjs --write
 node scripts/ops/dependency_upstream_watch.mjs --write
@@ -123,6 +126,8 @@ bash scripts/ops/incident_bundle_v2.sh output/ops/incidents-v2/manual-smoke
 `ops-privileged-evidence-capture-smoke` writes a non-root local smoke artifact under `output/ops/privileged-evidence` and is safe for development. Installing the host-side privileged collector, timer, group, or sudoers allowlist is intentionally separate and approval-gated; see `22-privileged-evidence-capture.md`.
 
 `ops-proactive-radar` is a read-only loop-start command. It looks for merge-blocked PRs, stacked draft PR pressure, stale ops artifacts, dirty worktree risk, and hidden ops scripts without printing secrets or mutating the host. It also reads `docs/ops/output-artifact-producers.json` so stale producer evidence points to exact `output/ops/...` paths and safe refresh commands.
+
+`ops-next-slice-selector` refreshes the proactive radar, then emits the single highest-ranked producer refresh task plus a short ranked preview. It writes under `output/ops/next-slice-selector` and never runs the selected refresh command for you.
 
 `ops-pr-stack-readiness` is a read-only GitHub PR-stack packet. It groups open PRs by stack, identifies dirty non-draft PRs, stale PRs, and non-main draft chains, and writes artifacts under `output/ops/pr-stack`.
 

--- a/docs/ops/output-artifact-producers.json
+++ b/docs/ops/output-artifact-producers.json
@@ -48,6 +48,13 @@
       "retentionClass": "next-slice-evidence",
       "cleanupApproval": "human"
     },
+    "next-slice-selector": {
+      "outputPath": "output/ops/next-slice-selector",
+      "refreshCommand": "make ops-next-slice-selector",
+      "freshnessDays": 1,
+      "retentionClass": "next-slice-evidence",
+      "cleanupApproval": "human"
+    },
     "output-retention": {
       "outputPath": "output/ops/output-retention",
       "refreshCommand": "make ops-output-retention",

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "ops:command-manifest": "node ./scripts/ops/ops_command_manifest.mjs --write --json",
     "ops:command-manifest:check": "node ./scripts/ops/ops_command_manifest.mjs --check --json",
     "ops:output:retention": "node ./scripts/ops/output_retention_scanner.mjs --write --json",
+    "ops:next-slice:selector": "node ./scripts/ops/next_slice_selector.mjs --refresh --write --json",
     "test:ops:command-surface": "node --test ./scripts/ops/command_surface_guard.test.mjs ./scripts/ops/ops_command_manifest.test.mjs",
     "ops:dependency:security-scout": "node ./scripts/ops/dependency_security_scout.mjs --write --json",
     "ops:dependency:remediation-packet": "node ./scripts/ops/dependency_remediation_packet.mjs --write --json",

--- a/scripts/ops/next_slice_selector.mjs
+++ b/scripts/ops/next_slice_selector.mjs
@@ -1,0 +1,237 @@
+#!/usr/bin/env node
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, relative, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const REPO_ROOT = resolve(dirname(__filename), "..", "..");
+const DEFAULT_RADAR = resolve(REPO_ROOT, "output", "ops", "proactive-radar", "latest.json");
+const DEFAULT_OUTPUT_DIR = resolve(REPO_ROOT, "output", "ops", "next-slice-selector");
+
+function clean(value) {
+  return String(value ?? "").replace(/\r/g, "").trim();
+}
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function repoRelative(path) {
+  return relative(REPO_ROOT, path).replace(/\\/g, "/") || ".";
+}
+
+function usage() {
+  return `Studio Brain next safe slice selector
+
+Usage:
+  node scripts/ops/next_slice_selector.mjs [--refresh] [--json] [--write]
+
+Options:
+  --refresh              Run the proactive radar before selecting.
+  --json                 Print JSON to stdout.
+  --write                Write latest JSON and Markdown artifacts.
+  --radar <path>         Radar JSON path. Default: output/ops/proactive-radar/latest.json.
+  --output-dir <path>    Artifact directory. Default: output/ops/next-slice-selector.
+
+This selector is read-only except for optional report writes. It never executes the selected refresh command.
+`;
+}
+
+function readFlagValue(argv, index, name) {
+  const arg = argv[index];
+  if (arg === name) {
+    if (!argv[index + 1]) throw new Error(`${name} requires a value.`);
+    return { matched: true, value: argv[index + 1], nextIndex: index + 1 };
+  }
+  if (arg.startsWith(`${name}=`)) {
+    return { matched: true, value: arg.slice(name.length + 1), nextIndex: index };
+  }
+  return { matched: false, value: "", nextIndex: index };
+}
+
+function parseArgs(argv) {
+  const options = {
+    refresh: false,
+    json: false,
+    write: false,
+    radar: DEFAULT_RADAR,
+    outputDir: DEFAULT_OUTPUT_DIR
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--help" || arg === "-h") {
+      process.stdout.write(usage());
+      process.exit(0);
+    }
+    if (arg === "--refresh") {
+      options.refresh = true;
+      continue;
+    }
+    if (arg === "--json") {
+      options.json = true;
+      continue;
+    }
+    if (arg === "--write") {
+      options.write = true;
+      continue;
+    }
+    const mappings = [
+      ["--radar", "radar"],
+      ["--output-dir", "outputDir"]
+    ];
+    let consumed = false;
+    for (const [flag, key] of mappings) {
+      const parsed = readFlagValue(argv, index, flag);
+      if (!parsed.matched) continue;
+      options[key] = parsed.value;
+      index = parsed.nextIndex;
+      consumed = true;
+      break;
+    }
+    if (consumed) continue;
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  options.radar = resolve(REPO_ROOT, options.radar);
+  options.outputDir = resolve(REPO_ROOT, options.outputDir);
+  return options;
+}
+
+function readJson(path) {
+  if (!existsSync(path)) return { ok: false, error: `${repoRelative(path)} is missing`, value: null };
+  try {
+    return { ok: true, error: "", value: JSON.parse(readFileSync(path, "utf8")) };
+  } catch (error) {
+    return { ok: false, error: `${repoRelative(path)} is invalid JSON: ${error.message}`, value: null };
+  }
+}
+
+function refreshRadar() {
+  const result = spawnSync(process.execPath, ["scripts/ops/proactive_issue_radar.mjs", "--write", "--json"], {
+    cwd: REPO_ROOT,
+    encoding: "utf8",
+    windowsHide: true,
+    timeout: 60_000,
+    env: { ...process.env }
+  });
+  if (result.error || result.status !== 0) {
+    return {
+      ok: false,
+      error: result.error?.message || clean(result.stderr) || `proactive radar exited ${result.status}`,
+      value: null
+    };
+  }
+  try {
+    return { ok: true, error: "", value: JSON.parse(result.stdout || "null") };
+  } catch (error) {
+    return { ok: false, error: `proactive radar emitted invalid JSON: ${error.message}`, value: null };
+  }
+}
+
+function buildReport(options) {
+  const generatedAt = nowIso();
+  const radar = options.refresh ? refreshRadar() : readJson(options.radar);
+  const radarReport = radar.value || {};
+  const allTasks = Array.isArray(radarReport.producerRefreshTasks) ? radarReport.producerRefreshTasks : [];
+  const tasks = allTasks.filter((task) => !String(task.title || "").includes("next-slice-selector"));
+  const nextTask = radarReport.nextProducerRefreshTask || tasks[0] || null;
+  const selectedTask = nextTask && String(nextTask.title || "").includes("next-slice-selector") ? tasks[0] || null : nextTask;
+  const staleProducerCount = Array.isArray(radarReport.sources?.producerArtifactFreshness)
+    ? radarReport.sources.producerArtifactFreshness.filter((entry) => entry.stale).length
+    : null;
+
+  return {
+    schema: "studio-brain.ops.next-slice-selector.v1",
+    generatedAt,
+    readOnly: true,
+    status: radar.ok ? nextTask ? "action_ready" : "ok" : "blocked",
+    source: {
+      refreshedRadar: options.refresh,
+      radarPath: repoRelative(options.radar),
+      radarOk: radar.ok,
+      radarError: radar.error,
+      radarGeneratedAt: radarReport.generatedAt || "",
+      radarStatus: radarReport.status || "unknown"
+    },
+    ignoredSelfTasks: allTasks.length - tasks.length,
+    nextTask: selectedTask,
+    rankedPreview: tasks.slice(0, 5),
+    staleProducerCount,
+    safeNextStep: selectedTask
+      ? selectedTask.proposedFix || selectedTask.title
+      : radar.ok
+        ? "No producer refresh task is currently selected."
+        : "Run make ops-proactive-radar, then rerun this selector.",
+    rollback: "No rollback needed; selector writes only ignored output artifacts when --write is used."
+  };
+}
+
+function renderMarkdown(report) {
+  const lines = [
+    "# Studio Brain Next Slice Selector",
+    "",
+    `- Generated at: ${report.generatedAt}`,
+    `- Status: ${report.status}`,
+    `- Read-only: ${report.readOnly ? "yes" : "no"}`,
+    `- Radar source: ${report.source.radarPath}`,
+    `- Radar refreshed: ${report.source.refreshedRadar ? "yes" : "no"}`,
+    `- Radar status: ${report.source.radarStatus}`,
+    `- Stale producer count: ${report.staleProducerCount ?? "unknown"}`,
+    `- Ignored selector self-tasks: ${report.ignoredSelfTasks}`,
+    "",
+    "## Next Task",
+    ""
+  ];
+  if (!report.nextTask) {
+    lines.push(`- ${report.safeNextStep}`);
+  } else {
+    lines.push(`- Title: ${report.nextTask.title}`);
+    lines.push(`- Rank: ${report.nextTask.rank}`);
+    lines.push(`- Score: ${report.nextTask.score}`);
+    lines.push(`- Priority: ${report.nextTask.priority}`);
+    lines.push(`- Command safety: ${report.nextTask.commandSafetyClass}`);
+    lines.push(`- Problem: ${report.nextTask.problem}`);
+    lines.push(`- Proposed fix: ${report.nextTask.proposedFix}`);
+    lines.push(`- Safety notes: ${report.nextTask.safetyNotes}`);
+  }
+  lines.push("");
+  lines.push("## Ranked Preview");
+  lines.push("");
+  if (!report.rankedPreview.length) lines.push("- No ranked producer refresh tasks.");
+  for (const task of report.rankedPreview) {
+    lines.push(`- #${task.rank} score ${task.score}: ${task.title} (${task.commandSafetyClass})`);
+  }
+  lines.push("");
+  lines.push("## Safety");
+  lines.push("");
+  lines.push(`- Safe next step: ${report.safeNextStep}`);
+  lines.push(`- Rollback: ${report.rollback}`);
+  lines.push("");
+  return `${lines.join("\n")}\n`;
+}
+
+function writeArtifacts(report, outputDir) {
+  mkdirSync(outputDir, { recursive: true });
+  const jsonPath = resolve(outputDir, "latest.json");
+  const markdownPath = resolve(outputDir, "latest.md");
+  writeFileSync(jsonPath, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+  writeFileSync(markdownPath, renderMarkdown(report), "utf8");
+  return { json: repoRelative(jsonPath), markdown: repoRelative(markdownPath) };
+}
+
+function main() {
+  try {
+    const options = parseArgs(process.argv.slice(2));
+    const report = buildReport(options);
+    if (options.write) report.paths = writeArtifacts(report, options.outputDir);
+    process.stdout.write(options.json ? `${JSON.stringify(report, null, 2)}\n` : renderMarkdown(report));
+  } catch (error) {
+    process.stderr.write(`next_slice_selector: ${error.message}\n`);
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- adds a dedicated read-only `ops-next-slice-selector` command and npm wrapper
- refreshes the proactive radar, then emits the single highest-ranked safe producer refresh task plus a ranked preview
- writes selector artifacts under `output/ops/next-slice-selector` with explicit retention/refresh policy
- documents the command in `docs/ops/README.md`

## Evidence
- Selector output status: `action_ready`
- Current selected task: `[ops] Refresh dependency-security-scout evidence artifact`
- Command surface guard sees 57 Make targets, 23 npm ops scripts, and 0 high/medium findings
- Output retention scanner status is `ok` with explicit `next-slice-selector` policy

## Testing
- node --check scripts/ops/next_slice_selector.mjs
- npm run ops:next-slice:selector
- npm run ops:command-surface:guard:check
- npm run ops:command-manifest:check
- npm run ops:output:retention
- git diff --check

## Risk
Low. The selector only runs read-only diagnostics and writes ignored output artifacts; it does not execute the selected refresh command or mutate host/Docker/DB/services.

## Rollback
Revert this PR to remove the selector command and its docs/policy entry. Generated ignored output can be discarded.

## Follow-up Tickets
- Add selector scoring weights to the producer policy file if operator tuning becomes useful.
- Teach the idle loop to consume `output/ops/next-slice-selector/latest.json` as its next work seed.