### PR TITLE
[ops] Mark manual selector tasks as review-only

### DIFF
--- a/scripts/ops/next_slice_selector.mjs
+++ b/scripts/ops/next_slice_selector.mjs
@@ -333,7 +333,9 @@ function buildReport(options) {
       safeNextStep: task.proposedFix
     }));
   const selectedTask = selectedProducerTask || fallbackTasks[0] || semanticTasks[0] || null;
-  const actionableTasks = [...tasks, ...fallbackTasks, ...semanticTasks].filter((task) => task.command || !["human-approval-review", "review-existing-packet"].includes(task.commandSafetyClass));
+  const nonActionableSafetyClasses = new Set(["human-approval-review", "review-existing-packet", "manual-planning"]);
+  const actionableTasks = [...tasks, ...fallbackTasks, ...semanticTasks].filter((task) => task.command || !nonActionableSafetyClasses.has(task.commandSafetyClass));
+  const hasManualReviewOnly = Boolean(selectedTask && selectedTask.commandSafetyClass === "manual-planning" && !actionableTasks.length);
   const staleProducerCount = Array.isArray(radarReport.sources?.producerArtifactFreshness)
     ? radarReport.sources.producerArtifactFreshness.filter((entry) => entry.stale).length
     : null;
@@ -346,6 +348,8 @@ function buildReport(options) {
       ? selectedTask
         ? selectedTask.commandSafetyClass === "human-approval-review" && !actionableTasks.length
           ? "blocked_on_approval"
+          : hasManualReviewOnly
+            ? "manual_review"
           : "action_ready"
         : "ok"
       : "blocked",


### PR DESCRIPTION
## Summary
- stop commandless manual-planning recommendations from counting as actionable automation work
- return manual_review when the selector only has a manual planning item and no executable/read-only command
- preserve blocked_on_approval behavior for approval-gated PR stack packets

## Evidence
- during active branch edits, current-worktree-dirty can appear as a radar recommendation with no command
- before this patch, that class could make the selector report action_ready despite having nothing safe to execute

## Testing
- node --check scripts/ops/next_slice_selector.mjs
- npm run ops:next-slice:selector
- synthetic fixture: node scripts/ops/next_slice_selector.mjs --radar output/ops/next-slice-selector/manual-review-fixture.json --json returned status manual_review
- git diff --check

## Risk
Low. Selector/report status change only; no operational commands are executed.

## Rollback
Revert this PR; manual-planning tasks will again be counted as actionable when no command exists.

## Follow-up
- add a committed fixture/unit test harness for selector status cases if this script gains more status states