### PR TITLE
[ops] Add approval-gate fallback lanes

### DIFF
--- a/scripts/ops/next_slice_selector.mjs
+++ b/scripts/ops/next_slice_selector.mjs
@@ -277,6 +277,31 @@ function semanticTasksFromRadar(radarReport) {
     .map((task, index) => ({ ...task, rank: index + 1 }));
 }
 
+function fallbackTasksFromRadar(radarReport) {
+  const tasks = Array.isArray(radarReport.approvalFallbackTasks) ? radarReport.approvalFallbackTasks : [];
+  return tasks.map((task, index) => ({
+    rank: index + 1,
+    score: task.score || 30,
+    id: `approval-fallback-${index + 1}`,
+    source: "proactive-radar-approval-fallback",
+    title: task.title || "Refresh fallback ops evidence",
+    type: "ops",
+    priority: task.priority || "P3",
+    effort: "S",
+    risk: "low",
+    command: task.command || "",
+    commandSafetyClass: task.commandSafetyClass || (task.command ? "read-only-report" : "manual-planning"),
+    problem: task.problem || "Primary radar findings are approval-gated.",
+    evidence: task.evidence || "",
+    proposedFix: task.proposedFix || task.title || "Refresh fallback evidence.",
+    safetyNotes: task.safetyNotes || "No destructive action is authorized by this selector.",
+    packetArtifact: null,
+    suggestedBranchName: "",
+    suggestedPrTitle: "",
+    acceptanceCriteria: task.acceptanceCriteria || []
+  }));
+}
+
 function buildReport(options) {
   const generatedAt = nowIso();
   const radar = options.refresh ? refreshRadar() : readJson(options.radar);
@@ -286,6 +311,7 @@ function buildReport(options) {
   const nextProducerTask = radarReport.nextProducerRefreshTask || tasks[0] || null;
   const selectedProducerTask = nextProducerTask && String(nextProducerTask.title || "").includes("next-slice-selector") ? tasks[0] || null : nextProducerTask;
   const semanticTasks = semanticTasksFromRadar(radarReport);
+  const fallbackTasks = fallbackTasksFromRadar(radarReport);
   const artifactConsistencyWarnings = semanticTasks
     .filter((task) => task.packetArtifact?.consistency?.ok === false)
     .map((task) => ({
@@ -306,8 +332,8 @@ function buildReport(options) {
       approvalRequiredPackets: task.packetArtifact.approvalRequiredPackets,
       safeNextStep: task.proposedFix
     }));
-  const selectedTask = selectedProducerTask || semanticTasks[0] || null;
-  const actionableTasks = [...tasks, ...semanticTasks].filter((task) => task.command || !["human-approval-review", "review-existing-packet"].includes(task.commandSafetyClass));
+  const selectedTask = selectedProducerTask || fallbackTasks[0] || semanticTasks[0] || null;
+  const actionableTasks = [...tasks, ...fallbackTasks, ...semanticTasks].filter((task) => task.command || !["human-approval-review", "review-existing-packet"].includes(task.commandSafetyClass));
   const staleProducerCount = Array.isArray(radarReport.sources?.producerArtifactFreshness)
     ? radarReport.sources.producerArtifactFreshness.filter((entry) => entry.stale).length
     : null;
@@ -333,8 +359,9 @@ function buildReport(options) {
     },
     ignoredSelfTasks: allTasks.length - tasks.length,
     nextTask: selectedTask,
-    rankedPreview: [...tasks, ...semanticTasks].slice(0, 5),
+    rankedPreview: [...tasks, ...fallbackTasks, ...semanticTasks].slice(0, 5),
     semanticTaskCount: semanticTasks.length,
+    fallbackTaskCount: fallbackTasks.length,
     actionableTaskCount: actionableTasks.length,
     artifactConsistencyWarnings,
     approvalGates,
@@ -360,6 +387,7 @@ function renderMarkdown(report) {
     `- Radar status: ${report.source.radarStatus}`,
     `- Stale producer count: ${report.staleProducerCount ?? "unknown"}`,
     `- Semantic radar tasks: ${report.semanticTaskCount ?? 0}`,
+    `- Approval fallback tasks: ${report.fallbackTaskCount ?? 0}`,
     `- Actionable task count: ${report.actionableTaskCount ?? 0}`,
     `- Artifact consistency warnings: ${report.artifactConsistencyWarnings?.length ?? 0}`,
     `- Approval gates: ${report.approvalGates?.length ?? 0}`,

--- a/scripts/ops/proactive_issue_radar.mjs
+++ b/scripts/ops/proactive_issue_radar.mjs
@@ -339,6 +339,29 @@ function makeFinding(severity, id, title, component, evidence, impact, safeNextS
   return { severity, id, title, component, evidence, impact, safeNextStep, rollback };
 }
 
+function packetApprovalStateForFinding(id) {
+  const paths = {
+    "non-draft-prs-not-mergeable": resolve(REPO_ROOT, "output", "ops", "pr-conflict-packets", "latest.json"),
+    "large-stacked-draft-pr-backlog": resolve(REPO_ROOT, "output", "ops", "pr-backlog-decision-packets", "latest.json")
+  };
+  const path = paths[id] || "";
+  if (!path) return null;
+  const report = readJsonFile(path, null);
+  if (!report) return { id, packetPath: repoRelative(path), ok: false, packets: 0, approvalRequiredPackets: 0, allPacketsRequireApproval: false };
+  const packets = Array.isArray(report.packets) ? report.packets : [];
+  const approvalRequiredPackets = packets.filter((packet) => packet.approvalRequired).length;
+  return {
+    id,
+    packetPath: repoRelative(path),
+    ok: true,
+    status: report.status || "unknown",
+    generatedAt: report.generatedAt || "",
+    packets: packets.length,
+    approvalRequiredPackets,
+    allPacketsRequireApproval: packets.length > 0 && approvalRequiredPackets === packets.length
+  };
+}
+
 function buildFindings({ prs, status, freshness, producerArtifacts, scripts }) {
   const findings = [];
   const rows = prs.rows || [];
@@ -448,6 +471,41 @@ function buildProducerRefreshTasks(producerArtifacts) {
     .map((task, index) => ({ ...task, rank: index + 1 }));
 }
 
+function buildApprovalFallbackTasks(producerArtifacts, approvalGateFindings, producerRefreshTasks) {
+  if (!approvalGateFindings.length || producerRefreshTasks.length) return [];
+  const excluded = new Set(["pr-stack", "pr-conflict-packets", "pr-backlog-decision-packets", "proactive-radar", "next-slice-selector", "privileged-evidence"]);
+  return producerArtifacts
+    .filter((entry) => !excluded.has(entry.producer))
+    .filter((entry) => inferRefreshCommandSafety(entry.refreshCommand) !== "human_approval_required")
+    .map((entry) => {
+      const commandSafetyClass = inferRefreshCommandSafety(entry.refreshCommand);
+      const ageDays = entry.ageDays === null ? entry.freshnessDays : entry.ageDays;
+      const freshnessRatio = entry.freshnessDays ? Number((ageDays / entry.freshnessDays).toFixed(2)) : 0;
+      return {
+        rank: 0,
+        score: Math.round((freshnessRatio * 30) + (commandSafetyClass === "read_only_local" ? 20 : 10)),
+        title: `[ops] Refresh ${entry.producer} evidence while PR gates await approval`,
+        labels: ["ops", "reliability", "evidence"],
+        priority: "P3",
+        command: entry.refreshCommand,
+        commandSafetyClass,
+        problem: "PR-stack work is currently approval-gated, but the ops loop can still refresh safe operational evidence.",
+        evidence: `${approvalGateFindings.length} approval-gated PR-stack finding(s); ${entry.producer} evidence is ${entry.ageDays === null ? "missing" : `${entry.ageDays}d old`} with a ${entry.freshnessDays}d threshold.`,
+        risk: "Without a fallback lane, the loop can spin on human gates and stop producing fresh operational evidence.",
+        proposedFix: `Run \`${entry.refreshCommand}\`, then rerun \`npm run ops:next-slice:selector\` to keep the loop moving.`,
+        acceptanceCriteria: [
+          `${entry.outputPath || "producer output path"} has fresh JSON or Markdown evidence.`,
+          "Selector no longer treats the approval-gated PR packets as executable automation work.",
+          "No destructive cleanup, PR closure, branch deletion, or host mutation is executed."
+        ],
+        safetyNotes: `Read-only evidence refresh; cleanup approval remains ${entry.cleanupApproval || "human"}.`
+      };
+    })
+    .sort((a, b) => b.score - a.score || a.title.localeCompare(b.title))
+    .slice(0, 5)
+    .map((task, index) => ({ ...task, rank: index + 1 }));
+}
+
 function inferRefreshCommandSafety(command) {
   const value = clean(command).toLowerCase();
   if (!value || value === "not listed") return "unknown";
@@ -480,7 +538,11 @@ function buildReport(options) {
   const producerArtifacts = producerArtifactFreshness(options.write ? { outputDir: options.outputDir, generatedAt } : null);
   const scripts = scriptInventory();
   const findings = buildFindings({ prs, status, freshness, producerArtifacts, scripts });
+  const approvalGateFindings = findings
+    .map((finding) => packetApprovalStateForFinding(finding.id))
+    .filter((state) => state?.allPacketsRequireApproval);
   const producerRefreshTasks = buildProducerRefreshTasks(producerArtifacts);
+  const approvalFallbackTasks = buildApprovalFallbackTasks(producerArtifacts, approvalGateFindings, producerRefreshTasks);
   return {
     schema: "studio-brain.ops.proactive-radar.v1",
     generatedAt,
@@ -511,9 +573,12 @@ function buildReport(options) {
       }
     },
     findings,
+    approvalGateFindings,
     recommendations: buildRecommendations(findings),
     nextProducerRefreshTask: producerRefreshTasks[0] || null,
-    producerRefreshTasks
+    producerRefreshTasks,
+    approvalFallbackTasks,
+    nextApprovalFallbackTask: approvalFallbackTasks[0] || null
   };
 }
 
@@ -540,6 +605,8 @@ function renderMarkdown(report) {
     `- Producer artifact paths tracked: ${report.sources.producerArtifactFreshness.length}`,
     `- Stale or missing producer artifact paths: ${report.sources.producerArtifactFreshness.filter((entry) => entry.stale).length}`,
     `- Next producer refresh: ${report.nextProducerRefreshTask ? `${report.nextProducerRefreshTask.title} (${report.nextProducerRefreshTask.commandSafetyClass})` : "none"}`,
+    `- Approval-gated findings: ${report.approvalGateFindings?.length || 0}`,
+    `- Next approval fallback: ${report.nextApprovalFallbackTask ? `${report.nextApprovalFallbackTask.title} (${report.nextApprovalFallbackTask.commandSafetyClass})` : "none"}`,
     "",
     "## Findings",
     ""
@@ -577,6 +644,26 @@ function renderMarkdown(report) {
   lines.push("");
   if (!report.producerRefreshTasks.length) lines.push("- No stale producer refresh tasks from current policy thresholds.");
   for (const task of report.producerRefreshTasks) {
+    lines.push(`### ${task.title}`);
+    lines.push("");
+    lines.push(`- Rank: ${task.rank}`);
+    lines.push(`- Score: ${task.score}`);
+    lines.push(`- Labels: ${task.labels.join(", ")}`);
+    lines.push(`- Priority: ${task.priority}`);
+    lines.push(`- Command safety: ${task.commandSafetyClass}`);
+    lines.push(`- Problem: ${task.problem}`);
+    lines.push(`- Evidence: ${task.evidence}`);
+    lines.push(`- Risk: ${task.risk}`);
+    lines.push(`- Proposed fix: ${task.proposedFix}`);
+    lines.push("- Acceptance criteria:");
+    for (const item of task.acceptanceCriteria) lines.push(`  - ${item}`);
+    lines.push(`- Safety notes: ${task.safetyNotes}`);
+    lines.push("");
+  }
+  lines.push("## Approval Fallback Tasks");
+  lines.push("");
+  if (!report.approvalFallbackTasks?.length) lines.push("- No approval fallback tasks from current evidence.");
+  for (const task of report.approvalFallbackTasks || []) {
     lines.push(`### ${task.title}`);
     lines.push("");
     lines.push(`- Rank: ${task.rank}`);


### PR DESCRIPTION
## Summary
- detect PR-stack findings whose current packets are fully human approval-gated
- emit read-only approval fallback tasks from proactive radar when no stale producer refresh exists
- let the next-slice selector choose those fallback tasks so the loop can keep producing evidence instead of spinning on approval gates

## Evidence
- clean main after #715 reported blocked_on_approval with actionableTaskCount 0
- current radar now emits approvalFallbackTasks such as dependency-cadence/security-scout/zero-baseline while #492 and the stacked draft cohort await owner decisions

## Testing
- node --check scripts/ops/proactive_issue_radar.mjs
- node --check scripts/ops/next_slice_selector.mjs
- npm run ops:proactive:radar
- npm run ops:next-slice:selector
- npm run ops:command-manifest:check
- npm run ops:command-surface:guard:check
- bash scripts/ops/ops_ci_validate.sh
- git diff --check

## Risk
Low. Read-only report/selector behavior only.

## Rollback
Revert this PR; selector returns to reporting approval-gated PR-stack findings without fallback lanes.

## Follow-up
- execute the selected fallback command and let the selector continue to the next safe evidence lane
- add value scoring so fallback lanes favor higher operational leverage over simple freshness