### PR TITLE
[ops] Expose hidden diagnostic wrappers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL := /bin/bash
 PG_CONTAINER ?= studiobrain_postgres
 PGDATABASE ?= monsoonfire_studio_os
 
-.PHONY: ops-check ops-inventory ops-postgres-review ops-postgres-sql ops-postgres-top-queries ops-postgres-query-tasks ops-postgres-growth-snapshot ops-postgres-autovacuum-stats ops-postgres-roles-extensions ops-docker-review ops-docker-posture ops-docker-tag-policy ops-capacity ops-import-pressure ops-cleanup-candidates ops-backup-evidence ops-postgres-backup-artifacts ops-restore-prereq ops-redis-minio-backup-evidence ops-db-docker-backup-rollup ops-command-surface-guard ops-command-manifest ops-output-retention ops-producer-refresh ops-ubuntu-review ops-host-failed-unit-trends ops-package-posture ops-time-sync ops-network-review ops-host-drift ops-systemd-drift ops-portal-bridge-review ops-app-review ops-dependency-review ops-dependency-cadence ops-dependency-security-scout ops-dependency-remediation-packet ops-dependency-upstream-watch ops-dependency-zero-baseline ops-idle-worker-effectivity ops-effectivity-report ops-evidence-freshness ops-slice-ledger ops-tool-inventory ops-admin-effectivity-audit ops-proactive-radar ops-next-slice-selector ops-pr-stack-readiness ops-pr-conflict-packets ops-pr-backlog-packets ops-privileged-evidence-read ops-privileged-evidence-capture ops-privileged-evidence-capture-smoke ops-work-packet ops-incident-bundle ops-incident-bundle-v2 ops-ci-validate ops-post-deploy-verify ops-docs ops-backlog ops-report
+.PHONY: ops-check ops-inventory ops-postgres-review ops-postgres-sql ops-postgres-top-queries ops-postgres-query-tasks ops-postgres-growth-snapshot ops-postgres-autovacuum-stats ops-postgres-roles-extensions ops-postgres-snapshot ops-docker-review ops-docker-posture ops-docker-tag-policy ops-capacity ops-import-pressure ops-cleanup-candidates ops-backup-evidence ops-postgres-backup-artifacts ops-restore-prereq ops-redis-minio-backup-evidence ops-db-docker-backup-rollup ops-command-surface-guard ops-command-manifest ops-output-retention ops-producer-refresh ops-ubuntu-review ops-host-failed-unit-trends ops-package-posture ops-time-sync ops-network-review ops-host-drift ops-systemd-drift ops-portal-bridge-review ops-app-review ops-dependency-review ops-dependency-inventory ops-dependency-cadence ops-dependency-security-scout ops-dependency-remediation-packet ops-dependency-upstream-watch ops-dependency-zero-baseline ops-idle-worker-effectivity ops-effectivity-report ops-evidence-freshness ops-slice-ledger ops-tool-inventory ops-admin-effectivity-audit ops-proactive-radar ops-next-slice-selector ops-pr-stack-readiness ops-pr-conflict-packets ops-pr-backlog-packets ops-privileged-evidence-read ops-privileged-evidence-capture ops-privileged-evidence-capture-smoke ops-work-packet ops-incident-bundle ops-incident-bundle-v2 ops-ci-validate ops-post-deploy-verify ops-docs ops-backlog ops-report
 
 ops-check: ops-inventory ops-docker-review ops-capacity ops-cleanup-candidates ops-backup-evidence ops-ubuntu-review ops-network-review ops-host-drift ops-systemd-drift ops-portal-bridge-review ops-app-review
 
@@ -45,6 +45,9 @@ ops-postgres-autovacuum-stats:
 
 ops-postgres-roles-extensions:
 	$(MAKE) ops-postgres-sql SQL=scripts/ops/postgres_roles_extensions_security_packet.sql
+
+ops-postgres-snapshot:
+	bash scripts/ops/postgres_readonly_snapshot_runner.sh
 
 ops-docker-review:
 	bash scripts/ops/docker_inventory.sh
@@ -122,6 +125,9 @@ ops-app-review:
 
 ops-dependency-review:
 	bash scripts/ops/npm_audit_inventory.sh
+
+ops-dependency-inventory:
+	bash scripts/ops/dependency_inventory.sh
 
 ops-dependency-cadence:
 	node scripts/ops/dependency_cadence_packet.mjs --refresh --write

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -57,11 +57,13 @@ make ops-systemd-drift
 make ops-portal-bridge-review
 make ops-app-review
 make ops-dependency-review
+make ops-dependency-inventory
 make ops-dependency-cadence
 make ops-dependency-security-scout
 make ops-dependency-remediation-packet
 make ops-dependency-upstream-watch
 make ops-dependency-zero-baseline
+make ops-postgres-snapshot
 make ops-idle-worker-effectivity
 make ops-effectivity-report
 make ops-evidence-freshness
@@ -100,6 +102,8 @@ npm run ops:dependency:security-scout
 npm run ops:dependency:remediation-packet
 npm run ops:dependency:upstream-watch
 npm run ops:dependency:zero-baseline
+npm run ops:dependency:inventory
+npm run ops:postgres:snapshot
 npm run ops:docker:tag-policy
 npm run ops:incident:bundle
 npm run ops:incident:bundle:v2
@@ -157,6 +161,10 @@ bash scripts/ops/incident_bundle_v2.sh output/ops/incidents-v2/manual-smoke
 `ops-command-surface-guard` checks that documented `make`, `npm run`, and direct `scripts/ops` commands still resolve. It writes artifacts under `output/ops/command-surface-guard` and is meant to catch command-wrapper drift before PRs stack up.
 
 `ops-command-manifest` writes a machine-readable inventory of Make targets, npm wrappers, direct ops scripts, docs coverage, lane classification, approval class, and output producer policy links. It writes under `output/ops/command-manifest` and does not execute the cataloged commands.
+
+`ops-dependency-inventory` prints read-only local tool versions plus ops/studio package scripts. It is also included inside incident bundles and avoids reading `.env` values.
+
+`ops-postgres-snapshot` writes redacted PostgreSQL DBA evidence under `output/ops/postgres/<timestamp>` using direct `psql` or the local Studio Brain Postgres container when available. It wraps packets in read-only transactions and degrades to skipped reports when credentials, Docker, or PostgreSQL are unavailable.
 
 `ops-output-retention` scans ignored `output/ops` artifacts for file count, total size, largest producers, stale files, and retention recommendations. It writes under `output/ops/output-retention` and never deletes, rotates, compresses, or prunes artifacts.
 

--- a/package.json
+++ b/package.json
@@ -98,6 +98,8 @@
     "ops:dependency:remediation-packet": "node ./scripts/ops/dependency_remediation_packet.mjs --write --json",
     "ops:dependency:upstream-watch": "node ./scripts/ops/dependency_upstream_watch.mjs --write --json",
     "ops:dependency:zero-baseline": "node ./scripts/ops/dependency_zero_baseline_guard.mjs --write --json",
+    "ops:dependency:inventory": "bash ./scripts/ops/dependency_inventory.sh",
+    "ops:postgres:snapshot": "bash ./scripts/ops/postgres_readonly_snapshot_runner.sh",
     "ops:privileged-evidence:read": "bash ./scripts/ops/privileged_evidence_read.sh",
     "ops:docker:tag-policy": "node ./scripts/ops/docker_floating_tag_policy.mjs --write --json",
     "portal:smoke:native-browser:shadow": "node ./scripts/native-browser-shadow-verifier.mjs --surface portal --base-url https://portal.monsoonfire.com --output-dir output/native-browser/portal/prod --shadow-of verify.portal.smoke --canonical-artifact-root output/playwright/portal/prod",

--- a/scripts/ops/proactive_issue_radar.mjs
+++ b/scripts/ops/proactive_issue_radar.mjs
@@ -281,12 +281,20 @@ function scriptInventory() {
   return scripts.map((path) => {
     const rel = repoRelative(path);
     const basename = rel.split("/").at(-1);
+    const type = basename.endsWith(".sql") ? "sql" : basename.endsWith(".mjs") ? "node" : "shell";
     return {
       path: rel,
-      type: basename.endsWith(".sql") ? "sql" : basename.endsWith(".mjs") ? "node" : "shell",
+      type,
+      operatorFacing: isOperatorFacingScript(basename, type),
       makeTarget: inferMakeTarget(makeText, basename)
     };
   });
+}
+
+function isOperatorFacingScript(basename, type) {
+  if (type === "sql") return false;
+  if (/\.test\.mjs$/i.test(basename)) return false;
+  return true;
 }
 
 function inferMakeTarget(makeText, basename) {
@@ -307,7 +315,7 @@ function buildFindings({ prs, status, freshness, producerArtifacts, scripts }) {
   const stackedDrafts = rows.filter((pr) => pr.isDraft && pr.baseRefName && pr.baseRefName !== "main");
   const staleArtifacts = freshness.filter((entry) => entry.stale);
   const staleProducerArtifacts = producerArtifacts.filter((entry) => entry.stale);
-  const hiddenScripts = scripts.filter((entry) => !entry.makeTarget);
+  const hiddenScripts = scripts.filter((entry) => entry.operatorFacing && !entry.makeTarget);
 
   if (!prs.ok) {
     findings.push(makeFinding("high", "github-pr-visibility-unavailable", "GitHub PR visibility is unavailable", "GitHub", prs.error, "Merge and release risk cannot be assessed automatically.", "Restore gh auth/network and rerun the radar.", "No repo rollback; this is read-only."));
@@ -459,7 +467,7 @@ function buildReport(options) {
       producerArtifactFreshness: producerArtifacts,
       scriptInventory: {
         count: scripts.length,
-        withoutMakeTarget: scripts.filter((script) => !script.makeTarget).map((script) => script.path)
+        withoutMakeTarget: scripts.filter((script) => script.operatorFacing && !script.makeTarget).map((script) => script.path)
       }
     },
     findings,


### PR DESCRIPTION
## Summary
- Add operator wrappers for the existing dependency inventory and PostgreSQL read-only snapshot diagnostics.
- Document both commands in the ops README and Windows-friendly npm list.
- Reduce proactive radar noise by treating test files and SQL sub-packets as internal helpers instead of missing operator commands.

## Evidence
- Before this slice, proactive radar reported hidden ops scripts including tests and SQL packets.
- After the change, \\
pm run ops:proactive:radar\\ reports \\scriptInventory.withoutMakeTarget: []\\ for operator-facing scripts.
- The new wrappers ran locally and degraded safely where Docker/Postgres were unavailable.

## Testing
- \\
pm run ops:dependency:inventory\\
- \\
pm run ops:postgres:snapshot -- output/ops/postgres/wrapper-smoke\\
- \\
ode --check scripts/ops/proactive_issue_radar.mjs\\
- \\
pm run ops:proactive:radar\\
- \\
pm run ops:command-manifest:check\\
- \\
pm run ops:command-surface:guard:check\\
- \\ash scripts/ops/ops_ci_validate.sh\\
- \\git diff --check\\

## Risk
Low. Command/docs/radar-only change. No host mutation, package changes, Docker changes, schema changes, or service restarts.

## Rollback
Revert this PR to remove the wrappers and restore the old radar classification.

## Follow-up tickets
- Consider adding dedicated producer policies for PostgreSQL snapshot artifacts if the team wants freshness tracking for them outside incident bundles.