### PR TITLE
[ops] Classify PR conflict packet output

### DIFF
--- a/docs/ops/output-artifact-producers.json
+++ b/docs/ops/output-artifact-producers.json
@@ -48,6 +48,13 @@
       "retentionClass": "ticket-evidence",
       "cleanupApproval": "human"
     },
+    "pr-conflict-packets": {
+      "outputPath": "output/ops/pr-conflict-packets",
+      "refreshCommand": "npm run ops:pr-conflict:packets",
+      "freshnessDays": 1,
+      "retentionClass": "ticket-evidence",
+      "cleanupApproval": "human"
+    },
     "proactive-radar": {
       "outputPath": "output/ops/proactive-radar",
       "refreshCommand": "npm run ops:proactive:radar",


### PR DESCRIPTION
## Summary
- Add an explicit output producer policy for \\pr-conflict-packets\\.
- Keep PR conflict packet freshness and retention visible to the ops output-retention tooling.

## Evidence
- \\
pm run ops:pr-conflict:packets\\ writes \\output/ops/pr-conflict-packets\\, but that output path did not have a dedicated producer policy.
- The policy now classifies the artifact as ticket evidence with human cleanup approval.

## Testing
- JSON parse for \\docs/ops/output-artifact-producers.json\\
- \\
pm run ops:producer:refresh -- --producer pr-conflict-packets --execute --json --timeout-ms 120000\\
- \\
pm run ops:output:retention\\
- \\
pm run ops:command-manifest:check\\
- \\
pm run ops:command-surface:guard:check\\
- \\git diff --check\\

## Risk
Low. Metadata-only producer-policy change; no host, Docker, database, or service mutation.

## Rollback
Revert this PR to remove the dedicated producer policy; the generated output remains ignored and non-destructive.

## Follow-up
Use the classified output to keep PR conflict/dirty-stack remediation packets fresh in future ops-doctor runs.