### PR TITLE
[ops] Classify Postgres output retention

### DIFF
--- a/docs/ops/output-artifact-producers.json
+++ b/docs/ops/output-artifact-producers.json
@@ -41,6 +41,13 @@
       "retentionClass": "trend",
       "cleanupApproval": "human"
     },
+    "postgres": {
+      "outputPath": "output/ops/postgres",
+      "refreshCommand": "npm run ops:postgres:snapshot",
+      "freshnessDays": 7,
+      "retentionClass": "trend",
+      "cleanupApproval": "human"
+    },
     "pr-stack": {
       "outputPath": "output/ops/pr-stack",
       "refreshCommand": "npm run ops:pr-stack:readiness",


### PR DESCRIPTION
## Summary
- add an explicit producer policy for output/ops/postgres
- connect the policy to the existing read-only 
pm run ops:postgres:snapshot command
- classify PostgreSQL snapshot output as trend evidence with human-approved cleanup only

## Evidence
- 
pm run ops:output:retention reported postgres as missing an explicit retention policy before this change
- after this change, the retention report status is ok and the postgres producer has policyStatus: ok

## Testing
- npm run ops:output:retention
- npm run ops:command-manifest:check
- git diff --check

## Risk
Low. Documentation/config policy only; no PostgreSQL command is executed by this PR.

## Rollback
Revert this PR; output-retention will return to default retention classification for output/ops/postgres.

## Follow-up
- surface output-retention findings directly in proactive radar recommendations
- consider explicit producer policies for any future non-standard output directories as they appear