### PR TITLE
[ops] Document next-slice selector statuses

### DIFF
--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -159,6 +159,14 @@ bash scripts/ops/incident_bundle_v2.sh output/ops/incidents-v2/manual-smoke
 
 `ops-next-slice-selector` refreshes the proactive radar, then emits the single highest-ranked producer refresh task plus a short ranked preview. It writes under `output/ops/next-slice-selector` and never runs the selected refresh command for you.
 
+Selector statuses are intentionally conservative:
+
+- `action_ready`: a safe read-only command or producer refresh is available to run.
+- `blocked_on_approval`: the highest-value remaining work is represented by approval-gated packets, such as dirty PR conflict packets or stacked draft owner decisions.
+- `manual_review`: the next item is commandless planning/review work, not executable automation.
+- `ok`: no producer refresh or radar recommendation task is currently selected.
+- `blocked`: selector input could not be read or refreshed.
+
 `ops-producer-refresh` reads `docs/ops/output-artifact-producers.json` and creates a safe refresh plan for stale producer evidence. It is plan-only by default; pass `-- --execute` through npm, or run the node script with `--execute`, when you intentionally want it to run selected read-only refresh commands. Live probes and approval-gated commands are skipped unless explicitly included.
 
 `ops-pr-stack-readiness` is a read-only GitHub PR-stack packet. It groups open PRs by stack, identifies dirty non-draft PRs, stale PRs, and non-main draft chains, and writes artifacts under `output/ops/pr-stack`.


### PR DESCRIPTION
## Summary
- document next-slice selector status meanings in docs/ops/README.md
- clarify that action_ready means a safe command exists, blocked_on_approval means packet review needs a human, and manual_review means no executable automation is available

## Evidence
- PR #722 added manual_review so the status vocabulary now needed operator-facing docs
- selector currently reports blocked_on_approval with 0 actionable tasks and approval-gated PR packet reviews

## Testing
- npm run ops:command-manifest:check
- npm run ops:next-slice:selector
- git diff --check

## Risk
Low. Documentation-only change.

## Rollback
Revert this PR; selector behavior remains unchanged but the new status vocabulary is undocumented.

## Follow-up
- add committed selector status fixtures if more states are introduced