### PR TITLE
[ops] Add dependency cadence packet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL := /bin/bash
 PG_CONTAINER ?= studiobrain_postgres
 PGDATABASE ?= monsoonfire_studio_os
 
-.PHONY: ops-check ops-inventory ops-postgres-review ops-postgres-sql ops-postgres-top-queries ops-postgres-query-tasks ops-postgres-growth-snapshot ops-postgres-autovacuum-stats ops-postgres-roles-extensions ops-docker-review ops-docker-posture ops-docker-tag-policy ops-capacity ops-import-pressure ops-cleanup-candidates ops-backup-evidence ops-postgres-backup-artifacts ops-restore-prereq ops-redis-minio-backup-evidence ops-db-docker-backup-rollup ops-command-surface-guard ops-command-manifest ops-output-retention ops-ubuntu-review ops-host-failed-unit-trends ops-package-posture ops-time-sync ops-network-review ops-host-drift ops-systemd-drift ops-portal-bridge-review ops-app-review ops-dependency-review ops-dependency-security-scout ops-dependency-remediation-packet ops-dependency-upstream-watch ops-dependency-zero-baseline ops-idle-worker-effectivity ops-effectivity-report ops-evidence-freshness ops-slice-ledger ops-tool-inventory ops-admin-effectivity-audit ops-proactive-radar ops-next-slice-selector ops-pr-stack-readiness ops-pr-conflict-packets ops-privileged-evidence-read ops-privileged-evidence-capture ops-privileged-evidence-capture-smoke ops-work-packet ops-incident-bundle ops-incident-bundle-v2 ops-ci-validate ops-post-deploy-verify ops-docs ops-backlog ops-report
+.PHONY: ops-check ops-inventory ops-postgres-review ops-postgres-sql ops-postgres-top-queries ops-postgres-query-tasks ops-postgres-growth-snapshot ops-postgres-autovacuum-stats ops-postgres-roles-extensions ops-docker-review ops-docker-posture ops-docker-tag-policy ops-capacity ops-import-pressure ops-cleanup-candidates ops-backup-evidence ops-postgres-backup-artifacts ops-restore-prereq ops-redis-minio-backup-evidence ops-db-docker-backup-rollup ops-command-surface-guard ops-command-manifest ops-output-retention ops-ubuntu-review ops-host-failed-unit-trends ops-package-posture ops-time-sync ops-network-review ops-host-drift ops-systemd-drift ops-portal-bridge-review ops-app-review ops-dependency-review ops-dependency-cadence ops-dependency-security-scout ops-dependency-remediation-packet ops-dependency-upstream-watch ops-dependency-zero-baseline ops-idle-worker-effectivity ops-effectivity-report ops-evidence-freshness ops-slice-ledger ops-tool-inventory ops-admin-effectivity-audit ops-proactive-radar ops-next-slice-selector ops-pr-stack-readiness ops-pr-conflict-packets ops-privileged-evidence-read ops-privileged-evidence-capture ops-privileged-evidence-capture-smoke ops-work-packet ops-incident-bundle ops-incident-bundle-v2 ops-ci-validate ops-post-deploy-verify ops-docs ops-backlog ops-report
 
 ops-check: ops-inventory ops-docker-review ops-capacity ops-cleanup-candidates ops-backup-evidence ops-ubuntu-review ops-network-review ops-host-drift ops-systemd-drift ops-portal-bridge-review ops-app-review
 
@@ -119,6 +119,9 @@ ops-app-review:
 
 ops-dependency-review:
 	bash scripts/ops/npm_audit_inventory.sh
+
+ops-dependency-cadence:
+	node scripts/ops/dependency_cadence_packet.mjs --refresh --write
 
 ops-dependency-security-scout:
 	node scripts/ops/dependency_security_scout.mjs --write

--- a/docs/ops/26-dependency-security-cadence.md
+++ b/docs/ops/26-dependency-security-cadence.md
@@ -9,6 +9,7 @@ Keep the dependency lane boring: verify the all-clean baseline regularly, distin
 ## Current Baseline
 
 - Baseline file: `docs/ops/dependency-zero-baseline.json`
+- Cadence packet command: `npm run ops:dependency:cadence`
 - Guard command: `npm run ops:dependency:zero-baseline`
 - Strict guard command: `node scripts/ops/dependency_zero_baseline_guard.mjs --strict --json`
 - Current expected state: Dependabot open alerts `0`, active local alerts `0`, stale alerts `0`, npm audit high/critical `0`, npm audit total `0`, upstream-watch items `0`
@@ -18,13 +19,14 @@ Keep the dependency lane boring: verify the all-clean baseline regularly, distin
 Run:
 
 ```bash
-npm run ops:dependency:zero-baseline
+npm run ops:dependency:cadence
 ```
 
 Acceptance:
 
 - `status` is `ok`.
 - `findings` is empty.
+- `output/ops/dependency-cadence/latest.md` exists and summarizes the scout, upstream-watch, and zero-baseline producers.
 - GitHub alert evidence is available unless this is an explicitly local-only run.
 
 If the command reports `unknown`, refresh GitHub CLI auth and npm registry access before treating the result as a security finding.
@@ -34,6 +36,7 @@ If the command reports `unknown`, refresh GitHub CLI auth and npm registry acces
 Run:
 
 ```bash
+npm run ops:dependency:cadence
 npm run ops:dependency:security-scout
 npm run ops:dependency:upstream-watch
 npm run ops:dependency:zero-baseline

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -56,6 +56,7 @@ make ops-systemd-drift
 make ops-portal-bridge-review
 make ops-app-review
 make ops-dependency-review
+make ops-dependency-cadence
 make ops-dependency-security-scout
 make ops-dependency-remediation-packet
 make ops-dependency-upstream-watch
@@ -89,6 +90,7 @@ npm run ops:command-manifest
 npm run ops:output:retention
 npm run ops:next-slice:selector
 npm run ops:pr-conflict:packets
+npm run ops:dependency:cadence
 npm run ops:dependency:security-scout
 npm run ops:dependency:remediation-packet
 npm run ops:dependency:upstream-watch
@@ -149,6 +151,8 @@ bash scripts/ops/incident_bundle_v2.sh output/ops/incidents-v2/manual-smoke
 The scanner reads producer freshness expectations from `docs/ops/output-artifact-producers.json`; missing producers fall back to a conservative 14-day review window and human-approved cleanup.
 
 `ops-dependency-security-scout` compares open Dependabot alerts, open Dependabot PR readiness, and local `npm audit` summaries across the repo's package surfaces. It writes issue-ready follow-up tasks under `output/ops/dependency-security-scout` and does not install, update, or fix packages.
+
+`ops-dependency-cadence` refreshes the dependency scout, upstream-watch, and zero-baseline producers, then writes one operator packet under `output/ops/dependency-cadence`. It does not install, update, audit-fix, override, remove, or rewrite dependencies.
 
 `ops-dependency-remediation-packet` turns high/critical npm audit findings into a read-only decision packet with dependency chains, owner-package candidates, latest-version hints, safe next steps, acceptance criteria, and rollback notes. It writes under `output/ops/dependency-remediation` and does not install, update, override, or remove dependencies.
 

--- a/docs/ops/output-artifact-producers.json
+++ b/docs/ops/output-artifact-producers.json
@@ -13,6 +13,13 @@
       "retentionClass": "latest-plus-history",
       "cleanupApproval": "human"
     },
+    "dependency-cadence": {
+      "outputPath": "output/ops/dependency-cadence",
+      "refreshCommand": "make ops-dependency-cadence",
+      "freshnessDays": 1,
+      "retentionClass": "latest-plus-history",
+      "cleanupApproval": "human"
+    },
     "dependency-security-scout": {
       "outputPath": "output/ops/dependency-security-scout",
       "refreshCommand": "make ops-dependency-security-scout",

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "ops:next-slice:selector": "node ./scripts/ops/next_slice_selector.mjs --refresh --write --json",
     "ops:pr-conflict:packets": "node ./scripts/ops/pr_conflict_packets.mjs --refresh --write --json",
     "test:ops:command-surface": "node --test ./scripts/ops/command_surface_guard.test.mjs ./scripts/ops/ops_command_manifest.test.mjs",
+    "ops:dependency:cadence": "node ./scripts/ops/dependency_cadence_packet.mjs --refresh --write --json",
     "ops:dependency:security-scout": "node ./scripts/ops/dependency_security_scout.mjs --write --json",
     "ops:dependency:remediation-packet": "node ./scripts/ops/dependency_remediation_packet.mjs --write --json",
     "ops:dependency:upstream-watch": "node ./scripts/ops/dependency_upstream_watch.mjs --write --json",

--- a/scripts/ops/dependency_cadence_packet.mjs
+++ b/scripts/ops/dependency_cadence_packet.mjs
@@ -1,0 +1,372 @@
+#!/usr/bin/env node
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, relative, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const REPO_ROOT = resolve(dirname(__filename), "..", "..");
+const DEFAULT_OUTPUT_DIR = resolve(REPO_ROOT, "output", "ops", "dependency-cadence");
+
+const PRODUCERS = [
+  {
+    id: "dependency-security-scout",
+    label: "Dependency security scout",
+    command: ["node", "scripts/ops/dependency_security_scout.mjs", "--write", "--json"],
+    latest: resolve(REPO_ROOT, "output", "ops", "dependency-security-scout", "latest.json")
+  },
+  {
+    id: "dependency-upstream-watch",
+    label: "Dependency upstream watch",
+    command: ["node", "scripts/ops/dependency_upstream_watch.mjs", "--write", "--json"],
+    latest: resolve(REPO_ROOT, "output", "ops", "dependency-upstream-watch", "latest.json")
+  },
+  {
+    id: "dependency-zero-baseline",
+    label: "Dependency zero-baseline guard",
+    command: ["node", "scripts/ops/dependency_zero_baseline_guard.mjs", "--write", "--json"],
+    latest: resolve(REPO_ROOT, "output", "ops", "dependency-zero-baseline", "latest.json")
+  }
+];
+
+function usage() {
+  return `Dependency cadence packet
+
+Usage:
+  node scripts/ops/dependency_cadence_packet.mjs [--json] [--write] [--refresh]
+
+Options:
+  --json                 Print JSON.
+  --write                Write latest JSON and Markdown artifacts.
+  --refresh              Refresh dependency producers before summarizing.
+  --output-dir <path>    Artifact directory. Default: output/ops/dependency-cadence.
+
+This command is read-only. It does not install, update, audit-fix, override,
+remove, or rewrite dependencies.
+`;
+}
+
+function parseArgs(argv) {
+  const options = {
+    json: false,
+    write: false,
+    refresh: false,
+    outputDir: DEFAULT_OUTPUT_DIR
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--help" || arg === "-h") {
+      process.stdout.write(usage());
+      process.exit(0);
+    }
+    if (arg === "--json") {
+      options.json = true;
+      continue;
+    }
+    if (arg === "--write") {
+      options.write = true;
+      continue;
+    }
+    if (arg === "--refresh") {
+      options.refresh = true;
+      continue;
+    }
+    if (arg === "--output-dir") {
+      if (!argv[index + 1]) throw new Error(`${arg} requires a value.`);
+      options.outputDir = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith("--output-dir=")) {
+      options.outputDir = arg.slice("--output-dir=".length);
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+  options.outputDir = resolve(REPO_ROOT, options.outputDir);
+  return options;
+}
+
+function repoRelative(path) {
+  return relative(REPO_ROOT, path).replace(/\\/g, "/") || ".";
+}
+
+function windowsCommand(command) {
+  if (process.platform !== "win32") return command;
+  if (command === "node") return process.execPath;
+  if (command === "npm") return "npm.cmd";
+  return command;
+}
+
+function windowsShellQuote(value) {
+  const text = String(value);
+  if (/^[A-Za-z0-9_./:=@-]+$/.test(text)) return text;
+  return `"${text.replace(/"/g, '\\"')}"`;
+}
+
+function run(command) {
+  const [rawCommand, ...rawArgs] = command;
+  const resolved = windowsCommand(rawCommand);
+  const useCmdShim = process.platform === "win32" && /\.cmd$/i.test(resolved);
+  const actualCommand = useCmdShim ? "cmd.exe" : resolved;
+  const actualArgs = useCmdShim
+    ? ["/d", "/s", "/c", [resolved, ...rawArgs].map(windowsShellQuote).join(" ")]
+    : rawArgs;
+  const result = spawnSync(actualCommand, actualArgs, {
+    cwd: REPO_ROOT,
+    encoding: "utf8",
+    windowsHide: true,
+    timeout: 300_000
+  });
+  return {
+    exitStatus: result.status ?? null,
+    stdout: result.stdout || "",
+    stderr: result.stderr || "",
+    error: result.error?.message || ""
+  };
+}
+
+function safeJsonParse(raw, fallback = null) {
+  try {
+    return JSON.parse(raw || "");
+  } catch {
+    return fallback;
+  }
+}
+
+function readJson(path) {
+  if (!existsSync(path)) return null;
+  return safeJsonParse(readFileSync(path, "utf8"), null);
+}
+
+function firstLines(text, maxLines = 4) {
+  return String(text || "").split(/\r?\n/).filter(Boolean).slice(0, maxLines).join("\n");
+}
+
+function loadProducer(producer, options) {
+  const commandText = producer.command.join(" ");
+  let refresh = null;
+  if (options.refresh) {
+    const result = run(producer.command);
+    refresh = {
+      command: commandText,
+      exitStatus: result.exitStatus,
+      error: firstLines(result.stderr || result.error),
+      parsed: safeJsonParse(result.stdout, null)
+    };
+  }
+  const report = refresh?.parsed || readJson(producer.latest);
+  return {
+    id: producer.id,
+    label: producer.label,
+    command: commandText,
+    latestPath: repoRelative(producer.latest),
+    refreshed: Boolean(options.refresh),
+    refreshExitStatus: refresh?.exitStatus ?? null,
+    refreshError: refresh?.error || "",
+    evidenceAvailable: Boolean(report),
+    status: report?.status || "unavailable",
+    generatedAt: report?.generatedAt || null,
+    summary: summarizeProducer(producer.id, report),
+    findingCount: Array.isArray(report?.findings) ? report.findings.length : null,
+    safeNextStep: nextStepForProducer(producer.id, report, refresh)
+  };
+}
+
+function summarizeProducer(id, report) {
+  if (!report) return {};
+  if (id === "dependency-security-scout") {
+    return {
+      openAlerts: report.summary?.openAlerts ?? null,
+      activeAlerts: report.summary?.activeAlerts ?? null,
+      staleAlerts: report.summary?.staleAlerts ?? null,
+      auditHighCritical: report.summary?.auditHighCritical ?? null,
+      auditTotal: report.summary?.auditTotal ?? null,
+      dependabotPrs: report.summary?.dependabotPrs ?? null
+    };
+  }
+  if (id === "dependency-upstream-watch") {
+    return {
+      itemCount: Array.isArray(report.items) ? report.items.length : null,
+      normalUpdateCandidates: countItems(report.items, "normal_update_candidate"),
+      lockfileRefreshCandidates: countItems(report.items, "lockfile_refresh_candidate"),
+      upstreamMovementNeeded: countItems(report.items, "upstream_movement_needed")
+    };
+  }
+  if (id === "dependency-zero-baseline") {
+    return {
+      findingCount: Array.isArray(report.findings) ? report.findings.length : null,
+      baselinePath: report.baseline?.path || null,
+      sourceCommit: report.baseline?.sourceCommit || null
+    };
+  }
+  return {};
+}
+
+function countItems(items, classification) {
+  return (Array.isArray(items) ? items : []).filter((item) => item.classification === classification).length;
+}
+
+function nextStepForProducer(id, report, refresh) {
+  if (refresh && refresh.exitStatus !== 0) {
+    return "Inspect the producer error, restore read-only GitHub/npm access if needed, and rerun the cadence packet.";
+  }
+  if (!report) {
+    return "Run this packet with --refresh to create missing dependency evidence artifacts.";
+  }
+  if (report.status === "ok") {
+    return "No dependency remediation action is needed; keep the cadence artifact fresh.";
+  }
+  if (id === "dependency-zero-baseline") {
+    return "Open the zero-baseline findings and decide whether the regression needs a dependency PR or an evidence-access fix.";
+  }
+  return "Open the producer's latest Markdown packet and classify active risk versus stale or unavailable evidence.";
+}
+
+function statusFromProducers(producers) {
+  if (producers.some((producer) => !producer.evidenceAvailable || producer.refreshExitStatus !== null && producer.refreshExitStatus !== 0)) {
+    return "unknown";
+  }
+  if (producers.some((producer) => producer.status !== "ok")) {
+    return "action_needed";
+  }
+  return "ok";
+}
+
+function buildFindings(producers) {
+  const findings = [];
+  for (const producer of producers) {
+    if (!producer.evidenceAvailable) {
+      findings.push({
+        severity: "medium",
+        title: `${producer.label} evidence is unavailable`,
+        affectedComponent: producer.id,
+        evidence: `${producer.latestPath} is missing or unreadable.`,
+        likelyImpact: "Operators cannot trust the dependency security baseline without this evidence.",
+        recommendedAction: "Run the cadence packet with --refresh and inspect producer access errors.",
+        safeNextStep: producer.safeNextStep,
+        rollback: "Revert this reporting PR or delete the ignored output artifact; no dependency state is changed.",
+        prSuitable: true
+      });
+      continue;
+    }
+    if (producer.status !== "ok") {
+      findings.push({
+        severity: producer.id === "dependency-zero-baseline" ? "high" : "medium",
+        title: `${producer.label} reports ${producer.status}`,
+        affectedComponent: producer.id,
+        evidence: `${producer.latestPath}; summary=${JSON.stringify(producer.summary)}`,
+        likelyImpact: "A dependency security regression or evidence gap can remain hidden between manual checks.",
+        recommendedAction: "Open the producer packet and create a focused remediation or evidence-access task.",
+        safeNextStep: producer.safeNextStep,
+        rollback: "Revert the eventual remediation PR; this cadence packet does not mutate dependencies.",
+        prSuitable: true
+      });
+    }
+  }
+  return findings;
+}
+
+function renderMarkdown(report) {
+  const lines = [
+    "# Dependency Cadence Packet",
+    "",
+    `Generated: ${report.generatedAt}`,
+    `Status: \`${report.status}\``,
+    `Read-only: ${report.readOnly ? "yes" : "no"}`,
+    `Refreshed producers: ${report.refreshed ? "yes" : "no"}`,
+    "",
+    "## Summary",
+    "",
+    `- Producers: ${report.summary.producerCount}`,
+    `- Evidence available: ${report.summary.availableCount}/${report.summary.producerCount}`,
+    `- Action-needed producers: ${report.summary.actionNeededCount}`,
+    `- Findings: ${report.findings.length}`,
+    "",
+    "## Producer Status",
+    ""
+  ];
+  for (const producer of report.producers) {
+    lines.push(`### ${producer.label}`);
+    lines.push("");
+    lines.push(`- Status: \`${producer.status}\``);
+    lines.push(`- Latest: \`${producer.latestPath}\``);
+    lines.push(`- Generated: ${producer.generatedAt || "unknown"}`);
+    lines.push(`- Summary: \`${JSON.stringify(producer.summary)}\``);
+    lines.push(`- Safe next step: ${producer.safeNextStep}`);
+    if (producer.refreshError) lines.push(`- Refresh error: \`${producer.refreshError}\``);
+    lines.push("");
+  }
+  lines.push("## Findings");
+  lines.push("");
+  if (report.findings.length === 0) {
+    lines.push("- No dependency cadence findings.");
+  } else {
+    for (const finding of report.findings) {
+      lines.push(`### ${finding.title}`);
+      lines.push("");
+      lines.push(`- Severity: ${finding.severity}`);
+      lines.push(`- Affected component: ${finding.affectedComponent}`);
+      lines.push(`- Evidence: ${finding.evidence}`);
+      lines.push(`- Likely impact: ${finding.likelyImpact}`);
+      lines.push(`- Recommended action: ${finding.recommendedAction}`);
+      lines.push(`- Safe next step: ${finding.safeNextStep}`);
+      lines.push(`- Rollback: ${finding.rollback}`);
+      lines.push(`- PR suitable: ${finding.prSuitable ? "yes" : "no"}`);
+      lines.push("");
+    }
+  }
+  lines.push("");
+  lines.push("## Safety Notes");
+  lines.push("");
+  lines.push("- This packet is read-only.");
+  lines.push("- It does not run `npm audit fix`, `npm install`, `npm update`, overrides, removals, or lockfile edits.");
+  lines.push("- Dependency fixes still require a separate reviewable PR with tests and rollback notes.");
+  lines.push("");
+  return `${lines.join("\n")}\n`;
+}
+
+function writeArtifacts(report, options) {
+  mkdirSync(options.outputDir, { recursive: true });
+  writeFileSync(resolve(options.outputDir, "latest.json"), `${JSON.stringify(report, null, 2)}\n`, "utf8");
+  writeFileSync(resolve(options.outputDir, "latest.md"), renderMarkdown(report), "utf8");
+}
+
+function buildReport(options) {
+  const producers = PRODUCERS.map((producer) => loadProducer(producer, options));
+  const findings = buildFindings(producers);
+  const status = statusFromProducers(producers);
+  return {
+    schema: "studio-brain.ops.dependency-cadence.v1",
+    generatedAt: new Date().toISOString(),
+    status,
+    readOnly: true,
+    refreshed: options.refresh,
+    approvalBoundary: "No dependency mutation, install, update, audit-fix, override, removal, or lockfile edit is performed.",
+    summary: {
+      producerCount: producers.length,
+      availableCount: producers.filter((producer) => producer.evidenceAvailable).length,
+      actionNeededCount: producers.filter((producer) => producer.status !== "ok").length,
+      highOrCriticalAuditCount: producers.find((producer) => producer.id === "dependency-security-scout")?.summary?.auditHighCritical ?? null,
+      upstreamWatchItemCount: producers.find((producer) => producer.id === "dependency-upstream-watch")?.summary?.itemCount ?? null,
+      zeroBaselineFindingCount: producers.find((producer) => producer.id === "dependency-zero-baseline")?.summary?.findingCount ?? null
+    },
+    producers,
+    findings,
+    safeNextStep: findings.length === 0
+      ? "Keep dependency evidence fresh on the documented daily/weekly cadence."
+      : "Create issue-ready remediation tasks for the findings before changing dependencies."
+  };
+}
+
+try {
+  const options = parseArgs(process.argv.slice(2));
+  const report = buildReport(options);
+  if (options.write) writeArtifacts(report, options);
+  process.stdout.write(options.json ? `${JSON.stringify(report, null, 2)}\n` : renderMarkdown(report));
+  process.exit(0);
+} catch (error) {
+  process.stderr.write(`dependency cadence packet failed: ${error instanceof Error ? error.message : String(error)}\n`);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- add a read-only dependency cadence packet that refreshes and summarizes dependency security scout, upstream-watch, and zero-baseline evidence
- register the new producer and expose make/npm wrappers
- update dependency cadence docs so operators have one command for daily evidence

## Evidence
- Current cadence output reports 3/3 producers available, 0 action-needed producers, 0 high/critical audit findings, 0 upstream-watch items, and 0 zero-baseline findings.

## Testing
- node --check scripts/ops/dependency_cadence_packet.mjs
- node scripts/ops/dependency_cadence_packet.mjs --json
- npm run ops:dependency:cadence
- npm run ops:command-manifest:check
- npm run ops:command-surface:guard:check
- bash scripts/ops/ops_ci_validate.sh
- git diff --check

## Risk / Rollback
- Risk: low; read-only reporting and docs/command-surface changes only.
- Rollback: revert this PR; ignored output artifacts may be deleted separately with normal human cleanup approval.

## Follow-ups
- Feed dependency cadence status into the next-slice selector or admin dashboard if it becomes a recurring operator signal.