### PR TITLE
[ops] Persist privileged evidence read status

### DIFF
--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -87,6 +87,7 @@ npm run ops:command-surface:guard
 npm run ops:command-manifest
 npm run ops:output:retention
 npm run ops:next-slice:selector
+npm run ops:privileged-evidence:read
 npm run ops:dependency:security-scout
 npm run ops:dependency:remediation-packet
 npm run ops:dependency:upstream-watch

--- a/docs/ops/output-artifact-producers.json
+++ b/docs/ops/output-artifact-producers.json
@@ -85,7 +85,7 @@
     },
     "privileged-evidence": {
       "outputPath": "output/ops/privileged-evidence",
-      "refreshCommand": "make ops-privileged-evidence-read",
+      "refreshCommand": "npm run ops:privileged-evidence:read",
       "freshnessDays": 7,
       "retentionClass": "approval-gated-evidence",
       "cleanupApproval": "human"

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "ops:dependency:remediation-packet": "node ./scripts/ops/dependency_remediation_packet.mjs --write --json",
     "ops:dependency:upstream-watch": "node ./scripts/ops/dependency_upstream_watch.mjs --write --json",
     "ops:dependency:zero-baseline": "node ./scripts/ops/dependency_zero_baseline_guard.mjs --write --json",
+    "ops:privileged-evidence:read": "bash ./scripts/ops/privileged_evidence_read.sh",
     "ops:docker:tag-policy": "node ./scripts/ops/docker_floating_tag_policy.mjs --write --json",
     "portal:smoke:native-browser:shadow": "node ./scripts/native-browser-shadow-verifier.mjs --surface portal --base-url https://portal.monsoonfire.com --output-dir output/native-browser/portal/prod --shadow-of verify.portal.smoke --canonical-artifact-root output/playwright/portal/prod",
     "codex:browser:verify:portal": "node ./scripts/native-browser-shadow-verifier.mjs --surface portal --base-url https://portal.monsoonfire.com --output-dir output/native-browser/portal/prod --shadow-of verify.portal.smoke --canonical-artifact-root output/playwright/portal/prod --app-handoff",

--- a/scripts/integrity-check.mjs
+++ b/scripts/integrity-check.mjs
@@ -270,6 +270,9 @@ function shouldNormalizeText(filePath) {
   if (/(^|\/)Caddyfile$/.test(normalized)) {
     return true;
   }
+  if (normalized.includes("/config/studiobrain/sudoers/")) {
+    return true;
+  }
   const ext = normalized.includes(".") ? `.${normalized.split(".").pop()}` : "";
   return TEXT_FILE_EXTENSIONS.has(ext);
 }

--- a/scripts/ops/privileged_evidence_read.sh
+++ b/scripts/ops/privileged_evidence_read.sh
@@ -8,6 +8,7 @@ SOURCE_PATH="${BASH_SOURCE[0]:-${0}}"
 SCRIPT_DIR="$(cd "$(dirname "${SOURCE_PATH}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." 2>/dev/null && pwd || pwd)"
 EVIDENCE_ROOT="${STUDIO_BRAIN_PRIVILEGED_EVIDENCE_DIR:-/var/lib/studio-brain/ops-evidence}"
+OUTPUT_DIR="${REPO_ROOT}/output/ops/privileged-evidence"
 RUN_SELECTOR="latest"
 LIST_ONLY=0
 SUMMARY_ONLY=0
@@ -41,6 +42,60 @@ require_value() {
     usage >&2
     exit 2
   fi
+}
+
+json_escape() {
+  printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g; s/	/\\t/g'
+}
+
+write_latest_artifacts() {
+  status="$1"
+  reason="${2:-}"
+  run_dir="${3:-}"
+  mkdir -p "${OUTPUT_DIR}" 2>/dev/null || return 0
+
+  generated_at="$(date -u +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date)"
+  file_count=0
+  summary_present=false
+  if [ -n "${run_dir}" ] && [ -d "${run_dir}" ]; then
+    file_count="$(find "${run_dir}" -maxdepth 1 -type f 2>/dev/null | wc -l | tr -d ' ')"
+    if [ -f "${run_dir}/summary.json" ]; then
+      summary_present=true
+    fi
+  fi
+
+  cat > "${OUTPUT_DIR}/latest.json" <<EOF
+{
+  "schema": "studio-brain.ops.privileged-evidence-read.v1",
+  "generatedAt": "$(json_escape "${generated_at}")",
+  "readOnly": true,
+  "status": "$(json_escape "${status}")",
+  "reason": "$(json_escape "${reason}")",
+  "evidenceRoot": "$(json_escape "${EVIDENCE_ROOT}")",
+  "runSelector": "$(json_escape "${RUN_SELECTOR}")",
+  "runDir": "$(json_escape "${run_dir}")",
+  "summaryPresent": ${summary_present},
+  "fileCount": ${file_count},
+  "safeNextStep": "If status is unavailable or missing, run the approval-gated collector or install the root-owned timer; do not bypass sudo or mutate host state from this reader."
+}
+EOF
+
+  cat > "${OUTPUT_DIR}/latest.md" <<EOF
+# Privileged Evidence Read
+
+- Generated: ${generated_at}
+- Status: ${status}
+- Reason: ${reason:-none}
+- Evidence root: ${EVIDENCE_ROOT}
+- Run selector: ${RUN_SELECTOR}
+- Run dir: ${run_dir:-none}
+- Summary present: ${summary_present}
+- File count: ${file_count}
+
+## Safety
+
+This reader is read-only. If privileged evidence is unavailable or missing, the safe next step is an approval-gated capture path, not sudo bypass or host mutation from the agent lane.
+EOF
 }
 
 while [ "$#" -gt 0 ]; do
@@ -94,12 +149,13 @@ done
 
 if [ ! -d "${EVIDENCE_ROOT}" ]; then
   fallback="${REPO_ROOT}/output/ops/privileged-evidence"
-  if [ -d "${fallback}" ]; then
+  if [ -d "${fallback}" ] && { [ -L "${fallback}/latest" ] || [ -d "${fallback}/latest" ] || [ -f "${fallback}/latest.path" ] || find "${fallback}" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | grep -q .; }; then
     EVIDENCE_ROOT="${fallback}"
   fi
 fi
 
 if [ ! -d "${EVIDENCE_ROOT}" ]; then
+  write_latest_artifacts "unavailable" "privileged evidence directory is not readable" ""
   cat <<EOF
 status: unavailable
 reason: privileged evidence directory is not readable
@@ -145,6 +201,7 @@ else
 fi
 
 if [ -z "${RUN_DIR}" ] || [ ! -d "${RUN_DIR}" ]; then
+  write_latest_artifacts "missing" "no privileged evidence run was found" ""
   cat <<EOF
 status: missing
 reason: no privileged evidence run was found
@@ -183,6 +240,8 @@ if [ "${LIST_ONLY}" = "1" ]; then
   find "${RUN_DIR}" -maxdepth 1 -type f -printf '%f\t%s bytes\n' 2>/dev/null | sort
   exit 0
 fi
+
+write_latest_artifacts "available" "" "${RUN_DIR}"
 
 printf 'status: available\n'
 printf 'evidence_root: %s\n' "${EVIDENCE_ROOT}"

--- a/studio-brain/.env.integrity.json
+++ b/studio-brain/.env.integrity.json
@@ -1,6 +1,6 @@
 {
   "schema": "studiobrain-infra-integrity-v1",
-  "generatedAt": "2026-05-08T00:57:25.762Z",
+  "generatedAt": "2026-05-08T05:01:05.840Z",
   "generatedBy": "scripts/integrity-check.mjs",
   "allowUnknown": false,
   "metadata": {
@@ -296,8 +296,8 @@
     },
     {
       "path": "scripts/integrity-check.mjs",
-      "sha256": "97d688fc6fceee427257ff8cff42dadc7bdf44e3ae3dfdb55ee57de4b6928d99",
-      "size": 20018
+      "sha256": "c0e685b3074d4d37ab79e46bba67224b3971bc85213404e7646702f3e952b815",
+      "size": 20100
     },
     {
       "path": "scripts/lib/codex-automation-env.mjs",
@@ -466,8 +466,8 @@
     },
     {
       "path": "scripts/ops/privileged_evidence_read.sh",
-      "sha256": "b748151144f85f7bb1badcce9ccf4725ddcc16333a7f3e6aea0b64814c41f4d6",
-      "size": 4966
+      "sha256": "ab44cff2e982125d9d6884aebdaf30f7e38759ee10c3a83df1ddc3e63f97705b",
+      "size": 7148
     },
     {
       "path": "scripts/ops/redis_minio_evidence_verifier.sh",


### PR DESCRIPTION
## Summary
- persist privileged evidence read results to output/ops/privileged-evidence/latest.{json,md}
- keep sudo/privileged evidence unavailability visible as an evidence-lane artifact instead of a recurring stale producer task
- add a Windows-friendly npm wrapper and point the producer refresh command at it

## Evidence
- Selector identified privileged evidence as stale because make ops-privileged-evidence-read printed status but did not create the expected artifact.
- Running npm run ops:privileged-evidence:read now writes a redacted read-only latest.json with status unavailable when /var/lib/studio-brain/ops-evidence is unreadable.

## Testing
- bash -n scripts/ops/privileged_evidence_read.sh
- npm run ops:privileged-evidence:read
- npm run ops:command-manifest:check
- npm run ops:command-surface:guard:check
- npm run ops:next-slice:selector -- --json
- git diff --check

## Risk
Low. This only writes ignored local ops artifacts and updates the documented producer refresh command. It does not collect privileged evidence, run sudo, or mutate host state.

## Rollback
Revert this commit. The reader returns to stdout-only behavior and the radar will again report privileged-evidence as missing until a separate artifact exists.

## Follow-up tickets
- Consider a generic Windows-safe producer command field so selector consumers can prefer npm wrappers where available.
- Continue the selector queue with incident and incident-v2 live probes.