### PR TITLE
[ops] Add incident npm wrappers

### DIFF
--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -97,6 +97,8 @@ npm run ops:dependency:remediation-packet
 npm run ops:dependency:upstream-watch
 npm run ops:dependency:zero-baseline
 npm run ops:docker:tag-policy
+npm run ops:incident:bundle
+npm run ops:incident:bundle:v2
 ```
 
 The scripts under `scripts/ops/` avoid environment dumps and degrade when Docker, PostgreSQL, or host-only tools are unavailable.

--- a/docs/ops/output-artifact-producers.json
+++ b/docs/ops/output-artifact-producers.json
@@ -85,14 +85,14 @@
     },
     "incidents": {
       "outputPath": "output/ops/incidents",
-      "refreshCommand": "make ops-incident-bundle",
+      "refreshCommand": "npm run ops:incident:bundle",
       "freshnessDays": 30,
       "retentionClass": "incident",
       "cleanupApproval": "human"
     },
     "incidents-v2": {
       "outputPath": "output/ops/incidents-v2",
-      "refreshCommand": "make ops-incident-bundle-v2",
+      "refreshCommand": "npm run ops:incident:bundle:v2",
       "freshnessDays": 30,
       "retentionClass": "incident",
       "cleanupApproval": "human"

--- a/package.json
+++ b/package.json
@@ -228,6 +228,8 @@
     "backup:verify:freshness": "node ./scripts/studiobrain-backup-drill.mjs verify --freshness-only --json --strict",
     "backup:restore:drill": "node ./scripts/studiobrain-backup-drill.mjs restore-drill --strict",
     "incident:bundle": "node ./scripts/studiobrain-incident-bundle.mjs",
+    "ops:incident:bundle": "bash ./scripts/ops/incident_bundle.sh",
+    "ops:incident:bundle:v2": "bash ./scripts/ops/incident_bundle_v2.sh",
     "studio:observability:up": "node ./scripts/studiobrain-observability-bundle.mjs up",
     "studio:observability:down": "node ./scripts/studiobrain-observability-bundle.mjs down",
     "studio:observability:status": "node ./scripts/studiobrain-observability-bundle.mjs status",

--- a/scripts/ops/disk_pressure.sh
+++ b/scripts/ops/disk_pressure.sh
@@ -2,6 +2,7 @@
 set -u
 
 # Read-only disk pressure snapshot. Uses sudo only when passwordless sudo is already available.
+OPS_COMMAND_TIMEOUT_SECONDS="${OPS_COMMAND_TIMEOUT_SECONDS:-30}"
 
 section() {
   printf '\n## %s\n' "$1"
@@ -9,7 +10,11 @@ section() {
 
 run_shell() {
   printf '\n$ %s\n' "$1"
-  bash -lc "$1" 2>&1 || printf 'WARN: command failed: %s\n' "$1"
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "${OPS_COMMAND_TIMEOUT_SECONDS}" bash -lc "$1" 2>&1 || printf 'WARN: command failed or timed out after %ss: %s\n' "${OPS_COMMAND_TIMEOUT_SECONDS}" "$1"
+  else
+    bash -lc "$1" 2>&1 || printf 'WARN: command failed: %s\n' "$1"
+  fi
 }
 
 section "Filesystems"


### PR DESCRIPTION
## Summary
- Add Windows-friendly npm wrappers for the read-only incident bundle scripts.
- Point incident producer refresh metadata at those npm wrappers.
- Document the wrappers in the ops README.
- Add a bounded timeout to `disk_pressure.sh` read-only subcommands so incident bundle collection degrades instead of hanging on slow mounts.

## Evidence
- After #702, the remaining producer refresh commands still assumed `make` for `incidents` and `incidents-v2`.
- During local wrapper smoke, the v1 bundle stalled in `disk_pressure.sh`; after adding `OPS_COMMAND_TIMEOUT_SECONDS`, the same npm wrapper completed.

## Testing
- `node -e "JSON.parse(require('fs').readFileSync('package.json','utf8')); JSON.parse(require('fs').readFileSync('docs/ops/output-artifact-producers.json','utf8')); console.log('json ok')"`
- `bash -n scripts/ops/disk_pressure.sh scripts/ops/incident_bundle.sh scripts/ops/incident_bundle_v2.sh`
- `npm run ops:command-manifest:check`
- `npm run ops:command-surface:guard:check`
- `npm run ops:output:retention`
- `npm run ops:next-slice:selector -- --json`
- `OPS_COMMAND_TIMEOUT_SECONDS=5 npm run ops:incident:bundle -- output/ops/incidents/npm-smoke-timeout`
- `INCIDENT_BUNDLE_V2_SMOKE=1 INCIDENT_INCLUDE_POST_DEPLOY=0 INCIDENT_INCLUDE_LOGS=0 npm run ops:incident:bundle:v2 -- output/ops/incidents-v2/npm-smoke-timeout`
- redaction smoke with `rg` over generated smoke outputs
- `bash scripts/ops/ops_ci_validate.sh`
- `git diff --check`

## Risk and rollback
Risk: low. The wrappers call existing read-only scripts, and the timeout only bounds read-only diagnostics. No host mutation, service restart, cleanup, schema change, package update, or privileged action is introduced.

Rollback: revert this PR to restore Makefile-only incident producer commands and the previous unbounded disk pressure helper.

## Follow-up tickets
- Consider making v2 the default incident producer once the operator experience is proven.
- Add per-check timeout status rows to v2 summary.json for richer triage.