### PR TITLE
[ops] Prefer npm producer refresh commands

### DIFF
--- a/docs/ops/output-artifact-producers.json
+++ b/docs/ops/output-artifact-producers.json
@@ -8,72 +8,79 @@
   "producers": {
     "dependency-zero-baseline": {
       "outputPath": "output/ops/dependency-zero-baseline",
-      "refreshCommand": "make ops-dependency-zero-baseline",
+      "refreshCommand": "npm run ops:dependency:zero-baseline",
       "freshnessDays": 1,
       "retentionClass": "latest-plus-history",
       "cleanupApproval": "human"
     },
     "dependency-cadence": {
       "outputPath": "output/ops/dependency-cadence",
-      "refreshCommand": "make ops-dependency-cadence",
+      "refreshCommand": "npm run ops:dependency:cadence",
       "freshnessDays": 1,
       "retentionClass": "latest-plus-history",
       "cleanupApproval": "human"
     },
     "dependency-security-scout": {
       "outputPath": "output/ops/dependency-security-scout",
-      "refreshCommand": "make ops-dependency-security-scout",
+      "refreshCommand": "npm run ops:dependency:security-scout",
       "freshnessDays": 1,
       "retentionClass": "latest-plus-history",
       "cleanupApproval": "human"
     },
     "dependency-remediation": {
       "outputPath": "output/ops/dependency-remediation",
-      "refreshCommand": "make ops-dependency-remediation-packet",
+      "refreshCommand": "npm run ops:dependency:remediation-packet",
       "freshnessDays": 7,
       "retentionClass": "decision-packet",
       "cleanupApproval": "human"
     },
     "dependency-upstream-watch": {
       "outputPath": "output/ops/dependency-upstream-watch",
-      "refreshCommand": "make ops-dependency-upstream-watch",
+      "refreshCommand": "npm run ops:dependency:upstream-watch",
       "freshnessDays": 7,
       "retentionClass": "trend",
       "cleanupApproval": "human"
     },
     "pr-stack": {
       "outputPath": "output/ops/pr-stack",
-      "refreshCommand": "make ops-pr-stack-readiness",
+      "refreshCommand": "npm run ops:pr-stack:readiness",
       "freshnessDays": 1,
       "retentionClass": "ticket-evidence",
       "cleanupApproval": "human"
     },
     "proactive-radar": {
       "outputPath": "output/ops/proactive-radar",
-      "refreshCommand": "make ops-proactive-radar",
+      "refreshCommand": "npm run ops:proactive:radar",
       "freshnessDays": 1,
       "retentionClass": "next-slice-evidence",
       "cleanupApproval": "human"
     },
     "next-slice-selector": {
       "outputPath": "output/ops/next-slice-selector",
-      "refreshCommand": "make ops-next-slice-selector",
+      "refreshCommand": "npm run ops:next-slice:selector",
       "freshnessDays": 1,
       "retentionClass": "next-slice-evidence",
       "cleanupApproval": "human"
     },
     "output-retention": {
       "outputPath": "output/ops/output-retention",
-      "refreshCommand": "make ops-output-retention",
+      "refreshCommand": "npm run ops:output:retention",
       "freshnessDays": 7,
       "retentionClass": "self-audit",
       "cleanupApproval": "human"
     },
     "command-manifest": {
       "outputPath": "output/ops/command-manifest",
-      "refreshCommand": "make ops-command-manifest",
+      "refreshCommand": "npm run ops:command-manifest",
       "freshnessDays": 7,
       "retentionClass": "tool-inventory",
+      "cleanupApproval": "human"
+    },
+    "ci-validate": {
+      "outputPath": "output/ops/ci-validate",
+      "refreshCommand": "bash scripts/ops/ops_ci_validate.sh",
+      "freshnessDays": 7,
+      "retentionClass": "self-audit",
       "cleanupApproval": "human"
     },
     "incidents": {

--- a/scripts/ops/next_slice_selector.mjs
+++ b/scripts/ops/next_slice_selector.mjs
@@ -164,7 +164,7 @@ function buildReport(options) {
       ? selectedTask.proposedFix || selectedTask.title
       : radar.ok
         ? "No producer refresh task is currently selected."
-        : "Run make ops-proactive-radar, then rerun this selector.",
+        : "Run npm run ops:proactive:radar, then rerun this selector.",
     rollback: "No rollback needed; selector writes only ignored output artifacts when --write is used."
   };
 }

--- a/scripts/ops/proactive_issue_radar.mjs
+++ b/scripts/ops/proactive_issue_radar.mjs
@@ -390,7 +390,7 @@ function buildProducerRefreshTasks(producerArtifacts) {
         problem: `${entry.producer} evidence is ${freshness}; freshness threshold is ${entry.freshnessDays} days.`,
         evidence: `Producer ${entry.producer} expects ${entry.outputPath || "missing outputPath"}; latest artifact ${entry.newestArtifact || "not found"}.`,
         risk: "The ops doctor can recommend stale next actions when producer evidence is missing or outside its freshness window.",
-        proposedFix: `Run the read-only refresh command \`${refreshCommand}\`, then rerun \`make ops-proactive-radar\` to confirm the artifact is fresh.`,
+        proposedFix: `Run the read-only refresh command \`${refreshCommand}\`, then rerun \`npm run ops:proactive:radar\` to confirm the artifact is fresh.`,
         acceptanceCriteria: [
           `${entry.outputPath || "producer output path"} exists with latest JSON or Markdown evidence.`,
           `Radar reports ${entry.producer} as fresh.`,


### PR DESCRIPTION
## Summary
- Prefer npm refresh commands in the ops producer policy for producers that already have npm wrappers.
- Add an explicit `ci-validate` producer retention policy so retention scans no longer flag it as unclassified.
- Update generated next-slice/radar guidance to rerun `npm run ops:proactive:radar` instead of assuming `make` is installed.

## Evidence
- In the Windows PowerShell lane, `make` was unavailable while npm wrappers succeeded for the same safe read-only producers.
- `npm run ops:output:retention` previously surfaced `ci-validate` as a missing explicit producer policy.

## Testing
- `node --check scripts/ops/proactive_issue_radar.mjs`
- `node --check scripts/ops/next_slice_selector.mjs`
- `node -e "JSON.parse(require('fs').readFileSync('docs/ops/output-artifact-producers.json','utf8')); console.log('json ok')"`
- `npm run ops:output:retention`
- `npm run ops:command-manifest:check`
- `npm run ops:command-surface:guard:check`
- `npm run ops:next-slice:selector -- --json`
- `npm run ops:proactive:radar`
- `bash scripts/ops/ops_ci_validate.sh`
- `git diff --check`

## Risk and rollback
Risk: low. This is docs/metadata plus generated operator guidance; no host mutation, cleanup, restart, schema change, or service-impacting action.

Rollback: revert this PR to restore the prior Makefile-first producer command metadata.

## Follow-up tickets
- Add npm wrappers for incident bundle producers so the remaining `make ops-incident-bundle*` producer commands become Windows-friendly too.
- Consider a producer refresh runner that executes safe refresh commands from `docs/ops/output-artifact-producers.json` and reports skipped approval-gated producers.