### PR TITLE
[ops] Hydrate PR stack mergeability

### DIFF
--- a/scripts/ops/pr_stack_readiness.mjs
+++ b/scripts/ops/pr_stack_readiness.mjs
@@ -118,7 +118,44 @@ function fetchPullRequests(repo) {
     "number,title,isDraft,mergeStateStatus,headRefName,baseRefName,updatedAt,url"
   ]);
   if (!result.ok) return { ok: false, error: result.error, rows: [] };
-  return { ok: true, error: "", rows: Array.isArray(result.json) ? result.json : [] };
+  const rows = Array.isArray(result.json) ? result.json : [];
+  const hydrated = hydrateUnknownMergeability(repo, rows);
+  return {
+    ok: true,
+    error: hydrated.error,
+    rows: hydrated.rows,
+    hydratedUnknown: hydrated.hydrated,
+    hydrationFailures: hydrated.failures
+  };
+}
+
+function hydrateUnknownMergeability(repo, rows) {
+  let hydrated = 0;
+  let failures = 0;
+  const nextRows = rows.map((row) => {
+    if (row.isDraft || row.mergeStateStatus !== "UNKNOWN") return row;
+    const result = runJson("gh", [
+      "pr",
+      "view",
+      String(row.number),
+      "--repo",
+      repo,
+      "--json",
+      "mergeStateStatus"
+    ]);
+    if (!result.ok || !result.json?.mergeStateStatus) {
+      failures += 1;
+      return { ...row, mergeStateHydration: "failed" };
+    }
+    hydrated += 1;
+    return { ...row, mergeStateStatus: result.json.mergeStateStatus, mergeStateHydration: "gh-pr-view" };
+  });
+  return {
+    rows: nextRows,
+    hydrated,
+    failures,
+    error: failures ? `${failures} UNKNOWN mergeability hydration attempt(s) failed` : ""
+  };
 }
 
 function ageDays(updatedAt) {
@@ -422,7 +459,13 @@ function buildReport(options) {
     readOnly: true,
     repo: options.repo,
     status: prs.ok ? dirtyNonDraft.length ? "blocked" : stackedDrafts.length ? "triage_needed" : "ok" : "unavailable",
-    source: { ok: prs.ok, error: prs.error, count: classified.length },
+    source: {
+      ok: prs.ok,
+      error: prs.error,
+      count: classified.length,
+      hydratedUnknown: prs.hydratedUnknown || 0,
+      hydrationFailures: prs.hydrationFailures || 0
+    },
     summary: {
       open: classified.length,
       nonDraft: classified.filter((pr) => !pr.isDraft).length,
@@ -453,6 +496,8 @@ function renderMarkdown(report) {
     `- Status: ${report.status}`,
     `- Repo: ${report.repo}`,
     `- Read-only: ${report.readOnly ? "yes" : "no"}`,
+    `- Hydrated unknown non-draft mergeability: ${report.source.hydratedUnknown ?? 0}`,
+    `- Mergeability hydration failures: ${report.source.hydrationFailures ?? 0}`,
     "",
     "## Summary",
     "",


### PR DESCRIPTION
## Summary
- hydrate non-draft `UNKNOWN` mergeability in `ops:pr-stack:readiness` using `gh pr view`, matching proactive radar behavior
- expose hydration counts in PR-stack JSON/Markdown source evidence
- prevents downstream conflict packets from disagreeing with proactive radar when `gh pr list` returns stale `UNKNOWN`

## Evidence
- before this change, `ops:pr-conflict:packets` could report 0 dirty PRs while radar selected `#492 DIRTY`
- after this change, `npm run ops:pr-stack:readiness` reports `dirtyNonDraft: 1` with `#492 DIRTY`, and `npm run ops:pr-conflict:packets` emits the enriched #492 packet

## Testing
- `node --check scripts/ops/pr_stack_readiness.mjs`
- `npm run ops:pr-stack:readiness`
- `npm run ops:pr-conflict:packets`
- `npm run ops:command-manifest:check`
- `npm run ops:command-surface:guard:check`
- `bash scripts/ops/ops_ci_validate.sh`
- `git diff --check`

## Risk
Low. Read-only reporting change; it only performs an additional GitHub metadata lookup for non-draft UNKNOWN mergeability rows.

## Rollback
Revert this PR to return PR-stack readiness to `gh pr list`-only mergeability classification.